### PR TITLE
Don't install requests with security extra

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ python-dateutil==2.8.0
 pytz==2019.1
 PyYAML==5.1
 raven==6.10.0
-requests[security]==2.21.0
+requests==2.21.0
 robotframework==3.1.1
 robotframework-seleniumlibrary==3.3.1
 rst2ansi==0.1.5


### PR DESCRIPTION
It's not needed in Python 2.7.6+, and it causes requests to use pyOpenSSL instead of the stdlib ssl module.

# Critical Changes

# Changes

# Issues Closed
