### PR TITLE
Feature/bell

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -54,3 +54,4 @@ flows:
 orgs:
     dev:
         days: 1
+

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1004,6 +1004,8 @@ def task_run(config, task_name, org, o, debug, debug_before, debug_after, no_pro
         # Unexpected exception; log to sentry and raise
         handle_exception_debug(config, debug, no_prompt=no_prompt)
 
+    config.alert("Task complete")
+
 
 # Add the task commands to the task group
 task.add_command(task_doc)
@@ -1115,6 +1117,8 @@ def flow_run(config, flow_name, org, delete_org, debug, o, skip, no_prompt):
                 "Scratch org deletion failed.  Ignoring the error below to complete the flow:"
             )
             click.echo(e.message)
+
+    config.alert("Flow Complete")
 
 
 flow.add_command(flow_list)

--- a/cumulusci/cli/config.py
+++ b/cumulusci/cli/config.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import click
+from subprocess import call
 
 import pkg_resources
 
@@ -60,13 +61,13 @@ class CliConfig(object):
             message = "We need your attention!"
         click.echo("\a")
         try:
-            os.system(
+            call(
                 """osascript -e 'display notification "{}" with title "{}"'""".format(
                     message, "CumulusCI"
                 )
             )
-        except:
-            pass
+        except OSError:
+            pass # we don't have oascript, probably.
 
     def get_org(self, org_name=None, fail_if_missing=True):
         if org_name:

--- a/cumulusci/cli/config.py
+++ b/cumulusci/cli/config.py
@@ -50,6 +50,24 @@ class CliConfig(object):
             self.keychain = self.keychain_class(self.project_config, self.keychain_key)
             self.project_config.set_keychain(self.keychain)
 
+    def alert(self, message=None):
+        try:
+            if self.project_config.dev_config__no_alert:
+                return
+        except AttributeError:
+            pass
+        if message is None:
+            message = "We need your attention!"
+        click.echo("\a")
+        try:
+            os.system(
+                """osascript -e 'display notification "{}" with title "{}"'""".format(
+                    message, "CumulusCI"
+                )
+            )
+        except:
+            pass
+
     def get_org(self, org_name=None, fail_if_missing=True):
         if org_name:
             org_config = self.keychain.get_org(org_name)

--- a/cumulusci/cli/tests/test_config.py
+++ b/cumulusci/cli/tests/test_config.py
@@ -176,8 +176,8 @@ class TestCliConfig(unittest.TestCase):
     @mock.patch("cumulusci.cli.config.click.echo")
     def test_no_alert(self, echo_mock, shell_mock):
         config = CliConfig()
-        config.project_config.dev_config = {"no_alert": True} #TODO: make this work
+        config.project_config.dev_config__no_alert = True
 
         config.alert("hello")
-        echo_mocj.assert_not_called()
+        echo_mock.assert_not_called()
         shell_mock.assert_not_called()

--- a/cumulusci/cli/tests/test_config.py
+++ b/cumulusci/cli/tests/test_config.py
@@ -163,7 +163,7 @@ class TestCliConfig(unittest.TestCase):
         with self.assertRaises(click.UsageError):
             config.check_cumulusci_version()
 
-    @mock.patch("cumulusci.cli.config.os.system")
+    @mock.patch("cumulusci.cli.config.call")
     @mock.patch("cumulusci.cli.config.click.echo")
     def test_alert(self, shell_mock, echo_mock):
         config = CliConfig()
@@ -172,7 +172,7 @@ class TestCliConfig(unittest.TestCase):
         echo_mock.assert_called_once()
         shell_mock.assert_called_once()
 
-    @mock.patch("cumulusci.cli.config.os.system")
+    @mock.patch("cumulusci.cli.config.call")
     @mock.patch("cumulusci.cli.config.click.echo")
     def test_no_alert(self, echo_mock, shell_mock):
         config = CliConfig()

--- a/cumulusci/cli/tests/test_config.py
+++ b/cumulusci/cli/tests/test_config.py
@@ -162,3 +162,22 @@ class TestCliConfig(unittest.TestCase):
 
         with self.assertRaises(click.UsageError):
             config.check_cumulusci_version()
+
+    @mock.patch("cumulusci.cli.config.os.system")
+    @mock.patch("cumulusci.cli.config.click.echo")
+    def test_alert(self, shell_mock, echo_mock):
+        config = CliConfig()
+
+        config.alert("hello")
+        echo_mock.assert_called_once()
+        shell_mock.assert_called_once()
+
+    @mock.patch("cumulusci.cli.config.os.system")
+    @mock.patch("cumulusci.cli.config.click.echo")
+    def test_no_alert(self, echo_mock, shell_mock):
+        config = CliConfig()
+        config.project_config.dev_config = {"no_alert": True} #TODO: make this work
+
+        config.alert("hello")
+        echo_mocj.assert_not_called()
+        shell_mock.assert_not_called()


### PR DESCRIPTION
# Changes
- Play a terminal "bell" sound when a task or flow completes execution. To silence this, you can set dev_config__no_alert in your local cumulusci.yml file.
- Attempt to display a notification on macOS also.
# Issues Closed
#325: terminal bell on task or flow complete

---
sample config:
*~/.cumulusci/cumulusci.yml*
```
dev_config:
    admin_email: christian.carter@salesforce.com
    no_alert: True
```