### PR TITLE
sfdx.SFDXBaseTask supports formatting extra with org_config; Add dx_set_defaultusername Task

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -82,9 +82,17 @@ tasks:
         group: Salesforce DX
     dx_push:
         description: Uses sfdx to push the force-app directory metadata into a scratch org
-        class_path: cumulusci.tasks.sfdx.SFDXOrgTask
+        class_path: cumulusci.tasks.sfdx.SFDXBaseTask
         options:
             command: 'force:source:push'
+        group: Salesforce DX
+    dx_set_defaultusername:
+        description: Sets sfdx's defaultusername as Org's sfdx alias
+        class_path: cumulusci.tasks.sfdx.SFDXBaseTask
+        options:
+            command: 'force:config:set'
+            extra: 'defaultusername="{org_config.sfdx_alias}"'
+            format_extra_with_org_config: True
         group: Salesforce DX
     execute_anon:
         description: Execute anonymous apex via the tooling api.

--- a/cumulusci/tasks/sfdx.py
+++ b/cumulusci/tasks/sfdx.py
@@ -28,6 +28,9 @@ class SFDXBaseTask(Command):
             "required": True,
         },
         "extra": {"description": "Append additional options to the command"},
+        "format_extra_with_org_config": {
+            "description": "Formats extra with org_config.  Example: {org_config.sfdx_alias}"
+        },
     }
 
     def _init_options(self, kwargs):
@@ -35,7 +38,12 @@ class SFDXBaseTask(Command):
         self.options["command"] = self._get_command()
         # Add extra command args from
         if self.options.get("extra"):
-            self.options["command"] += " {}".format(self.options["extra"])
+            extra = self.options["extra"]
+
+            if self.options.get("format_extra_with_org_config"):
+                extra = extra.format(org_config=self.org_config)
+
+            self.options["command"] += " {}".format(extra)
 
     def _get_command(self):
         command = "{SFDX_CLI} {command}".format(


### PR DESCRIPTION
# Critical Changes

# Changes
-  **sfdx.SFDXBaseTask** supports formatting `extra` with `self.org_config`
-  Added `dx_set_defaultusername` Task to set SFDX Default Username from `org_config`.   Useful for VS Code integration whose commands assume a Default Username is set.
    ```yaml
    class_path: cumulusci.tasks.sfdx.SFDXBaseTask
    options:
        command: 'force:config:set'
        extra: 'defaultusername="{org_config.sfdx_alias}"'
        format_extra_with_org_config: True
    ```

# Issues Closed
