### PR TITLE
Print a more useful error than 'ApexException' for anon apex task

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1004,7 +1004,7 @@ def task_run(config, task_name, org, o, debug, debug_before, debug_after, no_pro
         handle_exception_debug(config, debug, throw_exception=exception)
     except (CumulusCIFailure, ScratchOrgException) as e:
         # Expected failure; report without traceback
-        exception = click.ClickException("Failed: {}".format(e.__class__.__name__))
+        exception = click.ClickException(str(e) or e.__class__.__name__)
         handle_exception_debug(config, debug, throw_exception=exception)
     except Exception:
         # Unexpected exception; log to sentry and raise

--- a/cumulusci/core/exceptions.py
+++ b/cumulusci/core/exceptions.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-import textwrap
 
 
 class CumulusCIException(Exception):
@@ -217,8 +216,8 @@ class ApexException(CumulusCIFailure):
 
     def __str__(self):
         message, stacktrace = self.args
-        stacktrace = textwrap.indent("  ", stacktrace)
-        return "Apex error: {}\n  Stacktrace:\n{}".format(message, stacktrace)
+        stacktrace = "\n  ".join(stacktrace.splitlines())
+        return "Apex error: {}\n  Stacktrace:\n  {}".format(message, stacktrace)
 
 
 class PushApiObjectNotFound(CumulusCIException):

--- a/cumulusci/core/exceptions.py
+++ b/cumulusci/core/exceptions.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+import textwrap
 
 
 class CumulusCIException(Exception):
@@ -216,7 +217,8 @@ class ApexException(CumulusCIFailure):
 
     def __str__(self):
         message, stacktrace = self.args
-        return "Apex error: {}\nStacktrace:\n{}".format(message, stacktrace)
+        stacktrace = textwrap.indent("  ", stacktrace)
+        return "Apex error: {}\n  Stacktrace:\n{}".format(message, stacktrace)
 
 
 class PushApiObjectNotFound(CumulusCIException):

--- a/cumulusci/core/exceptions.py
+++ b/cumulusci/core/exceptions.py
@@ -206,13 +206,17 @@ class BrowserTestFailure(CumulusCIFailure):
 class ApexCompilationException(CumulusCIFailure):
     """ Raise when apex compilation fails """
 
-    pass
+    def __str__(self):
+        line, problem = self.args
+        return "Apex compilation failed on line {}: {}".format(line, problem)
 
 
 class ApexException(CumulusCIFailure):
     """ Raise when an Apex Exception is raised in an org """
 
-    pass
+    def __str__(self):
+        message, stacktrace = self.args
+        return "Apex error: {}\nStacktrace:\n{}".format(message, stacktrace)
 
 
 class PushApiObjectNotFound(CumulusCIException):

--- a/cumulusci/core/tests/test_exceptions.py
+++ b/cumulusci/core/tests/test_exceptions.py
@@ -1,0 +1,17 @@
+import unittest
+
+from cumulusci.core import exceptions
+
+
+class TestExceptions(unittest.TestCase):
+    def test_ApexCompilationException_str(self):
+        err = exceptions.ApexCompilationException(42, "Too many braces")
+        self.assertEqual(
+            "Apex compilation failed on line 42: Too many braces", str(err)
+        )
+
+    def test_ApexException(self):
+        err = exceptions.ApexException("Things got real", "Anon line 1")
+        self.assertEqual(
+            "Apex error: Things got real\nStacktrace:\nAnon line 1", str(err)
+        )

--- a/cumulusci/core/tests/test_exceptions.py
+++ b/cumulusci/core/tests/test_exceptions.py
@@ -13,5 +13,5 @@ class TestExceptions(unittest.TestCase):
     def test_ApexException(self):
         err = exceptions.ApexException("Things got real", "Anon line 1")
         self.assertEqual(
-            "Apex error: Things got real\nStacktrace:\nAnon line 1", str(err)
+            "Apex error: Things got real\n  Stacktrace:\n  Anon line 1", str(err)
         )


### PR DESCRIPTION
# Critical Changes

# Changes
* Improved error messages for errors while executing anonymous Apex

# Issues Closed
