### PR TITLE
Coverage for the rest of cumulusci.core

### DIFF
--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -52,9 +52,6 @@ class BaseFlow(object):
         self.parent = parent  # parent flow, if nested
         self.name = name  # the flows name.
         self.stepnum = stepnum  # a nested flow has a stepnum
-        self._skip_next = (
-            False
-        )  # internal only control flow option for subclasses to override a step execution in their pre.
         self._init_options()
         self._init_skip(skip)
         self._init_logger()
@@ -267,10 +264,6 @@ class BaseFlow(object):
         )
         self._pre_subflow(flow)
 
-        if self._skip_next:
-            self._skip_next = False
-            return
-
         flow()
         self._post_subflow(flow)
         self.steps.append(flow)
@@ -295,9 +288,6 @@ class BaseFlow(object):
         self.logger.info("")
         self.logger.info("Running task: %s", task.name)
         self._pre_task(task)
-        if self._skip_next:
-            self._skip_next = False
-            return
         try:
             task()
             self.logger.info("Task complete: %s", task.name)
@@ -353,10 +343,7 @@ class BaseFlow(object):
                     n += 1
                     parent = parent._find_step_by_name(value_parts[n])
                 for attr in value_parts[(n + 1) :]:
-                    if getattr(parent, "nested", None):
-                        parent = parent._find_step_by_name()
-                    else:
-                        parent = parent.return_values.get(attr)
+                    parent = parent.return_values.get(attr)
                 task_config.config["options"][option] = parent
 
         task_class = import_class(task_config.class_path)

--- a/cumulusci/core/keychain/EncryptedFileProjectKeychain.py
+++ b/cumulusci/core/keychain/EncryptedFileProjectKeychain.py
@@ -27,7 +27,7 @@ class EncryptedFileProjectKeychain(BaseEncryptedProjectKeychain):
                     config = f_item.read()
                 name = item.replace(extension, "")
                 if not key in self.config:
-                    self.config[key] = []
+                    self.config[key] = {}
                 self.config[key][name] = config
 
     def _load_file(self, dirname, filename, key):
@@ -70,7 +70,7 @@ class EncryptedFileProjectKeychain(BaseEncryptedProjectKeychain):
             )
 
         os.remove(full_path)
-        self._load_orgs()
+        del self.orgs[name]
 
     def _set_encrypted_org(self, name, encrypted, global_org):
         if global_org:

--- a/cumulusci/core/keychain/EnvironmentProjectKeychain.py
+++ b/cumulusci/core/keychain/EnvironmentProjectKeychain.py
@@ -19,16 +19,15 @@ class EnvironmentProjectKeychain(BaseProjectKeychain):
 
     def _get_env(self):
         """ loads the environment variables as unicode if ascii """
-        try:
-            return [(k.decode(), v.decode()) for k, v in list(os.environ.items())]
-        except AttributeError:
-            return list(os.environ.items())
+        env = {}
+        for k, v in os.environ.items():
+            k = k.decode() if isinstance(k, bytes) else k
+            v = v.decode() if isinstance(v, bytes) else v
+            env[k] = v
+        return list(env.items())
 
     def _load_app(self):
-        try:
-            app = os.environ.get(self.app_var.encode("ascii"))
-        except TypeError:
-            app = os.environ.get(self.app_var)
+        app = os.environ.get(self.app_var)
         if app:
             self.app = ConnectedAppOAuthConfig(json.loads(app))
 

--- a/cumulusci/core/tasks.py
+++ b/cumulusci/core/tasks.py
@@ -23,7 +23,7 @@ class BaseTask(object):
     code.
     """
 
-    task_docs = ''
+    task_docs = ""
     task_options = {}
     salesforce_task = False  # Does this task require a salesforce org?
 
@@ -151,7 +151,7 @@ class BaseTask(object):
 
     def _run_task(self):
         """ Subclasses should override to provide their implementation """
-        pass
+        raise NotImplementedError("Subclasses should provide their own implementation")
 
     def _log_begin(self):
         """ Log the beginning of the task execution """


### PR DESCRIPTION
(except for the retry and polling parts of tasks.py)

Changes made in passing:
- Removed some unused code in BaseFlow
- Fixed EncryptedFileProjectKeychain._load_files when the key doesn't exist yet
- Fixed EncryptedFileProjectKeychain.remove_org to remove the org in the instance's config, not just on disk.