### PR TITLE
Release 2.0.11

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+2.0.11 (2018-09-14)
+-------------------
+
+* `update_admin_profile` now uses xml parsing instead of string replacement for more targeted editing of Admin.profile to fix issues with deploying record types via dependencies
+
 2.0.10 (2018-09-13)
 -------------------
 

--- a/cumulusci/__init__.py
+++ b/cumulusci/__init__.py
@@ -2,5 +2,5 @@ from __future__ import unicode_literals
 import os
 
 __import__("pkg_resources").declare_namespace("cumulusci")
-__version__ = "2.0.10"
+__version__ = "2.0.11"
 __location__ = os.path.dirname(os.path.realpath(__file__))

--- a/cumulusci/tasks/salesforce/UpdateAdminProfile.py
+++ b/cumulusci/tasks/salesforce/UpdateAdminProfile.py
@@ -101,6 +101,7 @@ class UpdateAdminProfile(Deploy):
         self._set_classes_enabled()
         self._set_fields_editable()
         self._set_fields_readable()
+        self._set_pages_enabled()
         self._set_tabs_visibility()
         self._set_record_types()
 
@@ -130,6 +131,11 @@ class UpdateAdminProfile(Deploy):
         xpath = ".//sf:fieldPermissions[sf:readable='false']"
         for elem in self.tree.findall(xpath, self.namespaces):
             elem.find('sf:readable', self.namespaces).text = 'true'
+
+    def _set_pages_enabled(self):
+        xpath = ".//sf:pageAccesses[sf:enabled='false']"
+        for elem in self.tree.findall(xpath, self.namespaces):
+            elem.find('sf:enabled', self.namespaces).text = 'true'
 
     def _set_record_types(self):
         record_types = self.options.get('record_types')

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 build-base=pybuild
 
 [bumpversion]
-current_version = 2.0.10
+current_version = 2.0.11
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ test_requirements = [
 
 setup(
     name="cumulusci",
-    version="2.0.10",
+    version="2.0.11",
     description="Build and release tools for Salesforce developers",
     long_description=readme + "\n\n" + history,
     author="Salesforce.org",


### PR DESCRIPTION
Contains fix for a bug with deploying record types via dependencies.  Switches update_admin_profile to use etree instead of string replace to better target the elements to be modified