### PR TITLE
Clear up a couple of warnings by making regepx into raw-strings.

### DIFF
--- a/cumulusci/tasks/release_notes/parser.py
+++ b/cumulusci/tasks/release_notes/parser.py
@@ -44,7 +44,7 @@ class ChangeNotesLinesParser(BaseChangeNotesParser):
 
             # Look for h2
             if line.startswith("## "):
-                self.h2_title = re.sub("\s+#+$", "", line[3:]).lstrip()
+                self.h2_title = re.sub(r"\s+#+$", "", line[3:]).lstrip()
                 continue
 
             # Add all content once in the section
@@ -253,7 +253,7 @@ class GithubIssuesParser(IssuesParser):
         if is_beta:
             comment_prefix = self.ISSUE_COMMENT["beta"]
             version_parts = re.findall(
-                "{}(\d+\.\d+)-Beta_(\d+)".format(prefix_beta),
+                r"{}(\d+\.\d+)-Beta_(\d+)".format(prefix_beta),
                 self.release_notes_generator.current_tag,
             )
             version_str = "{} (Beta {})".format(*version_parts[0])


### PR DESCRIPTION
# Critical Changes

None

# Changes

Added two characters.

# Issues Closed

https://bugs.python.org/issue27364

You can see that they went through a similar process for the stdlib here:

https://bugs.python.org/file43550/invalid_stdlib_escapes_1.patch
