### PR TITLE
New/revised keywords for related lists in robot Salesforce library

### DIFF
--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -41,12 +41,48 @@ class Salesforce(object):
         self.selenium.click_link(locator)
         self.wait_until_modal_is_open()
 
+    def load_related_list(self, heading):
+        """Scroll down until related list loads.
+        """
+        locator = lex_locators["record"]["related"]["card"].format(heading)
+        el = None
+        while el is None:
+            self.selenium.execute_javascript(
+                "window.scrollTo(0,document.body.scrollHeight)"
+            )
+            self.wait_for_aura()
+            try:
+                el = self.selenium.get_webelement(locator)
+            except ElementNotFound:
+                time.sleep(.2)
+                continue
+
     def click_related_list_button(self, heading, button_title):
+        """Click a button in the heading of a related list.
+
+        Waits for a modal to open after clicking the button.
+        """
+        self.load_related_list(heading)
         locator = lex_locators["record"]["related"]["button"].format(
             heading, button_title
         )
         self.selenium.click_link(locator)
         self.wait_until_modal_is_open()
+
+    def click_related_item_link(self, heading, title):
+        self.load_related_list(heading)
+        locator = lex_locators["record"]["related"]["link"].format(heading, title)
+        self.selenium.click_link(locator)
+
+    def click_related_item_popup_link(self, heading, title, link):
+        self.load_related_list(heading)
+        locator = lex_locators["record"]["related"]["popup_trigger"].format(
+            heading, title
+        )
+        self.selenium.wait_until_page_contains_element(locator)
+        self.selenium.click_link(locator)
+        locator = lex_locators["popup"]["link"].format(link)
+        self.selenium.click_link(locator)
 
     def close_modal(self):
         """ Closes the open modal """

--- a/cumulusci/robotframework/locators.py
+++ b/cumulusci/robotframework/locators.py
@@ -31,9 +31,15 @@ lex_locators = {
             "field_value_unchecked": "//li[contains(@class, 'slds-page-header__detail-block')][.//span[contains(@class, 'slds-form-element__label')][@title='{}']]//span[contains(@class, 'uiOutputCheckbox')]//img[@alt='False']",
         },
         "related": {
+            "card": "//article[contains(@class, 'forceRelatedListCardDesktop')][.//img][.//span[@title='{}']]",
             "button": "//article[contains(@class, 'forceRelatedListCardDesktop')][.//img][.//span[@title='{}']]//a[@title='{}']",
             "count": "//article[contains(@class, 'forceRelatedListCardDesktop')][.//img]//span[@title='{}']/following-sibling::span",
+            "link": "//article[contains(@class, 'forceRelatedListCardDesktop')][.//img][.//span[@title='{}']]//table[contains(@class,'forceRecordLayout')]/tbody/tr[.//th/div/a[contains(@class,'textUnderline')]][.//td/a[@title='{}']]/th//a",
+            "popup_trigger": "//article[contains(@class, 'forceRelatedListCardDesktop')][.//img][.//span[@title='{}']]//tr[.//a[text()='{}']]//div[contains(@class, 'forceVirtualAction')]//a",
         },
+    },
+    "popup": {
+        "link": "//div[contains(@class, 'uiPopupTarget')][contains(@class, 'visible')]//a[@title='{}']"
     },
     "spinner": "css: div.slds-spinner",
     "tabs": {"tab": ""},

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ PyYAML==3.13
 raven==6.9.0
 requests[security]==2.19.1
 robotframework==3.0.4
-robotframework-seleniumlibrary==3.1.1
+robotframework-seleniumlibrary==3.2.0
 rst2ansi==0.1.5
 salesforce-bulk==2.1.0
 sarge==0.1.5.post0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ requirements = [
     "raven==6.9.0",
     "requests[security]==2.19.1",
     "robotframework==3.0.4",
-    "robotframework-seleniumlibrary==3.1.1",
+    "robotframework-seleniumlibrary==3.2.0",
     "rst2ansi==0.1.5",
     "salesforce-bulk==2.1.0",
     "sarge==0.1.5post0",


### PR DESCRIPTION
No tests because standard layouts don't use tabular related lists :(

# Critical Changes

# Changes
* New/revised keywords for related lists in robot Salesforce library:
  - ``Load Related List``: Scrolls to a related list and waits for it to load
  - ``Click Related List Button``: Automatically calls ``Load Related List`` first
  - ``Click Related Item Link``: Clicks the main link for an item in a related list
  - ``Click Related Item Popup Link``: Clicks a link in the popup menu for an item in a related list
  - Updated to robotframework-seleniumlibrary 3.2.0 which includes a ``Scroll Element Into View`` keyword

# Issues Closed
