### PR TITLE
Fix scrolling to related lists

### DIFF
--- a/cumulusci/__init__.py
+++ b/cumulusci/__init__.py
@@ -2,5 +2,5 @@ from __future__ import unicode_literals
 import os
 
 __import__("pkg_resources").declare_namespace("cumulusci")
-__version__ = "2.2.5.dev0"
+__version__ = "2.2.5.dev1"
 __location__ = os.path.dirname(os.path.realpath(__file__))

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -55,12 +55,10 @@ class Salesforce(object):
                 raise AssertionError(
                     "Timed out waiting for {} related list to load.".format(heading)
                 )
-            self.selenium.execute_javascript(
-                "window.scrollTo(0,Math.max(document.body.scrollHeight, document.documentElement.scrollHeight))"
-            )
+            self.selenium.execute_javascript("window.scrollBy(0, 100)")
             self.wait_for_aura()
             try:
-                self.selenium.scroll_element_into_view(locator)
+                self.selenium.get_webelement(locator)
                 break
             except ElementNotFound:
                 time.sleep(0.2)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.2.5.dev0
+current_version = 2.2.5.dev1
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ with open("requirements_dev.txt") as dev_requirements_file:
 
 setup(
     name="cumulusci",
-    version="2.2.5.dev0",
+    version="2.2.5.dev1",
     description="Build and release tools for Salesforce developers",
     long_description=readme + u"\n\n" + history,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
We can't jump all the way to the bottom because then the list ends up underneath the header and can't be clicked. So scroll a bit at a time instead.

# Critical Changes

# Changes

# Issues Closed
