### PR TITLE
Fixes for MetaDeploy publishing

### DIFF
--- a/cumulusci/core/config/BaseProjectConfig.py
+++ b/cumulusci/core/config/BaseProjectConfig.py
@@ -389,12 +389,14 @@ class BaseProjectConfig(BaseTaskFlowConfig):
         gh = get_github_api(github_config.username, github_config.password)
         return gh
 
-    def get_latest_version(self, beta=False):
+    def get_latest_version(self, beta=False, tag=False):
         """ Query Github Releases to find the latest production or beta release """
         gh = self.get_github_api()
         repo = gh.repository(self.repo_owner, self.repo_name)
         if not beta:
             release = repo.latest_release()
+            if tag:
+                return release.tag_name
             version = self.get_version_for_tag(release.tag_name)
             if version is not None:
                 return LooseVersion(version)
@@ -402,6 +404,8 @@ class BaseProjectConfig(BaseTaskFlowConfig):
             for release in repo.releases():
                 if not release.tag_name.startswith(self.project__git__prefix_beta):
                     continue
+                if tag:
+                    return release.tag_name
                 version = self.get_version_for_tag(release.tag_name)
                 if version is None:
                     continue

--- a/cumulusci/tasks/metadeploy.py
+++ b/cumulusci/tasks/metadeploy.py
@@ -19,6 +19,8 @@ class BaseMetaDeployTask(BaseTask):
         results = []
         while next_url is not None:
             response = self.api.request(method, next_url, **kwargs)
+            if response.status_code == 400:
+                raise requests.exceptions.HTTPError(response.content)
             response.raise_for_status()
             response = response.json()
             if "links" in response and collect_pages:


### PR DESCRIPTION
# Critical Changes

# Changes
* Added boolean arg `tag` to `get_latest_version` to allow returning the tag instead of the version
* `update_admin_profile` task now properly handles the default value for `package_xml` during freeze
* `metadeploy.Publish` task now raises a more helpful exception on HTTP400 that includes the response content showing what the issue was

# Issues Closed
