### PR TITLE
Fix a couple bugs related to generating passwords for new scratch orgs

### DIFF
--- a/cumulusci/cli/config.py
+++ b/cumulusci/cli/config.py
@@ -102,7 +102,10 @@ class CliRuntime(BaseCumulusCI):
             click.echo(click.style("The scratch org is expired", fg="yellow"))
             if click.confirm("Attempt to recreate the scratch org?", default=True):
                 self.keychain.create_scratch_org(
-                    org_name, org_config.config_name, org_config.days
+                    org_name,
+                    org_config.config_name,
+                    days=org_config.days,
+                    set_password=org_config.set_password,
                 )
                 click.echo(
                     "Org config was refreshed, attempting to recreate scratch org"

--- a/cumulusci/core/keychain/BaseProjectKeychain.py
+++ b/cumulusci/core/keychain/BaseProjectKeychain.py
@@ -71,7 +71,7 @@ class BaseProjectKeychain(BaseConfig):
     def _load_services(self):
         pass
 
-    def create_scratch_org(self, org_name, config_name, days=None, set_password=False):
+    def create_scratch_org(self, org_name, config_name, days=None, set_password=True):
         """ Adds/Updates a scratch org config to the keychain from a named config """
         scratch_config = getattr(
             self.project_config, "orgs__scratch__{}".format(config_name)


### PR DESCRIPTION
* A project's predefined scratch org configs now default to `set_password: True`
  (which was already the case for orgs created explicitly using `cci org scratch`)
* A scratch org config's set_password flag is now retained when recreating an expired org.


# Critical Changes

# Changes

# Issues Closed

Fixes #670 