### PR TITLE
Feature/makelife

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -74,3 +74,24 @@ Before you submit a pull request, check that it meets these guidelines:
 * New classes, functions, etc have docstrings.
 * New code has comments.
 * Code style and file structure is similar to the rest of the project.
+* You have run the `black` code formatter.
+
+Releasing CumulusCI
+-------------------
+
+It's easy to release a version of CumulusCI to GitHub and PyPi! First, create a new branch for your version:
+
+    $ git checkout -b feature/newversion
+
+After commiting any updates to HISTORY.rst and the docs, bump the version:
+
+    $ bump2version patch
+    $ git push -u origin HEAD
+
+Open a Pull Request on GitHub and request approval from another commiter. Once your PR has been merged, you can create the release tag and push an .egg to PyPi via twine.
+
+    $ git checkout master
+    $ git pull
+    $ make tag release
+
+Finally, head to the Release object that was autocreated in the GitHub repository, paste in the changelog notes and hit publish. Tada! You've published a new version of CCI.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -79,19 +79,25 @@ Before you submit a pull request, check that it meets these guidelines:
 Releasing CumulusCI
 -------------------
 
-It's easy to release a version of CumulusCI to GitHub and PyPi! First, create a new branch for your version:
+It's easy to release a version of CumulusCI to GitHub and PyPI! First, create a new branch for your version::
 
     $ git checkout -b feature/newversion
 
-After commiting any updates to HISTORY.rst and the docs, bump the version:
+After committing any updates to HISTORY.rst and the docs, bump the version::
 
     $ bump2version patch
     $ git push -u origin HEAD
 
-Open a Pull Request on GitHub and request approval from another commiter. Once your PR has been merged, you can create the release tag and push an .egg to PyPi via twine.
+Open a Pull Request on GitHub and request approval from another committer. Once your PR has been merged, you can create the release tag and then push the artifacts PyPI with twine::
 
     $ git checkout master
     $ git pull
     $ make tag release
 
 Finally, head to the Release object that was autocreated in the GitHub repository, paste in the changelog notes and hit publish. Tada! You've published a new version of CCI.
+
+Configuring Your Environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+To release CCI, you'll need twine and bump2version, both of which are installed with the deveopment requirements. You'll also need to configure your `pypirc`_ file with your PyPI credentials.
+
+.._pypirc: https://docs.python.org/2.7/distutils/packageindex.html#the-pypirc-file

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and 
 
 clean-build: ## remove build artifacts
 	rm -fr build/
+	rm -fr pybuild/
 	rm -fr dist/
 	rm -fr .eggs/
 	find . -name '*.egg-info' -exec rm -fr {} +
@@ -46,24 +47,24 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr .tox/
 	rm -f .coverage
 	rm -fr htmlcov/
+	rm -f output.xml
+	rm -f report.html
 
 lint: ## check style with flake8
 	flake8 cumulusci tests
 
 test: ## run tests quickly with the default Python
-	
-		python setup.py test
+	nosetests
 
 test-all: ## run tests on every Python version with tox
 	tox
 
-coverage: ## check code coverage quickly with the default Python
+coverage: ## check code coverage quickly with the default Python	
+	coverage run --source cumulusci nosetests
 	
-		coverage run --source cumulusci setup.py test
-	
-		coverage report -m
-		coverage html
-		$(BROWSER) htmlcov/index.html
+	coverage report -m
+	coverage html
+	$(BROWSER) htmlcov/index.html
 
 docs: ## generate Sphinx HTML documentation, including API docs
 	rm -f docs/cumulusci.rst
@@ -77,8 +78,9 @@ servedocs: docs ## compile the docs watching for changes
 	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
 
 release: clean ## package and upload a release
-	python setup.py sdist upload
-	python setup.py bdist_wheel upload
+	python setup.py sdist 
+	python setup.py bdist_wheel 
+	twine upload dist/*
 
 dist: clean ## builds source and wheel package
 	python setup.py sdist
@@ -87,3 +89,7 @@ dist: clean ## builds source and wheel package
 
 install: clean ## install the package to the active Python's site-packages
 	python setup.py install
+
+tag: clean
+	git tag -a -m 'version $$(python setup.py --version)' v$$(python setup.py --version)
+	git push --follow-tags

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,6 @@ install: clean ## install the package to the active Python's site-packages
 bump:
 	bump2version patch --verbose
 
-tag: clean bump
+tag: clean
 	git tag -a -m 'version $$(python setup.py --version)' v$$(python setup.py --version)
 	git push --follow-tags

--- a/Makefile
+++ b/Makefile
@@ -95,4 +95,4 @@ bump:
 
 tag: clean bump
 	git tag -a -m 'version $$(python setup.py --version)' v$$(python setup.py --version)
-	#git push --follow-tags
+	git push --follow-tags

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,9 @@ dist: clean ## builds source and wheel package
 install: clean ## install the package to the active Python's site-packages
 	python setup.py install
 
-tag: clean
+bump:
+	bump2version patch --verbose
+
+tag: clean bump
 	git tag -a -m 'version $$(python setup.py --version)' v$$(python setup.py --version)
-	git push --follow-tags
+	#git push --follow-tags

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 -e .
-bumpversion==0.5.3
+bump2version==0.5.10
 coverage==4.1
 coveralls==1.2.0
 flake8==2.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,11 +8,11 @@ tag = False
 
 [bumpversion:file:setup.py]
 search = version='{current_version}'
-replace = version='{new_version}'
+replace = {new_version}
 
 [bumpversion:file:cumulusci/__init__.py]
 search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
+replace = {new_version}
 
 [bdist_wheel]
 universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ build-base=pybuild
 current_version = 2.0.12
 commit = True
 tag = True
+tag_message = 'version {new_version}'
 
 [bumpversion:file:setup.py]
 search = version='{current_version}'

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,8 +4,7 @@ build-base=pybuild
 [bumpversion]
 current_version = 2.0.12
 commit = True
-tag = True
-tag_message = 'version {new_version}'
+tag = False
 
 [bumpversion:file:setup.py]
 search = version='{current_version}'


### PR DESCRIPTION
Updated the Makefile to run the tests the way we run them and release the package the way we release it. In the process, moved to the has-a-maintainer bump2version, and fixed up bumpversions configuration so that it doesn't create invalid python files.

At least wanted to get our current process documented in the repo and makefile before we change it.

# Critical Changes

# Changes

# Issues Closed
