### PR TITLE
Record dependencies in the release tag message when creating a github release

### DIFF
--- a/cumulusci/core/config/BaseProjectConfig.py
+++ b/cumulusci/core/config/BaseProjectConfig.py
@@ -518,10 +518,7 @@ class BaseProjectConfig(BaseTaskFlowConfig):
                         continue
                     value = "\n{}".format(" " * (indent + 4))
 
-                if key == "repo":
-                    pretty.append("{}{}: {}".format(prefix, key, value.full_name))
-                else:
-                    pretty.append("{}{}: {}".format(prefix, key, value))
+                pretty.append("{}{}: {}".format(prefix, key, value))
                 if extra:
                     pretty.extend(extra)
                 prefix = "{}    ".format(" " * indent)
@@ -582,7 +579,8 @@ class BaseProjectConfig(BaseTaskFlowConfig):
 
                 unpackaged_pre.append(
                     {
-                        "repo": repo,
+                        "repo_owner": repo_owner,
+                        "repo_name": repo_name,
                         "ref": tag,
                         "subfolder": subfolder,
                         "unmanaged": dependency.get("unmanaged"),
@@ -600,7 +598,8 @@ class BaseProjectConfig(BaseTaskFlowConfig):
                 subfolder = "src"
 
                 unmanaged_src = {
-                    "repo": repo,
+                    "repo_owner": repo_owner,
+                    "repo_name": repo_name,
                     "ref": tag,
                     "subfolder": subfolder,
                     "unmanaged": dependency.get("unmanaged"),
@@ -624,7 +623,8 @@ class BaseProjectConfig(BaseTaskFlowConfig):
                     continue
 
                 dependency = {
-                    "repo": repo,
+                    "repo_owner": repo_owner,
+                    "repo_name": repo_name,
                     "ref": tag,
                     "subfolder": subfolder,
                     "unmanaged": dependency.get("unmanaged"),

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -437,19 +437,18 @@ class TestBaseProjectConfig(unittest.TestCase):
         self.assertIsNone(config.get_static_dependencies())
 
     def test_pretty_dependencies(self):
-        repo = mock.Mock(full_name="TestRepo")
         dep = {
             "namespace": "npsp",
             "version": "3",
             "boolean": False,
-            "dependencies": [{"repo": repo, "dependencies": []}],
+            "dependencies": [{"repo_name": "TestRepo", "dependencies": []}],
         }
         config = BaseProjectConfig(BaseGlobalConfig())
         result = "\n".join(config.pretty_dependencies([dep]))
         self.assertEqual(
             """  - dependencies: 
     
-      - repo: TestRepo
+      - repo_name: TestRepo
     namespace: npsp
     version: 3""",
             result,
@@ -472,7 +471,8 @@ class TestBaseProjectConfig(unittest.TestCase):
             result,
             [
                 {
-                    u"repo": CUMULUSCI_TEST_REPO,
+                    u"repo_owner": "SFDO-Tooling",
+                    u"repo_name": "CumulusCI-Test",
                     u"ref": None,
                     u"subfolder": u"unpackaged/pre/pre",
                     u"unmanaged": True,
@@ -482,7 +482,8 @@ class TestBaseProjectConfig(unittest.TestCase):
                 },
                 {u"version": "2", u"namespace": "ccitestdep"},
                 {
-                    u"repo": CUMULUSCI_TEST_REPO,
+                    u"repo_owner": "SFDO-Tooling",
+                    u"repo_name": "CumulusCI-Test",
                     u"ref": None,
                     u"subfolder": u"src",
                     u"unmanaged": True,
@@ -491,7 +492,8 @@ class TestBaseProjectConfig(unittest.TestCase):
                     u"namespace_tokenize": None,
                 },
                 {
-                    u"repo": CUMULUSCI_TEST_REPO,
+                    u"repo_owner": "SFDO-Tooling",
+                    u"repo_name": "CumulusCI-Test",
                     u"ref": None,
                     u"subfolder": u"unpackaged/post/post",
                     u"unmanaged": True,
@@ -546,7 +548,8 @@ class TestBaseProjectConfig(unittest.TestCase):
             result,
             [
                 {
-                    u"repo": CUMULUSCI_TEST_REPO,
+                    u"repo_owner": "SFDO-Tooling",
+                    u"repo_name": "CumulusCI-Test",
                     u"ref": None,
                     u"subfolder": u"unpackaged/pre/pre",
                     u"unmanaged": True,
@@ -556,7 +559,8 @@ class TestBaseProjectConfig(unittest.TestCase):
                 },
                 {u"version": "1.1 (Beta 1)", u"namespace": "ccitestdep"},
                 {
-                    u"repo": CUMULUSCI_TEST_REPO,
+                    u"repo_owner": "SFDO-Tooling",
+                    u"repo_name": "CumulusCI-Test",
                     u"ref": None,
                     u"subfolder": u"src",
                     u"unmanaged": True,
@@ -565,7 +569,8 @@ class TestBaseProjectConfig(unittest.TestCase):
                     u"namespace_tokenize": None,
                 },
                 {
-                    u"repo": CUMULUSCI_TEST_REPO,
+                    u"repo_owner": "SFDO-Tooling",
+                    u"repo_name": "CumulusCI-Test",
                     u"ref": None,
                     u"subfolder": u"unpackaged/post/post",
                     u"unmanaged": True,

--- a/cumulusci/tasks/github/tests/test_release.py
+++ b/cumulusci/tasks/github/tests/test_release.py
@@ -68,10 +68,25 @@ class TestCreateRelease(unittest.TestCase, GithubApiTestMixin):
         )
 
         task = CreateRelease(
-            self.project_config, TaskConfig({"options": {"version": "1.0"}})
+            self.project_config,
+            TaskConfig(
+                {
+                    "options": {
+                        "version": "1.0",
+                        "dependencies": [{"namespace": "foo", "version": "1.0"}],
+                    }
+                }
+            ),
         )
         task()
-        self.assertEqual({"tag_name": "release/1.0", "name": "1.0"}, task.return_values)
+        self.assertEqual(
+            {
+                "tag_name": "release/1.0",
+                "name": "1.0",
+                "dependencies": [{"namespace": "foo", "version": "1.0"}],
+            },
+            task.return_values,
+        )
 
     @responses.activate
     def test_run_task__release_already_exists(self):

--- a/cumulusci/tasks/salesforce/UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/UpdateDependencies.py
@@ -183,7 +183,7 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
             self._install_dependency(dependency)
 
     def _install_dependency(self, dependency):
-        if "zip_url" or "repo" in dependency:
+        if "zip_url" or "repo_name" in dependency:
             package_zip = None
             if "zip_url" in dependency:
                 self.logger.info(
@@ -194,14 +194,18 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
                 package_zip = download_extract_zip(
                     dependency["zip_url"], subfolder=dependency.get("subfolder")
                 )
-            elif "repo" in dependency:
+            elif "repo_name" in dependency:
                 self.logger.info(
-                    "Deploying unmanaged metadata from /{} of {}".format(
-                        dependency["subfolder"], dependency["repo"].full_name
+                    "Deploying unmanaged metadata from /{} of {}/{}".format(
+                        dependency["subfolder"],
+                        dependency["repo_owner"],
+                        dependency["repo_name"],
                     )
                 )
                 package_zip = download_extract_github(
-                    dependency["repo"],
+                    self.project_config.get_github_api(),
+                    dependency["repo_owner"],
+                    dependency["repo_name"],
                     dependency["subfolder"],
                     ref=dependency.get("ref"),
                 )

--- a/cumulusci/tests/test_utils.py
+++ b/cumulusci/tests/test_utils.py
@@ -180,13 +180,15 @@ class TestUtils(unittest.TestCase):
         f.seek(0)
         zipbytes = f.read()
         mock_repo = mock.Mock(default_branch="master")
+        mock_github = mock.Mock()
+        mock_github.repository.return_value = mock_repo
 
         def assign_bytes(archive_type, zip_content, ref=None):
             zip_content.write(zipbytes)
 
         mock_archive = mock.Mock(return_value=True, side_effect=assign_bytes)
         mock_repo.archive = mock_archive
-        zf = utils.download_extract_github(mock_repo, "src")
+        zf = utils.download_extract_github(mock_github, "TestOwner", "TestRepo", "src")
         result = zf.read("test")
         self.assertEqual(b"test", result)
 

--- a/cumulusci/utils.py
+++ b/cumulusci/utils.py
@@ -148,7 +148,8 @@ def download_extract_zip(url, target=None, subfolder=None, headers=None):
     return zip_file
 
 
-def download_extract_github(github_repo, subfolder, ref=None):
+def download_extract_github(github_api, repo_owner, repo_name, subfolder, ref=None):
+    github_repo = github_api.repository(repo_owner, repo_name)
     if not ref:
         ref = github_repo.default_branch
     zip_content = io.BytesIO()


### PR DESCRIPTION
Also includes some minor refactoring to make sure that `get_static_dependencies` returns something that is JSON-serializable.


# Critical Changes

# Changes
* The `github_release` task now records the release dependencies as JSON in the release's tag message.

# Issues Closed
