### PR TITLE
Make sure we don't try to install beta dependencies into the packaging org

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -374,10 +374,13 @@ flows:
                 task: github_parent_to_children
 
     ci_master:
-        description: Deploy the package metadata to the packaging org and prepare for managed package version upload.  Inteded for use against master branch commits.
+        description: Deploy the package metadata to the packaging org and prepare for managed package version upload.  Intended for use against master branch commits.
         steps:
             1:
                 flow: dependencies
+                options:
+                    update_dependencies:
+                        include_beta: False
             2:
                 flow: deploy_packaging
             3:


### PR DESCRIPTION
We already have a check to make sure that the `include_beta` option for update_dependencies can't be used with a persistent org. But that means that if a project has turned include_beta on for the update_dependencies task in general, it can't be deployed to its packaging org. This makes sure that include_beta is turned off when using update_dependencies in the ci_master flow.

# Critical Changes

# Changes

# Issues Closed
