### PR TITLE
Add Ensure Record Types task

### DIFF
--- a/cumulusci/tasks/salesforce/EnsureRecordTypes.py
+++ b/cumulusci/tasks/salesforce/EnsureRecordTypes.py
@@ -1,0 +1,140 @@
+import os
+import re
+from cumulusci.core.exceptions import TaskOptionsError
+from cumulusci.tasks.salesforce import BaseSalesforceApiTask, Deploy
+from cumulusci.utils import temporary_dir
+
+BUSINESS_PROCESS_METADATA = """<businessProcesses>
+        <fullName>{record_type_developer_name}</fullName>
+        <isActive>true</isActive>
+        <values>
+            <fullName>{stage_name}</fullName>
+            <default>false</default>
+        </values>
+    </businessProcesses>"""
+
+BUSINESS_PROCESS_LINK = (
+    """<businessProcess>{record_type_developer_name}</businessProcess>"""
+)
+
+SOBJECT_METADATA = """<?xml version="1.0" encoding="utf-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    {business_process_metadata}
+    <recordTypes>
+        <fullName>{record_type_developer_name}</fullName>
+        <active>true</active>
+        {business_process_link}
+        <label>{record_type_label}</label>
+    </recordTypes>
+</CustomObject>
+"""
+
+PACKAGE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>*</members>
+        <name>CustomObject</name>
+    </types>
+    <version>45.0</version>
+</Package>"""
+
+SOBJECT_MAP = {
+    "Opportunity": "StageName",
+    "Lead": "Status",
+    "Case": "Status",
+    "Solution": "Status",
+}
+
+
+class EnsureRecordTypes(BaseSalesforceApiTask):
+    task_options = {
+        "record_type_developer_name": {
+            "description": "The Developer Name of the Record Type (unique).  Must contain only alphanumeric characters and underscores.",
+            "required": True,
+        },
+        "record_type_label": {
+            "description": "The Label of the Record Type.",
+            "required": True,
+        },
+        "sobject": {
+            "description": "The sObject on which to deploy the Record Type and optional Business Process.",
+            "required": True,
+        },
+    }
+    _deploy = Deploy
+
+    def _init_options(self, kwargs):
+        super(EnsureRecordTypes, self)._init_options(kwargs)
+
+        self.options["generate_business_process"] = False
+
+        # Validate developer name
+        if not re.match(r"^\w+$", self.options["record_type_developer_name"]):
+            raise TaskOptionsError(
+                "Record Type Developer Name value must contain only alphanumeric or underscore characters"
+            )
+
+    def _infer_business_process(self):
+        # If our sObject is Lead or Opportunity, we need to generate businessProcess
+        # metadata to make the record type deployable.
+        sobject = self.options["sobject"]
+
+        if sobject in SOBJECT_MAP:
+            self.options["generate_business_process"] = True
+            describe_results = getattr(self.sf, sobject).describe()
+            # Salesforce requires that at least one picklist value be present and active
+            self.options["stage_name"] = next(
+                filter(
+                    lambda pl: pl["active"],
+                    next(
+                        filter(
+                            lambda f: f["name"] == SOBJECT_MAP[sobject],
+                            describe_results["fields"],
+                        )
+                    )["picklistValues"],
+                )
+            )["value"]
+
+    def _build_package(self):
+        objects_app_path = "objects"
+        os.mkdir(objects_app_path)
+        with open(
+            os.path.join(objects_app_path, self.options["sobject"] + ".object"), "w"
+        ) as f:
+            if self.options["generate_business_process"]:
+                business_process_metadata = BUSINESS_PROCESS_METADATA.format(
+                    record_type_developer_name=self.options[
+                        "record_type_developer_name"
+                    ],
+                    stage_name=self.options["stage_name"],
+                )
+                business_process_link = BUSINESS_PROCESS_LINK.format(
+                    record_type_developer_name=self.options[
+                        "record_type_developer_name"
+                    ]
+                )
+            else:
+                business_process_metadata = business_process_link = ""
+
+            f.write(
+                SOBJECT_METADATA.format(
+                    record_type_developer_name=self.options[
+                        "record_type_developer_name"
+                    ],
+                    record_type_label=self.options["record_type_label"],
+                    business_process_metadata=business_process_metadata,
+                    business_process_link=business_process_link,
+                )
+            )
+        with open("package.xml", "w") as f:
+            f.write(PACKAGE_XML)
+
+    def _run_task(self):
+        self._infer_business_process()
+
+        with temporary_dir() as tempdir:
+            self._build_package()
+            d = self._deploy(
+                self.project_config, self.task_config, self.org_config, path=tempdir
+            )
+            d()

--- a/cumulusci/tasks/salesforce/EnsureRecordTypes.py
+++ b/cumulusci/tasks/salesforce/EnsureRecordTypes.py
@@ -83,17 +83,17 @@ class EnsureRecordTypes(BaseSalesforceApiTask):
             self.options["generate_business_process"] = True
             describe_results = getattr(self.sf, sobject).describe()
             # Salesforce requires that at least one picklist value be present and active
-            self.options["stage_name"] = next(
+            self.options["stage_name"] = list(
                 filter(
                     lambda pl: pl["active"],
-                    next(
+                    list(
                         filter(
                             lambda f: f["name"] == SOBJECT_MAP[sobject],
                             describe_results["fields"],
                         )
-                    )["picklistValues"],
+                    )[0]["picklistValues"],
                 )
-            )["value"]
+            )[0]["value"]
 
     def _build_package(self):
         objects_app_path = "objects"

--- a/cumulusci/tasks/salesforce/__init__.py
+++ b/cumulusci/tasks/salesforce/__init__.py
@@ -12,6 +12,7 @@ from cumulusci.tasks.salesforce.BaseSalesforceMetadataApiTask import (
 # inherit from BaseSalesforceApiTask
 from cumulusci.tasks.salesforce.PackageUpload import PackageUpload
 from cumulusci.tasks.salesforce.SOQLQuery import SOQLQuery
+from cumulusci.tasks.salesforce.EnsureRecordTypes import EnsureRecordTypes
 
 # inherit from BaseSalesforceMetadataApiTask
 from cumulusci.tasks.salesforce.BaseRetrieveMetadata import BaseRetrieveMetadata

--- a/cumulusci/tasks/salesforce/__init__.py
+++ b/cumulusci/tasks/salesforce/__init__.py
@@ -12,13 +12,15 @@ from cumulusci.tasks.salesforce.BaseSalesforceMetadataApiTask import (
 # inherit from BaseSalesforceApiTask
 from cumulusci.tasks.salesforce.PackageUpload import PackageUpload
 from cumulusci.tasks.salesforce.SOQLQuery import SOQLQuery
-from cumulusci.tasks.salesforce.EnsureRecordTypes import EnsureRecordTypes
 
 # inherit from BaseSalesforceMetadataApiTask
 from cumulusci.tasks.salesforce.BaseRetrieveMetadata import BaseRetrieveMetadata
 from cumulusci.tasks.salesforce.Deploy import Deploy
 from cumulusci.tasks.salesforce.GetInstalledPackages import GetInstalledPackages
 from cumulusci.tasks.salesforce.UpdateDependencies import UpdateDependencies
+
+# inherit from BaseSalesforceApiTask and use Deploy
+from cumulusci.tasks.salesforce.EnsureRecordTypes import EnsureRecordTypes
 
 # inherit from BaseRetrieveMetadata
 from cumulusci.tasks.salesforce.RetrievePackaged import RetrievePackaged

--- a/cumulusci/tasks/salesforce/tests/test_EnsureRecordTypes.py
+++ b/cumulusci/tasks/salesforce/tests/test_EnsureRecordTypes.py
@@ -1,0 +1,162 @@
+import mock
+import unittest
+import os
+
+from cumulusci.tasks.salesforce import EnsureRecordTypes
+from cumulusci.utils import temporary_dir
+from .util import create_task
+
+OPPORTUNITY_METADATA = """<?xml version="1.0" encoding="utf-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <businessProcesses>
+        <fullName>NPSP_Default</fullName>
+        <isActive>true</isActive>
+        <values>
+            <fullName>Test</fullName>
+            <default>false</default>
+        </values>
+    </businessProcesses>
+    <recordTypes>
+        <fullName>NPSP_Default</fullName>
+        <active>true</active>
+        <businessProcess>NPSP_Default</businessProcess>
+        <label>NPSP Default</label>
+    </recordTypes>
+</CustomObject>
+"""
+
+ACCOUNT_METADATA = """<?xml version="1.0" encoding="utf-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    
+    <recordTypes>
+        <fullName>NPSP_Default</fullName>
+        <active>true</active>
+        
+        <label>NPSP Default</label>
+    </recordTypes>
+</CustomObject>
+"""
+
+PACKAGE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>*</members>
+        <name>CustomObject</name>
+    </types>
+    <version>45.0</version>
+</Package>"""
+
+OPPORTUNITY_DESCRIBE = {
+    "fields": [
+        {"name": "Id"},
+        {
+            "name": "StageName",
+            "picklistValues": [
+                {"value": "Bad", "active": False},
+                {"value": "Test", "active": True},
+            ],
+        },
+    ]
+}
+
+
+class TestEnsureRecordTypes(unittest.TestCase):
+    def test_infers_correct_business_process(self):
+        task = create_task(
+            EnsureRecordTypes,
+            {
+                "record_type_developer_name": "NPSP_Default",
+                "record_type_label": "NPSP Default",
+                "sobject": "Opportunity",
+            },
+        )
+        task.sf = mock.Mock()
+        task.sf.Opportunity = mock.Mock()
+        task.sf.Opportunity.describe = mock.Mock(return_value=OPPORTUNITY_DESCRIBE)
+
+        task._infer_business_process()
+
+        self.assertTrue(task.options["generate_business_process"])
+        self.assertEqual("Test", task.options["stage_name"])
+
+    def test_no_business_process_where_unneeded(self):
+        task = create_task(
+            EnsureRecordTypes,
+            {
+                "record_type_developer_name": "NPSP_Default",
+                "record_type_label": "NPSP Default",
+                "sobject": "Account",
+            },
+        )
+        task.sf = mock.Mock()
+
+        task._infer_business_process()
+
+        self.assertFalse(task.options["generate_business_process"])
+        self.assertNotIn("stage_name", task.options)
+        task.sf.Account.describe.assert_not_called()
+
+    def test_generates_record_type_and_business_process(self):
+        task = create_task(
+            EnsureRecordTypes,
+            {
+                "record_type_developer_name": "NPSP_Default",
+                "record_type_label": "NPSP Default",
+                "sobject": "Opportunity",
+            },
+        )
+
+        task.sf = mock.Mock()
+        task.sf.Opportunity = mock.Mock()
+        task.sf.Opportunity.describe = mock.Mock(return_value=OPPORTUNITY_DESCRIBE)
+        task._infer_business_process()
+
+        with temporary_dir() as tempdir:
+            task._build_package()
+            with open(os.path.join("objects", "Opportunity.object"), "r") as f:
+                opp_contents = f.read()
+                self.assertMultiLineEqual(OPPORTUNITY_METADATA, opp_contents)
+            with open(os.path.join("package.xml"), "r") as f:
+                pkg_contents = f.read()
+                self.assertMultiLineEqual(PACKAGE_XML, pkg_contents)
+
+    def test_generates_record_type_only(self):
+        task = create_task(
+            EnsureRecordTypes,
+            {
+                "record_type_developer_name": "NPSP_Default",
+                "record_type_label": "NPSP Default",
+                "sobject": "Account",
+            },
+        )
+
+        task.sf = mock.Mock()
+        task._infer_business_process()
+
+        with temporary_dir() as tempdir:
+            task._build_package()
+            with open(os.path.join("objects", "Account.object"), "r") as f:
+                opp_contents = f.read()
+                self.assertMultiLineEqual(ACCOUNT_METADATA, opp_contents)
+            with open(os.path.join("package.xml"), "r") as f:
+                pkg_contents = f.read()
+                self.assertMultiLineEqual(PACKAGE_XML, pkg_contents)
+
+    def test_executes_deployment(self):
+        task = create_task(
+            EnsureRecordTypes,
+            {
+                "record_type_developer_name": "NPSP_Default",
+                "record_type_label": "NPSP Default",
+                "sobject": "Opportunity",
+            },
+        )
+
+        task.sf = mock.Mock()
+        task.sf.Opportunity = mock.Mock()
+        task.sf.Opportunity.describe = mock.Mock(return_value=OPPORTUNITY_DESCRIBE)
+        task._deploy = mock.Mock()
+        task._run_task()
+
+        task._deploy.assert_called_once()
+        task._deploy.return_value.assert_called_once()


### PR DESCRIPTION
# Critical Changes

# Changes

 - Add a task, Ensure Record Types, to generate a Record Type and optional Business Process for a specific sObject and deploy the metadata.

# Issues Closed
