### PR TITLE
Turn on requests logging when using debug flag

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -230,7 +230,8 @@ def main():
     This runs as the first step in processing any CLI command.
     """
     check_latest_version()
-    init_logger()
+    log_requests = "--debug" in sys.argv
+    init_logger(log_requests=log_requests)
 
 
 @click.command(name="version", help="Print the current version of CumulusCI")

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -239,7 +239,7 @@ def version():
     click.echo(cumulusci.__version__)
 
 
-@click.command(name="shell", help="Drop into a python shell")
+@click.command(name="shell", help="Drop into a Python shell")
 def shell():
     try:
         config = load_config(load_project_config=True, load_keychain=True)

--- a/cumulusci/cli/logger.py
+++ b/cumulusci/cli/logger.py
@@ -9,12 +9,15 @@ import requests
 
 def init_logger(log_requests=False):
     """ Initialize the logger """
+
+    logger = logging.getLogger(__name__.split(".")[0])
+    for handler in logger.handlers:  # pragma: nocover
+        logger.removeHandler(handler)
+
     formatter = coloredlogs.ColoredFormatter(fmt="%(asctime)s: %(message)s")
     handler = logging.StreamHandler()
     handler.setLevel(logging.DEBUG)
     handler.setFormatter(formatter)
-
-    logger = logging.getLogger(__name__.split(".")[0])
     logger.addHandler(handler)
     logger.setLevel(logging.DEBUG)
     logger.propagate = False

--- a/cumulusci/cli/logger.py
+++ b/cumulusci/cli/logger.py
@@ -4,20 +4,20 @@ from __future__ import unicode_literals
 import logging
 
 import coloredlogs
+import requests
 
 
-def init_logger():
+def init_logger(log_requests=False):
     """ Initialize the logger """
-
     formatter = coloredlogs.ColoredFormatter(fmt="%(asctime)s: %(message)s")
-
     handler = logging.StreamHandler()
     handler.setLevel(logging.DEBUG)
     handler.setFormatter(formatter)
 
     logger = logging.getLogger(__name__.split(".")[0])
-    for handler in logger.handlers:  # pragma: nocover
-        logger.removeHandler(handler)
     logger.addHandler(handler)
     logger.setLevel(logging.DEBUG)
     logger.propagate = False
+
+    if log_requests:
+        requests.packages.urllib3.add_stderr_logger()

--- a/cumulusci/cli/tests/test_logger.py
+++ b/cumulusci/cli/tests/test_logger.py
@@ -5,6 +5,8 @@ from ..logger import init_logger
 
 
 class TestLogger(unittest.TestCase):
+    @mock.patch("cumulusci.cli.logger.requests")
     @mock.patch("cumulusci.cli.logger.logging")
-    def test_init_logger(self, logging):
-        init_logger()
+    def test_init_logger(self, logging, requests):
+        init_logger(log_requests=True)
+        requests.packages.urllib3.add_stderr_logger.assert_called_once()


### PR DESCRIPTION
# Critical Changes

# Changes
* When running a task with the `--debug` flag, HTTP requests are logged.

# Issues Closed
