### PR TITLE
Fix bug in handling non-ascii characters in remove_xml_element utils

### DIFF
--- a/cumulusci/tests/test_utils.py
+++ b/cumulusci/tests/test_utils.py
@@ -317,7 +317,7 @@ class TestUtils(unittest.TestCase):
         zf.writestr("classes/test-meta.xml", b"<root>\xc3\xb1</root>")
 
         zf = utils.zip_clean_metaxml(zf)
-        self.assertEqual(b"<root>\xc3\xb1</root>", zf.read("classes/test-meta.xml"))
+        self.assertIn(b"<root>\xc3\xb1</root>", zf.read("classes/test-meta.xml"))
 
     def test_doc_task(self):
         task_config = TaskConfig(

--- a/cumulusci/tests/test_utils.py
+++ b/cumulusci/tests/test_utils.py
@@ -312,6 +312,13 @@ class TestUtils(unittest.TestCase):
         zf = utils.zip_clean_metaxml(zf, logger=logger)
         self.assertIn("classes/test-meta.xml", zf.namelist())
 
+    def test_zip_clean_metaxml__handles_nonascii(self):
+        zf = zipfile.ZipFile(io.BytesIO(), "w")
+        zf.writestr("classes/test-meta.xml", b"<root>\xc3\xb1</root>")
+
+        zf = utils.zip_clean_metaxml(zf)
+        self.assertEqual(b"<root>\xc3\xb1</root>", zf.read("classes/test-meta.xml"))
+
     def test_doc_task(self):
         task_config = TaskConfig(
             {

--- a/cumulusci/utils.py
+++ b/cumulusci/utils.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 from future import standard_library
+from future.utils import text_to_native_str
 
 standard_library.install_aliases()
 from builtins import str
@@ -25,13 +26,7 @@ CUMULUSCI_PATH = os.path.realpath(
 META_XML_CLEAN_DIRS = ("classes/", "triggers/", "pages/", "aura/", "components/")
 API_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
 DATETIME_LEN = len("2018-08-07T16:00:56.000")
-
-# xml.etree needs the encoding as a native string.
-# Because we're using unicode_literals and futurize's builtins.str,
-# we have to go through contortions to get one.
-# __file__ is arbitrarily used here as something that should be stringy.
-nativestr = type(__file__)
-UTF8 = nativestr("UTF-8")
+UTF8 = text_to_native_str("UTF-8")
 
 
 def parse_api_datetime(value):

--- a/cumulusci/utils.py
+++ b/cumulusci/utils.py
@@ -31,7 +31,7 @@ DATETIME_LEN = len("2018-08-07T16:00:56.000")
 # we have to go through contortions to get one.
 # __file__ is arbitrarily used here as something that should be stringy.
 nativestr = type(__file__)
-UTF8 = nativestr("utf-8")
+UTF8 = nativestr("UTF-8")
 
 
 def parse_api_datetime(value):


### PR DESCRIPTION
# Critical Changes

# Changes
* Fix issue deploying `-meta.xml` files with non-ASCII characters in Python 2.

# Issues Closed
