### PR TITLE
Retry Create Webdriver on connection reset

### DIFF
--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -1,15 +1,22 @@
 import logging
 import re
+import socket
 import time
 from robot.libraries.BuiltIn import BuiltIn
 from selenium.webdriver.common.keys import Keys
-from simple_salesforce import SalesforceMalformedRequest
 from simple_salesforce import SalesforceResourceNotFound
 from cumulusci.robotframework.locators import lex_locators
 from cumulusci.robotframework.utils import selenium_retry
 from SeleniumLibrary.errors import ElementNotFound
 
 OID_REGEX = r"^[a-zA-Z0-9]{15,18}$"
+
+try:
+    ConnectionResetError
+except NameError:
+    SOCKET_ERRORS = (socket.error,)
+else:
+    SOCKET_ERRORS = (socket.error, ConnectionResetError)
 
 
 @selenium_retry
@@ -31,6 +38,13 @@ class Salesforce(object):
     @property
     def cumulusci(self):
         return self.builtin.get_library_instance("cumulusci.robotframework.CumulusCI")
+
+    def create_webdriver_with_retry(self, *args, **kwargs):
+        """Call the Create Webdriver keyword and retry on socket errors."""
+        try:
+            return self.selenium.create_webdriver(*args, **kwargs)
+        except SOCKET_ERRORS:
+            return self.selenium.create_webdriver(*args, **kwargs)
 
     def click_modal_button(self, title):
         """Clicks a button in a Lightning modal."""

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -41,10 +41,12 @@ class Salesforce(object):
 
     def create_webdriver_with_retry(self, *args, **kwargs):
         """Call the Create Webdriver keyword and retry on socket errors."""
+        # Get selenium without referencing selenium.driver which doesn't exist yet
+        selenium = self.builtin.get_library_instance("SeleniumLibrary")
         try:
-            return self.selenium.create_webdriver(*args, **kwargs)
+            return selenium.create_webdriver(*args, **kwargs)
         except SOCKET_ERRORS:
-            return self.selenium.create_webdriver(*args, **kwargs)
+            return selenium.create_webdriver(*args, **kwargs)
 
     def click_modal_button(self, title):
         """Clicks a button in a Lightning modal."""

--- a/cumulusci/robotframework/Salesforce.robot
+++ b/cumulusci/robotframework/Salesforce.robot
@@ -49,7 +49,7 @@ Open Test Browser
 Open Test Browser Chrome
     [Arguments]     ${login_url}
     ${options} =                Get Chrome Options
-    Create Webdriver            Chrome  options=${options}
+    Create Webdriver With Retry  Chrome  options=${options}
     Set Selenium Implicit Wait  ${IMPLICIT_WAIT}
     Set Selenium Timeout        ${TIMEOUT}
     Go To                       ${login_url}


### PR DESCRIPTION
# Critical Changes

# Changes
* Robot Framework: Retry when there is a connection reset while opening the browser (probably due to delays in custom domain propagation). Due to a selenium bug, this was already retried in Python 2 but not in Python 3.

# Issues Closed
