### PR TITLE
Make sure Login Url can be resolved before continuing

### DIFF
--- a/cumulusci/robotframework/CumulusCI.py
+++ b/cumulusci/robotframework/CumulusCI.py
@@ -1,4 +1,9 @@
+from future import standard_library
+
+standard_library.install_aliases()
+from urllib.parse import urlparse
 import logging
+import socket
 
 from robot.api import logger
 from robot.libraries.BuiltIn import BuiltIn
@@ -112,7 +117,13 @@ class CumulusCI(object):
             org = self.org
         else:
             org = self.keychain.get_org(org)
-        return org.start_url
+        url = org.start_url
+
+        # Wait until the domain can be resolved
+        # (socket.getaddrinfo has no timeout)
+        socket.getaddrinfo(urlparse(url).hostname, None)
+
+        return url
 
     def get_namespace_prefix(self, package=None):
         """ Returns the namespace prefix (including __) for the specified package name.

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -7,7 +7,6 @@ from simple_salesforce import SalesforceResourceNotFound
 from cumulusci.robotframework.locators import lex_locators
 from cumulusci.robotframework.utils import selenium_retry
 from SeleniumLibrary.errors import ElementNotFound
-from urllib3.exceptions import ProtocolError
 
 OID_REGEX = r"^[a-zA-Z0-9]{15,18}$"
 
@@ -31,18 +30,6 @@ class Salesforce(object):
     @property
     def cumulusci(self):
         return self.builtin.get_library_instance("cumulusci.robotframework.CumulusCI")
-
-    def create_webdriver_with_retry(self, *args, **kwargs):
-        """Call the Create Webdriver keyword.
-
-        Retry on connection resets which can happen if custom domain propagation is slow.
-        """
-        # Get selenium without referencing selenium.driver which doesn't exist yet
-        selenium = self.builtin.get_library_instance("SeleniumLibrary")
-        try:
-            return selenium.create_webdriver(*args, **kwargs)
-        except ProtocolError:
-            return selenium.create_webdriver(*args, **kwargs)
 
     def click_modal_button(self, title):
         """Clicks a button in a Lightning modal."""

--- a/cumulusci/robotframework/Salesforce.robot
+++ b/cumulusci/robotframework/Salesforce.robot
@@ -49,7 +49,7 @@ Open Test Browser
 Open Test Browser Chrome
     [Arguments]     ${login_url}
     ${options} =                Get Chrome Options
-    Create Webdriver With Retry  Chrome  options=${options}
+    Create Webdriver            Chrome  options=${options}
     Set Selenium Implicit Wait  ${IMPLICIT_WAIT}
     Set Selenium Timeout        ${TIMEOUT}
     Go To                       ${login_url}


### PR DESCRIPTION
I think this'll work out as a cleaner way to avoid the ConnectionResetErrors we've been seeing. In Python 2 selenium would do this after catching the ConnectionResetError, but in Python 3 the exception is not caught because it is no longer a subclass of socket.error. My theory is that the ConnectionResetError is a consequence of the DNS delays so this may help. But it's possible we'll still need to explicitly catch ProtocolError (which urllib3 wraps around the ConnectionResetError).

# Critical Changes

# Changes
* Robot Framework: Make sure org domain can be resolved before trying to connect.

# Issues Closed
