### PR TITLE
Allow cci service commands to be run from outside a project repository

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -577,10 +577,10 @@ def service_list(config):
     data = []
     services = (
         config.project_config.services
-        if not config.global_keychain
+        if not config.is_global_keychain
         else config.global_config.services
     )
-    for serv, schema in list(services.items()):
+    for serv, schema in services.items():
         is_configured = ""
         if serv in config.keychain.list_services():
             is_configured = "* "
@@ -595,7 +595,7 @@ class ConnectServiceCommand(click.MultiCommand):
     def _get_services_config(self, config):
         return (
             config.project_config.services
-            if not config.global_keychain
+            if not config.is_global_keychain
             else config.global_config.services
         )
 
@@ -612,13 +612,13 @@ class ConnectServiceCommand(click.MultiCommand):
     def get_command(self, ctx, name):
         config = load_config(**self.load_config_kwargs)
         services = self._get_services_config(config)
-        attributes = iter(list(services.get(name, {}).get("attributes").items()))
+        attributes = services.get(name, {}).get("attributes").items()
         params = [self._build_param(attr, cnfg) for attr, cnfg in attributes]
-        if config.global_keychain is False:
+        if not config.is_global_keychain:
             params.append(click.Option(("--project",), is_flag=True))
 
         def callback(*args, **kwargs):
-            if config.global_keychain:
+            if config.is_global_keychain:
                 project = False
             else:
                 project = kwargs.get("project", False)

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -191,12 +191,14 @@ def handle_sentry_event(config, no_prompt):
 TEST_CONFIG = None
 
 
-def load_config(load_project_config=True, load_keychain=True, allow_global_keychain=False):
+def load_config(
+    load_project_config=True, load_keychain=True, allow_global_keychain=False
+):
     try:
         config = TEST_CONFIG or CliConfig(
-            load_project_config = load_project_config,
-            load_keychain = load_keychain,
-            allow_global_keychain = allow_global_keychain,
+            load_project_config=load_project_config,
+            load_keychain=load_keychain,
+            allow_global_keychain=allow_global_keychain,
         )
         config.check_cumulusci_version()
     except click.UsageError as e:
@@ -575,7 +577,7 @@ def service_list(config):
     data = []
     services = (
         config.project_config.services
-        if not config.global_keychain 
+        if not config.global_keychain
         else config.global_config.services
     )
     for serv, schema in list(services.items()):
@@ -588,14 +590,12 @@ def service_list(config):
 
 
 class ConnectServiceCommand(click.MultiCommand):
-    load_config_kwargs = {
-        "allow_global_keychain": True,
-    }
+    load_config_kwargs = {"allow_global_keychain": True}
 
     def _get_services_config(self, config):
         return (
             config.project_config.services
-            if not config.global_keychain 
+            if not config.global_keychain
             else config.global_config.services
         )
 
@@ -612,11 +612,7 @@ class ConnectServiceCommand(click.MultiCommand):
     def get_command(self, ctx, name):
         config = load_config(**self.load_config_kwargs)
         services = self._get_services_config(config)
-        attributes = iter(
-            list(
-                services.get(name, {}).get("attributes").items()
-            )
-        )
+        attributes = iter(list(services.get(name, {}).get("attributes").items()))
         params = [self._build_param(attr, cnfg) for attr, cnfg in attributes]
         if config.global_keychain is False:
             params.append(click.Option(("--project",), is_flag=True))

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -191,10 +191,12 @@ def handle_sentry_event(config, no_prompt):
 TEST_CONFIG = None
 
 
-def load_config(load_project_config=True, load_keychain=True):
+def load_config(load_project_config=True, load_keychain=True, allow_global_keychain=False):
     try:
         config = TEST_CONFIG or CliConfig(
-            load_project_config=load_project_config, load_keychain=load_keychain
+            load_project_config = load_project_config,
+            load_keychain = load_keychain,
+            allow_global_keychain = allow_global_keychain,
         )
         config.check_cumulusci_version()
     except click.UsageError as e:
@@ -567,11 +569,16 @@ project.add_command(project_dependencies)
 
 
 @click.command(name="list", help="List services available for configuration and use")
-@pass_config
+@pass_config(allow_global_keychain=True)
 def service_list(config):
     headers = ["service", "description", "is_configured"]
     data = []
-    for serv, schema in list(config.project_config.services.items()):
+    services = (
+        config.project_config.services
+        if not config.global_keychain 
+        else config.global_config.services
+    )
+    for serv, schema in list(services.items()):
         is_configured = ""
         if serv in config.keychain.list_services():
             is_configured = "* "
@@ -581,29 +588,44 @@ def service_list(config):
 
 
 class ConnectServiceCommand(click.MultiCommand):
+    load_config_kwargs = {
+        "allow_global_keychain": True,
+    }
+
+    def _get_services_config(self, config):
+        return (
+            config.project_config.services
+            if not config.global_keychain 
+            else config.global_config.services
+        )
+
     def list_commands(self, ctx):
         """ list the services that can be configured """
-        config = load_config()
-        return sorted(config.project_config.services.keys())
+        config = load_config(**self.load_config_kwargs)
+        services = self._get_services_config(config)
+        return sorted(services.keys())
 
     def _build_param(self, attribute, details):
         req = details["required"]
         return click.Option(("--{0}".format(attribute),), prompt=req, required=req)
 
     def get_command(self, ctx, name):
-        config = load_config()
-
+        config = load_config(**self.load_config_kwargs)
+        services = self._get_services_config(config)
         attributes = iter(
             list(
-                getattr(
-                    config.project_config, "services__{0}__attributes".format(name)
-                ).items()
+                services.get(name, {}).get("attributes").items()
             )
         )
         params = [self._build_param(attr, cnfg) for attr, cnfg in attributes]
-        params.append(click.Option(("--project",), is_flag=True))
+        if config.global_keychain is False:
+            params.append(click.Option(("--project",), is_flag=True))
 
-        def callback(project=False, *args, **kwargs):
+        def callback(*args, **kwargs):
+            if config.global_keychain:
+                project = False
+            else:
+                project = kwargs.get("project", False)
             serv_conf = dict(
                 (k, v) for k, v in list(kwargs.items()) if v != None
             )  # remove None values
@@ -626,7 +648,7 @@ def service_connect():
 
 @click.command(name="info", help="Show the details of a connected service")
 @click.argument("service_name")
-@pass_config
+@pass_config(allow_global_keychain=True)
 def service_info(config, service_name):
     try:
         service_config = config.keychain.get_service(service_name)

--- a/cumulusci/cli/config.py
+++ b/cumulusci/cli/config.py
@@ -19,7 +19,7 @@ class CliRuntime(BaseCumulusCI):
         try:
             super(CliRuntime, self).__init__(*args, **kwargs)
         except (ProjectConfigNotFound, NotInProject) as e:
-            raise click.UsageError("{}: {}".format(e.__class__.__name__, e))
+            raise click.UsageError(str(e))
         except ConfigError as e:
             raise click.UsageError("Config Error: {}".format(str(e)))
         except (KeychainKeyNotFound) as e:
@@ -28,7 +28,7 @@ class CliRuntime(BaseCumulusCI):
     def get_keychain_class(self):
         default_keychain_class = (
             self.project_config.cumulusci__keychain
-            if not self.global_keychain
+            if not self.is_global_keychain
             else self.global_config.cumulusci__keychain
         )
         keychain_class = os.environ.get(

--- a/cumulusci/cli/config.py
+++ b/cumulusci/cli/config.py
@@ -19,15 +19,20 @@ class CliRuntime(BaseCumulusCI):
         try:
             super(CliRuntime, self).__init__(*args, **kwargs)
         except (ProjectConfigNotFound, NotInProject) as e:
-            raise click.UsageError(str(e))
+            raise click.UsageError("{}: {}".format(e.__class__.__name__, e))
         except ConfigError as e:
             raise click.UsageError("Config Error: {}".format(str(e)))
         except (KeychainKeyNotFound) as e:
             raise click.UsageError("Keychain Error: {}".format(str(e)))
 
     def get_keychain_class(self):
+        default_keychain_class = (
+            self.project_config.cumulusci__keychain
+            if not self.global_keychain
+            else self.global_config.cumulusci__keychain
+        )
         keychain_class = os.environ.get(
-            "CUMULUSCI_KEYCHAIN_CLASS", self.project_config.cumulusci__keychain
+            "CUMULUSCI_KEYCHAIN_CLASS", default_keychain_class
         )
         return import_class(keychain_class)
 

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -334,13 +334,7 @@ test     Test Service  *""",
         config = mock.Mock()
         config.global_keychain = False
         config.project_config.services = {
-            "test": {
-                "attributes": {
-                    "attr": {
-                        "required": False
-                    }
-                }
-            }
+            "test": {"attributes": {"attr": {"required": False}}}
         }
 
         with mock.patch("cumulusci.cli.cci.TEST_CONFIG", config):
@@ -357,13 +351,7 @@ test     Test Service  *""",
         config = mock.Mock()
         config.global_keychain = True
         config.global_config.services = {
-            "test": {
-                "attributes": {
-                    "attr": {
-                        "required": False
-                    }
-                }
-            }
+            "test": {"attributes": {"attr": {"required": False}}}
         }
 
         with mock.patch("cumulusci.cli.cci.TEST_CONFIG", config):
@@ -373,6 +361,7 @@ test     Test Service  *""",
         config.keychain.set_service.assert_called_once()
 
         run_click_command(cmd, project=False)
+
     @mock.patch("click.echo")
     def test_service_info(self, echo):
         service_config = mock.Mock()

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -292,7 +292,7 @@ class TestCCI(unittest.TestCase):
     @mock.patch("click.echo")
     def test_service_list(self, echo):
         config = mock.Mock()
-        config.global_keychain = False
+        config.is_global_keychain = False
         config.project_config.services = {"test": {"description": "Test Service"}}
         config.keychain.list_services.return_value = ["test"]
 
@@ -309,7 +309,7 @@ test     Test Service  *""",
     def test_service_connect_list(self):
         multi_cmd = cci.ConnectServiceCommand()
         config = mock.Mock()
-        config.global_keychain = False
+        config.is_global_keychain = False
         config.project_config.services = {"test": {}}
         ctx = mock.Mock()
 
@@ -320,7 +320,7 @@ test     Test Service  *""",
     def test_service_connect_list_global_keychain(self):
         multi_cmd = cci.ConnectServiceCommand()
         config = mock.Mock()
-        config.global_keychain = True
+        config.is_global_keychain = True
         config.global_config.services = {"test": {}}
         ctx = mock.Mock()
 
@@ -332,7 +332,7 @@ test     Test Service  *""",
         multi_cmd = cci.ConnectServiceCommand()
         ctx = mock.Mock()
         config = mock.Mock()
-        config.global_keychain = False
+        config.is_global_keychain = False
         config.project_config.services = {
             "test": {"attributes": {"attr": {"required": False}}}
         }
@@ -349,7 +349,7 @@ test     Test Service  *""",
         multi_cmd = cci.ConnectServiceCommand()
         ctx = mock.Mock()
         config = mock.Mock()
-        config.global_keychain = True
+        config.is_global_keychain = True
         config.global_config.services = {
             "test": {"attributes": {"attr": {"required": False}}}
         }

--- a/cumulusci/core/keychain/EncryptedFileProjectKeychain.py
+++ b/cumulusci/core/keychain/EncryptedFileProjectKeychain.py
@@ -21,6 +21,8 @@ class EncryptedFileProjectKeychain(BaseEncryptedProjectKeychain):
         return self.project_config.project_local_dir
 
     def _load_files(self, dirname, extension, key):
+        if dirname is None:
+            return
         for item in sorted(os.listdir(dirname)):
             if item.endswith(extension):
                 with open(os.path.join(dirname, item), "r") as f_item:
@@ -31,6 +33,8 @@ class EncryptedFileProjectKeychain(BaseEncryptedProjectKeychain):
                 self.config[key][name] = config
 
     def _load_file(self, dirname, filename, key):
+        if dirname is None:
+            return
         full_path = os.path.join(dirname, filename)
         if not os.path.exists(full_path):
             return
@@ -75,6 +79,8 @@ class EncryptedFileProjectKeychain(BaseEncryptedProjectKeychain):
     def _set_encrypted_org(self, name, encrypted, global_org):
         if global_org:
             filename = os.path.join(self.config_local_dir, "{}.org".format(name))
+        elif self.project_local_dir is None:
+            return
         else:
             filename = os.path.join(self.project_local_dir, "{}.org".format(name))
         with open(filename, "wb") as f_org:

--- a/cumulusci/core/keychain/EncryptedFileProjectKeychain.py
+++ b/cumulusci/core/keychain/EncryptedFileProjectKeychain.py
@@ -11,10 +11,12 @@ class EncryptedFileProjectKeychain(BaseEncryptedProjectKeychain):
 
     @property
     def config_local_dir(self):
-        return os.path.join(
-            os.path.expanduser("~"),
-            self.project_config.global_config_obj.config_local_dir,
-        )
+        try:
+            config_local_dir = self.project_config.global_config_obj.config_local_dir
+        except AttributeError:
+            # Handle a global config passed as project config
+            config_local_dir = self.project_config.config_local_dir
+        return os.path.join(os.path.expanduser("~"), config_local_dir)
 
     @property
     def project_local_dir(self):

--- a/cumulusci/core/runtime.py
+++ b/cumulusci/core/runtime.py
@@ -23,7 +23,7 @@ class BaseCumulusCI(object):
         self.global_config = None
         self.project_config = None
         self.keychain = None
-        self.global_keychain = False
+        self.is_global_keychain = False
 
         self._load_global_config()
 
@@ -33,7 +33,7 @@ class BaseCumulusCI(object):
                 self._add_repo_to_path()
             except (NotInProject, ProjectConfigNotFound):
                 if allow_global_keychain:
-                    self.global_keychain = True
+                    self.is_global_keychain = True
                 else:
                     raise
             if load_keychain:
@@ -83,7 +83,7 @@ class BaseCumulusCI(object):
         )
 
     def _load_keychain(self):
-        if self.global_keychain:
+        if self.is_global_keychain:
             self.keychain = self.keychain_cls(self.global_config, self.keychain_key)
         else:
             self.keychain = self.keychain_cls(self.project_config, self.keychain_key)

--- a/cumulusci/core/tests/test_keychain.py
+++ b/cumulusci/core/tests/test_keychain.py
@@ -442,6 +442,11 @@ class TestEncryptedFileProjectKeychain(ProjectKeychainTestMixin):
     def test_set_and_get_org_global(self):
         self.test_set_and_get_org(True)
 
+    def test_set_and_get_org__global_config(self):
+        keychain = self.keychain_class(self.global_config, self.key)
+        keychain.set_org(self.org_config, False)
+        self.assertEqual(list(keychain.orgs.keys()), [])
+
     def test_load_files__empty(self):
         dummy_keychain = BaseEncryptedProjectKeychain(self.project_config, self.key)
         os.makedirs(os.path.join(self.tempdir_home, ".cumulusci", self.project_name))
@@ -456,6 +461,13 @@ class TestEncryptedFileProjectKeychain(ProjectKeychainTestMixin):
 
     def test_load_file(self):
         dummy_keychain = BaseEncryptedProjectKeychain(self.project_config, self.key)
+        self._write_file(os.path.join(self.tempdir_home, "config"), "foo")
+        keychain = self.keychain_class(self.project_config, self.key)
+        keychain._load_file(self.tempdir_home, "config", "from_file")
+        self.assertEqual("foo", keychain.config["from_file"])
+
+    def test_load_file__global_config(self):
+        dummy_keychain = BaseEncryptedProjectKeychain(self.global_config, self.key)
         self._write_file(os.path.join(self.tempdir_home, "config"), "foo")
         keychain = self.keychain_class(self.project_config, self.key)
         keychain._load_file(self.tempdir_home, "config", "from_file")


### PR DESCRIPTION
# Critical Changes

# Changes

* The `cci service` commands are now available even if not in a local git repository configured for CumulusCI.  The `--project` flag is not available on `cci service connect` when outside a project.
* `cumulusci.core.runtime.BaseCumulusCI` now supports the `allow_global_keychain` kwarg which will fall back to initializing the keychain with the global config run from outside a project git repository.

# Issues Closed
Fixes #963 