### PR TITLE
Improvements to push failure report

### DIFF
--- a/cumulusci/tasks/push/pushfails.py
+++ b/cumulusci/tasks/push/pushfails.py
@@ -70,7 +70,7 @@ class ReportPushFailures(BaseSalesforceApiTask):
 
         # Sort by error title
         for record in job_records:
-            errors = record.pop("PackagePushErrors", {}).get("records") or [
+            errors = (record.pop("PackagePushErrors", None) or {}).get("records") or [
                 {"ErrorTitle": "", "ErrorMessage": ""}
             ]
             error = errors[0]

--- a/cumulusci/tasks/push/pushfails.py
+++ b/cumulusci/tasks/push/pushfails.py
@@ -109,7 +109,6 @@ class ReportPushFailures(BaseSalesforceApiTask):
                 ):
                     continue  # pragma: nocover (skipped by compiler's optimizer)
                 org = org_map.get(result["SubscriberOrganizationKey"]) or {}
-                m = self.gack.search(error.get("ErrorMessage", ""))
                 w.writerow(
                     [
                         result["SubscriberOrganizationKey"],
@@ -121,8 +120,8 @@ class ReportPushFailures(BaseSalesforceApiTask):
                         error.get("ErrorTitle", ""),
                         error.get("ErrorType", ""),
                         error.get("ErrorMessage", ""),
-                        m.group("gack_id") if m else "",
-                        m.group("stacktrace_id") if m else "",
+                        error["GackId"],
+                        error["StacktraceId"],
                     ]
                 )
 

--- a/cumulusci/tasks/push/pushfails.py
+++ b/cumulusci/tasks/push/pushfails.py
@@ -5,7 +5,7 @@ get the job done kinda moment.
 """
 
 import re
-import csv
+import unicodecsv
 from cumulusci.core.utils import process_list_arg
 from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 
@@ -91,7 +91,7 @@ class ReportPushFailures(BaseSalesforceApiTask):
         ignore_errors = self.options["ignore_errors"]
         file_name = self.options["result_file"]
         with open(file_name, "w") as f:
-            w = csv.writer(f)
+            w = unicodecsv.writer(f, encoding="utf-8")
             w.writerow(self.headers)
             for result in job_records:
                 error = result["Error"]

--- a/cumulusci/tasks/push/pushfails.py
+++ b/cumulusci/tasks/push/pushfails.py
@@ -27,9 +27,7 @@ class ReportPushFailures(BaseSalesforceApiTask):
     api_version = "43.0"
     job_query = "SELECT ID, SubscriberOrganizationKey, (SELECT ErrorDetails, ErrorMessage, ErrorSeverity, ErrorTitle, ErrorType FROM PackagePushErrors) FROM PackagePushJob WHERE PackagePushRequestId = '{request_id}' AND Status !='Succeeded'"
     subscriber_query = "SELECT OrgKey, OrgName, OrgType, OrgStatus, InstanceName FROM PackageSubscriber WHERE OrgKey IN ({org_ids})"
-    gack = re.compile(
-        r"error number: (?P<gack_id>[\d-]+) \((?P<stacktrace_id>[\d-]+)\)"
-    )
+    gack = re.compile(r"(?P<gack_id>[\d-]+) \((?P<stacktrace_id>[\d-]+)\)")
     headers = [
         "OrganizationId",
         "OrgName",

--- a/cumulusci/tasks/tests/test_pushfails.py
+++ b/cumulusci/tasks/tests/test_pushfails.py
@@ -15,7 +15,7 @@ from cumulusci.tasks.salesforce.tests.util import create_task
 from cumulusci.tasks.push.pushfails import ReportPushFailures
 
 
-def error_record(gack=False):  # type: (bool) -> dict
+def error_record(gack=False, ErrorTitle="Unexpected Error"):  # type: (bool) -> dict
     """ a record that looks like the object returned from the sobject api query we use """
     return {
         "attributes": {"type": "job"},
@@ -30,7 +30,7 @@ def error_record(gack=False):  # type: (bool) -> dict
                     if gack
                     else "Who knows?",
                     "ErrorSeverity": "Severe",
-                    "ErrorTitle": "Unexpected Error" if gack else "IgnoreMe",
+                    "ErrorTitle": ErrorTitle,
                     "ErrorType": "Error",
                 }
             ],
@@ -50,8 +50,8 @@ class TestPushFailureTask(unittest.TestCase):
                 "done": True,
                 "totalSize": 2,
                 "records": [
-                    error_record(),
-                    error_record(True),
+                    error_record(ErrorTitle="IgnoreMe"),
+                    error_record(gack=True),
                     {
                         "attributes": {"type": "job"},
                         "SubscriberOrganizationKey": "00Dxxx000000001",

--- a/cumulusci/tasks/tests/test_pushfails.py
+++ b/cumulusci/tasks/tests/test_pushfails.py
@@ -42,21 +42,36 @@ class TestPushFailureTask(unittest.TestCase):
     def test_run_task(self,):
         task = create_task(ReportPushFailures, options={"request_id": "123"})
         task.sf = mock.Mock()
-        task.sf.query.return_value = {
-            "done": True,
-            "totalSize": 2,
-            "records": [
-                error_record(),
-                error_record(True),
-                {
-                    "attributes": {"type": "job"},
-                    "SubscriberOrganizationKey": "00Dxxx000000001",
-                },
-            ],
-        }
+        task.sf.query.side_effect = [
+            {
+                "done": True,
+                "totalSize": 2,
+                "records": [
+                    error_record(),
+                    error_record(True),
+                    {
+                        "attributes": {"type": "job"},
+                        "SubscriberOrganizationKey": "00Dxxx000000001",
+                    },
+                ],
+            },
+            {
+                "done": True,
+                "totalSize": 1,
+                "records": [
+                    {
+                        "OrgKey": "00Dxxx000000001",
+                        "OrgName": "Test Org",
+                        "OrgType": "Sandbox",
+                        "OrgStatus": "Demo",
+                        "InstanceName": "CSxx",
+                    }
+                ],
+            },
+        ]
         with temporary_dir():
             task()
-            task.sf.query.assert_called_once()
+            self.assertEqual(2, task.sf.query.call_count)
             self.assertTrue(
                 os.path.isfile(task.result), "the result file does not exist"
             )
@@ -64,4 +79,11 @@ class TestPushFailureTask(unittest.TestCase):
                 reader = csv.DictReader(f)
                 rows = list(reader)
             self.assertEqual(len(rows), 3)
-            self.assertEqual(rows[1]["Stacktrace Id"], "-4532")
+            self.assertEqual(rows[2]["Stacktrace Id"], "-4532")
+
+    def test_run_task__no_results(self):
+        task = create_task(ReportPushFailures, options={"request_id": "123"})
+        task.sf = mock.Mock()
+        task.sf.query.return_value = {"totalSize": 0, "records": [], "done": True}
+        task()
+        self.assertFalse(os.path.isfile(task.options["result_file"]))

--- a/cumulusci/tasks/tests/test_pushfails.py
+++ b/cumulusci/tasks/tests/test_pushfails.py
@@ -30,7 +30,7 @@ def error_record(gack=False):  # type: (bool) -> dict
                     if gack
                     else "Who knows?",
                     "ErrorSeverity": "Severe",
-                    "ErrorTitle": "Unexpected Error",
+                    "ErrorTitle": "Unexpected Error" if gack else "IgnoreMe",
                     "ErrorType": "Error",
                 }
             ],
@@ -40,7 +40,10 @@ def error_record(gack=False):  # type: (bool) -> dict
 
 class TestPushFailureTask(unittest.TestCase):
     def test_run_task(self,):
-        task = create_task(ReportPushFailures, options={"request_id": "123"})
+        task = create_task(
+            ReportPushFailures,
+            options={"request_id": "123", "ignore_errors": "IgnoreMe"},
+        )
         task.sf = mock.Mock()
         task.sf.query.side_effect = [
             {
@@ -78,8 +81,8 @@ class TestPushFailureTask(unittest.TestCase):
             with open(task.result, "r") as f:
                 reader = csv.DictReader(f)
                 rows = list(reader)
-            self.assertEqual(len(rows), 3)
-            self.assertEqual(rows[2]["Stacktrace Id"], "-4532")
+            self.assertEqual(len(rows), 2)
+            self.assertEqual(rows[1]["Stacktrace Id"], "-4532")
 
     def test_run_task__no_results(self):
         task = create_task(ReportPushFailures, options={"request_id": "123"})


### PR DESCRIPTION
# Critical Changes

# Changes

* Improvements to push failure report:
  * Include subscriber org info
  * Sort by stacktrace id and error title
  * Don't write file if no results
  * Fix gack regexp to match more gack ids
  * Add option to ignore specified error types/titles
  * Fix writing output with non-ASCII characters

# Issues Closed
