### PR TITLE
Add scratch org import

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -740,11 +740,11 @@ def org_default(config, org_name, unset):
 
 
 @click.command(name="import", help="Import a scratch org from Salesforce DX")
-@click.argument("username")
+@click.argument("username_or_alias")
 @click.argument("org_name")
 @pass_config
-def org_import(config, username, org_name):
-    org_config = {"username": username}
+def org_import(config, username_or_alias, org_name):
+    org_config = {"username": username_or_alias}
     scratch_org_config = ScratchOrgConfig(org_config, org_name)
     scratch_org_config.config["created"] = True
     config.keychain.set_org(scratch_org_config)

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -739,6 +739,24 @@ def org_default(config, org_name, unset):
         click.echo("{} is now the default org".format(org_name))
 
 
+@click.command(name="import", help="Import a scratch org from Salesforce DX")
+@click.option("username", "--username", help="Username for the scratch org to import")
+@click.option(
+    "org_name", "--org_name", help="Name that will be used by the imported scratch org"
+)
+@pass_config
+def org_import(config, username, org_name):
+    org_config = {"username": username}
+    scratch_org_config = ScratchOrgConfig(org_config, org_name)
+    scratch_org_config.config["created"] = True
+    config.keychain.set_org(scratch_org_config)
+    click.echo(
+        "Imported scratch org: {org_id}, username: {username}".format(
+            **scratch_org_config.scratch_info
+        )
+    )
+
+
 @click.command(name="info", help="Display information for a connected org")
 @click.argument("org_name", required=False)
 @click.option("print_json", "--json", is_flag=True, help="Print as JSON")
@@ -892,6 +910,7 @@ def org_scratch_delete(config, org_name):
 org.add_command(org_browser)
 org.add_command(org_connect)
 org.add_command(org_default)
+org.add_command(org_import)
 org.add_command(org_info)
 org.add_command(org_list)
 org.add_command(org_remove)

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -740,10 +740,8 @@ def org_default(config, org_name, unset):
 
 
 @click.command(name="import", help="Import a scratch org from Salesforce DX")
-@click.option("username", "--username", help="Username for the scratch org to import")
-@click.option(
-    "org_name", "--org_name", help="Name that will be used by the imported scratch org"
-)
+@click.argument("username")
+@click.argument("org_name")
 @pass_config
 def org_import(config, username, org_name):
     org_config = {"username": username}

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -436,7 +436,10 @@ test     Test Service  *""",
         out = []
         with mock.patch("click.echo", out.append):
             run_click_command(
-                cci.org_import, username="test@test.org", org_name="test", config=config
+                cci.org_import,
+                username_or_alias="test@test.org",
+                org_name="test",
+                config=config,
             )
             config.keychain.set_org.assert_called_once()
         self.assertTrue(

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -436,7 +436,7 @@ test     Test Service  *""",
         out = []
         with mock.patch("click.echo", out.append):
             run_click_command(
-                cci.org_import, config=config, username="test@test.org", org_name="test"
+                cci.org_import, username="test@test.org", org_name="test", config=config
             )
             config.keychain.set_org.assert_called_once()
         self.assertTrue(

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -373,6 +373,14 @@ If for some reason the whole scratch org config misbehaves, you can easily recre
 
     $ cci org scratch dev dev
 
+There may be times when you need to import an existing scratch org that wasn't created by CumulusCI. You can do so with `cci org import <username_or_alias> <org_name>`:
+
+.. code-block:: console
+
+    $ cci org import test-...@example.com dev
+    2018-11-15 09:23:16: Getting scratch org info from Salesforce DX
+    Imported scratch org: 00D...........0, username: test-...@example.com
+
 You can hop into a browser logged into any org in your keychain with `cci org browser <org_name>`.
 
 


### PR DESCRIPTION
# Critical Changes

# Changes
Add the `org import` command. When given a sfdx username (or an alias) and an org name `import` will import a scratch org into the cumulusci keychain.
# Issues Closed
- #877 
- #674