### PR TITLE
Feature/ziplogging

### DIFF
--- a/cumulusci/tests/test_utils.py
+++ b/cumulusci/tests/test_utils.py
@@ -234,6 +234,15 @@ class TestUtils(unittest.TestCase):
         result = zf.read("test")
         self.assertEqual(contents, result)
 
+    def test_zip_strip_namespace_logs(self):
+        zf = zipfile.ZipFile(io.BytesIO(), "w")
+        zf.writestr("ns__test", "ns__test ns:test")
+
+        logger = mock.Mock()
+        zf = utils.zip_strip_namespace(zf, "ns", logger=logger)
+        logger.info.assert_called_once()
+
+
     def test_zip_tokenize_namespace(self):
         zf = zipfile.ZipFile(io.BytesIO(), "w")
         zf.writestr("ns__test", "ns__test ns:test")

--- a/cumulusci/utils.py
+++ b/cumulusci/utils.py
@@ -250,15 +250,18 @@ def zip_strip_namespace(zip_src, namespace, logger=None):
     zip_dest = zipfile.ZipFile(io.BytesIO(), "w", zipfile.ZIP_DEFLATED)
     for name in zip_src.namelist():
         try:
-            content = zip_src.read(name)
-            content = unicode(content)
-            content = content.replace(namespace_prefix, "")
-            content = content.replace(lightning_namespace, "c:")
-            name = name.replace(namespace_prefix, "")
+            orig_content = zip_src.read(name)
+            orig_content = unicode(orig_content)
+            new_content = orig_content.replace(namespace_prefix, "")
+            new_content = new_content.replace(lightning_namespace, "c:")
+            name = name.replace(namespace_prefix, "")  # not...sure...this..gets...used
+            if orig_content != new_content and logger:
+                logger.info("  {file_name}: removed {namespace}")
         except UnicodeDecodeError:
             # if we cannot decode the content, don't try and replace it.
-            pass
-        zip_dest.writestr(name, content)
+            new_content = zip_src.read(name)
+
+        zip_dest.writestr(name, new_content)
     return zip_dest
 
 

--- a/cumulusci/utils.py
+++ b/cumulusci/utils.py
@@ -259,7 +259,7 @@ def zip_strip_namespace(zip_src, namespace, logger=None):
                 logger.info("  {file_name}: removed {namespace}")
         except UnicodeDecodeError:
             # if we cannot decode the content, don't try and replace it.
-            new_content = zip_src.read(name)
+            new_content = orig_content
 
         zip_dest.writestr(name, new_content)
     return zip_dest


### PR DESCRIPTION
# Critical Changes

# Changes
- When using the `strip_namespace` option on deployments, we now log which files had changes made before deploying.

# Issues Closed
