### PR TITLE
Feature/populate robusto

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,10 +99,10 @@ jobs:
           name: Run robot tests
           command: |
             mkdir -p robot_results/robot
-            venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/cumulusci/base.robot -o xunit robot_results/robot/cumulusci.xml
-            venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/salesforce/api.robot -o xunit robot_results/robot/salesforce_api.xml
-            venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/salesforce/ui.robot -o xunit robot_results/robot/salesforce_ui.xml
-            venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/salesforce/ui.robot -o xunit robot_results/robot/salesforce_ui.xml -o vars BROWSER:headlessfirefox
+            venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/cumulusci  -o xunit robot_results/robot/cumulusci.xml
+            venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/salesforce -o include api -o xunit robot_results/robot/salesforce_api.xml
+            venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/salesforce -o exclude api -o vars BROWSER:headlesschrome -o xunit robot_results/robot/salesforce_ui_chrome.xml
+            venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/salesforce -o exclude api -o vars BROWSER:headlessfirefox -o xunit robot_results/robot/salesforce_ui_firefox.xml
       - run:
           name: Delete scratch org
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
             mkdir -p robot_results/robot
             venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/cumulusci  -o xunit robot_results/robot/cumulusci.xml
             venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/salesforce -o include api -o xunit robot_results/robot/salesforce_api.xml
-            venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/salesforce -o exclude api -o vars BROWSER:headlesschrome -o xunit robot_results/robot/salesforce_ui_chrome.xml
+            venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/salesforce -o exclude api -o xunit robot_results/robot/salesforce_ui_chrome.xml
             venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/salesforce -o exclude api -o vars BROWSER:headlessfirefox -o xunit robot_results/robot/salesforce_ui_firefox.xml
       - run:
           name: Delete scratch org

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ selenium-screenshot-*
 log.html
 report.html
 output.xml
+geckodriver.log
 **/.sfdx
 htmlcov/
 .pytest_cache/

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -160,6 +160,14 @@ class Salesforce(object):
                 return oid_match.group(2)
         raise AssertionError("Could not parse record id from url: {}".format(url))
 
+    def get_field_value(self, label):
+        """Return the current value of a form field based on the field label"""
+        input_element_id = self.selenium.get_element_attribute(
+            "xpath://label[contains(., '{}')]".format(label), "for"
+        )
+        value = self.selenium.get_value(input_element_id)
+        return value
+
     def get_locator(self, path, *args, **kwargs):
         """ Returns a rendered locator string from the Salesforce lex_locators
             dictionary.  This can be useful if you want to use an element in

--- a/cumulusci/robotframework/locators.py
+++ b/cumulusci/robotframework/locators.py
@@ -17,7 +17,7 @@ lex_locators = {
     },
     "object": {
         "button": "css: div.windowViewMode-normal ul.forceActionsContainer.oneActionsRibbon a[title='{}']",
-        "field": "//div[contains(@class, 'uiInput')][.//label[contains(@class, 'uiLabel')][.//span[text()='{}']]]//input",
+        "field": "//div[contains(@class, 'uiInput')][.//label[contains(@class, 'uiLabel')][.//span[text()='{}']]]//*[self::input or self::textarea]",
         "field_lookup_link": "//a[@role='option'][.//div[@title='{}']]",
         "field_lookup_value": "//div[contains(@class, 'uiInput')][.//label[contains(@class, 'uiLabel')][.//span[text()='{}']]]//span[contains(@class,'pillText')]",
         "record_type_option": "//div[contains(@class, 'changeRecordTypeOptionRightColumn')]//span[text()='{}']",

--- a/cumulusci/robotframework/tests/salesforce/api.robot
+++ b/cumulusci/robotframework/tests/salesforce/api.robot
@@ -1,7 +1,8 @@
 *** Settings ***
 
-Resource       cumulusci/robotframework/Salesforce.robot
+Resource        cumulusci/robotframework/Salesforce.robot
 Suite Teardown  Delete Session Records
+Force Tags      api
 
 *** Keywords ***
 

--- a/cumulusci/robotframework/tests/salesforce/populate.robot
+++ b/cumulusci/robotframework/tests/salesforce/populate.robot
@@ -1,0 +1,89 @@
+*** Settings ***
+Documentation
+...  This suite tests the `Populate Field` keyword.
+...  Specifically, it verifies that the keyword properly
+...  overwrites previous values. We had some bugs where
+...  new values were getting appended rather than replacing
+...  existing values.
+...
+...  This suite uses an opportunity, since the edit dialog
+...  has several different field types on it.
+
+Library   String
+Library   DateTime
+Resource  cumulusci/robotframework/Salesforce.robot
+
+Suite Setup     run keywords
+...  Open test browser
+...  Create opportunity
+Suite Teardown  Delete Records and Close Browser
+
+*** Keywords ***
+Create opportunity
+    [Documentation]
+    ...  Creates a test opportunity with a random name and a close
+    ...  date 30 days in the future. A reference to the created
+    ...  opportunity will be stored in the suite variable ${opportunity},
+    ...  and be return as the result of this keyword.
+
+    ${30 days from now}=  Get Current Date  increment=30 days  result_format=%Y-%m-%d
+    ${random}=  Generate random string  8  [NUMBERS]
+    ${opportunity_id}=    Salesforce Insert  Opportunity
+    ...                   Name=Test Opportunity ${random}
+    ...                   CloseDate=2018-04-01
+    ...                   Amount=100000
+    ...                   Probability=42
+    ...                   StageName=Prospecting
+    ...                   Description=Clever description here
+    &{opportunity}=       Salesforce Get  Opportunity  ${opportunity_id}
+    set suite variable    ${opportunity}
+    [Return]  ${opportunity}
+
+Verify "populate field" replaces previous value
+    [Arguments]  ${field name}  ${new value}
+    [Documentation]
+    ...  Verify that a field has the expected value after calling 'populate field'
+    ...  This keyword will NOT cause the test to fail immediately, so that we can
+    ...  check multiple fields before the test completes
+
+    populate field      ${field name}    ${new value}
+    ${actual value}=    get field value  ${field name}
+
+    run keyword and continue on failure
+    ...  should be equal as strings  ${new value}  ${actual value}
+    ...  Expected modal field ${field name} to be '${new value}' but it was '${actual value}'
+
+*** Test cases ***
+Test Populate ability to clear a field
+    [Documentation]
+    ...  We've had problems with the populate keyword not always
+    ...  clearing the field before inserting text. This will try
+    ...  to set various fields to a new value and verify that the
+    ...  new value overwrites the old rather than append to it
+
+    [Setup]  run keywords
+    ...  go to object home     Opportunity
+    ...  AND  click link            ${opportunity['Name']}
+    ...  AND  click button          title:Edit
+    ...  AND  wait until modal is open
+
+    ${60 days from now}=  Get Current Date  increment=60 days  result_format=%Y-%m-%d
+
+    ## currency / number
+    Verify "populate field" replaces previous value  Amount            90000
+
+    ## string
+    Verify "populate field" replaces previous value  Next Step         whatever
+
+    ## percentage / number
+    Verify "populate field" replaces previous value  Probability (%)   99
+
+    ## multi-line text field
+    Verify "populate field" replaces previous value  Description       yada yada yada
+
+    ## date field
+    # N.B. Close date is last because it pops up a date dialog. If there
+    # are more fields after, we have to wait for the dialog to be dismissed.
+    # This test is just easier if we modify the date last so we don't have to
+    # deal with that.
+    Verify "populate field" replaces previous value  Close Date        ${60 days from now}

--- a/cumulusci/robotframework/tests/salesforce/populate.robot
+++ b/cumulusci/robotframework/tests/salesforce/populate.robot
@@ -30,7 +30,7 @@ Create opportunity
     ${random}=  Generate random string  8  [NUMBERS]
     ${opportunity_id}=    Salesforce Insert  Opportunity
     ...                   Name=Test Opportunity ${random}
-    ...                   CloseDate=2018-04-01
+    ...                   CloseDate=${30 days from now}
     ...                   Amount=100000
     ...                   Probability=42
     ...                   StageName=Prospecting


### PR DESCRIPTION
The main change in this branch is to fix a bug where `populate field` would append rather than overwrite the data in a currency field. I used this as an excuse to do a fair amount of refactoring of the helper functions used by that keyword. 

This has a robot test that exercises this keyword on several different field types. To support the writing of that test I added a new Salesforce.py keyword `get field value`, and tweaked `populate field` to work on a multiline textarea in addition to an input. 

Tested on chrome, firefox, headlesschrome, and headlessfirefox, and I also ran the NPSP tests (branch feature/robot__bge-automation) to make sure I didn't break anything. 

# Critical Changes

# Changes

# Issues Closed
