### PR TITLE
Default the step 'kind' to 'metadata' for Deploy tasks

### DIFF
--- a/cumulusci/tasks/salesforce/Deploy.py
+++ b/cumulusci/tasks/salesforce/Deploy.py
@@ -135,3 +135,10 @@ class Deploy(BaseSalesforceMetadataApiTask):
         )
         zipf = zip_clean_metaxml(zipf, logger=self.logger)
         return zipf
+
+    def freeze(self, step):
+        steps = super(Deploy, self).freeze(step)
+        for step in steps:
+            if step["kind"] == "other":
+                step["kind"] = "metadata"
+        return steps

--- a/cumulusci/tasks/tests/test_metadeploy.py
+++ b/cumulusci/tasks/tests/test_metadeploy.py
@@ -174,7 +174,7 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
                 },
                 {
                     "is_required": True,
-                    "kind": "other",
+                    "kind": "metadata",
                     "name": "Update Admin Profile",
                     "path": "install_prod.config_managed.update_admin_profile",
                     "step_num": "1.3.2",


### PR DESCRIPTION
Tasks based on `Deploy` should show up in MetaDeploy as "metadata" rather than "other"

# Critical Changes

# Changes

# Issues Closed
