### PR TITLE
Workaround for pip's change in behavior

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: Install dependencies
           command: |
             virtualenv venv
-            venv/bin/pip install $(grep black requirements_dev.txt | cut -d';' -f 1)
+            venv/bin/pip install --no-use-pep517 $(grep black requirements_dev.txt | cut -d';' -f 1)
       - run:
           name: Run black
           command: |
@@ -81,7 +81,7 @@ jobs:
           name: Install Python dependencies
           command: |
             virtualenv venv
-            venv/bin/pip install -r requirements_dev.txt
+            venv/bin/pip install --no-use-pep517 -r requirements_dev.txt
       - run:
           name: Install sfdx
           command: |
@@ -136,7 +136,7 @@ jobs:
           name: Install Python dependencies
           command: |
             virtualenv venv
-            venv/bin/pip install -r requirements_dev.txt
+            venv/bin/pip install --no-use-pep517 -r requirements_dev.txt
       - run:
           name: Check out CumulusCI-Test
           command: |

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -57,7 +57,7 @@ Ready to contribute? Here's how to set up CumulusCI for local development.
 2. Clone your fork to your local workspace.
 3. Create a fresh virtual environment using virtualenv and install development requirements::
 
-    $ pip install -r requirements_dev.txt
+    $ pip install --no-use-pep517 -r requirements_dev.txt
 
 4. Install ``pre-commit`` hooks for ``black`` and ``flake8``::
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,5 @@ setenv =
 
 commands = coverage run {envbindir}/pytest []
 
-; If you want to make tox run the tests with the same versions, create a
-; requirements.txt with the pinned versions and uncomment the following lines:
-deps =
-    --no-use-pep517 -r {toxinidir}/requirements_dev.txt
+install_command =
+    python -m pip install --no-use-pep517 -r {toxinidir}/requirements_dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,7 @@ setenv =
 
 commands = coverage run {envbindir}/pytest []
 
+deps =	
+    -r{toxinidir}/requirements_dev.txt
 install_command =
-    python -m pip install --no-use-pep517 -r {toxinidir}/requirements_dev.txt
+    python -m pip install --no-use-pep517 {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ commands = coverage run {envbindir}/pytest []
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following lines:
 deps =
-    -r{toxinidir}/requirements_dev.txt
+    --no-use-pep517 -r {toxinidir}/requirements_dev.txt


### PR DESCRIPTION
pip 19.1 breaks when doing an editable (`-e`) install of a package that has a pyproject.toml without a build_system specified. Unfortunately we have such a file because it's where `black` looks for configuration.

See https://github.com/pypa/pip/pull/6370 and https://github.com/pypa/pip/issues/6433 for more discussion.

# Critical Changes

# Changes

# Issues Closed
