### PR TITLE
bulkdata task supports NULL DATETIME

### DIFF
--- a/cumulusci/tasks/bulkdata.py
+++ b/cumulusci/tasks/bulkdata.py
@@ -50,8 +50,6 @@ class EpochType(types.TypeDecorator):
     def process_result_value(self, value, dialect):
         if value is not None:
             return self.epoch + datetime.timedelta(seconds=value / 1000)
-        else:
-            return None
 
 
 # Listen for sqlalchemy column_reflect event and map datetime fields to EpochType

--- a/cumulusci/tasks/bulkdata.py
+++ b/cumulusci/tasks/bulkdata.py
@@ -48,7 +48,10 @@ class EpochType(types.TypeDecorator):
         return int((value - self.epoch).total_seconds()) * 1000
 
     def process_result_value(self, value, dialect):
-        return self.epoch + datetime.timedelta(seconds=value / 1000)
+        if value is not None:
+            return self.epoch + datetime.timedelta(seconds=value / 1000)
+        else:
+            return None
 
 
 # Listen for sqlalchemy column_reflect event and map datetime fields to EpochType

--- a/cumulusci/tasks/tests/test_bulkdata.py
+++ b/cumulusci/tasks/tests/test_bulkdata.py
@@ -31,8 +31,14 @@ class TestEpochType(unittest.TestCase):
 
     def test_process_result_value(self):
         obj = bulkdata.EpochType()
+
+        # Non-None value
         result = obj.process_result_value(1000, None)
         self.assertEqual(datetime(1970, 1, 1, 0, 0, 1), result)
+
+        # None value
+        result = obj.process_result_value(None, None)
+        self.assertEqual(None, result)
 
     def test_setup_epoch(self):
         column_info = {"type": types.DateTime()}
@@ -70,7 +76,6 @@ class TestDeleteData(unittest.TestCase):
         api.get_all_results_for_query_batch.return_value = [BULK_DELETE_QUERY_RESULT]
         api.create_job.return_value = delete_job = "3"
         api.headers.return_value = {}
-        delete_batch = "4"
         responses.add(
             method="POST",
             url="http://api/job/3/batch",


### PR DESCRIPTION
# Critical Changes

# Changes
-  `cumulusci/tasks/bulkdata.py`
    -  `EpochType.process_result_value` supports a `None` value
    - Updated test `TestEpochType.test_process_result_value` in `.../tests/test_bulkdata.py'

# Issues Closed
