### PR TITLE
For cci org info --json, serialize unknown types by stringifying them

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -792,7 +792,15 @@ def org_info(config, org_name, print_json):
     org_config.refresh_oauth_token(config.keychain)
 
     if print_json:
-        click.echo(json.dumps(org_config.config, sort_keys=True, indent=4, default=str))
+        click.echo(
+            json.dumps(
+                org_config.config,
+                sort_keys=True,
+                indent=4,
+                default=str,
+                separators=(",", ": "),
+            )
+        )
     else:
         render_recursive(org_config.config)
 

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -792,7 +792,7 @@ def org_info(config, org_name, print_json):
     org_config.refresh_oauth_token(config.keychain)
 
     if print_json:
-        click.echo(json.dumps(org_config.config, sort_keys=True, indent=4))
+        click.echo(json.dumps(org_config.config, sort_keys=True, indent=4, default=str))
     else:
         render_recursive(org_config.config)
 

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -506,8 +506,12 @@ test     Test Service  *""",
         config.keychain.set_org.assert_called_once_with(org_config)
 
     def test_org_info_json(self):
+        class Unserializable(object):
+            def __str__(self):
+                return "<unserializable>"
+
         org_config = mock.Mock()
-        org_config.config = {"test": "test"}
+        org_config.config = {"test": "test", "unserializable": Unserializable()}
         org_config.expires = date.today()
         config = mock.Mock()
         config.get_org.return_value = ("test", org_config)
@@ -519,7 +523,10 @@ test     Test Service  *""",
             )
 
         org_config.refresh_oauth_token.assert_called_once()
-        self.assertEqual('{\n    "test": "test"\n}', "".join(out))
+        self.assertEqual(
+            '{\n    "test": "test",\n    "unserializable": "<unserializable>"\n}',
+            "".join(out),
+        )
         config.keychain.set_org.assert_called_once_with(org_config)
 
     @mock.patch("click.echo")


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed
Fixes #1013 