### PR TITLE
Generate encryption key and store using keyring

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 # Black-compatible flake8 config
 
 [flake8]
-ignore = E203, E266, E501, W503
+ignore = E203, E266, E402, E501, W503
 max-line-length = 80
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -4,7 +4,6 @@ from future import standard_library
 standard_library.install_aliases()
 from past.builtins import basestring
 from builtins import str
-from builtins import object
 from collections import OrderedDict
 import functools
 import json
@@ -13,7 +12,6 @@ import os
 import sys
 import webbrowser
 import code
-import yaml
 import time
 
 from contextlib import contextmanager
@@ -28,25 +26,20 @@ from jinja2 import Environment
 from jinja2 import PackageLoader
 
 import cumulusci
-from cumulusci.core.config import FlowConfig
 from cumulusci.core.config import BaseConfig
 from cumulusci.core.config import OrgConfig
 from cumulusci.core.config import ScratchOrgConfig
 from cumulusci.core.config import ServiceConfig
 from cumulusci.core.config import TaskConfig
 from cumulusci.core.config import BaseGlobalConfig
-from cumulusci.core.exceptions import ConfigError
 from cumulusci.core.exceptions import CumulusCIFailure
 from cumulusci.core.exceptions import CumulusCIUsageError
-from cumulusci.core.exceptions import FlowNotFoundError
 from cumulusci.core.exceptions import OrgNotFound
-from cumulusci.core.exceptions import NotInProject
-from cumulusci.core.exceptions import ProjectConfigNotFound
 from cumulusci.core.exceptions import ScratchOrgException
 from cumulusci.core.exceptions import ServiceNotConfigured
 from cumulusci.core.exceptions import TaskNotFoundError
 from cumulusci.core.utils import import_class
-from cumulusci.cli.config import CliConfig
+from cumulusci.cli.config import CliRuntime
 from cumulusci.cli.config import get_installed_version
 from cumulusci.utils import doc_task
 from cumulusci.oauth.salesforce import CaptureSalesforceOAuth
@@ -195,7 +188,7 @@ def load_config(
     load_project_config=True, load_keychain=True, allow_global_keychain=False
 ):
     try:
-        config = TEST_CONFIG or CliConfig(
+        config = TEST_CONFIG or CliRuntime(
             load_project_config=load_project_config,
             load_keychain=load_keychain,
             allow_global_keychain=allow_global_keychain,
@@ -437,7 +430,6 @@ def project_init(config):
     context["git"] = git_config
 
     #     test:
-    test_config = []
     click.echo()
     click.echo(click.style("# Apex Tests Configuration", bold=True, fg="blue"))
     click.echo(
@@ -623,7 +615,7 @@ class ConnectServiceCommand(click.MultiCommand):
             else:
                 project = kwargs.get("project", False)
             serv_conf = dict(
-                (k, v) for k, v in list(kwargs.items()) if v != None
+                (k, v) for k, v in list(kwargs.items()) if v is not None
             )  # remove None values
             config.keychain.set_service(name, ServiceConfig(serv_conf), project)
             if project:
@@ -707,7 +699,7 @@ def org_connect(config, org_name, sandbox, login_url, default, global_org):
 
     try:
         connected_app = config.keychain.get_service("connected_app")
-    except ServiceNotConfigured as e:
+    except ServiceNotConfigured:
         raise ServiceNotConfigured(
             "Connected App is required but not configured. "
             + "Configure the Connected App service:\n"
@@ -731,7 +723,7 @@ def org_connect(config, org_name, sandbox, login_url, default, global_org):
     config.keychain.set_org(org_config, global_org)
 
     if default:
-        org = config.keychain.set_default_org(org_name)
+        config.keychain.set_default_org(org_name)
         click.echo("{} is now the default org".format(org_name))
 
 
@@ -900,7 +892,7 @@ def org_scratch(config, config_name, org_name, default, devhub, days, no_passwor
     )
 
     if default:
-        org = config.keychain.set_default_org(org_name)
+        config.keychain.set_default_org(org_name)
         click.echo("{} is now the default org".format(org_name))
 
 

--- a/cumulusci/cli/config.py
+++ b/cumulusci/cli/config.py
@@ -52,7 +52,11 @@ class CliRuntime(BaseCumulusCI):
             if has_functioning_keychain:
                 key = random_alphanumeric_underscore(length=16)
             else:
-                raise KeychainKeyNotFound("Unable to store encryption key.")
+                raise KeychainKeyNotFound(
+                    "Unable to store CumulusCI encryption key. "
+                    "You can configure it manually by setting the CUMULUSCI_KEY "
+                    "environment variable to a random 16-character string."
+                )
         if has_functioning_keychain and not key_from_keyring:
             keyring.set_password("cumulusci", "CUMULUSCI_KEY", key)
         return key

--- a/cumulusci/cli/config.py
+++ b/cumulusci/cli/config.py
@@ -3,6 +3,7 @@ import sys
 from subprocess import call
 
 import click
+import keyring
 import pkg_resources
 
 from cumulusci.core.runtime import BaseCumulusCI
@@ -12,6 +13,7 @@ from cumulusci.core.exceptions import OrgNotFound
 from cumulusci.core.exceptions import KeychainKeyNotFound
 from cumulusci.core.exceptions import ProjectConfigNotFound
 from cumulusci.core.utils import import_class
+from cumulusci.utils import random_alphanumeric_underscore
 
 
 class CliRuntime(BaseCumulusCI):
@@ -37,7 +39,23 @@ class CliRuntime(BaseCumulusCI):
         return import_class(keychain_class)
 
     def get_keychain_key(self):
-        return os.environ.get("CUMULUSCI_KEY")
+        key_from_env = os.environ.get("CUMULUSCI_KEY")
+        try:
+            key_from_keyring = keyring.get_password("cumulusci", "CUMULUSCI_KEY")
+            has_functioning_keychain = True
+        except Exception:
+            key_from_keyring = None
+            has_functioning_keychain = False
+        # If no key in environment or file, generate one
+        key = key_from_env or key_from_keyring
+        if key is None:
+            if has_functioning_keychain:
+                key = random_alphanumeric_underscore(length=16)
+            else:
+                raise KeychainKeyNotFound("Unable to store encryption key.")
+        if has_functioning_keychain and not key_from_keyring:
+            keyring.set_password("cumulusci", "CUMULUSCI_KEY", key)
+        return key
 
     def alert(self, message="We need your attention!"):
         if self.project_config and self.project_config.dev_config__no_alert:

--- a/cumulusci/cli/tests/test_config.py
+++ b/cumulusci/cli/tests/test_config.py
@@ -83,10 +83,12 @@ class TestCliRuntime(unittest.TestCase):
         self.assertNotEqual(self.key, config.keychain.key)
         self.assertEqual(16, len(config.keychain.key))
 
-    def test_get_keychain_key__warns_if_generated_key_cannot_be_stored(self):
+    @mock.patch("cumulusci.cli.config.keyring")
+    def test_get_keychain_key__warns_if_generated_key_cannot_be_stored(self, keyring):
         del os.environ["CUMULUSCI_KEY"]
+        keyring.get_password.side_effect = Exception
 
-        with self.assertRaises(KeychainKeyNotFound):
+        with self.assertRaises(click.UsageError):
             CliRuntime()
 
     def test_get_org(self):

--- a/cumulusci/cli/tests/test_config.py
+++ b/cumulusci/cli/tests/test_config.py
@@ -8,24 +8,27 @@ import unittest
 import click
 
 import cumulusci
-from cumulusci.cli.config import CliConfig
+from cumulusci.cli.config import CliRuntime
 from cumulusci.core.config import OrgConfig
 from cumulusci.core.exceptions import ConfigError
+from cumulusci.core.exceptions import KeychainKeyNotFound
 from cumulusci.core.exceptions import NotInProject
 from cumulusci.core.exceptions import OrgNotFound
 from cumulusci.core.exceptions import ProjectConfigNotFound
 
 
-class TestCliConfig(unittest.TestCase):
+class TestCliRuntime(unittest.TestCase):
     key = "1234567890abcdef"
 
     @classmethod
     def setUpClass(cls):
         os.chdir(os.path.dirname(cumulusci.__file__))
-        os.environ["CUMULUSCI_KEY"] = cls.key
+
+    def setUp(self):
+        os.environ["CUMULUSCI_KEY"] = self.key
 
     def test_init(self):
-        config = CliConfig()
+        config = CliRuntime()
 
         for key in {"cumulusci", "tasks", "flows", "services", "orgs", "project"}:
             self.assertIn(key, config.global_config.config)
@@ -34,33 +37,60 @@ class TestCliConfig(unittest.TestCase):
             self.assertIn(key, config.keychain.config)
         self.assertIn(config.project_config.repo_root, sys.path)
 
-    @mock.patch("cumulusci.cli.config.CliConfig._load_project_config")
+    @mock.patch("cumulusci.cli.config.CliRuntime._load_project_config")
     def test_load_project_not_in_project(self, load_proj_cfg_mock):
         load_proj_cfg_mock.side_effect = NotInProject
 
         with self.assertRaises(click.UsageError):
-            CliConfig()
+            CliRuntime()
 
-    @mock.patch("cumulusci.cli.config.CliConfig._load_project_config")
+    @mock.patch("cumulusci.cli.config.CliRuntime._load_project_config")
     def test_load_project_config_no_file(self, load_proj_cfg_mock):
         load_proj_cfg_mock.side_effect = ProjectConfigNotFound
         with self.assertRaises(click.UsageError):
-            CliConfig()
+            CliRuntime()
 
-    @mock.patch("cumulusci.cli.config.CliConfig._load_project_config")
+    @mock.patch("cumulusci.cli.config.CliRuntime._load_project_config")
     def test_load_project_config_error(self, load_proj_cfg_mock):
         load_proj_cfg_mock.side_effect = ConfigError
 
         with self.assertRaises(click.UsageError):
-            CliConfig()
+            CliRuntime()
 
-    def test_load_keychain__no_key(self):
-        with mock.patch.dict(os.environ, {"CUMULUSCI_KEY": ""}):
-            with self.assertRaises(click.UsageError):
-                config = CliConfig()
+    @mock.patch("cumulusci.cli.config.keyring")
+    def test_get_keychain_key__migrates_from_env_to_keyring(self, keyring):
+        keyring.get_password.return_value = None
+
+        config = CliRuntime()
+        self.assertEqual(self.key, config.keychain.key)
+        keyring.set_password.assert_called_once_with(
+            "cumulusci", "CUMULUSCI_KEY", self.key
+        )
+
+    @mock.patch("cumulusci.cli.config.keyring")
+    def test_get_keychain_key__env_takes_precedence(self, keyring):
+        keyring.get_password.return_value = "overridden"
+
+        config = CliRuntime()
+        self.assertEqual(self.key, config.keychain.key)
+
+    @mock.patch("cumulusci.cli.config.keyring")
+    def test_get_keychain_key__generates_key(self, keyring):
+        del os.environ["CUMULUSCI_KEY"]
+        keyring.get_password.return_value = None
+
+        config = CliRuntime()
+        self.assertNotEqual(self.key, config.keychain.key)
+        self.assertEqual(16, len(config.keychain.key))
+
+    def test_get_keychain_key__warns_if_generated_key_cannot_be_stored(self):
+        del os.environ["CUMULUSCI_KEY"]
+
+        with self.assertRaises(KeychainKeyNotFound):
+            CliRuntime()
 
     def test_get_org(self):
-        config = CliConfig()
+        config = CliRuntime()
         config.keychain = mock.Mock()
         config.keychain.get_org.return_value = org_config = OrgConfig({}, "test")
 
@@ -69,7 +99,7 @@ class TestCliConfig(unittest.TestCase):
         self.assertIs(org_config, org_config_result)
 
     def test_get_org_default(self):
-        config = CliConfig()
+        config = CliRuntime()
         config.keychain = mock.Mock()
         org_config = OrgConfig({}, "test")
         config.keychain.get_default_org.return_value = ("test", org_config)
@@ -79,7 +109,7 @@ class TestCliConfig(unittest.TestCase):
         self.assertIs(org_config, org_config_result)
 
     def test_get_org_missing(self):
-        config = CliConfig()
+        config = CliRuntime()
         config.keychain = mock.Mock()
         config.keychain.get_org.return_value = None
 
@@ -88,7 +118,7 @@ class TestCliConfig(unittest.TestCase):
 
     @mock.patch("click.confirm")
     def test_check_org_expired(self, confirm):
-        config = CliConfig()
+        config = CliRuntime()
         config.keychain = mock.Mock()
         org_config = OrgConfig(
             {
@@ -105,7 +135,7 @@ class TestCliConfig(unittest.TestCase):
 
     @mock.patch("click.confirm")
     def test_check_org_expired_decline(self, confirm):
-        config = CliConfig()
+        config = CliRuntime()
         config.keychain = mock.Mock()
         org_config = OrgConfig(
             {
@@ -121,13 +151,13 @@ class TestCliConfig(unittest.TestCase):
             config.check_org_expired("test", org_config)
 
     def test_check_org_overwrite_not_found(self):
-        config = CliConfig()
+        config = CliRuntime()
         config.keychain.get_org = mock.Mock(side_effect=OrgNotFound)
 
         self.assertTrue(config.check_org_overwrite("test"))
 
     def test_check_org_overwrite_scratch_exists(self):
-        config = CliConfig()
+        config = CliRuntime()
         config.keychain.get_org = mock.Mock(
             return_value=OrgConfig({"scratch": True, "created": True}, "test")
         )
@@ -136,7 +166,7 @@ class TestCliConfig(unittest.TestCase):
             config.check_org_overwrite("test")
 
     def test_check_org_overwrite_non_scratch_exists(self):
-        config = CliConfig()
+        config = CliRuntime()
         config.keychain.get_org = mock.Mock(
             return_value=OrgConfig({"scratch": False}, "test")
         )
@@ -145,7 +175,7 @@ class TestCliConfig(unittest.TestCase):
             config.check_org_overwrite("test")
 
     def test_check_cumulusci_version(self):
-        config = CliConfig()
+        config = CliRuntime()
         config.project_config.minimum_cumulusci_version = "999"
 
         with self.assertRaises(click.UsageError):
@@ -155,7 +185,7 @@ class TestCliConfig(unittest.TestCase):
     @mock.patch("cumulusci.cli.config.click.echo")
     @mock.patch("sys.platform", "darwin")
     def test_alert_osx(self, echo_mock, shell_mock):
-        config = CliConfig()
+        config = CliRuntime()
 
         config.alert("hello")
         echo_mock.assert_called_once()
@@ -166,7 +196,7 @@ class TestCliConfig(unittest.TestCase):
     @mock.patch("cumulusci.cli.config.click.echo")
     @mock.patch("sys.platform", "linux2")
     def test_alert_linux(self, echo_mock, shell_mock):
-        config = CliConfig()
+        config = CliRuntime()
 
         config.alert("hello")
         echo_mock.assert_called_once()
@@ -177,7 +207,7 @@ class TestCliConfig(unittest.TestCase):
     @mock.patch("cumulusci.cli.config.click.echo")
     @mock.patch("sys.platform", "darwin")
     def test_alert__disabled(self, echo_mock, shell_mock):
-        config = CliConfig()
+        config = CliRuntime()
         config.project_config.dev_config__no_alert = True
 
         config.alert("hello")
@@ -189,7 +219,7 @@ class TestCliConfig(unittest.TestCase):
     @mock.patch("sys.platform", "darwin")
     def test_alert__os_error(self, echo_mock, shell_mock):
         shell_mock.side_effect = OSError
-        config = CliConfig()
+        config = CliRuntime()
         config.alert("hello")
         echo_mock.assert_called_once()
         shell_mock.assert_called_once()

--- a/cumulusci/core/keychain/BaseEncryptedProjectKeychain.py
+++ b/cumulusci/core/keychain/BaseEncryptedProjectKeychain.py
@@ -110,10 +110,6 @@ class BaseEncryptedProjectKeychain(BaseProjectKeychain):
 
     def _validate_key(self):
         if not self.key:
-            raise KeychainKeyNotFound(
-                "The CUMULUSCI_KEY environment variable is not set."
-            )
+            raise KeychainKeyNotFound("The keychain key was not found.")
         if len(self.key) != 16:
-            raise ConfigError(
-                "The CUMULUSCI_KEY environment variable must be 16 characters long."
-            )
+            raise ConfigError("The keychain key must be 16 characters long.")

--- a/cumulusci/robotframework/CumulusCI.py
+++ b/cumulusci/robotframework/CumulusCI.py
@@ -4,7 +4,7 @@ from robot.api import logger
 from robot.libraries.BuiltIn import BuiltIn
 from simple_salesforce import Salesforce
 
-from cumulusci.cli.config import CliConfig
+from cumulusci.cli.config import CliRuntime
 from cumulusci.core.config import TaskConfig
 from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.core.tasks import CURRENT_TASK
@@ -18,7 +18,7 @@ class CumulusCI(object):
 
         This library allows Robot Framework tests to access credentials to a
         Salesforce org created by CumulusCI, including Scratch Orgs.  It also
-        exposes the core logic of CumulusCI including interactions with the 
+        exposes the core logic of CumulusCI including interactions with the
         Salesforce API's and project specific configuration including custom
         and customized tasks and flows.
 
@@ -55,7 +55,7 @@ class CumulusCI(object):
                 return CURRENT_TASK.stack[0].project_config
             else:
                 logger.console("Initializing CumulusCI config\n")
-                self._project_config = CliConfig().project_config
+                self._project_config = CliRuntime().project_config
         return self._project_config
 
     def set_project_config(self, project_config):
@@ -91,7 +91,7 @@ class CumulusCI(object):
     def set_login_url(self):
         """ Sets the LOGIN_URL variable in the suite scope which will
             automatically log into the target Salesforce org.
-    
+
             Typically, this is run during Suite Setup
         """
         BuiltIn().set_suite_variable("${LOGIN_URL}", self.org.start_url)
@@ -137,7 +137,7 @@ class CumulusCI(object):
     def run_task(self, task_name, **options):
         """ Runs a named CumulusCI task for the current project with optional
             support for overriding task options via kwargs.
-            
+
             Examples:
             | =Keyword= | =task_name= | =task_options=             | =comment=                        |
             | Run Task  | deploy      |                            | Run deploy with standard options |

--- a/cumulusci/utils.py
+++ b/cumulusci/utils.py
@@ -3,7 +3,6 @@ from future import standard_library
 from future.utils import text_to_native_str
 
 standard_library.install_aliases()
-import difflib
 import fnmatch
 import io
 import math
@@ -16,7 +15,7 @@ import textwrap
 import zipfile
 from builtins import str
 from contextlib import contextmanager
-from datetime import timedelta, datetime
+from datetime import datetime
 
 import requests
 
@@ -193,7 +192,7 @@ def zip_inject_namespace(
     namespaced_org=None,
     logger=None,
 ):
-    """ Replaces %%%NAMESPACE%%% for all files and ___NAMESPACE___ in all 
+    """ Replaces %%%NAMESPACE%%% for all files and ___NAMESPACE___ in all
         filenames in the zip with the either '' if no namespace is provided
         or 'namespace__' if provided.
     """
@@ -222,8 +221,6 @@ def zip_inject_namespace(
     namespaced_org_or_c = namespace if namespaced_org else "c"
 
     zip_dest = zipfile.ZipFile(io.BytesIO(), "w", zipfile.ZIP_DEFLATED)
-
-    differ = difflib.Differ()
 
     for name in zip_src.namelist():
         orig_name = str(name)
@@ -281,8 +278,8 @@ def zip_inject_namespace(
 
 
 def zip_strip_namespace(zip_src, namespace, logger=None):
-    """ Given a namespace, strips 'namespace__' from all files and filenames 
-        in the zip 
+    """ Given a namespace, strips 'namespace__' from all files and filenames
+        in the zip
     """
     namespace_prefix = "{}__".format(namespace)
     lightning_namespace = "{}:".format(namespace)
@@ -311,8 +308,8 @@ def zip_strip_namespace(zip_src, namespace, logger=None):
 
 
 def zip_tokenize_namespace(zip_src, namespace, logger=None):
-    """ Given a namespace, replaces 'namespace__' with %%%NAMESPACE%%% for all 
-        files and ___NAMESPACE___ in all filenames in the zip 
+    """ Given a namespace, replaces 'namespace__' with %%%NAMESPACE%%% for all
+        files and ___NAMESPACE___ in all filenames in the zip
     """
     if not namespace:
         return zip_src
@@ -337,7 +334,7 @@ def zip_tokenize_namespace(zip_src, namespace, logger=None):
 
 
 def zip_clean_metaxml(zip_src, logger=None):
-    """ Given a zipfile, cleans all *-meta.xml files in the zip for 
+    """ Given a zipfile, cleans all *-meta.xml files in the zip for
         deployment by stripping all <packageVersions/> elements
     """
     zip_dest = zipfile.ZipFile(io.BytesIO(), "w", zipfile.ZIP_DEFLATED)
@@ -494,7 +491,7 @@ def random_alphanumeric_underscore(length):
 
         # Ensure the string is the right length
         byte_length = math.ceil((length * 3) / 4)
-        return secrets.token_urlsafe(length).replace("-", "_")[:length]
+        return secrets.token_urlsafe(byte_length).replace("-", "_")[:length]
     else:
         import random
         import string

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -98,17 +98,6 @@ If you want to use our example project, fork our CumulusCI-Test repo:
 
 If you are using the CumulusCI-Test repo with a Developer Edition Salesforce org, you will need to enable Chatter in the org if it is not already enabled.  With Salesforce DX Scratch Orgs, this is handled for you.
 
-Keychain Key
-------------
-
-The cci command stores all credentials in AES encrypted files under the ~/.cumulusci folder (macOS). To use the CLI, you must set the environment variable `CUMULUSCI_KEY` to a 16 character string which is your password to access your keychain. You can use Last Pass to generate a key for you. Do not forget this password!:
-
-.. code-block:: console
-
-    $ export CUMULUSCI_KEY=0a2b4c6d8e0f2g4h  # Must be 16 characters long
-
-For Windows, go to Control Panel -> System and Security -> System -> Advanced System Settings and click the Environment Variables button. Create a new user variable and system variable with CUMULUSCI_KEY as the Name and your generated key as the Value.
-
 Project Initialization
 ----------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ github3.py==1.3.0
 humanfriendly==4.17
 jinja2==2.10
 jwcrypto==0.6.0
+keyring==17.1.1
 lxml==4.3.0
 MarkupSafe==1.1.0
 plaintable==0.1.1


### PR DESCRIPTION
This updates where the CLI looks for the keychain key. Rather than requiring the user to configure the CUMULUSCI_KEY environment variable, we now generate a key and store it in the system keychain using the `keyring` library. The environment variable is still given priority for backwards compatibility, and if there's no key in the keyring yet it will be migrated from the environment variable.

Apologies for also mixing some cleanup into the same pull request (updating CliConfig references to CliRuntime and misc flake8 fixes). The primary changes are in cumulusci/cli/config.py
