### PR TITLE
Add an 'ignore' option for UninstallPackagedIncremental

### DIFF
--- a/cumulusci/tasks/salesforce/tests/test_UninstallPackagedIncremental.py
+++ b/cumulusci/tasks/salesforce/tests/test_UninstallPackagedIncremental.py
@@ -35,7 +35,11 @@ class TestUninstallPackagedIncremental(unittest.TestCase):
                 )
             project_config = create_project_config()
             project_config.config["project"]["package"]["name"] = "TestPackage"
-            task = create_task(UninstallPackagedIncremental, {}, project_config)
+            task = create_task(
+                UninstallPackagedIncremental,
+                {"ignore": {"ApexClass": ["Ignored"]}},
+                project_config,
+            )
             zf = zipfile.ZipFile(io.BytesIO(), "w")
             zf.writestr(
                 "package.xml",
@@ -49,6 +53,7 @@ class TestUninstallPackagedIncremental(unittest.TestCase):
         <members>Class1</members>
         <members>Class2</members>
         <members>Class3</members>
+        <members>Ignored</members>
         <name>ApexClass</name>
     </types>
     <types>


### PR DESCRIPTION
I intend to use this to avoid trying to delete quick actions that get implicitly added to the package in DE orgs but can't be deleted because they are referenced from layouts.


# Critical Changes

# Changes
* ``uninstall_packaged_incremental`` task: Added "ignore" option to specify components to skip trying to delete even if they are present in the org but not in the local source.

# Issues Closed
