### PR TITLE
Ignore push errors that aren't problematic by default

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -144,6 +144,10 @@ tasks:
     push_failure_report:
         description: Produce a CSV report of the failed and otherwise anomalous push jobs.
         class_path: cumulusci.tasks.push.pushfails.ReportPushFailures
+        options:
+            ignore_errors:
+              - "Salesforce Subscription Expired"
+              - "Package Uninstalled"
     query:
         description: Queries the connected org
         class_path: cumulusci.tasks.salesforce.SOQLQuery


### PR DESCRIPTION
# Critical Changes

# Changes

* In the push failure report, ignore "Package Uninstalled" and "Salesforce Subscription Expired" errors by default.

# Issues Closed
