### PR TITLE
Add cumulusci.maxPoll.managed to cumulusci.properties

### DIFF
--- a/build/cumulusci.xml
+++ b/build/cumulusci.xml
@@ -40,7 +40,7 @@
           <mkdir dir="${basedir}/installdeploy/installedPackages"/>
           <echo file="${basedir}/installdeploy/package.xml"><![CDATA[<Package xmlns="http://soap.sforce.com/2006/04/metadata"><types><members>@{namespace}</members><name>InstalledPackage</name></types><version>${cumulusci.package.apiVersion}</version></Package>]]></echo>
           <echo file="${basedir}/installdeploy/installedPackages/@{namespace}.installedPackage"><![CDATA[<InstalledPackage xmlns="http://soap.sforce.com/2006/04/metadata"><versionNumber>@{version}</versionNumber>${passwordElement}</InstalledPackage>]]></echo>
-          <sf:deploy deployRoot="${basedir}/installdeploy" username="@{username}" password="@{password}" maxPoll="500" />
+          <sf:deploy deployRoot="${basedir}/installdeploy" username="@{username}" password="@{password}" maxPoll="${cumulusci.maxPoll.managed}" />
           <delete dir="${basedir}/installdeploy"/>
       </sequential>
   </macrodef>
@@ -59,7 +59,7 @@
           <echo file="${basedir}/installdeploy/package.xml"><![CDATA[<Package xmlns="http://soap.sforce.com/2006/04/metadata"><version>${cumulusci.package.apiVersion}</version></Package>]]></echo>
           <echo file="${basedir}/installdeploy/destructiveChanges.xml"><![CDATA[<Package xmlns="http://soap.sforce.com/2006/04/metadata"><types><members>@{namespace}</members><name>InstalledPackage</name></types><version>${cumulusci.package.apiVersion}</version></Package>]]></echo>
           <echo file="${basedir}/installdeploy/installedPackages/@{namespace}.installedPackage"><![CDATA[<InstalledPackage xmlns="http://soap.sforce.com/2006/04/metadata"><versionNumber>@{version}</versionNumber></InstalledPackage>]]></echo>
-          <sf:deploy deployRoot="${basedir}/installdeploy" username="@{username}" password="@{password}" maxPoll="500" />
+          <sf:deploy deployRoot="${basedir}/installdeploy" username="@{username}" password="@{password}" maxPoll="${cumulusci.maxPoll.managed}" />
       </sequential>
   </macrodef>
 

--- a/template/cumulusci.properties
+++ b/template/cumulusci.properties
@@ -7,3 +7,4 @@ cumulusci.package.uninstallClass=
 cumulusci.github.url.raw=https://raw.github.com/YOUR_ORG_OR_USER/YOUR_REPO_NAME
 cumulusci.maxPoll.test=400
 cumulusci.maxPoll.notest=200
+cumulusci.maxPoll.managed=400


### PR DESCRIPTION
# Warning
- The updateRequiredPackages target now requires the cumulusci.maxPoll.managed property in cumulusci.properties which allows projects to control the timeouts for managed package installation and uninstallation.  You will need to add this property to your cumulusci.properties file.
# Info
# Issues

Fixes #33 
