### PR TITLE
Adding mkdir attribute to retrievedPackaged target.

### DIFF
--- a/build/cumulusci.xml
+++ b/build/cumulusci.xml
@@ -192,9 +192,15 @@
   <macrodef name="retrievePackaged" description="Retrieves all metadata from a given package into the specified dir">
     <attribute name="package" description="The package name" />
     <attribute name="dir" description="The local directory to store the metadata files" />
+  	<attribute name="mkdir" description="Whether to delete and recreate the target dir" default="true" />
     <sequential>
-      <delete dir="@{dir}" />
-      <mkdir dir="@{dir}"/>
+      <if>
+      	<istrue value="@{mkdir}"/>
+      	<then>
+      	    <delete dir="@{dir}" />
+      	    <mkdir dir="@{dir}"/>
+      	</then>
+      </if>
       <sf:retrieve 
         username="${sf.username}" 
         password="${sf.password}" 


### PR DESCRIPTION
Fixes #80.

@jlantz ~ Please double-check this doesn't cause any unexpected consequences. I was surprised the argument was missing. Target seems to work fine with this addition.
