### PR TITLE
Fix update checking timestamp reading.

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -57,8 +57,14 @@ def timestamp_file():
     if not os.path.exists(config_dir):
         os.mkdir(config_dir)
 
-    with open(os.path.join(config_dir, "cumulus_timestamp"), "r+") as f:
-        yield f
+    timestamp_file = os.path.join(config_dir, "cumulus_timestamp")
+
+    try:
+        with open(timestamp_file, "r+") as f:
+            yield f
+    except FileNotFoundError:  # file does not exist
+        with open(timestamp_file, "w+") as f:
+            yield f
 
 
 FINAL_VERSION_RE = re.compile(r"^[\d\.]+$")

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -62,7 +62,7 @@ def timestamp_file():
     try:
         with open(timestamp_file, "r+") as f:
             yield f
-    except OSError:  # file does not exist
+    except IOError:  # file does not exist
         with open(timestamp_file, "w+") as f:
             yield f
 

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -62,7 +62,7 @@ def timestamp_file():
     try:
         with open(timestamp_file, "r+") as f:
             yield f
-    except FileNotFoundError:  # file does not exist
+    except OSError:  # file does not exist
         with open(timestamp_file, "w+") as f:
             yield f
 

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -57,7 +57,7 @@ def timestamp_file():
     if not os.path.exists(config_dir):
         os.mkdir(config_dir)
 
-    with open(os.path.join(config_dir, "cumulus_timestamp"), "w+") as f:
+    with open(os.path.join(config_dir, "cumulus_timestamp"), "r+") as f:
         yield f
 
 


### PR DESCRIPTION
w+ erases the file first. r+ doesn't.

So before, it would erase the file before trying to read the value. The value was therefore always replaced with "0". Now it will read the result or write the result based on the caller's preference.

We don't cache this underlying file object so its safe that we read it and then write to it a few milliseconds later. It's a different file object.
