### PR TITLE
Handle publishing a different tag than what is currently checked out

### DIFF
--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -133,6 +133,11 @@ class DummyRepository(object):
             if release.tag_name.startswith("release/"):
                 return release
 
+    def branch(self, name):
+        branch = mock.Mock()
+        branch.commit.sha = "sha"
+        return branch
+
 
 class DummyRelease(object):
     def __init__(self, tag_name, name=None):
@@ -527,7 +532,7 @@ class TestBaseProjectConfig(unittest.TestCase):
                 {
                     u"repo_owner": "SFDO-Tooling",
                     u"repo_name": "CumulusCI-Test",
-                    u"ref": None,
+                    u"ref": "sha",
                     u"subfolder": u"unpackaged/pre/pre",
                     u"unmanaged": True,
                     u"namespace_inject": None,
@@ -538,7 +543,7 @@ class TestBaseProjectConfig(unittest.TestCase):
                 {
                     u"repo_owner": "SFDO-Tooling",
                     u"repo_name": "CumulusCI-Test",
-                    u"ref": None,
+                    u"ref": "sha",
                     u"subfolder": u"src",
                     u"unmanaged": True,
                     u"namespace_inject": None,
@@ -548,7 +553,7 @@ class TestBaseProjectConfig(unittest.TestCase):
                 {
                     u"repo_owner": "SFDO-Tooling",
                     u"repo_name": "CumulusCI-Test",
-                    u"ref": None,
+                    u"ref": "sha",
                     u"subfolder": u"unpackaged/post/post",
                     u"unmanaged": True,
                     u"namespace_inject": "ccitest",
@@ -579,7 +584,7 @@ class TestBaseProjectConfig(unittest.TestCase):
                 {
                     u"repo_owner": "SFDO-Tooling",
                     u"repo_name": "CumulusCI-Test",
-                    u"ref": None,
+                    u"ref": "sha",
                     u"subfolder": u"src",
                     u"unmanaged": True,
                     u"namespace_inject": None,
@@ -636,7 +641,7 @@ class TestBaseProjectConfig(unittest.TestCase):
                 {
                     u"repo_owner": "SFDO-Tooling",
                     u"repo_name": "CumulusCI-Test",
-                    u"ref": None,
+                    u"ref": "sha",
                     u"subfolder": u"unpackaged/pre/pre",
                     u"unmanaged": True,
                     u"namespace_inject": None,
@@ -647,7 +652,7 @@ class TestBaseProjectConfig(unittest.TestCase):
                 {
                     u"repo_owner": "SFDO-Tooling",
                     u"repo_name": "CumulusCI-Test",
-                    u"ref": None,
+                    u"ref": "sha",
                     u"subfolder": u"src",
                     u"unmanaged": True,
                     u"namespace_inject": None,
@@ -657,7 +662,7 @@ class TestBaseProjectConfig(unittest.TestCase):
                 {
                     u"repo_owner": "SFDO-Tooling",
                     u"repo_name": "CumulusCI-Test",
-                    u"ref": None,
+                    u"ref": "sha",
                     u"subfolder": u"unpackaged/post/post",
                     u"unmanaged": True,
                     u"namespace_inject": "ccitest",

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -101,7 +101,7 @@ class DummyRepository(object):
         self.name = name
         self.html_url = "https://github.com/{}/{}".format(owner, name)
         self._contents = contents
-        self._releases = releases
+        self._releases = releases or []
 
     def file_contents(self, path, **kw):
         try:
@@ -120,11 +120,6 @@ class DummyRepository(object):
     def _build_url(self, *args, **kw):
         return self._api
 
-    def _get(self, url):
-        res = mock.Mock()
-        res.json.return_value = {"name": "2"}
-        return res
-
     def releases(self):
         return iter(self._releases)
 
@@ -133,10 +128,26 @@ class DummyRepository(object):
             if release.tag_name.startswith("release/"):
                 return release
 
+    def release_from_tag(self, tag_name):
+        for release in self._releases:
+            if release.tag_name == tag_name:
+                return release
+        raise NotFoundError(DummyResponse("", 404))
+
     def branch(self, name):
         branch = mock.Mock()
-        branch.commit.sha = "sha"
+        branch.commit.sha = "commit_sha"
         return branch
+
+    def tag(self, sha):
+        tag = mock.Mock()
+        tag.object.sha = "tag_sha"
+        return tag
+
+    def ref(self, s):
+        ref = mock.Mock()
+        ref.object.sha = "ref_sha"
+        return ref
 
 
 class DummyRelease(object):
@@ -212,6 +223,7 @@ class TestBaseProjectConfig(unittest.TestCase):
                 "src": {},
                 "unpackaged/post": {},
             },
+            [DummyRelease("release/2.0", "2.0")],
         )
 
         CUMULUSCI_REPO = DummyRepository(
@@ -219,10 +231,10 @@ class TestBaseProjectConfig(unittest.TestCase):
             "CumulusCI",
             {},
             [
-                DummyRelease("release/1.0"),
-                DummyRelease("beta-wrongprefix"),
-                DummyRelease("beta/1.0-Beta_2"),
-                DummyRelease("beta/1.0-Beta_1"),
+                DummyRelease("release/1.0", "1.0"),
+                DummyRelease("beta-wrongprefix", "wrong"),
+                DummyRelease("beta/1.0-Beta_2", "1.0 (Beta 2)"),
+                DummyRelease("beta/1.0-Beta_1", "1.0 (Beta 1)"),
             ],
         )
 
@@ -532,18 +544,18 @@ class TestBaseProjectConfig(unittest.TestCase):
                 {
                     u"repo_owner": "SFDO-Tooling",
                     u"repo_name": "CumulusCI-Test",
-                    u"ref": "sha",
+                    u"ref": "commit_sha",
                     u"subfolder": u"unpackaged/pre/pre",
                     u"unmanaged": True,
                     u"namespace_inject": None,
                     u"namespace_strip": None,
                     u"namespace_tokenize": None,
                 },
-                {u"version": "2", u"namespace": "ccitestdep"},
+                {u"version": "2.0", u"namespace": "ccitestdep"},
                 {
                     u"repo_owner": "SFDO-Tooling",
                     u"repo_name": "CumulusCI-Test",
-                    u"ref": "sha",
+                    u"ref": "commit_sha",
                     u"subfolder": u"src",
                     u"unmanaged": True,
                     u"namespace_inject": None,
@@ -553,7 +565,7 @@ class TestBaseProjectConfig(unittest.TestCase):
                 {
                     u"repo_owner": "SFDO-Tooling",
                     u"repo_name": "CumulusCI-Test",
-                    u"ref": "sha",
+                    u"ref": "commit_sha",
                     u"subfolder": u"unpackaged/post/post",
                     u"unmanaged": True,
                     u"namespace_inject": "ccitest",
@@ -580,11 +592,11 @@ class TestBaseProjectConfig(unittest.TestCase):
         self.assertEqual(
             result,
             [
-                {u"version": "2", u"namespace": "ccitestdep"},
+                {u"version": "2.0", u"namespace": "ccitestdep"},
                 {
                     u"repo_owner": "SFDO-Tooling",
                     u"repo_name": "CumulusCI-Test",
-                    u"ref": "sha",
+                    u"ref": "commit_sha",
                     u"subfolder": u"src",
                     u"unmanaged": True,
                     u"namespace_inject": None,
@@ -597,7 +609,11 @@ class TestBaseProjectConfig(unittest.TestCase):
     def test_process_github_dependency_with_tag(self):
         global_config = BaseGlobalConfig()
         config = BaseProjectConfig(global_config)
-        config.get_github_api = mock.Mock(return_value=self._make_github())
+        github = self._make_github()
+        github.repositories["CumulusCI-Test"]._releases = [
+            DummyRelease("release/1.0", "1.0")
+        ]
+        config.get_github_api = mock.Mock(return_value=github)
         config.keychain = DummyKeychain()
 
         result = config.process_github_dependency(
@@ -610,7 +626,7 @@ class TestBaseProjectConfig(unittest.TestCase):
             {
                 "namespace": "ccitest",
                 "version": "1.0",
-                "dependencies": [{"namespace": "ccitestdep", "version": "2"}],
+                "dependencies": [{"namespace": "ccitestdep", "version": "2.0"}],
             },
             result,
         )
@@ -622,7 +638,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         github = self._make_github()
         github.repositories["CumulusCI-Test-Dep"]._releases = [
             DummyRelease("beta/1.1-Beta_1", "1.1 (Beta 1)"),
-            DummyRelease("release/1.0"),
+            DummyRelease("release/1.0", "1.0"),
         ]
         config.get_github_api = mock.Mock(return_value=github)
 
@@ -641,7 +657,7 @@ class TestBaseProjectConfig(unittest.TestCase):
                 {
                     u"repo_owner": "SFDO-Tooling",
                     u"repo_name": "CumulusCI-Test",
-                    u"ref": "sha",
+                    u"ref": "commit_sha",
                     u"subfolder": u"unpackaged/pre/pre",
                     u"unmanaged": True,
                     u"namespace_inject": None,
@@ -652,7 +668,7 @@ class TestBaseProjectConfig(unittest.TestCase):
                 {
                     u"repo_owner": "SFDO-Tooling",
                     u"repo_name": "CumulusCI-Test",
-                    u"ref": "sha",
+                    u"ref": "commit_sha",
                     u"subfolder": u"src",
                     u"unmanaged": True,
                     u"namespace_inject": None,
@@ -662,7 +678,59 @@ class TestBaseProjectConfig(unittest.TestCase):
                 {
                     u"repo_owner": "SFDO-Tooling",
                     u"repo_name": "CumulusCI-Test",
-                    u"ref": "sha",
+                    u"ref": "commit_sha",
+                    u"subfolder": u"unpackaged/post/post",
+                    u"unmanaged": True,
+                    u"namespace_inject": "ccitest",
+                    u"namespace_strip": None,
+                    u"namespace_tokenize": None,
+                },
+            ],
+        )
+
+    def test_process_github_dependency_ref(self):
+        global_config = BaseGlobalConfig()
+        config = BaseProjectConfig(global_config)
+        config.keychain = DummyKeychain()
+        config.get_github_api = mock.Mock(return_value=self._make_github())
+
+        result = config.process_github_dependency(
+            {
+                "github": "https://github.com/SFDO-Tooling/CumulusCI-Test.git",
+                "unmanaged": True,
+                "ref": "other_commit_sha",
+                "skip": ["unpackaged/pre/skip", "unpackaged/post/skip"],
+            },
+            "",
+        )
+        self.assertEqual(
+            result,
+            [
+                {
+                    u"repo_owner": "SFDO-Tooling",
+                    u"repo_name": "CumulusCI-Test",
+                    u"ref": "other_commit_sha",
+                    u"subfolder": u"unpackaged/pre/pre",
+                    u"unmanaged": True,
+                    u"namespace_inject": None,
+                    u"namespace_strip": None,
+                    u"namespace_tokenize": None,
+                },
+                {u"version": "2.0", u"namespace": "ccitestdep"},
+                {
+                    u"repo_owner": "SFDO-Tooling",
+                    u"repo_name": "CumulusCI-Test",
+                    u"ref": "other_commit_sha",
+                    u"subfolder": u"src",
+                    u"unmanaged": True,
+                    u"namespace_inject": None,
+                    u"namespace_strip": None,
+                    u"namespace_tokenize": None,
+                },
+                {
+                    u"repo_owner": "SFDO-Tooling",
+                    u"repo_name": "CumulusCI-Test",
+                    u"ref": "other_commit_sha",
                     u"subfolder": u"unpackaged/post/post",
                     u"unmanaged": True,
                     u"namespace_inject": "ccitest",
@@ -677,14 +745,26 @@ class TestBaseProjectConfig(unittest.TestCase):
         config = BaseProjectConfig(global_config)
         config.keychain = DummyKeychain()
         github = self._make_github()
-        github.repositories["CumulusCI-Test-Dep"]._get = mock.Mock(
-            side_effect=Exception
-        )
+        github.repositories["CumulusCI-Test-Dep"]._releases = []
         config.get_github_api = mock.Mock(return_value=github)
 
         with self.assertRaises(DependencyResolutionError):
             config.process_github_dependency(
                 {"github": "https://github.com/SFDO-Tooling/CumulusCI-Test-Dep.git"}
+            )
+
+    def test_process_github_dependency_tag_not_found(self):
+        global_config = BaseGlobalConfig()
+        config = BaseProjectConfig(global_config)
+        config.keychain = DummyKeychain()
+        config.get_github_api = mock.Mock(return_value=self._make_github())
+
+        with self.assertRaises(DependencyResolutionError):
+            config.process_github_dependency(
+                {
+                    "github": "https://github.com/SFDO-Tooling/CumulusCI-Test-Dep.git",
+                    "tag": "bogus",
+                }
             )
 
 

--- a/cumulusci/core/utils.py
+++ b/cumulusci/core/utils.py
@@ -12,6 +12,7 @@ from past.builtins import basestring
 from future.utils import native_str
 
 from datetime import datetime
+import copy
 import pytz
 import time
 import yaml
@@ -130,7 +131,7 @@ def dictmerge(a, b, name=None):
                     if key in a:
                         a[key] = dictmerge(a[key], b[key], name)
                     else:
-                        a[key] = b[key]
+                        a[key] = copy.copy(b[key])
             else:
                 raise TypeError(
                     'Cannot merge non-dict of type "{}" into dict "{}"'.format(

--- a/cumulusci/tasks/metadeploy.py
+++ b/cumulusci/tasks/metadeploy.py
@@ -1,8 +1,12 @@
+import json
 import requests
 
+from cumulusci.core.config import BaseProjectConfig
 from cumulusci.core.config import TaskConfig
 from cumulusci.core.tasks import BaseTask
 from cumulusci.core.flowrunner import FlowCoordinator
+from cumulusci.utils import download_extract_github
+from cumulusci.utils import temporary_dir
 
 
 class BaseMetaDeployTask(BaseTask):
@@ -67,12 +71,41 @@ class Publish(BaseMetaDeployTask):
 
     def _run_task(self):
         tag = self.options["tag"]
-        label = self.project_config.get_version_for_tag(tag)
-        # @@@ handle checkout/publish from a release tag instead of current commit
-        steps = self._freeze_steps()
 
+        repo_owner = self.project_config.repo_owner
+        repo_name = self.project_config.repo_name
+        gh = self.project_config.get_github_api()
+        repo = gh.repository(repo_owner, repo_name)
+        commit_sha = repo.ref("tags/{}".format(tag)).object.sha
+        self.logger.info(
+            "Downloading commit {} of {}/{} from GitHub".format(
+                commit_sha, repo_owner, repo_name
+            )
+        )
+        zf = download_extract_github(gh, repo_owner, repo_name, ref=commit_sha)
+        with temporary_dir() as project_dir:
+            zf.extractall(project_dir)
+            project_config = BaseProjectConfig(
+                self.project_config.global_config_obj,
+                repo_info={
+                    "root": project_dir,
+                    "owner": repo_owner,
+                    "name": repo_name,
+                    "url": self.project_config.repo_url,
+                    "branch": tag,
+                    "commit": commit_sha,
+                },
+            )
+            project_config.set_keychain(self.project_config.keychain)
+            steps = self._freeze_steps(project_config)
+        self.logger.debug("Publishing steps:\n", json.dumps(steps, indent=4))
+
+        import pdb
+
+        pdb.set_trace()
         # create version (not listed yet)
         product_url = self.base_url + "/products/{}".format(self.options["product_id"])
+        label = self.project_config.get_version_for_tag(tag)
         version = self._call_api(
             "POST",
             "/versions",
@@ -115,16 +148,15 @@ class Publish(BaseMetaDeployTask):
             "PATCH", "/versions/{}".format(version["id"]), json={"is_listed": True}
         )
         self.logger.info("Published Version {}".format(version["url"]))
-        # @@@ link to metadeploy frontend
 
-    def _freeze_steps(self):
+    def _freeze_steps(self, project_config):
         flow_name = self.options["flow"]
         flow_config = self.project_config.get_flow(flow_name)
         flow = FlowCoordinator(self.project_config, flow_config, name=flow_name)
         steps = []
         for step in flow.steps:
             task = step.task_class(
-                self.project_config, TaskConfig(step.task_config), name=step.task_name
+                project_config, TaskConfig(step.task_config), name=step.task_name
             )
             steps.extend(task.freeze(step))
         return steps

--- a/cumulusci/tasks/metadeploy.py
+++ b/cumulusci/tasks/metadeploy.py
@@ -76,7 +76,7 @@ class Publish(BaseMetaDeployTask):
         repo_name = self.project_config.repo_name
         gh = self.project_config.get_github_api()
         repo = gh.repository(repo_owner, repo_name)
-        commit_sha = repo.ref("tags/{}".format(tag)).object.sha
+        commit_sha = repo.tag(repo.ref("tags/" + tag).object.sha).object.sha
         self.logger.info(
             "Downloading commit {} of {}/{} from GitHub".format(
                 commit_sha, repo_owner, repo_name
@@ -98,11 +98,8 @@ class Publish(BaseMetaDeployTask):
             )
             project_config.set_keychain(self.project_config.keychain)
             steps = self._freeze_steps(project_config)
-        self.logger.debug("Publishing steps:\n", json.dumps(steps, indent=4))
+        self.logger.debug("Publishing steps:\n" + json.dumps(steps, indent=4))
 
-        import pdb
-
-        pdb.set_trace()
         # create version (not listed yet)
         product_url = self.base_url + "/products/{}".format(self.options["product_id"])
         label = self.project_config.get_version_for_tag(tag)
@@ -151,8 +148,8 @@ class Publish(BaseMetaDeployTask):
 
     def _freeze_steps(self, project_config):
         flow_name = self.options["flow"]
-        flow_config = self.project_config.get_flow(flow_name)
-        flow = FlowCoordinator(self.project_config, flow_config, name=flow_name)
+        flow_config = project_config.get_flow(flow_name)
+        flow = FlowCoordinator(project_config, flow_config, name=flow_name)
         steps = []
         for step in flow.steps:
             task = step.task_class(

--- a/cumulusci/tasks/salesforce/DeployBundles.py
+++ b/cumulusci/tasks/salesforce/DeployBundles.py
@@ -52,7 +52,7 @@ class DeployBundles(Deploy):
                 {
                     "repo_owner": self.project_config.repo_owner,
                     "repo_name": self.project_config.repo_name,
-                    "tag": self.project_config.repo_commit,
+                    "ref": self.project_config.repo_commit,
                     "subfolder": "/".join([path, item]),
                 }
             )

--- a/cumulusci/utils.py
+++ b/cumulusci/utils.py
@@ -148,16 +148,19 @@ def download_extract_zip(url, target=None, subfolder=None, headers=None):
     return zip_file
 
 
-def download_extract_github(github_api, repo_owner, repo_name, subfolder, ref=None):
+def download_extract_github(
+    github_api, repo_owner, repo_name, subfolder=None, ref=None
+):
     github_repo = github_api.repository(repo_owner, repo_name)
     if not ref:
         ref = github_repo.default_branch
     zip_content = io.BytesIO()
     github_repo.archive("zipball", zip_content, ref=ref)
     zip_file = zipfile.ZipFile(zip_content)
-    root_folder = sorted(zip_file.namelist())[0]
-    subfolder_dir = root_folder + subfolder
-    zip_file = zip_subfolder(zip_file, subfolder_dir)
+    path = sorted(zip_file.namelist())[0]
+    if subfolder:
+        path = path + subfolder
+    zip_file = zip_subfolder(zip_file, path)
     return zip_file
 
 


### PR DESCRIPTION
- This gives the metadeploy publishing task the ability to release a tag even if it's not what's currently checked out. The task fetches the archive for the specified tag into a temporary directory, constructs a project_config for it, and uses that to freeze the installation steps.
- Make get_static_dependencies return a specific commit ref for metadata bundles -- for the tag if specified, otherwise for the most recent release if there is one, otherwise for the head of master.

# Critical Changes

# Changes

# Issues Closed
