### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+# Black-compatible flake8 config
+
+[flake8]
+ignore = E203, E266, E501, W503
+max-line-length = 80
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.0.0
+    hooks:
+    - id: check-merge-conflict
+    - id: flake8

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -59,11 +59,15 @@ Ready to contribute? Here's how to set up CumulusCI for local development.
 
     $ pip install -r requirements_dev.txt
 
-4. After making changes, run the tests and make sure they all pass::
+4. Install ``pre-commit`` hooks for ``black`` and ``flake8``::
+
+    $ pre-commit install --install-hooks
+
+5. After making changes, run the tests and make sure they all pass::
 
     $ pytest
 
-5. Push your changes to GitHub and submit a pull request. The base branch should be a new feature branch that we create to receive the changes (contact us to create the branch). This allows us to test the changes using our build system before merging to master.
+6. Push your changes to GitHub and submit a pull request. The base branch should be a new feature branch that we create to receive the changes (contact us to create the branch). This allows us to test the changes using our build system before merging to master.
 
 Pull Request Guidelines
 -----------------------

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,6 +6,7 @@ coverage==4.5.2
 coveralls==1.5.1
 flake8==3.6.0
 mock==2.0.0
+pre-commit==1.12.0
 pytest==4.0.0
 responses==0.10.4
 Sphinx==1.8.2


### PR DESCRIPTION
Install `pre-commit`:

```shell
pip install pre-commit
```

Install the hooks:

```shell
pre-commit install --install-hooks
```

Added `pre-commit==1.12.0` to `requirements_dev.txt`. Created a yaml file (`.pre-commit-config.yaml`):

```yaml
repos:
-   repo: https://github.com/ambv/black
    rev: stable
    hooks:
    - id: black
-   repo: https://github.com/pre-commit/pre-commit-hooks
    rev: v2.0.0
    hooks:
    - id: check-merge-conflict
    - id: flake8
```

Includes three hooks:

1. `black` 
2. `flake8`
3. `check-merge-conflict` : Refuse to commit files containing conflict markers

The only hook we've discussed is `black`... the other two can be removed if necessary.

# Critical Changes

# Changes

# Issues Closed