### PR TITLE
Remove pip workaround

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: Install dependencies
           command: |
             virtualenv venv
-            venv/bin/pip install --no-use-pep517 $(grep black requirements_dev.txt | cut -d';' -f 1)
+            venv/bin/pip install $(grep black requirements_dev.txt | cut -d';' -f 1)
       - run:
           name: Run black
           command: |
@@ -81,7 +81,7 @@ jobs:
           name: Install Python dependencies
           command: |
             virtualenv venv
-            venv/bin/pip install --no-use-pep517 -r requirements_dev.txt
+            venv/bin/pip install -r requirements_dev.txt
       - run:
           name: Install sfdx
           command: |
@@ -136,7 +136,7 @@ jobs:
           name: Install Python dependencies
           command: |
             virtualenv venv
-            venv/bin/pip install --no-use-pep517 -r requirements_dev.txt
+            venv/bin/pip install -r requirements_dev.txt
       - run:
           name: Check out CumulusCI-Test
           command: |

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -57,7 +57,7 @@ Ready to contribute? Here's how to set up CumulusCI for local development.
 2. Clone your fork to your local workspace.
 3. Create a fresh virtual environment using virtualenv and install development requirements::
 
-    $ pip install --no-use-pep517 -r requirements_dev.txt
+    $ pip install -r requirements_dev.txt
 
 4. Install ``pre-commit`` hooks for ``black`` and ``flake8``::
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,5 +9,3 @@ commands = coverage run {envbindir}/pytest []
 
 deps =	
     -r{toxinidir}/requirements_dev.txt
-install_command =
-    python -m pip install --no-use-pep517 {opts} {packages}


### PR DESCRIPTION
pip 19.1.1 fixed editable installs when the project has a pyproject.toml that doesn't specify a build system, so we shouldn't need this workaround any longer -- but let's see what CI says.

# Critical Changes

# Changes

# Issues Closed
