### PR TITLE
Use python3 as default language version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_language_version:
+    python: python3
 repos:
 -   repo: https://github.com/ambv/black
     rev: stable


### PR DESCRIPTION
This will avoid a `CalledProcessError` on pre-commit's first run when a virtualenv has been created without the `-p python3.6` option.


# Critical Changes

# Changes

# Issues Closed
