### PR TITLE
Make destroy method for unmanaged deployments configurable

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -76,6 +76,17 @@
         <property name="cumulusci.test.namematch" value="%\_TEST" />
       </else>
     </if>
+    
+    <!-- Allow UNMANAGED_DESTROY_MODE environment variable to override cumulusci.unmanaged.destroy.mode -->
+    <if>
+      <isset property="env.UNMANAGED_DESTROY_MODE" />
+      <then>
+        <var name="cumulusci.unmanaged.destroy.mode" value="${env.UNMANAGED_DESTROY_MODE}" />
+      </then>
+      <else>
+        <property name="cumulusci.unmanaged.destroy.mode" value="full" />
+      </else>
+    </if>
 
     <!-- Setup a blank namespace prefix string.  Managed deployments need to override this property before calling deployUnpackagedPost -->
     <property name="cumulusci.namespace.prefix" value="" />
@@ -198,16 +209,23 @@
         <antcall target="createUnmanagedPackage" />
 
         <!-- Uninstall all unpackaged code from the target org.  We have to do this first so we can uninstall and reinstall any managed packages not at the right version -->
-        <!-- <antcall target="uninstall" /> -->
-        <!-- Attempt to destroy any stale metadata but continue even if this fails -->
-        <trycatch>
-            <try>
-                <antcall target="destroyStaleMetadata" />
-            </try>
-            <catch>
-                <echo>First run of destroyStaleMetadata failed.  Ignoring for now but it may cause build failures in other targets.</echo>
-            </catch>
-        </trycatch>
+        <if>
+            <equals arg1="${cumulusci.unmanaged.destroy.mode}" arg2="full" />
+            <then>
+                <antcall target="uninstall" />
+            </then>
+            <else>
+                <!-- Attempt to destroy any stale metadata but continue even if this fails -->
+                <trycatch>
+                    <try>
+                        <antcall target="destroyStaleMetadata" />
+                    </try>
+                    <catch>
+                        <echo>First run of destroyStaleMetadata failed.  Ignoring for now but it may cause build failures in other targets.</echo>
+                    </catch>
+                </trycatch>
+            </else>
+        </if>
 
         <!-- Update any managed packages which are not at the right version -->
         <antcall target="updateRequiredPackages" />
@@ -218,8 +236,13 @@
         <!-- Deploy the src directory -->
         <antcall target="deployWithoutTest" />
         
-        <!-- Finally, delete any metadata from the org which is not in the repo -->
-        <antcall target="destroyStaleMetadata" />
+        <if>
+            <not><equals arg1="${cumulusci.unmanaged.destroy.mode}" arg2="full" /></not>
+            <then>
+                <!-- Finally, delete any metadata from the org which is not in the repo -->
+                <antcall target="destroyStaleMetadata" />
+            </then>
+        </if>
         
         <!-- Deploy any unpackaged metadata bundles needed after the deployment -->
         <antcall target="deployUnpackagedPost" />


### PR DESCRIPTION
Sometimes there might be a need to not do a full wipe of all metadata in unmanaged builds (deployCI).  A new environment variable, UNMANAGED_DESTROY_MODE, can be set to anything other than `full` which will use destroyStaleMetadata instead of uninstall to incrementally delete metadata rather than do a full uninstall at the start of every build.

NOTE: Using destroyStaleMetadata in deployCI can cause build failures if building two different branches with different version.properties requirements.
