### PR TITLE
Set all record type defaults to false before updating

### DIFF
--- a/cumulusci/tasks/salesforce/UpdateAdminProfile.py
+++ b/cumulusci/tasks/salesforce/UpdateAdminProfile.py
@@ -11,35 +11,26 @@ from cumulusci.utils import elementtree_parse_file
 from cumulusci.utils import findReplace
 from cumulusci.utils import findReplaceRegex
 
-rt_visibility_template = """
-<recordTypeVisibilities>
-    <default>{default}</default>
-    <recordType>{record_type}</recordType>
-    <visible>{visible}</visible>
-    <personAccountDefault>{person_account_default}</personAccountDefault>
-</recordTypeVisibilities>
-"""
-
 
 class UpdateAdminProfile(Deploy):
     name = "UpdateAdminProfile"
 
     task_options = {
         "package_xml": {
-            "description": "Override the default package.xml file for retrieving the Admin.profile and all objects and classes that need to be included by providing a path to your custom package.xml",
+            "description": "Override the default package.xml file for retrieving the Admin.profile and all objects and classes that need to be included by providing a path to your custom package.xml"
         },
         "record_types": {
-            "description": "A list of dictionaries containing the required key `record_type` with a value specifying the record type in format <object>.<developer_name>.  Record type names can use the token strings {managed} and {namespaced_org} for namespace prefix injection as needed.  By default, all listed record types will be set to visible and not default.  Use the additional keys `visible`, `default`, and `person_account_default` set to true/false to override.  NOTE: Setting record_types is only supported in cumulusci.yml, command line override is not supported.",
+            "description": "A list of dictionaries containing the required key `record_type` with a value specifying the record type in format <object>.<developer_name>.  Record type names can use the token strings {managed} and {namespaced_org} for namespace prefix injection as needed.  By default, all listed record types will be set to visible and not default.  Use the additional keys `visible`, `default`, and `person_account_default` set to true/false to override.  NOTE: Setting record_types is only supported in cumulusci.yml, command line override is not supported."
         },
         "managed": {
-            "description": "If True, uses the namespace prefix where appropriate.  Use if running against an org with the managed package installed.  Defaults to False",
+            "description": "If True, uses the namespace prefix where appropriate.  Use if running against an org with the managed package installed.  Defaults to False"
         },
         "namespaced_org": {
-            "description": "If True, attempts to prefix all unmanaged metadata references with the namespace prefix for deployment to the packaging org or a namespaced scratch org.  Defaults to False",
+            "description": "If True, attempts to prefix all unmanaged metadata references with the namespace prefix for deployment to the packaging org or a namespaced scratch org.  Defaults to False"
         },
     }
 
-    namespaces = {'sf': 'http://soap.sforce.com/2006/04/metadata'}
+    namespaces = {"sf": "http://soap.sforce.com/2006/04/metadata"}
 
     def _init_options(self, kwargs):
         super(UpdateAdminProfile, self)._init_options(kwargs)
@@ -49,23 +40,25 @@ class UpdateAdminProfile(Deploy):
                 CUMULUSCI_PATH, "cumulusci", "files", "admin_profile.xml"
             )
 
-        self.options['managed'] = process_bool_arg(
-            self.options.get('managed', False)
-        )
+        self.options["managed"] = process_bool_arg(self.options.get("managed", False))
 
-        self.options['namespaced_org'] = process_bool_arg(
-            self.options.get('namespaced_org', False)
+        self.options["namespaced_org"] = process_bool_arg(
+            self.options.get("namespaced_org", False)
         )
 
         # For namespaced orgs, managed should always be True
-        if self.options['namespaced_org']:
-            self.options['managed'] = True
+        if self.options["namespaced_org"]:
+            self.options["managed"] = True
 
         # Set up namespace prefix strings
-        namespace_prefix = '{}__'.format(self.project_config.project__package__namespace)
+        namespace_prefix = "{}__".format(
+            self.project_config.project__package__namespace
+        )
         self.namespace_prefixes = {
-            'managed': namespace_prefix if self.options['managed'] else '',
-            'namespaced_org': namespace_prefix if self.options['namespaced_org'] else '',
+            "managed": namespace_prefix if self.options["managed"] else "",
+            "namespaced_org": namespace_prefix
+            if self.options["namespaced_org"]
+            else "",
         }
 
         # Read in the package.xml file
@@ -106,70 +99,81 @@ class UpdateAdminProfile(Deploy):
         self._set_record_types()
 
         self.tree.write(
-            path,
-            "utf-8",
-            xml_declaration=True,
-            default_namespace=self.namespaces['sf'],
+            path, "utf-8", xml_declaration=True, default_namespace=self.namespaces["sf"]
         )
 
     def _set_apps_visible(self):
         xpath = ".//sf:applicationVisibilities[sf:visible='false']"
         for elem in self.tree.findall(xpath, self.namespaces):
-            elem.find('sf:visible', self.namespaces).text = 'true'
+            elem.find("sf:visible", self.namespaces).text = "true"
 
     def _set_classes_enabled(self):
         xpath = ".//sf:classAccess[sf:enabled='false']"
         for elem in self.tree.findall(xpath, self.namespaces):
-            elem.find('sf:enabled', self.namespaces).text = 'true'
+            elem.find("sf:enabled", self.namespaces).text = "true"
 
     def _set_fields_editable(self):
         xpath = ".//sf:fieldPermissions[sf:editable='false']"
         for elem in self.tree.findall(xpath, self.namespaces):
-            elem.find('sf:editable', self.namespaces).text = 'true'
+            elem.find("sf:editable", self.namespaces).text = "true"
 
     def _set_fields_readable(self):
         xpath = ".//sf:fieldPermissions[sf:readable='false']"
         for elem in self.tree.findall(xpath, self.namespaces):
-            elem.find('sf:readable', self.namespaces).text = 'true'
+            elem.find("sf:readable", self.namespaces).text = "true"
 
     def _set_pages_enabled(self):
         xpath = ".//sf:pageAccesses[sf:enabled='false']"
         for elem in self.tree.findall(xpath, self.namespaces):
-            elem.find('sf:enabled', self.namespaces).text = 'true'
+            elem.find("sf:enabled", self.namespaces).text = "true"
 
     def _set_record_types(self):
-        record_types = self.options.get('record_types')
-        if not record_types:
-            return
+        record_types = self.options.get("record_types") or []
+
+        # If defaults are specified,
+        # clear any pre-existing defaults
+        if any("default" in rt for rt in record_types):
+            for default in ("sf:default", "sf:personAccountDefault"):
+                xpath = ".//sf:recordTypeVisibilities/{}".format(default)
+                for elem in self.tree.findall(xpath, self.namespaces):
+                    elem.text = "false"
 
         # Set recordTypeVisibilities
         for rt in record_types:
             # Replace namespace prefix tokens in rt name
-            rt_prefixed = rt['record_type'].format(**self.namespace_prefixes)
+            rt_prefixed = rt["record_type"].format(**self.namespace_prefixes)
 
             # Look for the recordTypeVisiblities element
-            xpath = ".//sf:recordTypeVisibilities[sf:recordType='{}']".format(rt_prefixed)
+            xpath = ".//sf:recordTypeVisibilities[sf:recordType='{}']".format(
+                rt_prefixed
+            )
             elem = self.tree.find(xpath, self.namespaces)
             if elem is None:
                 raise TaskOptionsError(
-                    "Record Type {} not found in retrieved Admin.profile".format(rt['record_type'])
+                    "Record Type {} not found in retrieved Admin.profile".format(
+                        rt["record_type"]
+                    )
                 )
 
             # Set visibile
-            elem.find("sf:visible", self.namespaces).text = str(rt.get("visible", "true"))
-                
+            elem.find("sf:visible", self.namespaces).text = str(
+                rt.get("visible", "true")
+            ).lower()
+
             # Set default
-            elem.find("sf:default", self.namespaces).text = str(rt.get("default", "false"))
+            elem.find("sf:default", self.namespaces).text = str(
+                rt.get("default", "false")
+            ).lower()
 
             # Set person account default if element exists
             pa_default = elem.find("sf:personAccountDefault", self.namespaces)
             if pa_default is not None:
-                pa_default.text = str(rt.get("person_account_default", "false"))
-                
+                pa_default.text = str(rt.get("person_account_default", "false")).lower()
+
     def _set_tabs_visibility(self):
         xpath = ".//sf:tabVisibilities[sf:visibility='Hidden']"
         for elem in self.tree.findall(xpath, self.namespaces):
-            elem.find('sf:visibility', self.namespaces).text = 'DefaultOn'
+            elem.find("sf:visibility", self.namespaces).text = "DefaultOn"
 
     def _deploy_metadata(self):
         self.logger.info("Deploying updated Admin.profile from {}".format(self.tempdir))

--- a/cumulusci/tasks/salesforce/tests/test_UpdateAdminProfile.py
+++ b/cumulusci/tasks/salesforce/tests/test_UpdateAdminProfile.py
@@ -1,0 +1,174 @@
+import mock
+import os
+import unittest
+
+from cumulusci.core.config import BaseGlobalConfig
+from cumulusci.core.config import BaseProjectConfig
+from cumulusci.core.config import OrgConfig
+from cumulusci.core.config import TaskConfig
+from cumulusci.core.exceptions import TaskOptionsError
+from cumulusci.tasks.salesforce import UpdateAdminProfile
+
+ADMIN_PROFILE_BEFORE = """<?xml version='1.0' encoding='utf-8'?>
+<Profile xmlns="http://soap.sforce.com/2006/04/metadata">
+    <applicationVisibilities>
+        <application>npsp__Nonprofit_CRM</application>
+        <default>true</default>
+        <visible>false</visible>
+    </applicationVisibilities>
+    <classAccess>
+        <apexClass>TestClass</apexClass>
+        <enabled>false</enabled>
+    </classAccess>
+    <fieldPermissions>
+        <field>Account.TestField__c</field>
+        <editable>false</editable>
+        <readable>false</readable>
+    </fieldPermissions>
+    <pageAccesses>
+        <apexPage>TestPage</apexPage>
+        <enabled>false</enabled>
+    </pageAccesses>
+    <recordTypeVisibilities>
+        <recordType>Account.Business_Account</recordType>
+        <default>true</default>
+        <personAccountDefault>true</personAccountDefault>
+        <visible>true</visible>
+    </recordTypeVisibilities>
+    <recordTypeVisibilities>
+        <recordType>Account.HH_Account</recordType>
+        <default>false</default>
+        <personAccountDefault>false</personAccountDefault>
+        <visible>false</visible>
+    </recordTypeVisibilities>
+    <tabVisibilities>
+        <tab>NPSP_Settings</tab>
+        <visibility>Hidden</visibility>
+    </tabVisibilities>
+</Profile>"""
+
+ADMIN_PROFILE_EXPECTED = """<?xml version='1.0' encoding='utf-8'?>
+<Profile xmlns="http://soap.sforce.com/2006/04/metadata">
+    <applicationVisibilities>
+        <application>npsp__Nonprofit_CRM</application>
+        <default>true</default>
+        <visible>true</visible>
+    </applicationVisibilities>
+    <classAccess>
+        <apexClass>TestClass</apexClass>
+        <enabled>true</enabled>
+    </classAccess>
+    <fieldPermissions>
+        <field>Account.TestField__c</field>
+        <editable>true</editable>
+        <readable>true</readable>
+    </fieldPermissions>
+    <pageAccesses>
+        <apexPage>TestPage</apexPage>
+        <enabled>true</enabled>
+    </pageAccesses>
+    <recordTypeVisibilities>
+        <recordType>Account.Business_Account</recordType>
+        <default>false</default>
+        <personAccountDefault>false</personAccountDefault>
+        <visible>true</visible>
+    </recordTypeVisibilities>
+    <recordTypeVisibilities>
+        <recordType>Account.HH_Account</recordType>
+        <default>true</default>
+        <personAccountDefault>true</personAccountDefault>
+        <visible>true</visible>
+    </recordTypeVisibilities>
+    <tabVisibilities>
+        <tab>NPSP_Settings</tab>
+        <visibility>DefaultOn</visibility>
+    </tabVisibilities>
+</Profile>"""
+
+
+@mock.patch(
+    "cumulusci.tasks.salesforce.BaseSalesforceTask._update_credentials", mock.Mock()
+)
+class TestUpdateAdminProfile(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        self.project_config = BaseProjectConfig(BaseGlobalConfig())
+        self.task_config = TaskConfig(
+            {
+                "options": {
+                    "record_types": [
+                        {
+                            "record_type": "Account.HH_Account",
+                            "default": True,
+                            "person_account_default": True,
+                        }
+                    ],
+                    "namespaced_org": True,
+                }
+            }
+        )
+        self.org_config = OrgConfig({}, "test")
+
+    def test_run_task(self):
+        task = UpdateAdminProfile(
+            self.project_config, self.task_config, self.org_config
+        )
+
+        def _retrieve_unpackaged():
+            profiles_path = os.path.join(task.tempdir, "profiles")
+            admin_profile_path = os.path.join(profiles_path, "Admin.profile")
+            os.mkdir(profiles_path)
+            with open(admin_profile_path, "w") as f:
+                f.write(ADMIN_PROFILE_BEFORE)
+
+        def _check_result():
+            with open(
+                os.path.join(task.tempdir, "profiles", "Admin.profile"), "r"
+            ) as f:
+                result = f.read()
+            self.assertMultiLineEqual(ADMIN_PROFILE_EXPECTED, result)
+
+        task._retrieve_unpackaged = _retrieve_unpackaged
+        task._deploy_metadata = _check_result
+        task()
+
+    def test_run_task__record_type_not_found(self):
+        task_config = TaskConfig(
+            {
+                "options": {
+                    "record_types": [{"record_type": "DOESNT_EXIST"}],
+                    "namespaced_org": True,
+                }
+            }
+        )
+        task = UpdateAdminProfile(self.project_config, task_config, self.org_config)
+
+        def _retrieve_unpackaged():
+            profiles_path = os.path.join(task.tempdir, "profiles")
+            admin_profile_path = os.path.join(profiles_path, "Admin.profile")
+            os.mkdir(profiles_path)
+            with open(admin_profile_path, "w") as f:
+                f.write(ADMIN_PROFILE_BEFORE)
+
+        task._retrieve_unpackaged = _retrieve_unpackaged
+        with self.assertRaises(TaskOptionsError):
+            task()
+
+    @mock.patch("cumulusci.salesforce_api.metadata.ApiRetrieveUnpackaged.__call__")
+    def test_retrieve_unpackaged(self, ApiRetrieveUnpackaged):
+        task = UpdateAdminProfile(
+            self.project_config, self.task_config, self.org_config
+        )
+        task.tempdir = "/tmp"
+        task._retrieve_unpackaged()
+        ApiRetrieveUnpackaged.assert_called_once()
+
+    def test_deploy_metadata(self):
+        task = UpdateAdminProfile(
+            self.project_config, self.task_config, self.org_config
+        )
+        task.tempdir = "/tmp"
+        task._get_api = mock.Mock()
+        task._deploy_metadata()
+        task._get_api.assert_called_once()


### PR DESCRIPTION
to avoid "Error: More than 1 default record type specified for: [sObject]"

I also ran black and added tests for UpdateAdminProfile