### PR TITLE
S-Controls are deletable now

### DIFF
--- a/cumulusci/tasks/salesforce/UninstallPackagedIncremental.py
+++ b/cumulusci/tasks/salesforce/UninstallPackagedIncremental.py
@@ -11,7 +11,7 @@ from cumulusci.utils import temporary_dir
 
 class UninstallPackagedIncremental(UninstallPackaged):
     name = "UninstallPackagedIncremental"
-    skip_types = ["RecordType", "Scontrol"]
+    skip_types = ["RecordType"]
     task_options = {
         "path": {
             "description": "The local path to compare to the retrieved packaged metadata from the org.  Defaults to src",


### PR DESCRIPTION
# Critical Changes

# Changes
* The uninstall_packaged_incremental task will now delete S-Controls that are no longer in the repository.

# Issues Closed
