### PR TITLE
Feature/push fails

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1101,7 +1101,7 @@ def flow_run(config, flow_name, org, delete_org, debug, o, skip, no_prompt):
         exception = click.UsageError(e.message)
         handle_exception_debug(config, debug, throw_exception=exception)
     except (CumulusCIFailure, ScratchOrgException) as e:
-        exception = click.ClickException('Failed: {}'.format(e.__class__.__name__))
+        exception = click.ClickException("Failed: {}".format(e.__class__.__name__))
         handle_exception_debug(config, debug, throw_exception=exception)
     except Exception:
         handle_exception_debug(config, debug, no_prompt=no_prompt)

--- a/cumulusci/core/exceptions.py
+++ b/cumulusci/core/exceptions.py
@@ -6,15 +6,18 @@ class CumulusCIException(Exception):
 
     pass
 
+
 class CumulusCIUsageError(CumulusCIException):
     """ An exception thrown due to improper usage which should be resolvable by proper usage """
 
     pass
 
+
 class CumulusCIFailure(CumulusCIException):
     """ An exception representing a failure such as a Metadata deployment failure or a test failure.  CI systems can handle these to determine fail vs error status """
 
     pass
+
 
 class NotInProject(CumulusCIUsageError):
     """ Raised when no project can be found in the current context """
@@ -141,6 +144,7 @@ class FlowConfigError(CumulusCIException):
 
     pass
 
+
 class FlowNotFoundError(CumulusCIUsageError):
     """ Raise when flow is not found in project config """
 
@@ -233,6 +237,7 @@ class PushApiObjectNotFound(CumulusCIException):
     """ Raise when Salesforce Push API object is not found """
 
     pass
+
 
 class RobotTestFailure(CumulusCIFailure):
     """ Raise when a robot test fails in a test suite """

--- a/cumulusci/core/tests/test_keychain.py
+++ b/cumulusci/core/tests/test_keychain.py
@@ -442,14 +442,12 @@ class TestEncryptedFileProjectKeychain(ProjectKeychainTestMixin):
         dummy_keychain = BaseEncryptedProjectKeychain(self.project_config, self.key)
         os.makedirs(os.path.join(self.tempdir_home, ".cumulusci", self.project_name))
         self._write_file(
-            os.path.join(
-                self.tempdir_home, "test.org"
-            ),
+            os.path.join(self.tempdir_home, "test.org"),
             dummy_keychain._encrypt_config(BaseConfig({"foo": "bar"})),
         )
         keychain = self.keychain_class(self.project_config, self.key)
-        del keychain.config['orgs']
-        keychain._load_files(self.tempdir_home, '.org', 'orgs')
+        del keychain.config["orgs"]
+        keychain._load_files(self.tempdir_home, ".org", "orgs")
         self.assertIn("foo", keychain.get_org("test").config)
 
     def test_load_file(self):
@@ -467,12 +465,12 @@ class TestEncryptedFileProjectKeychain(ProjectKeychainTestMixin):
 
     def test_remove_org__not_found(self):
         keychain = self.keychain_class(self.project_config, self.key)
-        keychain.orgs['test'] = mock.Mock()
+        keychain.orgs["test"] = mock.Mock()
         with self.assertRaises(OrgNotFound):
             keychain.remove_org("test")
 
     def test_remove_org__global__not_found(self):
         keychain = self.keychain_class(self.project_config, self.key)
-        keychain.orgs['test'] = mock.Mock()
+        keychain.orgs["test"] = mock.Mock()
         with self.assertRaises(OrgNotFound):
             keychain.remove_org("test", global_org=True)

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -141,6 +141,9 @@ tasks:
         class_path: cumulusci.tasks.push.tasks.SchedulePushOrgList
         options:
             orgs: push/orgs_trial.txt
+    push_failure_report:
+        description: Produce a CSV report of the failed and otherwise anomalous push jobs.
+        class_path: cumulusci.tasks.push.pushfails.ReportPushFailures
     query:
         description: Queries the connected org
         class_path: cumulusci.tasks.salesforce.SOQLQuery

--- a/cumulusci/salesforce_api/exceptions.py
+++ b/cumulusci/salesforce_api/exceptions.py
@@ -1,6 +1,7 @@
 from cumulusci.core.exceptions import CumulusCIException
 from cumulusci.core.exceptions import CumulusCIFailure
 
+
 class MetadataApiError(CumulusCIFailure):
     def __init__(self, message, response):
         super(MetadataApiError, self).__init__(message)
@@ -13,6 +14,7 @@ class MetadataComponentFailure(MetadataApiError):
 
 class MissingOAuthError(CumulusCIException):
     pass
+
 
 class MissingOrgCredentialsError(CumulusCIException):
     pass

--- a/cumulusci/tasks/command.py
+++ b/cumulusci/tasks/command.py
@@ -75,7 +75,7 @@ class Command(BaseTask):
         return env
 
     def _process_output(self, line):
-        self.logger.info(line.decode('utf-8').rstrip())
+        self.logger.info(line.decode("utf-8").rstrip())
 
     def _handle_returncode(self, returncode, stderr):
         if returncode:

--- a/cumulusci/tasks/push/pushfails.py
+++ b/cumulusci/tasks/push/pushfails.py
@@ -66,4 +66,4 @@ class PushFailTask(BaseSalesforceApiTask):
                 )
 
         self.logger.debug("Written out to {file_name}.".format(file_name=file_name))
-        return records
+        return file_name

--- a/cumulusci/tasks/push/pushfails.py
+++ b/cumulusci/tasks/push/pushfails.py
@@ -1,0 +1,69 @@
+""" simple task(s) for reporting on push upgrade jobs.
+
+this doesn't use the nearby push_api module, and was just a quick ccistyle
+get the job done kinda moment.
+"""
+
+import re
+import csv
+from cumulusci.tasks.salesforce import BaseSalesforceApiTask
+
+
+class PushFailTask(BaseSalesforceApiTask):
+    """ Produce a report of the failed and otherwise anomalous push jobs from
+    a specified push request id, and write it out to a results CSV.  """
+
+    task_doc = __doc__
+    task_options = {
+        "request_id": {
+            "description": "PackagePushRequest ID for the request you need to report on.",
+            "required": True,
+        },
+        "result_file": {"description": "Where to write results"},
+    }
+    api_version = "43.0"
+    query = "SELECT ID, SubscriberOrganizationKey, (SELECT ErrorDetails, ErrorMessage, ErrorSeverity, ErrorTitle, ErrorType FROM PackagePushErrors) FROM PackagePushJob WHERE PackagePushRequestId = '{request_id}' AND Status !='Succeeded'"
+    gack = re.compile(r"error number: ([\d-]+) \(([\d-]+)\)")
+    headers = [
+        "OrganizationId",
+        "ErrorSeverity",
+        "ErrorTitle",
+        "ErrorType",
+        "ErrorMessage",
+        "Gack Id",
+        "Stacktrace Id",
+    ]
+
+    def _run_task(self):
+        formatted_query = self.query.format(**self.options)
+        self.logger.debug("Running query: " + formatted_query)
+
+        result = self.sf.query(formatted_query)
+        records = result["records"]
+        self.logger.debug(
+            "Query is complete: {done}. Found {n} results.".format(
+                done=result["done"], n=result["totalSize"]
+            )
+        )
+
+        file_name = self.options.get("result_file", "push_fails.csv")
+        with open(file_name, "wb") as f:
+            w = csv.writer(f)
+            w.writerow(self.headers)
+            for result in records:
+                error = result["PackagePushErrors"]["records"][0]
+                m = self.gack.search(error["ErrorMessage"])
+                w.writerow(
+                    [
+                        result["SubscriberOrganizationKey"],
+                        error["ErrorSeverity"],
+                        error["ErrorTitle"],
+                        error["ErrorType"],
+                        error["ErrorMessage"],
+                        m.groups()[0] if m else "",
+                        m.groups()[1] if m else "",
+                    ]
+                )
+
+        self.logger.debug("Written out to {file_name}.".format(file_name=file_name))
+        return records

--- a/cumulusci/tasks/push/pushfails.py
+++ b/cumulusci/tasks/push/pushfails.py
@@ -20,7 +20,9 @@ class ReportPushFailures(BaseSalesforceApiTask):
             "description": "PackagePushRequest ID for the request you need to report on.",
             "required": True,
         },
-        "result_file": {"description": "Where to write results"},
+        "result_file": {
+            "description": "Path to write a CSV file with the results. Defaults to 'push_fails.csv'."
+        },
     }
     api_version = "43.0"
     query = "SELECT ID, SubscriberOrganizationKey, (SELECT ErrorDetails, ErrorMessage, ErrorSeverity, ErrorTitle, ErrorType FROM PackagePushErrors) FROM PackagePushJob WHERE PackagePushRequestId = '{request_id}' AND Status !='Succeeded'"

--- a/cumulusci/tasks/push/pushfails.py
+++ b/cumulusci/tasks/push/pushfails.py
@@ -12,7 +12,7 @@ from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 class ReportPushFailures(BaseSalesforceApiTask):
     """ Produce a report of the failed and otherwise anomalous push jobs.
 
-    Takes a push request id and writes results to a CSV file.  """
+    Takes a push request id and writes results to a CSV file. The task result contains the filename. """
 
     task_doc = __doc__
     task_options = {

--- a/cumulusci/tasks/push/pushfails.py
+++ b/cumulusci/tasks/push/pushfails.py
@@ -11,7 +11,7 @@ from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 
 class ReportPushFailures(BaseSalesforceApiTask):
     """ Produce a report of the failed and otherwise anomalous push jobs.
-    
+
     Takes a push request id and writes results to a CSV file.  """
 
     task_doc = __doc__

--- a/cumulusci/tasks/robotframework/robotframework.py
+++ b/cumulusci/tasks/robotframework/robotframework.py
@@ -22,9 +22,7 @@ class Robot(BaseSalesforceTask):
         "vars": {
             "description": "Pass values to override variables in the format VAR1:foo,VAR2:bar"
         },
-        "xunit": {
-            "description": "Set an XUnit format output file for test results"
-        },
+        "xunit": {"description": "Set an XUnit format output file for test results"},
         "options": {
             "description": "A dictionary of options to robot.run method.  See docs here for format.  NOTE: There is no cci CLI support for this option since it requires a dictionary.  Use this option in the cumulusci.yml when defining custom tasks where you can easily create a dictionary in yaml."
         },

--- a/cumulusci/tasks/tests/test_pushfails.py
+++ b/cumulusci/tasks/tests/test_pushfails.py
@@ -1,0 +1,4 @@
+import unittest
+
+class TestPushFailureTask(unittest.TestCase):
+    pass

--- a/cumulusci/tasks/tests/test_pushfails.py
+++ b/cumulusci/tasks/tests/test_pushfails.py
@@ -50,7 +50,7 @@ class TestPushFailureTask(unittest.TestCase):
         self.task_config = TaskConfig({"options": {"request_id": "123"}})
 
     @mock.patch("cumulusci.tasks.push.pushfails.ReportPushFailures._update_credentials")
-    def test_run_task(self, *mocks):
+    def test_run_task(self, *_):
         task = ReportPushFailures(
             self.project_config, self.task_config, self.org_config
         )
@@ -67,7 +67,7 @@ class TestPushFailureTask(unittest.TestCase):
                 },
             ],
         }
-        with temporary_dir() as d:
+        with temporary_dir() as temp_dir:
             task()
             task.sf.query.assert_called_once()
             self.assertTrue(

--- a/cumulusci/tasks/tests/test_pushfails.py
+++ b/cumulusci/tasks/tests/test_pushfails.py
@@ -49,8 +49,11 @@ class TestPushFailureTask(unittest.TestCase):
 
         self.task_config = TaskConfig({"options": {"request_id": "123"}})
 
-    @mock.patch("cumulusci.tasks.push.pushfails.ReportPushFailures._update_credentials")
-    def test_run_task(self, *_):
+    @mock.patch(
+        "cumulusci.tasks.push.pushfails.ReportPushFailures._update_credentials",
+        mock.Mock(),
+    )
+    def test_run_task(self,):
         task = ReportPushFailures(
             self.project_config, self.task_config, self.org_config
         )
@@ -67,7 +70,7 @@ class TestPushFailureTask(unittest.TestCase):
                 },
             ],
         }
-        with temporary_dir() as temp_dir:
+        with temporary_dir():
             task()
             task.sf.query.assert_called_once()
             self.assertTrue(

--- a/cumulusci/tasks/tests/test_pushfails.py
+++ b/cumulusci/tasks/tests/test_pushfails.py
@@ -1,4 +1,66 @@
+import mock
+import os.path
 import unittest
 
+from cumulusci.core.config import (
+    BaseGlobalConfig,
+    BaseProjectConfig,
+    TaskConfig,
+    OrgConfig,
+)
+from cumulusci.utils import temporary_dir
+from cumulusci.core.keychain import BaseProjectKeychain
+from cumulusci.tests.util import get_base_config
+from cumulusci.tasks.push.pushfails import PushFailTask
+
+
+def ErrorRecord(gack=False):
+    """ Return a dictionary that looks like the result of our nested query on the push api """
+    return {
+        "attributes": {"type": "job"},
+        "SubscriberOrganizationKey": "00Dxxx000000001",
+        "PackagePushErrors": {
+            "totalSize": 1,
+            "records": [
+                {
+                    "attributes": {"type": "error"},
+                    "ErrorDetails": "None to be had",
+                    "ErrorMessage": "There was an error number: 123456-765432 (-4532)"
+                    if gack
+                    else "Who knows?",
+                    "ErrorSeverity": "Severe",
+                    "ErrorTitle": "Unexpected Error",
+                    "ErrorType": "Error",
+                }
+            ],
+        },
+    }
+
+
 class TestPushFailureTask(unittest.TestCase):
-    pass
+    def setUp(self):
+        self.project_config = BaseProjectConfig(BaseGlobalConfig(), get_base_config())
+        keychain = BaseProjectKeychain(self.project_config, "")
+        self.project_config.set_keychain(keychain)
+        self.org_config = OrgConfig(
+            {"instance_url": "example.com", "access_token": "abc123"}, "test"
+        )
+
+        self.task_config = TaskConfig({"options": {"request_id": "123"}})
+
+    @mock.patch("cumulusci.tasks.push.pushfails.PushFailTask._update_credentials")
+    def test_run_task(self, *mocks):
+        task = PushFailTask(self.project_config, self.task_config, self.org_config)
+        task.sf = mock.Mock()
+        task.sf.query.return_value = {
+            "done": True,
+            "totalSize": 2,
+            "records": [ErrorRecord(), ErrorRecord(True)],
+        }
+        with temporary_dir() as d:
+            task()
+            task.sf.query.assert_called_once()
+            self.assert_(os.path.isfile(task.result), "the result file does not exist")
+            with open(task.result, "r") as f:
+                lines = f.readlines()
+            self.assertEqual(len(lines), 3)

--- a/cumulusci/tasks/tests/test_pushfails.py
+++ b/cumulusci/tasks/tests/test_pushfails.py
@@ -11,7 +11,7 @@ from cumulusci.core.config import (
 )
 from cumulusci.utils import temporary_dir
 from cumulusci.core.keychain import BaseProjectKeychain
-from cumulusci.tests.util import get_base_config
+from cumulusci.tasks.salesforce.tests.util import SalesforceTaskTestCase
 from cumulusci.tasks.push.pushfails import ReportPushFailures
 
 
@@ -38,25 +38,11 @@ def error_record(gack=False):  # type: (bool) -> dict
     }
 
 
-class TestPushFailureTask(unittest.TestCase):
-    def setUp(self):
-        self.project_config = BaseProjectConfig(BaseGlobalConfig(), get_base_config())
-        keychain = BaseProjectKeychain(self.project_config, "")
-        self.project_config.set_keychain(keychain)
-        self.org_config = OrgConfig(
-            {"instance_url": "example.com", "access_token": "abc123"}, "test"
-        )
+class TestPushFailureTask(SalesforceTaskTestCase):
+    task_class = ReportPushFailures
 
-        self.task_config = TaskConfig({"options": {"request_id": "123"}})
-
-    @mock.patch(
-        "cumulusci.tasks.push.pushfails.ReportPushFailures._update_credentials",
-        mock.Mock(),
-    )
     def test_run_task(self,):
-        task = ReportPushFailures(
-            self.project_config, self.task_config, self.org_config
-        )
+        task = self.create_task(options={"request_id": "123"})
         task.sf = mock.Mock()
         task.sf.query.return_value = {
             "done": True,


### PR DESCRIPTION
I didn't wire up the task in cumulusci.yml because its pretty rarely used and you can just do it in your local if you need to. Happy to add it to the global if we want...or strategize about how to register the mostly-releng-tasks....

Also ran black on the stuff that hasn't been formatted yet.

# Changes

- Adds a PushFailTask class that generates a report of push failures from a given request id. 