### PR TITLE
Avoid infinite scrolling if the related list isn't found

### DIFF
--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -48,7 +48,13 @@ class Salesforce(object):
         """
         locator = lex_locators["record"]["related"]["card"].format(heading)
         el = None
+        i = 0
         while el is None:
+            i += 1
+            if i > 50:
+                raise AssertionError(
+                    "Timed out waiting for {} related list to load.".format(heading)
+                )
             self.selenium.execute_javascript(
                 "window.scrollTo(0,document.body.scrollHeight)"
             )


### PR DESCRIPTION
# Critical Changes

# Changes
* Robot Framework: Fix "Load Related List" keyword to time out if the list isn't found instead of waiting forever.

# Issues Closed
