### PR TITLE
Decompress static resources on retrieve

### DIFF
--- a/cumulusci/tasks/salesforce/sourcetracking.py
+++ b/cumulusci/tasks/salesforce/sourcetracking.py
@@ -118,6 +118,9 @@ retrieve_changes_task_options["api_version"] = {
 retrieve_changes_task_options["namespace_tokenize"] = BaseRetrieveMetadata.task_options[
     "namespace_tokenize"
 ]
+retrieve_changes_task_options[
+    "static_resource_path"
+] = BaseRetrieveMetadata.task_options["static_resource_path"]
 
 
 class RetrieveChanges(BaseRetrieveMetadata, ListChanges, BaseSalesforceApiTask):


### PR DESCRIPTION
# Critical Changes

# Changes

* Added `static_resource_path` option to BaseRetrieveMetadata task.  If set, will handle decompressing the static resources into a different directory after retrieve

# Issues Closed
