### PR TITLE
Feature/fix codeship exit code evals

### DIFF
--- a/ci/codeship.sh
+++ b/ci/codeship.sh
@@ -137,7 +137,7 @@ if [ $BUILD_TYPE == "master" ]; then
         #cp -a clone clone2
         #cd clone2
         runAntTarget deployCI
-       if [[ $ant_status -ne 0 ]]; then exit 1; fi
+        if [[ $? -ne 0 ]]; then exit 1; fi
 
     else
         echo
@@ -163,7 +163,7 @@ if [ $BUILD_TYPE == "master" ]; then
     #echo "Running deployCIPackageOrg from /home/rof/clone"
     #cd /home/rof/clone
     runAntTarget deployCIPackageOrg
-   if [[ $ant_status -ne 0 ]]; then exit 1; fi
+    if [[ $? -ne 0 ]]; then exit 1; fi
 
     
     #echo
@@ -215,7 +215,6 @@ if [ $BUILD_TYPE == "master" ]; then
     echo "Attempting install of $PACKAGE_VERSION"
 
     tries=0
-    ant_status=0
     while [ $tries -lt $PACKAGE_AVAILABLE_RETRY_COUNT ]; do
         tries=$[tries + 1]
         echo
@@ -224,10 +223,9 @@ if [ $BUILD_TYPE == "master" ]; then
         echo "-----------------------------------------------------------------"
         echo
         runAntTarget deployManagedBeta
-   if [[ $ant_status -eq 0 ]]; then break; fi
-
+        if [[ $? -eq 0 ]]; then break; fi
     done
-   if [[ $ant_status -ne 0 ]]; then exit 1; fi
+    if [[ $? -ne 0 ]]; then exit 1; fi
 
     echo
     echo "-----------------------------------------------------------------"
@@ -235,7 +233,7 @@ if [ $BUILD_TYPE == "master" ]; then
     echo "-----------------------------------------------------------------"
     echo
     runAntTarget runAllTestsManaged
-   if [[ $ant_status -ne 0 ]]; then exit 1; fi
+    if [[ $? -ne 0 ]]; then exit 1; fi
     
     if [ "$GITHUB_USERNAME" != "" ]; then   
         # Create GitHub Release


### PR DESCRIPTION
Fixes issue where the codeship environment throws errors when evaluating runAntTarget exit codes:

Exampe:
`../CumulusCI/ci/codeship.sh: line 140: [: !=: unary operator expected`
