### PR TITLE
Reduce diff from retrieve_scratch by adding retrieve_unpackaged/update_package_xml

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -57,7 +57,7 @@ tasks:
         description: Converts force-app directory in sfdx format into metadata format under src
         class_path: cumulusci.tasks.sfdx.SFDXBaseTask
         options:
-            command: 'force:mdapi:convert -r force-app -d src'
+            command: 'force:source:convert -d src'
     dx_pull:
         description: Uses sfdx to pull from a scratch org into the force-app directory
         class_path: cumulusci.tasks.sfdx.SFDXOrgTask
@@ -501,6 +501,18 @@ flows:
                 options:
                     publish: True
                     tag: ^^github_release.tag_name
+
+    retrieve_scratch:
+        description: Retrieves declarative changes made in a scratch org and converts to src directory
+        steps:
+            1:
+                task: dx_convert_to
+            2:
+                task: dx_pull
+            3:
+                task: dx_convert_from
+            4:
+                task: update_package_xml
 
     unmanaged_ee:
         description: Deploy the unmanaged package metadata and all dependencies to the target EE org

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -511,11 +511,15 @@ flows:
             4:
                 task: update_package_xml
             # The conversion reorders elements in .object files and others.
-            # Deploy to the org and retrieve via mdapi to reduce the diff
+            # Retrieve from the org using the new package.xml and then rewrite
+            # the package.xml 
             5:
-                task: deploy
+                task: retrieve_unpackaged
+                options:
+                    package_xml: src/package.xml
+                    path: src
             6:
-                task: retrieve_src
+                task: update_package_xml
 
     unmanaged_ee:
         description: Deploy the unmanaged package metadata and all dependencies to the target EE org

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -513,6 +513,12 @@ flows:
                 task: dx_convert_from
             4:
                 task: update_package_xml
+            # The conversion reorders elements in .object files and others.
+            # Deploy to the org and retrieve via mdapi to reduce the diff
+            5:
+                task: deploy
+            6:
+                task: retrieve_src
 
     unmanaged_ee:
         description: Deploy the unmanaged package metadata and all dependencies to the target EE org

--- a/cumulusci/tasks/command.py
+++ b/cumulusci/tasks/command.py
@@ -75,7 +75,7 @@ class Command(BaseTask):
         return env
 
     def _process_output(self, line):
-        self.logger.info(line.rstrip())
+        self.logger.info(line.decode('utf-8').rstrip())
 
     def _handle_returncode(self, returncode, stderr):
         if returncode:


### PR DESCRIPTION
The sfdx force:source:convert command reorders xml elements inside .object files (and probably others) which causes unnecessary diffs.  Since the src directory in a CumulusCI project should for now be in the format retrieved via mdapi, this branch adds retrieve_unpackaged and update_package_xml to the end of the flow to properly format the files under src.