### PR TITLE
WIP - new BaseLibrary, mixins for Salesforce, plus tests

### DIFF
--- a/cumulusci/robotframework/BaseLibrary.py
+++ b/cumulusci/robotframework/BaseLibrary.py
@@ -1,0 +1,42 @@
+import logging
+from robot.libraries.BuiltIn import BuiltIn, RobotNotRunningError
+from cumulusci.robotframework.utils import RetryingSeleniumLibraryMixin
+
+
+class BaseLibrary(RetryingSeleniumLibraryMixin):
+    ROBOT_LIBRARY_SCOPE = "GLOBAL"
+
+    def __init__(self, debug=False):
+        self.debug = debug
+        self.retry_selenium = True
+        # Turn off info logging of all http requests
+        logging.getLogger("requests.packages.urllib3.connectionpool").setLevel(
+            logging.WARN
+        )
+
+    @property
+    def salesforce_api_version(self):
+        try:
+            client = self.cumulusci.tooling
+            response = client._call_salesforce(
+                "GET", "https://{}/services/data".format(client.sf_instance)
+            )
+            latest_api_version = float(response.json()[-1]["version"])
+            return latest_api_version
+
+        except RobotNotRunningError:
+            # not sure if this should return None, a reasonable default value,
+            # or raise an exception. :-\
+            return None
+
+    @property
+    def builtin(self):
+        return BuiltIn()
+
+    @property
+    def cumulusci(self):
+        return self.builtin.get_library_instance("cumulusci.robotframework.CumulusCI")
+
+    @property
+    def salesforce(self):
+        return self.builtin.get_library_instance("cumulusci.robotframework.Salesforce")

--- a/cumulusci/robotframework/FormsMixin.py
+++ b/cumulusci/robotframework/FormsMixin.py
@@ -1,0 +1,2 @@
+class FormsMixin(object):
+    pass

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -1,38 +1,32 @@
 import logging
 import re
 import time
-from robot.libraries.BuiltIn import BuiltIn
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.action_chains import ActionChains
 
 from simple_salesforce import SalesforceResourceNotFound
 from cumulusci.robotframework.locators import lex_locators
-from cumulusci.robotframework.utils import selenium_retry
 from SeleniumLibrary.errors import ElementNotFound
 from urllib3.exceptions import ProtocolError
+
+from cumulusci.robotframework.BaseLibrary import BaseLibrary
+from cumulusci.robotframework.FormsMixin import FormsMixin
 
 OID_REGEX = r"^(%2F)?([a-zA-Z0-9]{15,18})$"
 
 
-@selenium_retry
-class Salesforce(object):
+class Salesforce(BaseLibrary, FormsMixin):
     ROBOT_LIBRARY_SCOPE = "GLOBAL"
 
     def __init__(self, debug=False):
+        super(Salesforce, self).__init__()
         self.debug = debug
+
         self._session_records = []
         # Turn off info logging of all http requests
         logging.getLogger("requests.packages.urllib3.connectionpool").setLevel(
             logging.WARN
         )
-
-    @property
-    def builtin(self):
-        return BuiltIn()
-
-    @property
-    def cumulusci(self):
-        return self.builtin.get_library_instance("cumulusci.robotframework.CumulusCI")
 
     def create_webdriver_with_retry(self, *args, **kwargs):
         """Call the Create Webdriver keyword.

--- a/cumulusci/robotframework/__init__.py
+++ b/cumulusci/robotframework/__init__.py
@@ -1,0 +1,1 @@
+from .BaseLibrary import BaseLibrary  # noqa F401

--- a/cumulusci/robotframework/tests/salesforce/TestLibrary.py
+++ b/cumulusci/robotframework/tests/salesforce/TestLibrary.py
@@ -1,0 +1,47 @@
+from robot.libraries.BuiltIn import BuiltIn
+from cumulusci.robotframework import BaseLibrary
+from cumulusci.robotframework.utils import selenium_retry
+import time
+
+"""
+    execute javascript  raise_red()  # or maybe simulate_popup()
+    execute javascript  setTimeout(function() {whatever}, 1000)
+    # this should fail immediately, but pass after the retry
+    click element with retry  id='red'
+    ${duration}=  get duration of previous keyword
+
+"""
+
+
+class TestLibrary(BaseLibrary):
+    def __init__(self):
+        super(TestLibrary, self).__init__()
+        self.duration = None
+        self.initialized = True
+
+    @property
+    def builtin(self):
+        return BuiltIn()
+
+    def get_duration_of_previous_keyword(self):
+        return self.duration
+
+    def click_element_with_default_retry(self, locator):
+        start = time.time()
+        self.selenium.click_element(locator)
+        end = time.time()
+        self.duration = end - start
+
+    @selenium_retry(True)
+    def click_element_with_explicit_retry(self, locator):
+        start = time.time()
+        self.selenium.click_element(locator)
+        end = time.time()
+        self.duration = end - start
+
+    @selenium_retry(False)
+    def click_element_without_retry(self, locator):
+        start = time.time()
+        self.selenium.click_element(locator)
+        end = time.time()
+        self.duration = end - start

--- a/cumulusci/robotframework/tests/salesforce/retry.robot
+++ b/cumulusci/robotframework/tests/salesforce/retry.robot
@@ -1,0 +1,122 @@
+*** Settings ***
+
+Resource        cumulusci/robotframework/Salesforce.robot
+Library         TestLibrary.py
+Library         Dialogs
+
+Suite setup     Open test page in browser  ${BROWSER}
+Suite teardown  Close all browsers
+
+
+*** Variables ***
+
+${BROWSER}  chrome
+
+*** Keywords ***
+
+Open test page in browser
+    [Documentation]
+    ...  This opens a browser and loads the file 'testpage.html',
+    ...  which is in the same folder as this test case
+    [Arguments]  ${BROWSER}
+
+    ${here}=      evaluate  os.path.dirname($suite_source)        modules=os
+    ${testfile}=  evaluate  os.path.join($here, "testpage.html")  modules=os
+    open browser  file://${testfile}  ${BROWSER}
+
+
+*** Test Cases ***
+
+Verify that TestLibrary is initialized
+    [Documentation]
+    ...  Verify that the library is initialized. This test was aded
+    ...  when I was refactoring RetryingSeleniumLibraryMixin and
+    ...  Salesforce.py, and discovered that the __init__ wasn't being
+    ...  called after some of my changes. This test exists to make
+    ...  sure that doesn't happen again.
+
+    ${testlib}=  get library instance  TestLibrary
+    Should be true  ${testlib.initialized}
+    ...  Expected TestLibrary.initialized value: "${testlib.initialized}"
+
+Verify BaseLibrary properties are inherited
+    [Documentation]
+    ...  Verify that all of the BaseLibrary properties are inherited
+    ...  by TestLibrary
+    ${testlib}=  get library instance  TestLibrary
+    Variable should exist  ${testlib.builtin}
+    Variable should exist  ${testlib.cumulusci}
+    Variable should exist  ${testlib.salesforce}
+    Variable should exist  ${testlib.salesforce_api_version}
+
+Verify automatic selenium retry on undecorated keyword
+    [Documentation]
+    ...  This test verifies that methods in the library have the retry
+    ...  behavior added by default when inheriting from BaseLibrary
+
+    [Setup]  Reload page
+
+    # assert that the green div isn't clickable
+    # note: chrome and firefox throw different errors, so we have to
+    # be a bit loosey-goosey with the expected error.
+
+    run keyword and expect error  *Element*green-div*is not clickable*
+    ...  click element  id:green-div
+
+    # Now, arrange for the element to be clickable in the near future
+    # and try again. This time, we should automatically wait for two
+    # seconds, and the click should succeed
+
+    ${testlib}=  get library instance  TestLibrary
+    ${expected_retry_count}=  evaluate  $testlib.retry_count + 1
+    execute javascript        return setTimeout(raise_green, 500)
+    click element with default retry  id:green-div
+
+    # assert that the retry happened
+    ${duration}=  get duration of previous keyword
+    should be true  $duration > 2.0
+    should be equal as numbers  ${testlib.retry_count}  ${expected_retry_count}
+
+Verify @selenium_retry(True) keyword decorator
+    [Documentation]
+    ...  This test verifies that we automatically retry selenium
+    ...  instructions that fail under certain circumstances when the
+    ...  keyword is explicitly decorated with @selenium_retry(True)
+
+    [Setup]  Reload page
+
+    # assert that the green div isn't clickable
+    # note: chrome and firefox throw different errors, so we have to
+    # be a bit loosey-goosey with the expected error.
+
+    run keyword and expect error  *Element*green-div*is not clickable*
+    ...  click element  id:green-div
+
+    # Now, arrange for the element to be clickable in the near future
+    # and try again. This time, we should automatically wait for two
+    # seconds, and the click should succeed
+
+    ${testlib}=  get library instance  TestLibrary
+    ${expected_retry_count}=  evaluate  $testlib.retry_count + 1
+    execute javascript        return setTimeout(raise_green, 500)
+    click element with explicit retry  id:green-div
+
+    # assert that the retry happened
+    ${duration}=  get duration of previous keyword
+    should be true  $duration > 2.0
+    should be equal as numbers  ${testlib.retry_count}  ${expected_retry_count}
+
+Verify @selenium_retry(False) decorator
+    [Documentation]
+    ...  Verify that a keyword which uses the @selenium_retry(False)
+    ...  decorator does not attempt a retry
+    [Setup]  reload page
+
+    # try to click the hidden green div and verify
+    # that no retry was attempted
+    ${testlib}=  get library instance  TestLibrary
+    ${expected_retry_count}=  evaluate  $testlib.retry_count
+
+    run keyword and expect error  *Element*green-div*is not clickable*
+    ...  click element without retry  id:green-div
+    should be equal as numbers  ${testlib.retry_count}  ${expected_retry_count}

--- a/cumulusci/robotframework/tests/salesforce/testpage.html
+++ b/cumulusci/robotframework/tests/salesforce/testpage.html
@@ -1,0 +1,53 @@
+<html>
+  <head>
+    <style>
+      body {
+          width: 600px;
+      }
+      .block {
+          position: fixed;
+          top: 150;
+          left: 10;
+          width: 100px;
+          height: 100px;
+          background-color: red;
+          display: flex;
+          text-align: center;
+          justify-content:center;
+          align-content:center;
+          flex-direction:column;
+      }
+      #red-div {
+          background-color: red;
+      }
+      #green-div {
+          background-color: green;
+      }
+    </style>
+    <script>
+      function raise_red() {
+          document.getElementById('red-div').style.zIndex = 1;
+          document.getElementById('green-div').style.zIndex = -1;
+      }
+      function raise_green() {
+          document.getElementById('red-div').style.zIndex = -1;
+          document.getElementById('green-div').style.zIndex = 1;
+      }
+    </script>
+  </head>
+  <body>
+    <p>This page is for testing the ability to click on an element
+    that is temporarily hidden by another element. The tests rely
+    on the fact that the green div is hidden behind the red div,
+    and is raised while the test is running.</p>
+
+    <p>
+      <button id='red-button' onclick='raise_red()'>Raise the red div</button>
+      <button id='green-button' onclick='raise_green()'>Raise the green div</button>
+    </p>
+
+    <div class='block' id='green-div'>Green means go</div>
+    <div class='block' id='red-div'>Red means stop</div>
+
+  </body>
+</html>


### PR DESCRIPTION
This change includes a proof of concept for the following features:

- Support for keyword mixins in order to organize all of the Salesforce keywords
- A new BaseLibrary class to serve as the base class for keyword libraries
- Bug fixes to our selenium_retry machinery to support mixins, and to support firefox
- A  robot test which tests some of the above

Note: I haven't actually moved or refactored any of the keywords in Salesforce.py. This change makes the changes necessary to support that. The main goal was to be able to use the mixins, which was difficult given the current implementation of the selenium_retry decorator for classes. 

TL;DR: Going forward, keyword libraries should inherit from `BaseLibrary` rather than use the `@selenium_retry` decorator on a class, and Salesforce.py keywords should be organized into a series of mixin classes for maintainability.


# Critical Changes

# Changes

# Issues Closed
