### PR TITLE
Update scratch org definition files to use orgPreferenceSettings

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -488,6 +488,7 @@ def project_init(config):
                 package_name=context["package_name"],
                 org_name="Beta Test Org",
                 edition="Developer",
+                managed=True,
             )
         )
     with open(os.path.join("orgs", "dev.json"), "w") as f:
@@ -496,6 +497,7 @@ def project_init(config):
                 package_name=context["package_name"],
                 org_name="Dev Org",
                 edition="Developer",
+                managed=False,
             )
         )
     with open(os.path.join("orgs", "feature.json"), "w") as f:
@@ -504,6 +506,7 @@ def project_init(config):
                 package_name=context["package_name"],
                 org_name="Feature Test Org",
                 edition="Developer",
+                managed=False,
             )
         )
     with open(os.path.join("orgs", "release.json"), "w") as f:
@@ -512,6 +515,7 @@ def project_init(config):
                 package_name=context["package_name"],
                 org_name="Release Test Org",
                 edition="Enterprise",
+                managed=True,
             )
         )
 

--- a/cumulusci/files/templates/project/scratch_def.json
+++ b/cumulusci/files/templates/project/scratch_def.json
@@ -1,10 +1,11 @@
 {
   "orgName": "{{ package_name }} - {{ org_name }}",
   "edition": "{{ edition }}",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "ChatterEnabled"
-    ]
+  "settings": {
+    "orgPreferenceSettings": {
+      "s1DesktopEnabled": true,
+      "chatterEnabled": true,
+      "translation": true
+    }
   }
 }

--- a/cumulusci/files/templates/project/scratch_def.json
+++ b/cumulusci/files/templates/project/scratch_def.json
@@ -3,9 +3,11 @@
   "edition": "{{ edition }}",
   "settings": {
     "orgPreferenceSettings": {
-      "s1DesktopEnabled": true,
-      "chatterEnabled": true,
-      "translation": true
+      "s1DesktopEnabled": true
+      , "chatterEnabled": true
+      {% if not managed %}
+      , "translation": true 
+      {% endif %}
     }
   }
 }

--- a/orgs/beta.json
+++ b/orgs/beta.json
@@ -1,11 +1,11 @@
 {
   "orgName": "CumulusCI - Beta Test Org",
   "edition": "Developer",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "Translation",
-      "ChatterEnabled" 
-    ]
+  "settings": {
+    "orgPreferenceSettings": {
+      "s1DesktopEnabled": true,
+      "chatterEnabled": true,
+      "translation": true
+    }
   }
 }

--- a/orgs/beta.json
+++ b/orgs/beta.json
@@ -3,9 +3,8 @@
   "edition": "Developer",
   "settings": {
     "orgPreferenceSettings": {
-      "s1DesktopEnabled": true,
-      "chatterEnabled": true,
-      "translation": true
+      "s1DesktopEnabled": true
+      , "chatterEnabled": true
     }
   }
 }

--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -1,11 +1,11 @@
 {
   "orgName": "CumulusCI - Dev Workspace",
   "edition": "Developer",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "Translation",
-      "ChatterEnabled"
-    ]
+  "settings": {
+    "orgPreferenceSettings": {
+      "s1DesktopEnabled": true,
+      "chatterEnabled": true,
+      "translation": true
+    }
   }
 }

--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -3,9 +3,9 @@
   "edition": "Developer",
   "settings": {
     "orgPreferenceSettings": {
-      "s1DesktopEnabled": true,
-      "chatterEnabled": true,
-      "translation": true
+      "s1DesktopEnabled": true
+      , "chatterEnabled": true
+      , "translation": true
     }
   }
 }

--- a/orgs/feature.json
+++ b/orgs/feature.json
@@ -1,11 +1,11 @@
 {
   "orgName": "CumulusCI - Feature Test Org",
   "edition": "Developer",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "Translation",
-      "ChatterEnabled" 
-    ]
+  "settings": {
+    "orgPreferenceSettings": {
+      "s1DesktopEnabled": true,
+      "chatterEnabled": true,
+      "translation": true
+    }
   }
 }

--- a/orgs/feature.json
+++ b/orgs/feature.json
@@ -3,9 +3,9 @@
   "edition": "Developer",
   "settings": {
     "orgPreferenceSettings": {
-      "s1DesktopEnabled": true,
-      "chatterEnabled": true,
-      "translation": true
+      "s1DesktopEnabled": true
+      , "chatterEnabled": true
+      , "translation": true
     }
   }
 }

--- a/orgs/release.json
+++ b/orgs/release.json
@@ -3,9 +3,8 @@
   "edition": "Enterprise",
   "settings": {
     "orgPreferenceSettings": {
-      "s1DesktopEnabled": true,
-      "chatterEnabled": true,
-      "translation": true
+      "s1DesktopEnabled": true
+      , "chatterEnabled": true
     }
   }
 }

--- a/orgs/release.json
+++ b/orgs/release.json
@@ -1,11 +1,11 @@
 {
   "orgName": "CumulusCI - Release Test Org",
   "edition": "Enterprise",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "Translation",
-      "ChatterEnabled" 
-    ]
+  "settings": {
+    "orgPreferenceSettings": {
+      "s1DesktopEnabled": true,
+      "chatterEnabled": true,
+      "translation": true
+    }
   }
 }


### PR DESCRIPTION
# Critical Changes

# Changes

 - Reformat scratch org definition files to use [`orgPreferenceSettings` instead of `orgPreferences`](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_scratch_orgs_def_file_config_values.htm), which is now deprecated.
 - Parameterize generation of scratch org definition files based on managed or unmanaged environments.

# Issues Closed
