### PR TITLE
Various updates to the install_upgrade flow

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -597,19 +597,19 @@ flows:
             3:
                 task: deploy_post
 
-    install_upgrade:
-        description: Install the latest production version as an upgrade from the previous one
+    install_regression:
+        description: Install the latest beta dependencies and upgrade to the latest beta version from the most recent production version
         steps:
             1:
-                flow: dependencies
+                flow: beta_dependencies
             2:
                 task: install_managed
                 options:
                     version: previous
             3:
-                flow: config_managed
+                task: install_managed_beta
             4:
-                task: install_managed
+                flow: config_managed
 
     release_beta:
         description: Upload and release a beta version of the metadata currently in packaging


### PR DESCRIPTION
* Rename it to install_regression since it's really focused on that use case
* Install beta versions of dependencies
* Install beta version of the main package
* Run config_managed after upgrading so it works if the metadata refers to new components from the package


# Critical Changes

# Changes

# Issues Closed
