### PR TITLE
Filter tags by prefix

### DIFF
--- a/cumulusci/core/config/BaseProjectConfig.py
+++ b/cumulusci/core/config/BaseProjectConfig.py
@@ -395,12 +395,18 @@ class BaseProjectConfig(BaseTaskFlowConfig):
         repo = gh.repository(self.repo_owner, self.repo_name)
         if not beta:
             release = repo.latest_release()
+            prefix = self.project__git__prefix_release
+            if not release.tag_name.startswith(prefix):
+                return self._get_latest_tag_for_prefix(repo, prefix)
             return release.tag_name
         else:
-            for release in repo.releases():
-                if not release.tag_name.startswith(self.project__git__prefix_beta):
-                    continue
-                return release.tag_name
+            return self._get_latest_tag_for_prefix(repo, self.project__git__prefix_beta)
+
+    def _get_latest_tag_for_prefix(self, repo, prefix):
+        for release in repo.releases():
+            if not release.tag_name.startswith(prefix):
+                continue
+            return release.tag_name
 
     def get_latest_version(self, beta=False):
         """ Query Github Releases to find the latest production or beta release """

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -416,6 +416,19 @@ class TestBaseProjectConfig(unittest.TestCase):
         result = config.get_latest_tag()
         self.assertEqual("release/1.1", result)
 
+    def test_get_latest_tag_matching_prefix(self):
+        config = BaseProjectConfig(
+            BaseGlobalConfig(),
+            {"project": {"git": {"prefix_beta": "beta/", "prefix_release": "rel/"}}},
+        )
+        github = self._make_github()
+        github.repositories["CumulusCI"]._releases.append(
+            DummyRelease("rel/0.9", "0.9")
+        )
+        config.get_github_api = mock.Mock(return_value=github)
+        result = config.get_latest_tag()
+        self.assertEqual("rel/0.9", result)
+
     def test_get_latest_tag_beta(self):
         config = BaseProjectConfig(
             BaseGlobalConfig(),


### PR DESCRIPTION
# Critical Changes

# Changes
- When multiple namespaces (tag prefixes) coexist in a repository, `repo.latest_release()` may return the incorrect tag. This PR adds a check for the correct tag prefix, and iterates over all releases when there is a mismatch.

# Issues Closed
