### PR TITLE
Strip trailing slash from instance URL

### DIFF
--- a/cumulusci/tasks/apex/tests/test_apex_tasks.py
+++ b/cumulusci/tasks/apex/tests/test_apex_tasks.py
@@ -56,10 +56,14 @@ class TestRunApexTests(unittest.TestCase):
         keychain = BaseProjectKeychain(self.project_config, "")
         self.project_config.set_keychain(keychain)
         self.org_config = OrgConfig(
-            {"id": "foo/1", "instance_url": "example.com", "access_token": "abc123"},
+            {
+                "id": "foo/1",
+                "instance_url": "https://example.com",
+                "access_token": "abc123",
+            },
             "test",
         )
-        self.base_tooling_url = "https://{}/services/data/v{}/tooling/".format(
+        self.base_tooling_url = "{}/services/data/v{}/tooling/".format(
             self.org_config.instance_url, self.api_version
         )
 
@@ -265,10 +269,14 @@ class TestAnonymousApexTask(unittest.TestCase):
         keychain = BaseProjectKeychain(self.project_config, "")
         self.project_config.set_keychain(keychain)
         self.org_config = OrgConfig(
-            {"id": "foo/1", "instance_url": "example.com", "access_token": "abc123"},
+            {
+                "id": "foo/1",
+                "instance_url": "https://example.com",
+                "access_token": "abc123",
+            },
             "test",
         )
-        self.base_tooling_url = "https://{}/services/data/v{}/tooling/".format(
+        self.base_tooling_url = "{}/services/data/v{}/tooling/".format(
             self.org_config.instance_url, self.api_version
         )
 
@@ -400,10 +408,14 @@ class TestRunBatchApex(unittest.TestCase):
         keychain = BaseProjectKeychain(self.project_config, "")
         self.project_config.set_keychain(keychain)
         self.org_config = OrgConfig(
-            {"id": "foo/1", "instance_url": "example.com", "access_token": "abc123"},
+            {
+                "id": "foo/1",
+                "instance_url": "https://example.com",
+                "access_token": "abc123",
+            },
             "test",
         )
-        self.base_tooling_url = "https://{}/services/data/v{}/tooling/".format(
+        self.base_tooling_url = "{}/services/data/v{}/tooling/".format(
             self.org_config.instance_url, self.api_version
         )
 

--- a/cumulusci/tasks/salesforce/BaseSalesforceApiTask.py
+++ b/cumulusci/tasks/salesforce/BaseSalesforceApiTask.py
@@ -23,7 +23,7 @@ class BaseSalesforceApiTask(BaseSalesforceTask):
             api_version = self.project_config.project__package__api_version
 
         rv = Salesforce(
-            instance=self.org_config.instance_url.replace("https://", ""),
+            instance_url=self.org_config.instance_url,
             session_id=self.org_config.access_token,
             version=api_version,
         )
@@ -38,7 +38,7 @@ class BaseSalesforceApiTask(BaseSalesforceTask):
 
     def _init_bulk(self):
         return SalesforceBulk(
-            host=self.org_config.instance_url.replace("https://", ""),
+            host=self.org_config.instance_url.replace("https://", "").rstrip("/"),
             sessionId=self.org_config.access_token,
         )
 

--- a/cumulusci/tasks/salesforce/tests/test_base_tasks.py
+++ b/cumulusci/tasks/salesforce/tests/test_base_tasks.py
@@ -8,6 +8,7 @@ from cumulusci.core.config import TaskConfig
 from cumulusci.core.exceptions import ServiceNotConfigured
 from cumulusci.tasks.salesforce import BaseRetrieveMetadata
 from cumulusci.tasks.salesforce import BaseSalesforceTask
+from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 from cumulusci.tasks.salesforce import BaseSalesforceMetadataApiTask
 from cumulusci.tasks.salesforce import BaseUninstallMetadata
 from cumulusci.tests.util import create_project_config
@@ -42,6 +43,15 @@ class TestBaseSalesforceTask(unittest.TestCase):
             self.project_config, self.task_config, self.org_config
         )
         self.project_config.keychain.set_org.assert_called_once()
+
+
+class TestBaseSalesforceApiTask(unittest.TestCase):
+    def test_sf_instance(self):
+        org_config = OrgConfig(
+            {"instance_url": "https://foo/", "access_token": "TOKEN"}, "test"
+        )
+        task = create_task(BaseSalesforceApiTask, org_config=org_config)
+        self.assertFalse(task.sf.sf_instance.endswith("/"))
 
 
 class TestBaseSalesforceMetadataApiTask(unittest.TestCase):

--- a/cumulusci/tasks/tests/test_bulkdata.py
+++ b/cumulusci/tasks/tests/test_bulkdata.py
@@ -52,7 +52,7 @@ def _make_task(task_class, task_config):
     keychain = BaseProjectKeychain(project_config, "")
     project_config.set_keychain(keychain)
     org_config = DummyOrgConfig(
-        {"instance_url": "example.com", "access_token": "abc123"}, "test"
+        {"instance_url": "https://example.com", "access_token": "abc123"}, "test"
     )
     return task_class(project_config, task_config, org_config)
 

--- a/cumulusci/tasks/tests/test_salesforce.py
+++ b/cumulusci/tasks/tests/test_salesforce.py
@@ -36,9 +36,9 @@ class TestSalesforceToolingTask(unittest.TestCase):
 
         self.task_config = TaskConfig()
         self.org_config = OrgConfig(
-            {"instance_url": "example.com", "access_token": "abc123"}, "test"
+            {"instance_url": "https://example.com", "access_token": "abc123"}, "test"
         )
-        self.base_tooling_url = "https://{}/services/data/v{}/tooling/".format(
+        self.base_tooling_url = "{}/services/data/v{}/tooling/".format(
             self.org_config.instance_url, self.api_version
         )
 


### PR DESCRIPTION
# Critical Changes

# Changes
* Fixed a bug where using the Salesforce REST API did not work if the `instance_url` was configured with a trailing slash.

# Issues Closed
