### PR TITLE
Force purgeOnDelete to false for production orgs

### DIFF
--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -97,7 +97,3 @@ class OrgConfig(BaseConfig):
             "is_sandbox": org_info["IsSandbox"],
         }
         self.config.update(result)
-
-    @property
-    def org_type(self):
-        return self.config.get("org_type")

--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -41,6 +41,7 @@ class OrgConfig(BaseConfig):
         if info != self.config:
             self.config.update(info)
         self._load_userinfo()
+        self._load_orginfo()
 
     @property
     def lightning_base_url(self):
@@ -83,3 +84,20 @@ class OrgConfig(BaseConfig):
 
     def can_delete(self):
         return False
+
+    def _load_orginfo(self):
+        headers = {"Authorization": "Bearer " + self.access_token}
+        org_info = requests.get(
+            self.instance_url
+            + "/services/data/v45.0/sobjects/Organization/{}".format(self.org_id),
+            headers=headers,
+        ).json()
+        result = {
+            "org_type": org_info["OrganizationType"],
+            "is_sandbox": org_info["IsSandbox"],
+        }
+        self.config.update(result)
+
+    @property
+    def org_type(self):
+        return self.config.get("org_type")

--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -62,8 +62,6 @@ class ScratchOrgConfig(OrgConfig):
             raise ScratchOrgException(message)
 
         else:
-            json_txt = "".join(stdout_list)
-
             try:
                 org_info = json.loads("".join(stdout_list))
             except Exception as e:
@@ -270,7 +268,6 @@ class ScratchOrgConfig(OrgConfig):
         p = sarge.Command(command, stdout=sarge.Capture(buffer_size=-1), shell=True)
         p.run()
 
-        org_info = None
         stdout = []
         for line in io.TextIOWrapper(p.stdout):
             stdout.append(line)
@@ -319,3 +316,5 @@ class ScratchOrgConfig(OrgConfig):
 
         # Get org info via sfdx force:org:display
         self.scratch_info
+        # Get additional org info by querying API
+        self._load_orginfo()

--- a/cumulusci/core/tests/test_config_expensive.py
+++ b/cumulusci/core/tests/test_config_expensive.py
@@ -129,7 +129,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         os.chdir(self.tempdir_project)
         global_config = BaseGlobalConfig()
         with self.assertRaises(NotInProject):
-            config = BaseProjectConfig(global_config)
+            BaseProjectConfig(global_config)
 
     def test_load_project_config_no_config(self, mock_class):
         mock_class.return_value = self.tempdir_home
@@ -137,7 +137,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         os.chdir(self.tempdir_project)
         global_config = BaseGlobalConfig()
         with self.assertRaises(ProjectConfigNotFound):
-            config = BaseProjectConfig(global_config)
+            BaseProjectConfig(global_config)
 
     def test_load_project_config_empty_config(self, mock_class):
         mock_class.return_value = self.tempdir_home
@@ -525,7 +525,7 @@ class TestScratchOrgConfig(unittest.TestCase):
         p.run.assert_called_once()
 
     def test_force_refresh_oauth_token_error(self, Command):
-        Command.return_value = p = mock.Mock(
+        Command.return_value = mock.Mock(
             stdout=io.BytesIO(b"error"), stderr=io.BytesIO(b""), returncode=1
         )
 
@@ -550,6 +550,7 @@ class TestScratchOrgConfig(unittest.TestCase):
         config._scratch_info = {}
         config._scratch_info_date = datetime.now() - timedelta(days=1)
         config.force_refresh_oauth_token = mock.Mock()
+        config._load_orginfo = mock.Mock()
 
         config.refresh_oauth_token(keychain=None)
 

--- a/cumulusci/salesforce_api/metadata.py
+++ b/cumulusci/salesforce_api/metadata.py
@@ -370,10 +370,10 @@ class ApiDeploy(BaseMetadataApiCall):
             self.purge_on_delete = "true"
         # Disable purge on delete entirely for non sandbox or DE orgs as it is
         # not allowed
-        # FIXME: To implement this, the task needs to be able to provide the org_type
-        # org_type = self.task.org_config.org_type
-        # if org_type.find('Sandbox') == -1 and org_type != 'Developer Edition':
-        #    self.purge_on_delete = 'false'
+        org_type = self.task.org_config.org_type
+        is_sandbox = self.task.org_config.is_sandbox
+        if org_type != "Developer Edition" and not is_sandbox:
+            self.purge_on_delete = "false"
 
     def _build_envelope_start(self):
         if self.package_zip:

--- a/cumulusci/salesforce_api/tests/test_metadata.py
+++ b/cumulusci/salesforce_api/tests/test_metadata.py
@@ -583,7 +583,7 @@ class TestApiDeploy(BaseTestMetadataApi):
 
     def _expected_envelope_start(self):
         return self.envelope_start.format(
-            package_zip=self.package_zip, purge_on_delete="true"
+            package_zip=self.package_zip, purge_on_delete="false"
         )
 
     def _response_call_success_result(self, response_result):


### PR DESCRIPTION
The purgeOnDelete flag for MD-API deployments is only valid in Developer Edition orgs and sandboxes. This automatically sets it to false for orgs that don't meet those criteria.

This involves adding a REST API call to query the Organization object after refreshing the oauth token so that the OrgConfig can provide awareness of the org's edition.

# Critical Changes

# Changes

# Issues Closed
