### PR TITLE
Add Beta Dependency Flow

### DIFF
--- a/cumulusci/core/config/BaseProjectConfig.py
+++ b/cumulusci/core/config/BaseProjectConfig.py
@@ -402,7 +402,7 @@ class BaseProjectConfig(BaseTaskFlowConfig):
         self._check_keychain()
         return self.keychain.set_org(name, org_config)
 
-    def get_static_dependencies(self, dependencies=None):
+    def get_static_dependencies(self, dependencies=None, install_latest=None):
         """ Resolves the project -> dependencies section of cumulusci.yml
             to convert dynamic github dependencies into static dependencies
             by inspecting the referenced repositories
@@ -418,7 +418,9 @@ class BaseProjectConfig(BaseTaskFlowConfig):
             if "github" not in dependency:
                 static_dependencies.append(dependency)
             else:
-                static = self.process_github_dependency(dependency)
+                static = self.process_github_dependency(
+                    dependency, install_latest=install_latest
+                )
                 static_dependencies.extend(static)
         return static_dependencies
 
@@ -447,7 +449,7 @@ class BaseProjectConfig(BaseTaskFlowConfig):
                 prefix = "{}    ".format(" " * indent)
         return pretty
 
-    def process_github_dependency(self, dependency, indent=None):
+    def process_github_dependency(self, dependency, indent=None, install_latest=None):
         if not indent:
             indent = ""
 
@@ -566,7 +568,7 @@ class BaseProjectConfig(BaseTaskFlowConfig):
         prefix_release = project.get("git", {}).get("prefix_release", "release/")
         dependencies = project.get("dependencies")
         if dependencies:
-            dependencies = self.get_static_dependencies(dependencies)
+            dependencies = self.get_static_dependencies(dependencies, install_latest=install_latest)
 
         # Create the final ordered list of all parsed dependencies
         repo_dependencies = []
@@ -580,15 +582,7 @@ class BaseProjectConfig(BaseTaskFlowConfig):
             if tag:
                 version = self.get_version_for_tag(tag, prefix_beta, prefix_release)
             else:
-                # github3.py doesn't support the latest release API so we hack
-                # it together here
-                url = repo._build_url("releases/latest", base_url=repo._api)
-                try:
-                    version = repo._get(url).json()["name"]
-                except Exception as e:
-                    self.logger.warn(
-                        "{}{}: {}".format(indent, e.__class__.__name__, e.message)
-                    )
+                version = self._find_release_version(repo, indent, install_latest)
 
             if not version:
                 raise DependencyResolutionError(
@@ -614,3 +608,20 @@ class BaseProjectConfig(BaseTaskFlowConfig):
             repo_dependencies.extend(unpackaged_post)
 
         return repo_dependencies
+
+    def _find_release_version(self, repo, indent, install_latest=None):
+        version = None
+        if install_latest:
+            latest_release = repo.iter_releases(1).next()
+            version = latest_release.name
+        else:
+            # github3.py doesn't support the latest release api so we hack
+            # it together here
+            url = repo._build_url("releases/latest", base_url=repo._api)
+            try:
+                version = repo._get(url).json()["name"]
+            except Exception as e:
+                self.logger.warn(
+                    "{}{}: {}".format(indent, e.__class__.__name__, e.message)
+                )
+        return version

--- a/cumulusci/core/config/BaseProjectConfig.py
+++ b/cumulusci/core/config/BaseProjectConfig.py
@@ -619,7 +619,7 @@ class BaseProjectConfig(BaseTaskFlowConfig):
     def _find_release_version(self, repo, indent, include_beta=None):
         version = None
         if include_beta:
-            latest_release = repo.iter_releases(1).next()
+            latest_release = next(repo.iter_releases())
             version = latest_release.name
         else:
             # github3.py doesn't support the latest release api so we hack

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -585,7 +585,7 @@ class TestBaseProjectConfig(unittest.TestCase):
                 "skip": ["unpackaged/pre/skip", "unpackaged/post/skip"],
             },
             "",
-            install_latest=True
+            include_beta=True
         )
         print result
         self.assertEqual(

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -159,13 +159,14 @@ class DummyRepository(object):
         res.json.return_value = {"name": "2"}
         return res
 
-    def iter_releases(self):
+    def iter_releases(self, count=None):
         return iter(self.releases)
 
 
 class DummyRelease(object):
-    def __init__(self, tag_name):
+    def __init__(self, tag_name, name=None):
         self.tag_name = tag_name
+        self.name = name
 
 
 CUMULUSCI_TEST_REPO = DummyRepository(
@@ -566,6 +567,61 @@ class TestBaseProjectConfig(unittest.TestCase):
             },
             result,
         )
+
+    def test_process_github_dependency_latest(self):
+        global_config = BaseGlobalConfig()
+        config = BaseProjectConfig(global_config)
+        config.get_github_api = DummyGithub
+        config.keychain = DummyKeychain()
+        CUMULUSCI_TEST_DEP_REPO.releases = [
+            DummyRelease("beta/1.1-Beta_1", "1.1 (Beta 1)"),
+            DummyRelease("release/1.0"),
+        ]
+
+        result = config.process_github_dependency(
+            {
+                "github": "https://github.com/SFDO-Tooling/CumulusCI-Test.git",
+                "unmanaged": True,
+                "skip": ["unpackaged/pre/skip", "unpackaged/post/skip"],
+            },
+            "",
+            install_latest=True
+        )
+        print result
+        self.assertEqual(
+            result,
+            [
+                {
+                    u"headers": {u"Authorization": u"token password"},
+                    u"namespace_inject": None,
+                    u"namespace_strip": None,
+                    u"namespace_tokenize": None,
+                    u"subfolder": u"CumulusCI-Test-master/unpackaged/pre/pre",
+                    u"unmanaged": True,
+                    u"zip_url": u"https://github.com/SFDO-Tooling/CumulusCI-Test/archive/master.zip",
+                },
+                {u"version": "1.1 (Beta 1)", u"namespace": "ccitestdep"},
+                {
+                    u"headers": {u"Authorization": u"token password"},
+                    u"namespace_inject": None,
+                    u"namespace_strip": None,
+                    u"namespace_tokenize": None,
+                    u"subfolder": u"CumulusCI-Test-master/src",
+                    u"unmanaged": True,
+                    u"zip_url": u"https://github.com/SFDO-Tooling/CumulusCI-Test/archive/master.zip",
+                },
+                {
+                    u"headers": {u"Authorization": u"token password"},
+                    u"namespace_inject": "ccitest",
+                    u"namespace_strip": None,
+                    u"namespace_tokenize": None,
+                    u"subfolder": u"CumulusCI-Test-master/unpackaged/post/post",
+                    u"unmanaged": True,
+                    u"zip_url": u"https://github.com/SFDO-Tooling/CumulusCI-Test/archive/master.zip",
+                },
+            ],
+        )
+        CUMULUSCI_TEST_DEP_REPO.releases = None
 
     def test_process_github_dependency_cannot_find_latest(self):
         global_config = BaseGlobalConfig()

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -159,7 +159,7 @@ class DummyRepository(object):
         res.json.return_value = {"name": "2"}
         return res
 
-    def iter_releases(self, count=None):
+    def iter_releases(self):
         return iter(self.releases)
 
 

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -266,6 +266,20 @@ flows:
                 options:
                     managed: True
 
+    ci_beta_dependencies:
+        description: Install the latest beta version of dependenices and run apex tests. 
+        steps:
+            1:
+                flow: beta_dependencies
+            2:
+                flow: deploy_unmanaged
+            3:
+                flow: config_apextest
+            4:
+                task: run_tests
+            5:
+                task: github_parent_to_children
+
     ci_feature:
         description: Prepare an unmanaged metadata test org and run apex tests.  Intended for use against feature branch commits.
         steps:
@@ -349,6 +363,16 @@ flows:
         steps:
             1:
                 task: update_dependencies
+            2:
+                task: deploy_pre
+
+    beta_dependencies:
+        description: Deploy the latest (beta) version of dependencies to prepare the org environment for the package metadata
+        steps:
+            1:
+                task: update_dependencies
+                options:
+                    install_latest: True
             2:
                 task: deploy_pre
                             

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -266,20 +266,6 @@ flows:
                 options:
                     managed: True
 
-    ci_beta_dependencies:
-        description: Install the latest beta version of dependenices and run apex tests. 
-        steps:
-            1:
-                flow: beta_dependencies
-            2:
-                flow: deploy_unmanaged
-            3:
-                flow: config_apextest
-            4:
-                task: run_tests
-            5:
-                task: github_parent_to_children
-
     ci_feature:
         description: Prepare an unmanaged metadata test org and run apex tests.  Intended for use against feature branch commits.
         steps:
@@ -293,7 +279,21 @@ flows:
                 task: run_tests
             5:
                 task: github_parent_to_children
-                    
+
+    ci_feature_beta_deps:
+        description: Install the latest beta version of dependencies and run apex tests.
+        steps:
+            1:
+                flow: beta_dependencies
+            2:
+                flow: deploy_unmanaged
+            3:
+                flow: config_apextest
+            4:
+                task: run_tests
+            5:
+                task: github_parent_to_children
+
     ci_master:
         description: Deploy the package metadata to the packaging org and prepare for managed package version upload.  Inteded for use against master branch commits.
         steps:
@@ -372,7 +372,7 @@ flows:
             1:
                 task: update_dependencies
                 options:
-                    install_latest: True
+                    include_beta: True
             2:
                 task: deploy_pre
                             

--- a/cumulusci/tasks/salesforce/UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/UpdateDependencies.py
@@ -25,7 +25,7 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
         "purge_on_delete": {
             "description": "Sets the purgeOnDelete option for the deployment. Defaults to True"
         },
-        "install_latest": {
+        "include_beta": {
             "description": "Install the most recent release, even if beta. Defaults to False."
         },
     }
@@ -38,8 +38,8 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
         self.options["namespaced_org"] = process_bool_arg(
             self.options.get("namespaced_org", False)
         )
-        self.options["install_latest"] = process_bool_arg(
-            self.options.get("install_latest", False)
+        self.options["include_beta"] = process_bool_arg(
+            self.options.get("include_beta", False)
         )
 
     def _run_task(self):
@@ -47,16 +47,16 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
             self.logger.info("Project has no dependencies, doing nothing")
             return
 
-        if self.options["install_latest"] and not isinstance(
+        if self.options["include_beta"] and not isinstance(
             self.org_config, ScratchOrgConfig
         ):
             raise TaskOptionsError(
-                "Target org must be a scratch org when `install_latest` is true."
+                "Target org must be a scratch org when `include_beta` is true."
             )
 
         self.logger.info("Preparing static dependencies map")
         dependencies = self.project_config.get_static_dependencies(
-            install_latest=self.options["install_latest"]
+            include_beta=self.options["include_beta"]
         )
 
         self.installed = self._get_installed()

--- a/cumulusci/tasks/salesforce/UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/UpdateDependencies.py
@@ -1,6 +1,8 @@
 from distutils.version import LooseVersion
 
 from cumulusci.core.utils import process_bool_arg
+from cumulusci.core.config import ScratchOrgConfig
+from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.salesforce_api.metadata import ApiDeploy
 from cumulusci.salesforce_api.metadata import ApiRetrieveInstalledPackages
 from cumulusci.salesforce_api.package_zip import InstallPackageZipBuilder
@@ -23,6 +25,9 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
         "purge_on_delete": {
             "description": "Sets the purgeOnDelete option for the deployment. Defaults to True"
         },
+        "install_latest": {
+            "description": "Install the most recent release, even if beta. Defaults to False."
+        },
     }
 
     def _init_options(self, kwargs):
@@ -33,14 +38,26 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
         self.options["namespaced_org"] = process_bool_arg(
             self.options.get("namespaced_org", False)
         )
+        self.options["install_latest"] = process_bool_arg(
+            self.options.get("install_latest", False)
+        )
 
     def _run_task(self):
         if not self.project_config.project__dependencies:
             self.logger.info("Project has no dependencies, doing nothing")
             return
 
+        if self.options["install_latest"] and not isinstance(
+            self.org_config, ScratchOrgConfig
+        ):
+            raise TaskOptionsError(
+                "Target org must be a scratch org when `install_latest` is true."
+            )
+
         self.logger.info("Preparing static dependencies map")
-        dependencies = self.project_config.get_static_dependencies()
+        dependencies = self.project_config.get_static_dependencies(
+            install_latest=self.options["install_latest"]
+        )
 
         self.installed = self._get_installed()
         self.uninstall_queue = []

--- a/cumulusci/tasks/salesforce/tests/test_UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/tests/test_UpdateDependencies.py
@@ -110,7 +110,7 @@ class TestUpdateDependencies(unittest.TestCase):
         project_config = create_project_config()
         project_config.config["project"]["dependencies"] = [{"namespace": "foo"}]
         task = create_task(UpdateDependencies, project_config=project_config)
-        task.options["install_latest"] = True
+        task.options["include_beta"] = True
         task.org_config = OrgConfig(None, None)
 
         with self.assertRaises(TaskOptionsError):

--- a/cumulusci/tasks/salesforce/tests/test_UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/tests/test_UpdateDependencies.py
@@ -3,6 +3,8 @@ import mock
 import unittest
 import zipfile
 
+from cumulusci.core.config import OrgConfig
+from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.tasks.salesforce import UpdateDependencies
 from cumulusci.tests.util import create_project_config
 from .util import create_task
@@ -103,3 +105,13 @@ class TestUpdateDependencies(unittest.TestCase):
         task.api_class = mock.Mock(return_value=api)
         task()
         api.assert_not_called()
+
+    def test_update_dependency_latest_option_err(self):
+        project_config = create_project_config()
+        project_config.config["project"]["dependencies"] = [{"namespace": "foo"}]
+        task = create_task(UpdateDependencies, project_config=project_config)
+        task.options["install_latest"] = True
+        task.org_config = OrgConfig(None, None)
+
+        with self.assertRaises(TaskOptionsError):
+            task()


### PR DESCRIPTION
# Critical Changes

# Changes
Adds a flow, `ci_beta_dependencies` to install the latest beta of project dependencies and run tests. Includes task error when running against non-scratch orgs.
# Issues Closed
