### PR TITLE
Feature/circleci preserve robot logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,13 +102,13 @@ jobs:
             # we need to modify our task to make it easier to save the
             # output.xml file with a unique name. Until then, we have
             # to manually preserve each file under a different name
-            venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/cumulusci  -o xunit robot_results/robot/cumulusci.xml
+            venv/bin/coverage run --append venv/bin/cci task run robot -o name "CumulusCI" -o suites cumulusci/robotframework/tests/cumulusci  -o xunit robot_results/robot/cumulusci.xml
             mv output.xml robot_results/robot/cumulusci-output.xml
-            venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/salesforce -o include api -o xunit robot_results/robot/salesforce_api.xml
+            venv/bin/coverage run --append venv/bin/cci task run robot -o name "Salesforce API" -o suites cumulusci/robotframework/tests/salesforce -o include api -o xunit robot_results/robot/salesforce_api.xml
             mv output.xml robot_results/robot/salesforce_api-output.xml
-            venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/salesforce -o exclude api -o xunit robot_results/robot/salesforce_ui_chrome.xml
+            venv/bin/coverage run --append venv/bin/cci task run robot -o name "Salesforce UI Chrome" -o suites cumulusci/robotframework/tests/salesforce -o exclude api -o xunit robot_results/robot/salesforce_ui_chrome.xml
             mv output.xml robot_results/robot/salesforce_ui_chrome-output.xml
-            venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/salesforce -o exclude api -o vars BROWSER:headlessfirefox -o xunit robot_results/robot/salesforce_ui_firefox.xml
+            Salesforce\ UI\ Firefoxvenv/bin/coverage run --append venv/bin/cci task run robot -o name "Salesforce UI Firefox" -o suites cumulusci/robotframework/tests/salesforce -o exclude api -o vars BROWSER:headlessfirefox -o xunit robot_results/robot/salesforce_ui_firefox.xml
             mv output.xml robot_results/robot/salesforce_ui_firefox-output.xml
       - run:
           name: Consolidate robot outputs into a single report and log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,10 +99,21 @@ jobs:
           name: Run robot tests
           command: |
             mkdir -p robot_results/robot
+            # we need to modify our task to make it easier to save the
+            # output.xml file with a unique name. Until then, we have
+            # to manually preserve each file under a different name
             venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/cumulusci  -o xunit robot_results/robot/cumulusci.xml
+            mv output.xml robot_results/robot/cumulusci-output.xml
             venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/salesforce -o include api -o xunit robot_results/robot/salesforce_api.xml
+            mv output.xml robot_results/robot/salesforce_api-output.xml
             venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/salesforce -o exclude api -o xunit robot_results/robot/salesforce_ui_chrome.xml
+            mv output.xml robot_results/robot/salesforce_ui_chrome-output.xml
             venv/bin/coverage run --append venv/bin/cci task run robot -o suites cumulusci/robotframework/tests/salesforce -o exclude api -o vars BROWSER:headlessfirefox -o xunit robot_results/robot/salesforce_ui_firefox.xml
+            mv output.xml robot_results/robot/salesforce_ui_firefox-output.xml
+      - run:
+          name: Consolidate robot outputs into a single report and log
+          command: |
+            venv/bin/rebot --outputdir robot_results/robot  robot_results/robot/*-output.xml
       - run:
           name: Delete scratch org
           command: |
@@ -115,6 +126,9 @@ jobs:
           when: always
       - store_test_results:
           path: robot_results
+      - store_artifacts:
+          path: robot_results/
+          destination: robot
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
             mv output.xml robot_results/robot/salesforce_api-output.xml
             venv/bin/coverage run --append venv/bin/cci task run robot -o name "Salesforce UI Chrome" -o suites cumulusci/robotframework/tests/salesforce -o exclude api -o xunit robot_results/robot/salesforce_ui_chrome.xml
             mv output.xml robot_results/robot/salesforce_ui_chrome-output.xml
-            Salesforce\ UI\ Firefoxvenv/bin/coverage run --append venv/bin/cci task run robot -o name "Salesforce UI Firefox" -o suites cumulusci/robotframework/tests/salesforce -o exclude api -o vars BROWSER:headlessfirefox -o xunit robot_results/robot/salesforce_ui_firefox.xml
+            venv/bin/coverage run --append venv/bin/cci task run robot -o name "Salesforce UI Firefox" -o suites cumulusci/robotframework/tests/salesforce -o exclude api -o vars BROWSER:headlessfirefox -o xunit robot_results/robot/salesforce_ui_firefox.xml
             mv output.xml robot_results/robot/salesforce_ui_firefox-output.xml
       - run:
           name: Consolidate robot outputs into a single report and log

--- a/cumulusci/tasks/robotframework/robotframework.py
+++ b/cumulusci/tasks/robotframework/robotframework.py
@@ -29,6 +29,7 @@ class Robot(BaseSalesforceTask):
         "options": {
             "description": "A dictionary of options to robot.run method.  See docs here for format.  NOTE: There is no cci CLI support for this option since it requires a dictionary.  Use this option in the cumulusci.yml when defining custom tasks where you can easily create a dictionary in yaml."
         },
+        "name": {"description": "Sets the name of the top level test suite"},
         "pdb": {"description": "If true, run the Python debugger when tests fail."},
         "verbose": {"description": "If true, log each keyword as it runs."},
     }
@@ -55,7 +56,7 @@ class Robot(BaseSalesforceTask):
     def _run_task(self):
         self.options["vars"].append("org:{}".format(self.org_config.name))
         options = self.options["options"].copy()
-        for option in ("test", "include", "exclude", "xunit"):
+        for option in ("test", "include", "exclude", "xunit", "name"):
             if option in self.options:
                 options[option] = self.options[option]
         options["variable"] = self.options.get("vars") or []


### PR DESCRIPTION
This adds a new 'name' option to the robot task, and a modified .circleci/config.yml file that
will save the robot artifacts (log.html, report.html, etc)

My initial goal was to only make changes to circleci, but the combined robot report was hard to grok since three of the four test runs had the same name inside the report. By default the name is based off of the folder, so without the change to the task it showed up as three test runs all named "salesforce". So, I added the 'name' option so each run can have a name representative of what is being tested.

# Critical Changes

# Changes

# Issues Closed
