### PR TITLE
Allow configuration of scratch org user email address

### DIFF
--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -8,6 +8,7 @@ import re
 import sarge
 from simple_salesforce import Salesforce
 
+from cumulusci.utils import get_git_config
 from cumulusci.core.config import FAILED_TO_CREATE_SCRATCH_ORG
 from cumulusci.core.config import OrgConfig
 from cumulusci.core.exceptions import ScratchOrgException
@@ -140,20 +141,8 @@ class ScratchOrgConfig(OrgConfig):
     def email_address(self):
         email_address = self.config.get("email_address")
         if not email_address:
-            # Obtain a default email address from Git.
-            p = sarge.Command(
-                "git config --get user.email",
-                stderr=sarge.Capture(buffer_size=-1),
-                stdout=sarge.Capture(buffer_size=-1),
-                shell=True,
-            )
-            p.run()
-            email_address = io.TextIOWrapper(p.stdout).read().strip()
-
-            if p.returncode or not email_address:
-                email_address = None
-            else:
-                self.config["email_address"] = email_address
+            email_address = get_git_config("user.email")
+            self.config["email_address"] = email_address
 
         return email_address
 

--- a/cumulusci/core/tests/test_config_expensive.py
+++ b/cumulusci/core/tests/test_config_expensive.py
@@ -403,18 +403,14 @@ class TestScratchOrgConfig(unittest.TestCase):
 
     def test_email_address_from_config(self, Command):
         config = ScratchOrgConfig({"email_address": "test@example.com"}, "test")
-        Command.return_value = p = mock.Mock(
-            stdout=io.BytesIO(b""), stderr=io.BytesIO(b""), returncode=0
-        )
 
         self.assertEqual("test@example.com", config.email_address)
-        p.run.assert_not_called()
+        Command.return_value.assert_not_called()
 
     def test_email_address_from_git(self, Command):
         config = ScratchOrgConfig({}, "test")
-        out = b"test@example.com"
         Command.return_value = p = mock.Mock(
-            stdout=io.BytesIO(out), stderr=io.BytesIO(b""), returncode=0
+            stdout=io.BytesIO(b"test@example.com"), stderr=io.BytesIO(b""), returncode=0
         )
 
         self.assertEqual("test@example.com", config.email_address)
@@ -425,15 +421,6 @@ class TestScratchOrgConfig(unittest.TestCase):
         config = ScratchOrgConfig({}, "test")
         Command.return_value = p = mock.Mock(
             stdout=io.BytesIO(b""), stderr=io.BytesIO(b""), returncode=0
-        )
-
-        self.assertEqual(None, config.email_address)
-        p.run.assert_called_once()
-
-    def test_email_address_git_error(self, Command):
-        config = ScratchOrgConfig({}, "test")
-        Command.return_value = p = mock.Mock(
-            stdout=io.BytesIO(b""), stderr=io.BytesIO(b""), returncode=-1
         )
 
         self.assertEqual(None, config.email_address)

--- a/cumulusci/core/tests/test_config_expensive.py
+++ b/cumulusci/core/tests/test_config_expensive.py
@@ -9,6 +9,7 @@ import unittest
 
 import mock
 
+from cumulusci.utils import temporary_dir
 from cumulusci.core.utils import ordered_yaml_load
 from cumulusci.core.config import ScratchOrgConfig
 from cumulusci.core.config import BaseGlobalConfig
@@ -296,7 +297,9 @@ class TestScratchOrgConfig(unittest.TestCase):
             stderr=io.BytesIO(b"error"), stdout=io.BytesIO(b"out"), returncode=1
         )
 
-        config = ScratchOrgConfig({"username": "test"}, "test")
+        config = ScratchOrgConfig(
+            {"username": "test", "email_address": "test@example.com"}, "test"
+        )
 
         try:
             config.scratch_info
@@ -310,10 +313,15 @@ class TestScratchOrgConfig(unittest.TestCase):
             stderr=io.BytesIO(b"error"), stdout=io.BytesIO(b"out"), returncode=0
         )
 
-        config = ScratchOrgConfig({"config_file": "tmp"}, "test")
+        config = ScratchOrgConfig(
+            {"config_file": "tmp.json", "email_address": "test@example.com"}, "test"
+        )
 
-        with self.assertRaises(ScratchOrgException):
-            config.scratch_info
+        with temporary_dir():
+            with open("tmp.json", "w") as f:
+                f.write("{}")
+            with self.assertRaises(ScratchOrgException):
+                config.scratch_info
 
     def test_scratch_info_password_from_config(self, Command):
         result = b"""{
@@ -387,11 +395,49 @@ class TestScratchOrgConfig(unittest.TestCase):
         config = ScratchOrgConfig({"password": "test"}, "test")
         self.assertEqual(config.password, "test")
 
-    def test_pasword_from_scratch_info(self, Command):
+    def test_password_from_scratch_info(self, Command):
         config = ScratchOrgConfig({}, "test")
         _marker = object()
         config._scratch_info = {"password": _marker}
         self.assertIs(config.password, _marker)
+
+    def test_email_address_from_config(self, Command):
+        config = ScratchOrgConfig({"email_address": "test@example.com"}, "test")
+        Command.return_value = p = mock.Mock(
+            stdout=io.BytesIO(b""), stderr=io.BytesIO(b""), returncode=0
+        )
+
+        self.assertEqual("test@example.com", config.email_address)
+        p.run.assert_not_called()
+
+    def test_email_address_from_git(self, Command):
+        config = ScratchOrgConfig({}, "test")
+        out = b"test@example.com"
+        Command.return_value = p = mock.Mock(
+            stdout=io.BytesIO(out), stderr=io.BytesIO(b""), returncode=0
+        )
+
+        self.assertEqual("test@example.com", config.email_address)
+        config.email_address  # Make sure value is cached
+        p.run.assert_called_once()
+
+    def test_email_address_not_present(self, Command):
+        config = ScratchOrgConfig({}, "test")
+        Command.return_value = p = mock.Mock(
+            stdout=io.BytesIO(b""), stderr=io.BytesIO(b""), returncode=0
+        )
+
+        self.assertEqual(None, config.email_address)
+        p.run.assert_called_once()
+
+    def test_email_address_git_error(self, Command):
+        config = ScratchOrgConfig({}, "test")
+        Command.return_value = p = mock.Mock(
+            stdout=io.BytesIO(b""), stderr=io.BytesIO(b""), returncode=-1
+        )
+
+        self.assertEqual(None, config.email_address)
+        p.run.assert_called_once()
 
     def test_days(self, Command):
         config = ScratchOrgConfig({"days": 2}, "test")
@@ -426,9 +472,20 @@ class TestScratchOrgConfig(unittest.TestCase):
             stdout=io.BytesIO(out), stderr=io.BytesIO(b""), returncode=0
         )
 
-        config = ScratchOrgConfig({"config_file": "tmp", "set_password": True}, "test")
+        config = ScratchOrgConfig(
+            {
+                "config_file": "tmp.json",
+                "set_password": True,
+                "email_address": "test@example.com",
+            },
+            "test",
+        )
         config.generate_password = mock.Mock()
-        config.create_org()
+        with temporary_dir():
+            with open("tmp.json", "w") as f:
+                f.write("{}")
+
+            config.create_org()
 
         p.run.assert_called_once()
         self.assertEqual(config.config["org_id"], "ORG_ID")
@@ -437,6 +494,40 @@ class TestScratchOrgConfig(unittest.TestCase):
         config.generate_password.assert_called_once()
         self.assertTrue(config.config["created"])
         self.assertEqual(config.scratch_org_type, "workspace")
+
+        # Validate the SFDX command generated uses the email address provided.
+        self.assertIn("test@example.com", Command.call_args[0][0])
+
+    def test_create_org_uses_org_def_email(self, Command):
+        out = b"Successfully created scratch org: ORG_ID, username: USERNAME"
+        Command.return_value = p = mock.Mock(
+            stdout=io.BytesIO(out), stderr=io.BytesIO(b""), returncode=0
+        )
+
+        config = ScratchOrgConfig(
+            {
+                "config_file": "tmp.json",
+                "set_password": True,
+                "email_address": "test@example.com",
+            },
+            "test",
+        )
+        config.generate_password = mock.Mock()
+        with temporary_dir():
+            with open("tmp.json", "w") as f:
+                f.write('{"adminEmail": "other_test@example.com"}')
+
+            config.create_org()
+
+        p.run.assert_called_once()
+        self.assertEqual(config.config["org_id"], "ORG_ID")
+        self.assertEqual(config.config["username"], "USERNAME")
+        self.assertIn("date_created", config.config)
+        config.generate_password.assert_called_once()
+        self.assertTrue(config.config["created"])
+        self.assertEqual(config.scratch_org_type, "workspace")
+
+        self.assertNotIn("test@example.com", Command.call_args[0][0])
 
     def test_create_org_no_config_file(self, Command):
         config = ScratchOrgConfig({}, "test")
@@ -448,10 +539,16 @@ class TestScratchOrgConfig(unittest.TestCase):
             stdout=io.BytesIO(b""), stderr=io.BytesIO(b"scratcherror"), returncode=1
         )
 
-        config = ScratchOrgConfig({"config_file": "tmp"}, "test")
-        with self.assertRaises(ScratchOrgException) as ctx:
-            config.create_org()
-            self.assertIn("scratcherror", str(ctx.error))
+        config = ScratchOrgConfig(
+            {"config_file": "tmp.json", "email_address": "test@example.com"}, "test"
+        )
+        with temporary_dir():
+            with open("tmp.json", "w") as f:
+                f.write("{}")
+
+            with self.assertRaises(ScratchOrgException) as ctx:
+                config.create_org()
+                self.assertIn("scratcherror", str(ctx.error))
 
     def test_generate_password(self, Command):
         p = mock.Mock(

--- a/cumulusci/utils.py
+++ b/cumulusci/utils.py
@@ -8,6 +8,7 @@ import io
 import math
 import os
 import re
+import sarge
 import shutil
 import sys
 import tempfile
@@ -529,3 +530,16 @@ def os_friendly_path(path):
     if os.sep != "/":
         path = path.replace("/", os.sep)
     return path
+
+
+def get_git_config(config_key):
+    p = sarge.Command(
+        sarge.shell_format('git config --get "{0!s}"', config_key),
+        stderr=sarge.Capture(buffer_size=-1),
+        stdout=sarge.Capture(buffer_size=-1),
+        shell=True,
+    )
+    p.run()
+    config_value = io.TextIOWrapper(p.stdout).read().strip()
+
+    return config_value if config_value and not p.returncode else None


### PR DESCRIPTION
# Critical Changes

# Changes

- Allow configuration of the email address assigned to scratch org users, with the order of priority being (1) any `adminEmail` key in the scratch org definition; (2) the `email_address` property on the scratch org configuration in `cumulusci.yml`; (3) the `user.email` configuration property in Git.

# Issues Closed
