### PR TITLE
Enable parallel execution of Apex test classes

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -51,6 +51,7 @@
     <property name="cumulusci.package.installClass" value="" />
     <property name="cumulusci.package.uninstallClass" value="" />
     <property name="cumulusci.package.apiVersion" value="31.0" />
+    <property name="cumulusci.test.namematch" value="%\_TEST" />
     <property name="cumulusci.maxPoll.test" value="400" />
     <property name="cumulusci.maxPoll.notest" value="200" />
     <property name="cumulusci.maxPoll.managed" value="400" />
@@ -235,7 +236,7 @@
         <antcall target="deployUnpackagedPost" />
 
         <!-- Run all tests -->
-        <antcall target="runAllTests" />
+        <antcall target="runAllTestsManaged" />
 
         <antcall target="postDeployCIPackageOrg" />
     </target>
@@ -495,10 +496,45 @@
         </if>
     </target>
 
-    <!-- runAllTests: Uses an empty package manifest to trigger execution of all tests in the target org without deploying any actual code changes -->
+    <!-- runAllTests: Runs all unmanaged tests -->
     <target name="runAllTests">
         <echo>----------------------------------------------------------------------------</echo>
-        <sf:deploy username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" deployRoot="${cumulus_ci.basedir}/empty" runAllTests="true" maxPoll="${cumulusci.maxPoll.test}" />
+        <if>
+            <equals arg1="${env.TEST_MODE}" arg2="parallel" />
+            <then>
+                <exec executable="python" failonerror="true">
+                  <env key="SF_USERNAME" value="${sf.username}" />
+                  <env key="SF_PASSWORD" value="${sf.password}" />
+                  <env key="SF_SERVERURL" value="${sf.serverurl}" />
+                  <env key="APEX_TEST_NAME_MATCH" value="${cumulusci.test.namematch}" />
+                  <arg value="${cumulus_ci.basedir}/../ci/run_apex_tests.py" />
+                </exec>
+            </then>
+            <else>
+                <sf:deploy username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" deployRoot="${cumulus_ci.basedir}/empty" runAllTests="true" maxPoll="${cumulusci.maxPoll.test}" />
+            </else>
+        </if>
+    </target>
+
+    <!-- runAllTestsManaged: Runs all managed tests from package's namespace -->
+    <target name="runAllTestsManaged">
+        <echo>----------------------------------------------------------------------------</echo>
+        <if>
+            <equals arg1="${env.TEST_MODE}" arg2="parallel" />
+            <then>
+                <exec executable="python" failonerror="true">
+                  <env key="SF_USERNAME" value="${sf.username}" />
+                  <env key="SF_PASSWORD" value="${sf.password}" />
+                  <env key="SF_SERVERURL" value="${sf.serverurl}" />
+                  <env key="APEX_TEST_NAME_MATCH" value="${cumulusci.test.namematch}" />
+                  <env key="NAMESPACE" value="${cumulusci.package.namespace}" />
+                  <arg value="${cumulus_ci.basedir}/../ci/run_apex_tests.py" />
+                </exec>
+            </then>
+            <else>
+                <sf:deploy username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" deployRoot="${cumulus_ci.basedir}/empty" runAllTests="true" maxPoll="${cumulusci.maxPoll.test}" />
+            </else>
+        </if>
     </target>
 
     <!-- updatePackageXml: Builds a new package.xml based upon the metadata in the src directory -->

--- a/ci/codeship.sh
+++ b/ci/codeship.sh
@@ -105,6 +105,13 @@ function waitOnBackgroundJobs {
     fi
 }
 
+#-----------------------------------
+# Set up dependencies for async test
+#-----------------------------------
+if [ "$TEST_MODE" == 'parallel' ]; then
+    pip install --upgrade simple-salesforce
+fi
+
 #---------------------------------
 # Run the build for the build type
 #---------------------------------
@@ -226,7 +233,7 @@ if [ $BUILD_TYPE == "master" ]; then
     echo "ant runAllTests: Testing $PACKAGE_VERSION in beta org"
     echo "-----------------------------------------------------------------"
     echo
-    runAntTarget runAllTests
+    runAntTarget runAllTestsManaged
     if [ $ant_status != 0 ]; then exit 1; fi
     
     if [ "$GITHUB_USERNAME" != "" ]; then   

--- a/ci/run_apex_tests.py
+++ b/ci/run_apex_tests.py
@@ -1,0 +1,131 @@
+import os
+import sys
+from time import sleep
+from simple_salesforce import Salesforce
+
+def run_tests():
+    username = os.environ.get('SF_USERNAME')
+    password = os.environ.get('SF_PASSWORD')
+    serverurl = os.environ.get('SF_SERVERURL')
+    test_name_match = os.environ.get('APEX_TEST_NAME_MATCH', '%_TEST')
+    namespace = os.environ.get('NAMESPACE', None)
+    poll_interval = int(os.environ.get('POLL_INTERVAL', 10))
+    
+    if namespace:
+        namespace = "'%s'" % namespace
+    else:
+        namespace = 'null'
+    
+    sandbox = False
+    if serverurl.find('test.salesforce.com') != -1:
+        sandbox = True
+    
+    sf = Salesforce(username=username, password=password, security_token='', sandbox=sandbox)
+    
+    # Change base_url to use the tooling api
+    sf.base_url = sf.base_url + 'tooling/'
+    
+    # Get all test classes for namespace
+    print "Querying ApexClasses with NamespacePrefix = %s and Name like '%s'" % (namespace, test_name_match)
+    sys.stdout.flush()
+    res = sf.query_all("SELECT Id, Name FROM ApexClass WHERE NamespacePrefix = %s and Name LIKE '%s'" % (namespace, test_name_match))
+    print "Found %s classes" % res['totalSize']
+    sys.stdout.flush()
+
+    if not res['totalSize']:
+        return {'Pass': 0, 'Failed': 0, 'CompileFail': 0, 'Skip': 0}
+    
+    classes_by_id = {}
+    results_by_class_name = {}
+    
+    for cls in res['records']:
+        classes_by_id[cls['Id']] = cls['Name']
+        results_by_class_name[cls['Name']] = {}
+    
+    # Run all the tests
+    print "Queuing tests for execution..."
+    sys.stdout.flush()
+    job_id = sf.restful('runTestsAsynchronous', params={'classids': ','.join(classes_by_id.keys())})
+    
+    # Loop waiting for the tests to complete
+    while True:
+        res = sf.query_all("SELECT Id, Status, ApexClassId FROM ApexTestQueueItem WHERE ParentJobId = '%s'" % job_id)
+        counts = {
+            'Queued': 0,
+            'Processing': 0,
+            'Aborted': 0,
+            'Completed': 0,
+            'Failed': 0,
+            'Preparing': 0,
+            'Holding': 0,
+        }
+        for item in res['records']:
+            counts[item['Status']] += 1
+    
+        # If all tests have run, break from the loop
+        if not counts['Queued'] and not counts['Processing']:
+            print ''
+            print '-------------------------------------------------------------------------------'
+            print 'Test Results'
+            print '-------------------------------------------------------------------------------'
+            sys.stdout.flush()
+            break
+        
+        print 'Completed: %(Completed)s  Processing: %(Processing)s  Queued: %(Queued)s' % counts
+        sys.stdout.flush()
+        sleep(poll_interval)
+    
+    # Get the test results by method
+    res = sf.query_all("SELECT StackTrace,Message, AsyncApexJobId,MethodName, Outcome, ApexClassId FROM ApexTestResult WHERE AsyncApexJobId = '%s'" % job_id)
+    
+    counts = {
+        'Pass': 0,
+        'Failed': 0,
+        'CompileFail': 0,
+        'Skip': 0,
+    }
+    for result in res['records']:
+        class_name = classes_by_id[result['ApexClassId']]
+        results_by_class_name[class_name][result['MethodName']] = result
+        counts[result['Outcome']] += 1
+    
+    class_names = results_by_class_name.keys()
+    class_names.sort()
+    for class_name in class_names:
+        print 'Class: %s' % class_name
+        sys.stdout.flush()
+        method_names = results_by_class_name[class_name].keys()
+        method_names.sort()
+        for method_name in method_names:
+            result = results_by_class_name[class_name][method_name]
+    
+            # Output result for method
+            print '   %(Outcome)s: %(MethodName)s' % result
+    
+            # Print message and stack trace if failed
+            if result['Outcome'] in ['Failed','CompileFail']:
+                print '   Message: %(Message)s' % result
+                print '   StackTrace: %(StackTrace)s' % result
+            sys.stdout.flush()
+    
+    print '-------------------------------------------------------------------------------'
+    print 'Passed: %(Pass)s  Failed: %(Failed)s  Compile Fail: %(CompileFail)s  Skipped: %(Skip)s' % counts
+    print '-------------------------------------------------------------------------------'
+    sys.stdout.flush()
+
+    return counts
+
+if __name__ == '__main__':
+    try:
+        counts = run_tests()
+        # Exit with status 1 if test failures occurred
+        if counts['Failed'] or counts['CompileFail'] or counts['Skip']:
+            sys.exit(1)
+            
+    except:
+        import traceback
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        print '-'*60
+        traceback.print_exception(exc_type, exc_value, exc_traceback, file=sys.stdout)
+        print '-'*60
+        sys.exit(1)


### PR DESCRIPTION
This branch adds support for running Apex tests in parallel.  This functionality is turned on via an environment variable.  To enable parallel test execution, do the following:
1. Set the `TEST_MODE` environment variable to `parallel`
2. If your test class naming convention differs from %_TEST, set the cumulusci.test.namematch to a like query on class name which will match your test classes (i.e. `TEST_%`)
3. If building on your local machine with TEST_MODE=parallel, you will need to install the simple-salesforce python library.  The recommended way is to set up a python virtualenv and then activate it:
   
   `virtualenv SOMEDIR`
   `source SOMEDIR/bin/activate`
   `pip install simple-salesforce`
