### PR TITLE
String format package_xml to allow for handling of namespace prefixes

### DIFF
--- a/cumulusci/tasks/salesforce/UpdateAdminProfile.py
+++ b/cumulusci/tasks/salesforce/UpdateAdminProfile.py
@@ -61,6 +61,10 @@ class UpdateAdminProfile(Deploy):
         )
         with open(path, "r") as f:
             self._package_xml_content = f.read()
+            
+        self._package_xml_content = self._package_xml_content.format(
+            **self.namespace_prefixes
+        )
 
     def _run_task(self):
         self.tempdir = tempfile.mkdtemp()

--- a/cumulusci/tasks/salesforce/UpdateAdminProfile.py
+++ b/cumulusci/tasks/salesforce/UpdateAdminProfile.py
@@ -61,7 +61,7 @@ class UpdateAdminProfile(Deploy):
         )
         with open(path, "r") as f:
             self._package_xml_content = f.read()
-            
+
         self._package_xml_content = self._package_xml_content.format(
             **self.namespace_prefixes
         )


### PR DESCRIPTION
# Critical Changes

# Changes

* The `update_admin_profile` task now uses Python string formatting on the package.xml file used for retrieve.  This allows injection of namespace prefixes using `{managed}` and `{namespaced_org}`.

# Issues Closed
