### PR TITLE
Publish to MetaDeploy using plan configuration

### DIFF
--- a/cumulusci/core/tasks.py
+++ b/cumulusci/core/tasks.py
@@ -234,7 +234,7 @@ class BaseTask(object):
             "kind": "other",
             "is_required": True,
         }
-        ui_step.update(self.task_config.get("ui_options", {}))
+        ui_step.update(self.task_config.config.get("ui_options", {}))
         ui_step.update(
             {
                 "path": step.path,

--- a/cumulusci/core/tasks.py
+++ b/cumulusci/core/tasks.py
@@ -229,14 +229,18 @@ class BaseTask(object):
             )
 
     def freeze(self, step):
-        return [
+        ui_step = {
+            "name": self.task_config.name or self.name,
+            "kind": "other",
+            "is_required": True,
+        }
+        ui_step.update(self.task_config.get("ui_options", {}))
+        ui_step.update(
             {
-                "name": self.task_config.name or self.name,
-                "kind": "other",
-                "is_required": True,
                 "path": step.path,
                 "step_num": str(step.step_num),
                 "task_class": self.task_config.class_path,
                 "task_config": {"options": self.options},
             }
-        ]
+        )
+        return [ui_step]

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -159,6 +159,10 @@ tasks:
         description: Publishes a release to the mrbelvedere web installer
         class_path: cumulusci.tasks.mrbelvedere.MrbelvederePublish
         group: Release Management
+    metadeploy_publish:
+        description: Publish a release to the MetaDeploy web installer
+        class_path: cumulusci.tasks.metadeploy.Publish
+        group: Release Management
     push_all:
         description: Schedules a push upgrade of a package version to all subscribers
         class_path: cumulusci.tasks.push.tasks.SchedulePushOrgQuery

--- a/cumulusci/tasks/metadeploy.py
+++ b/cumulusci/tasks/metadeploy.py
@@ -2,6 +2,7 @@ import json
 import requests
 
 from cumulusci.core.config import BaseProjectConfig
+from cumulusci.core.config import FlowConfig
 from cumulusci.core.config import TaskConfig
 from cumulusci.core.tasks import BaseTask
 from cumulusci.core.flowrunner import FlowCoordinator
@@ -36,51 +37,35 @@ class BaseMetaDeployTask(BaseTask):
 
 
 class Publish(BaseMetaDeployTask):
-    """Publishes an installation plan to MetaDeploy.
+    """Publishes installation plans to MetaDeploy.
     """
 
     task_options = {
-        "flow": {"description": "Name of flow to publish", "required": True},
-        "product_id": {
-            "description": "Id of the product in MetaDeploy",
-            "required": True,
-        },
-        "tag": {"description": "Name of git tag to publish", "required": True},
-        "title": {"description": "Title of the installation plan.", "required": True},
-        "description": {
-            "description": "Description of the version.",
-            "required": False,
-        },
-        "slug": {
-            "description": "URL slug for the installation plan.",
-            "required": True,
-        },
-        "tier": {
-            "description": "UI tier of MetaDeploy plan (primary/secondary/additional)",
-            "required": True,
-        },
-        "plan_template_id": {
-            "description": "Optional id of a PlanTemplate to use as a source for text.",
-            "required": False,
-        },
-        "allowed_list_id": {
-            "description": "Optional id of an AllowedList used to restrict access to the plan.",
-            "required": False,
-        },
-        "preflight_message_additional": {
-            "description": "Message displayed before installation (markdown), "
-            "added to the text from the plan template.",
-            "required": False,
-        },
-        "post_install_message_additional": {
-            "description": "Message displayed after installation (markdown), "
-            "added to the text from the plan template.",
+        "tag": {"description": "Name of the git tag to publish", "required": True},
+        "plan": {
+            "description": "Name of the plan(s) to publish. "
+            "This refers to the `plans` section of cumulusci.yml. "
+            "By default, all plans will be published.",
             "required": False,
         },
     }
 
+    def _init_task(self):
+        plan_name = self.options.get("plan")
+        if plan_name:
+            plan_configs = {}
+            plan_configs[plan_name] = getattr(
+                self.project_config, "plans__{}".format(plan_name)
+            )
+            self.plan_configs = plan_configs
+        else:
+            self.plan_configs = self.project_config.plans
+
     def _run_task(self):
+        # Find or create Version
         tag = self.options["tag"]
+        # version = self._find_or_create_version()
+        version = None
 
         # Check out the specified tag
         repo_owner = self.project_config.repo_owner
@@ -89,9 +74,7 @@ class Publish(BaseMetaDeployTask):
         repo = gh.repository(repo_owner, repo_name)
         commit_sha = repo.tag(repo.ref("tags/" + tag).object.sha).object.sha
         self.logger.info(
-            "Downloading commit {} of {}/{} from GitHub".format(
-                commit_sha, repo_owner, repo_name
-            )
+            "Downloading commit {} of {} from GitHub".format(commit_sha, repo.full_name)
         )
         zf = download_extract_github(gh, repo_owner, repo_name, ref=commit_sha)
         with temporary_dir() as project_dir:
@@ -108,20 +91,32 @@ class Publish(BaseMetaDeployTask):
                 },
             )
             project_config.set_keychain(self.project_config.keychain)
-            steps = self._freeze_steps(project_config)
+
+            # create each plan
+            for plan_name, plan_config in self.plan_configs.items():
+                self._publish_plan(project_config, version, plan_name, plan_config)
+
+            # update version to set is_listed=True
+            self._call_api(
+                "PATCH", "/versions/{}".format(version["id"]), json={"is_listed": True}
+            )
+            self.logger.info("Published Version {}".format(version["url"]))
+
+    def _publish_plan(self, project_config, version, plan_name, plan_config):
+        steps = self._freeze_steps(project_config, plan_config)
+        import pdb
+
+        pdb.set_trace()
         self.logger.debug("Publishing steps:\n" + json.dumps(steps, indent=4))
 
-        # find or create version
-        version = self._find_or_create_version()
-
-        # create plan
-        plan_template_id = self.options.get("plan_template_id")
+        # Create Plan
+        plan_template_id = plan_config.get("plan_template_id")
         plan_template_url = (
             self.base_url + "/plantemplates/{}".format(plan_template_id)
             if plan_template_id
             else None
         )
-        allowed_list_id = self.options.get("allowed_list_id")
+        allowed_list_id = plan_config.get("allowed_list_id")
         allowed_list_url = (
             self.base_url + "/allowedlists/{}".format(allowed_list_id)
             if allowed_list_id
@@ -131,40 +126,27 @@ class Publish(BaseMetaDeployTask):
             "POST",
             "/plans",
             json={
+                "is_listed": plan_config.get("is_listed", True),
                 "plan_template": plan_template_url,
-                "post_install_message_additional": self.options.get(
+                "post_install_message_additional": plan_config.get(
                     "post_install_message_additional", ""
                 ),
-                "preflight_message_additional": self.options.get(
+                "preflight_message_additional": plan_config.get(
                     "preflight_message_additional", ""
                 ),
                 "steps": steps,
-                "tier": self.options["tier"],
-                "title": self.options["title"],
+                "tier": plan_config["tier"],
+                "title": plan_config["title"],
                 "version": version["url"],
                 "visible_to": allowed_list_url,
             },
         )
         self.logger.info("Created Plan {}".format(plan["url"]))
 
-        # create plan slug
-        planslug = self._call_api(
-            "POST",
-            "/planslug",
-            json={"parent": plan["url"], "slug": self.options["slug"]},
-        )
-        self.logger.info("Created PlanSlug {}".format(planslug["url"]))
-
-        # update version to set is_listed=True
-        self._call_api(
-            "PATCH", "/versions/{}".format(version["id"]), json={"is_listed": True}
-        )
-        self.logger.info("Published Version {}".format(version["url"]))
-
-    def _freeze_steps(self, project_config):
-        flow_name = self.options["flow"]
-        flow_config = project_config.get_flow(flow_name)
-        flow = FlowCoordinator(project_config, flow_config, name=flow_name)
+    def _freeze_steps(self, project_config, plan_config):
+        steps = plan_config["steps"]
+        flow_config = FlowConfig(plan_config)
+        flow = FlowCoordinator(project_config, flow_config)
         steps = []
         for step in flow.steps:
             task = step.task_class(
@@ -176,14 +158,25 @@ class Publish(BaseMetaDeployTask):
     def _find_or_create_version(self):
         """Create a Version in MetaDeploy if it doesn't already exist
         """
+        repo_url = self.project_config.repo_url
         tag = self.options["tag"]
-        product_url = self.base_url + "/products/{}".format(self.options["product_id"])
+
+        # Find product
+        try:
+            result = self._call_api("GET", "/products", params={"repo_url": repo_url})
+        except requests.exceptions.HTTPError:
+            raise Exception(
+                "No product found in MetaDeploy with repo URL {}".format(repo_url)
+            )
+        else:
+            result = result["data"][0]
+            product_id = result["id"]
+            product_url = result["url"]
+
         label = self.project_config.get_version_for_tag(tag)
         try:
             result = self._call_api(
-                "GET",
-                "/versions",
-                params={"product": self.options["product_id"], "label": label},
+                "GET", "/versions", params={"product": product_id, "label": label}
             )
         except requests.exceptions.HTTPError:
             version = self._call_api(

--- a/cumulusci/tasks/salesforce/DeployBundles.py
+++ b/cumulusci/tasks/salesforce/DeployBundles.py
@@ -46,6 +46,8 @@ class DeployBundles(Deploy):
             return []
         steps = []
         for i, item in enumerate(sorted(os.listdir(path)), 1):
+            if not os.path.isdir(os.path.join(path, item)):
+                continue
             name = os.path.basename(item)
             subpath = os.path.relpath(
                 os.path.join(os.path.realpath(path), item),

--- a/cumulusci/tasks/salesforce/DeployBundles.py
+++ b/cumulusci/tasks/salesforce/DeployBundles.py
@@ -40,7 +40,7 @@ class DeployBundles(Deploy):
         return api()
 
     def freeze(self, step):
-        ui_options = step.task_config.get("ui_options", {})
+        ui_options = self.task_config.config.get("ui_options", {})
         path = self.options["path"]
         if not os.path.isdir(path):
             return []

--- a/cumulusci/tasks/salesforce/DeployBundles.py
+++ b/cumulusci/tasks/salesforce/DeployBundles.py
@@ -40,6 +40,7 @@ class DeployBundles(Deploy):
         return api()
 
     def freeze(self, step):
+        ui_options = step.task_config.get("ui_options", {})
         path = self.options["path"]
         if not os.path.isdir(path):
             return []
@@ -61,15 +62,19 @@ class DeployBundles(Deploy):
                 }
             )
             task_config = {"options": {"dependencies": [dependency]}}
-            steps.append(
+            ui_step = {
+                "name": "Deploy {}".format(subpath),
+                "kind": "metadata",
+                "is_required": True,
+            }
+            ui_step.update(ui_options.get(name, {}))
+            ui_step.update(
                 {
-                    "name": "Deploy {}".format(subpath),
                     "path": "{}.{}".format(step.path, name),
                     "step_num": "{}.{}".format(step.step_num, i),
-                    "kind": "metadata",
-                    "is_required": True,
                     "task_class": "cumulusci.tasks.salesforce.UpdateDependencies",
                     "task_config": task_config,
                 }
             )
+            steps.append(ui_step)
         return steps

--- a/cumulusci/tasks/salesforce/InstallPackageVersion.py
+++ b/cumulusci/tasks/salesforce/InstallPackageVersion.py
@@ -88,14 +88,18 @@ class InstallPackageVersion(Deploy):
         options = self.options.copy()
         options["version"] = str(options["version"])
         name = options.pop("name")
-        return [
+        ui_step = {
+            "name": "Install {} {}".format(name, options["version"]),
+            "kind": "managed",
+            "is_required": True,
+        }
+        ui_step.update(step.task_config.get("ui_options", {}))
+        ui_step.update(
             {
-                "name": "Install {} {}".format(name, options["version"]),
-                "kind": "managed",
-                "is_required": True,
                 "path": step.path,
                 "step_num": str(step.step_num),
                 "task_class": self.task_config.class_path,
                 "task_config": {"options": options},
             }
-        ]
+        )
+        return [ui_step]

--- a/cumulusci/tasks/salesforce/UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/UpdateDependencies.py
@@ -284,7 +284,7 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
         return api()
 
     def freeze(self, step):
-        ui_options = step.task_config.get("ui_options", {})
+        ui_options = self.task_config.config.get("ui_options", {})
         dependencies = self.project_config.get_static_dependencies(
             self.options["dependencies"], include_beta=self.options["include_beta"]
         )

--- a/cumulusci/tasks/salesforce/UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/UpdateDependencies.py
@@ -284,6 +284,7 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
         return api()
 
     def freeze(self, step):
+        ui_options = step.task_config.get("ui_options", {})
         dependencies = self.project_config.get_static_dependencies(
             self.options["dependencies"], include_beta=self.options["include_beta"]
         )
@@ -300,17 +301,17 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
                 name = name or "Deploy {}".format(dependency["subfolder"])
             task_config = {"options": self.options.copy()}
             task_config["options"]["dependencies"] = [dependency]
-            steps.append(
+            ui_step = {"name": name, "kind": kind, "is_required": True}
+            ui_step.update(ui_options.get(str(i), {}))
+            ui_step.update(
                 {
-                    "name": name,
                     "path": "{}.{}".format(step.path, i),
                     "step_num": "{}.{}".format(step.step_num, i),
-                    "kind": kind,
-                    "is_required": True,
                     "task_class": self.task_config.class_path,
                     "task_config": task_config,
                 }
             )
+            steps.append(ui_step)
         return steps
 
     def _flatten(self, dependencies):

--- a/cumulusci/tasks/salesforce/UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/UpdateDependencies.py
@@ -302,7 +302,7 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
             task_config = {"options": self.options.copy()}
             task_config["options"]["dependencies"] = [dependency]
             ui_step = {"name": name, "kind": kind, "is_required": True}
-            ui_step.update(ui_options.get(str(i), {}))
+            ui_step.update(ui_options.get(i, {}))
             ui_step.update(
                 {
                     "path": "{}.{}".format(step.path, i),

--- a/cumulusci/tasks/tests/test_metadeploy.py
+++ b/cumulusci/tasks/tests/test_metadeploy.py
@@ -3,7 +3,6 @@ import json
 import unittest
 import zipfile
 
-import mock
 import requests
 import responses
 import yaml
@@ -17,6 +16,8 @@ from cumulusci.tests.util import create_project_config
 
 
 class TestBaseMetaDeployTask(unittest.TestCase):
+    maxDiff = None
+
     @responses.activate
     def test_call_api__400(self):
         responses.add("GET", "https://metadeploy/rest", status=400, body=b"message")
@@ -59,6 +60,15 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
     @responses.activate
     def test_run_task(self):
         project_config = create_project_config()
+        project_config.config["project"]["git"]["repo_url"] = "EXISTING_REPO"
+        project_config.config["plans"] = {
+            "install": {
+                "title": "Test Install",
+                "slug": "install",
+                "tier": "primary",
+                "steps": {1: {"flow": "install_prod"}},
+            }
+        }
         project_config.keychain.set_service(
             "metadeploy", ServiceConfig({"url": "https://metadeploy", "token": "TOKEN"})
         )
@@ -69,6 +79,11 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
             ),
         )
 
+        responses.add(
+            "GET",
+            "https://metadeploy/products?repo_url=EXISTING_REPO",
+            json={"data": [{"id": "abcdef", "url": "https://EXISTING_PRODUCT"}]},
+        )
         responses.add(
             "GET",
             "https://api.github.com/repos/TestOwner/TestRepo",
@@ -111,7 +126,9 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
             json=self._get_expected_release("release/1.0"),
         )
         responses.add(
-            "GET", "https://metadeploy/versions?product=abcdef&label=1.0", status=400
+            "GET",
+            "https://metadeploy/versions?product=abcdef&label=1.0",
+            json={"data": []},
         )
         responses.add(
             "POST",
@@ -123,39 +140,21 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
             "https://metadeploy/plans",
             json={"url": "https://metadeploy/plans/1"},
         )
-        responses.add(
-            "POST",
-            "https://metadeploy/planslug",
-            json={"url": "https://metadeploy/planslug/1"},
-        )
         responses.add("PATCH", "https://metadeploy/versions/1", json={})
 
-        task_config = TaskConfig(
-            {
-                "options": {
-                    "flow": "install_prod",
-                    "product_id": "abcdef",
-                    "tag": "release/1.0",
-                    "title": "Test Product",
-                    "slug": "test",
-                    "tier": "primary",
-                    "preflight_message": "preflight",
-                    "post_install_message": "post-install",
-                }
-            }
-        )
+        task_config = TaskConfig({"options": {"tag": "release/1.0"}})
         task = Publish(project_config, task_config)
         task()
 
-        steps = json.loads(responses.calls[-3].request.body)["steps"]
+        steps = json.loads(responses.calls[-2].request.body)["steps"]
         self.assertEqual(
             [
                 {
                     "is_required": True,
                     "kind": "managed",
                     "name": "Install Test Product 1.0",
-                    "path": "install_managed",
-                    "step_num": "2",
+                    "path": "install_prod.install_managed",
+                    "step_num": "1.2",
                     "task_class": "cumulusci.tasks.salesforce.InstallPackageVersion",
                     "task_config": {
                         "options": {
@@ -172,8 +171,8 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
                     "is_required": True,
                     "kind": "other",
                     "name": "Update Admin Profile",
-                    "path": "config_managed.update_admin_profile",
-                    "step_num": "3.2",
+                    "path": "install_prod.config_managed.update_admin_profile",
+                    "step_num": "1.3.2",
                     "task_class": "cumulusci.tasks.salesforce.UpdateAdminProfile",
                     "task_config": {
                         "options": {"managed": True, "namespaced_org": False}
@@ -187,27 +186,69 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
     def test_find_or_create_version__already_exists(self):
         responses.add(
             "GET",
+            "https://metadeploy/products?repo_url=EXISTING_REPO",
+            json={"data": [{"id": "abcdef", "url": "https://EXISTING_PRODUCT"}]},
+        )
+        responses.add(
+            "GET",
             "https://metadeploy/versions?product=abcdef&label=1.0",
             json={"data": [{"url": "http://EXISTING_VERSION"}]},
         )
 
         project_config = create_project_config()
+        project_config.config["project"]["git"]["repo_url"] = "EXISTING_REPO"
+        project_config.config["plans"] = {
+            "install": {
+                "title": "Test Install",
+                "slug": "install",
+                "tier": "primary",
+                "steps": {1: {"flow": "install_prod"}},
+            }
+        }
         project_config.keychain.set_service(
             "metadeploy", ServiceConfig({"url": "https://metadeploy", "token": "TOKEN"})
         )
-        task_config = TaskConfig(
-            {
-                "options": {
-                    "flow": "install_prod",
-                    "product_id": "abcdef",
-                    "tag": "release/1.0",
-                    "title": "Test Product",
-                    "slug": "test",
-                    "tier": "primary",
-                }
-            }
-        )
+        task_config = TaskConfig({"options": {"tag": "release/1.0"}})
         task = Publish(project_config, task_config)
         task._init_task()
         version = task._find_or_create_version()
         self.assertEqual("http://EXISTING_VERSION", version["url"])
+
+    @responses.activate
+    def test_find_or_create_version__product_not_found(self):
+        responses.add(
+            "GET",
+            "https://metadeploy/products?repo_url=EXISTING_REPO",
+            json={"data": []},
+        )
+        project_config = create_project_config()
+        project_config.config["project"]["git"]["repo_url"] = "EXISTING_REPO"
+        project_config.keychain.set_service(
+            "metadeploy", ServiceConfig({"url": "https://metadeploy", "token": "TOKEN"})
+        )
+        task_config = TaskConfig({"options": {"tag": "release/1.0"}})
+        task = Publish(project_config, task_config)
+        task._init_task()
+        with self.assertRaises(Exception):
+            task._find_or_create_version()
+
+    @responses.activate
+    def test_init_task__named_plan(self):
+        project_config = create_project_config()
+        project_config.config["project"]["git"]["repo_url"] = "EXISTING_REPO"
+        expected_plans = {
+            "install": {
+                "title": "Test Install",
+                "slug": "install",
+                "tier": "primary",
+                "steps": {1: {"flow": "install_prod"}},
+            }
+        }
+        project_config.config["plans"] = expected_plans
+        project_config.keychain.set_service(
+            "metadeploy", ServiceConfig({"url": "https://metadeploy", "token": "TOKEN"})
+        )
+        task_config = TaskConfig({"options": {"tag": "release/1.0", "plan": "install"}})
+        task = Publish(project_config, task_config)
+        task._init_task()
+        self.assertEqual(expected_plans, task.plan_configs)


### PR DESCRIPTION
This makes some significant changes to the metadeploy publish task:
* Plan options are now read from a new `plans` section of cumulusci.yml instead of from task options. (See https://github.com/SalesforceFoundation/Cumulus/pull/4111 for an example of how the plan configuration will look for NPSP.) This means that a single run of the task can now handle publishing multiple plans, and we can configure a generic `metadeploy_publish` task instead of needing to set up different tasks for each project.
* Plan steps are now defined inline in the plan configuration rather than by naming a flow. This makes it easier to configure a plan that is like an existing flow with one or two adjustments.
* There is now a way to customize MetaDeploy step settings such as `name` and `is_required` on a step-by-step basis, using `ui_options` in the plan config.
* The task will now find or create a PlanTemplate as necessary, matching existing PlanTemplates on the product and plan name. This means the plan config no longer needs to reference a PlanTemplate by id, which makes it easier to publish to multiple instances of MetaDeploy.

# Critical Changes

# Changes

# Issues Closed
