### PR TITLE
Validate GitHub service attributes before saving

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -39,7 +39,7 @@ from cumulusci.core.exceptions import OrgNotFound
 from cumulusci.core.exceptions import ScratchOrgException
 from cumulusci.core.exceptions import ServiceNotConfigured
 from cumulusci.core.exceptions import TaskNotFoundError
-from cumulusci.core.utils import import_class
+from cumulusci.core.utils import import_global
 from cumulusci.cli.config import CliRuntime
 from cumulusci.cli.config import get_installed_version
 from cumulusci.utils import doc_task
@@ -621,15 +621,13 @@ class ConnectServiceCommand(click.MultiCommand):
 
     def get_command(self, ctx, name):
         config = load_config(**self.load_config_kwargs)
-
         try:
-            attributes = getattr(
-                config.project_config, "services__{0}__attributes".format(name)
-            ).items()
+            service_config = getattr(config.project_config, "services__{}".format(name))
         except AttributeError:
             raise click.UsageError(
                 "Sorry, I don't know about the '{0}' service.".format(name)
             )
+        attributes = service_config["attributes"].items()
 
         params = [self._build_param(attr, cnfg) for attr, cnfg in attributes]
         if not config.is_global_keychain:
@@ -639,15 +637,27 @@ class ConnectServiceCommand(click.MultiCommand):
             if config.is_global_keychain:
                 project = False
             else:
-                project = kwargs.get("project", False)
+                project = kwargs.pop("project", False)
             serv_conf = dict(
                 (k, v) for k, v in list(kwargs.items()) if v is not None
             )  # remove None values
+
+            # A service can define a callable to validate the service config
+            validator_path = service_config.get("validator")
+            if validator_path:
+                validator = import_global(validator_path)
+                try:
+                    validator(serv_conf)
+                except Exception as e:
+                    raise click.UsageError(str(e))
+
             config.keychain.set_service(name, ServiceConfig(serv_conf), project)
             if project:
-                click.echo("{0} is now configured for this project".format(name))
+                click.echo("{0} is now configured for this project.".format(name))
             else:
-                click.echo("{0} is now configured for global use".format(name))
+                click.echo(
+                    "{0} is now configured for all CumulusCI projects.".format(name)
+                )
 
         ret = click.Command(name, params=params, callback=callback)
         return ret
@@ -1051,7 +1061,7 @@ def task_run(config, task_name, org, o, debug, debug_before, debug_after, no_pro
 
     # Get the class to look up options
     class_path = task_config.get("class_path")
-    task_class = import_class(class_path)
+    task_class = import_global(class_path)
 
     # Parse command line options and add to task config
     if o:

--- a/cumulusci/cli/config.py
+++ b/cumulusci/cli/config.py
@@ -13,7 +13,7 @@ from cumulusci.core.exceptions import NotInProject
 from cumulusci.core.exceptions import OrgNotFound
 from cumulusci.core.exceptions import KeychainKeyNotFound
 from cumulusci.core.exceptions import ProjectConfigNotFound
-from cumulusci.core.utils import import_class
+from cumulusci.core.utils import import_global
 from cumulusci.utils import get_cci_upgrade_command
 from cumulusci.utils import random_alphanumeric_underscore
 
@@ -38,7 +38,7 @@ class CliRuntime(BaseCumulusCI):
         keychain_class = os.environ.get(
             "CUMULUSCI_KEYCHAIN_CLASS", default_keychain_class
         )
-        return import_class(keychain_class)
+        return import_global(keychain_class)
 
     def get_keychain_key(self):
         key_from_env = os.environ.get("CUMULUSCI_KEY")

--- a/cumulusci/core/flowrunner.py
+++ b/cumulusci/core/flowrunner.py
@@ -64,7 +64,7 @@ from operator import attrgetter
 from cumulusci.core.config import TaskConfig
 from cumulusci.core.config import FlowConfig
 from cumulusci.core.exceptions import FlowConfigError, FlowInfiniteLoopError
-from cumulusci.core.utils import import_class
+from cumulusci.core.utils import import_global
 
 # TODO: define exception types: flowfailure, taskimporterror, etc?
 
@@ -450,7 +450,7 @@ class FlowCoordinator(object):
 
             # get implementation class. raise/fail if it doesn't exist, because why continue
             try:
-                task_class = import_class(task_config["class_path"])
+                task_class = import_global(task_config["class_path"])
             except (ImportError, AttributeError):
                 # TODO: clean this up and raise a taskimporterror or something else correcter.
                 raise FlowConfigError("Task named {} has bad classpath")

--- a/cumulusci/core/github.py
+++ b/cumulusci/core/github.py
@@ -1,5 +1,6 @@
 """Wraps the github3 library to configure request retries."""
 
+from cumulusci.core.exceptions import GithubException
 from github3 import login
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
@@ -13,3 +14,15 @@ def get_github_api(username, password):
     gh.session.mount("http://", adapter)
     gh.session.mount("https://", adapter)
     return gh
+
+
+def validate_service(options):
+    username = options["username"]
+    password = options["password"]
+    gh = get_github_api(username, password)
+    try:
+        gh.rate_limit()
+    except Exception as e:
+        raise GithubException(
+            "Could not confirm access to the GitHub API: {}".format(str(e))
+        )

--- a/cumulusci/core/tests/test_github.py
+++ b/cumulusci/core/tests/test_github.py
@@ -3,8 +3,11 @@ import io
 import unittest
 
 import mock
+import responses
 
+from cumulusci.core.exceptions import GithubException
 from cumulusci.core.github import get_github_api
+from cumulusci.core.github import validate_service
 
 
 class MockHttpResponse(mock.Mock):
@@ -39,3 +42,9 @@ class TestGithub(unittest.TestCase):
 
         gh.octocat("meow")
         self.assertEqual(_make_request.call_count, 2)
+
+    @responses.activate
+    def test_validate_service(self):
+        responses.add("GET", "/rate_limit", status=401)
+        with self.assertRaises(GithubException):
+            validate_service({"username": "BOGUS", "password": "BOGUS"})

--- a/cumulusci/core/utils.py
+++ b/cumulusci/core/utils.py
@@ -1,6 +1,6 @@
 """ Utilities for CumulusCI Core
 
-import_class: task class defn import helper
+import_global: task class defn import helper
 process_bool_arg: determine true/false for a commandline arg
 decode_to_unicode: get unicode string from sf api """
 from __future__ import unicode_literals
@@ -21,13 +21,17 @@ from collections import OrderedDict
 from cumulusci.core.exceptions import ConfigMergeError
 
 
-def import_class(path):
+def import_global(path):
     """ Import a class from a string module class path """
     components = path.split(".")
     module = components[:-1]
     module = ".".join(module)
     mod = __import__(module, fromlist=[native_str(components[-1])])
     return getattr(mod, native_str(components[-1]))
+
+
+# For backwards-compatibility
+import_class = import_global
 
 
 def parse_datetime(dt_str, format):

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -719,6 +719,7 @@ services:
       email:
         description: The email address to used by Github tasks when an operation requires an email address.
         required: True
+    validator: cumulusci.core.github.validate_service
   metaci:
     description: Connect with a MetaCI site to run builds of projects from this repository
     attributes:

--- a/cumulusci/robotframework/CumulusCI.py
+++ b/cumulusci/robotframework/CumulusCI.py
@@ -8,7 +8,7 @@ from cumulusci.cli.config import CliRuntime
 from cumulusci.core.config import TaskConfig
 from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.core.tasks import CURRENT_TASK
-from cumulusci.core.utils import import_class
+from cumulusci.core.utils import import_global
 from cumulusci.robotframework.utils import set_pdb_trace
 from cumulusci.tasks.robotframework.robotframework import Robot
 
@@ -179,7 +179,7 @@ class CumulusCI(object):
         return rv
 
     def _init_task(self, class_path, options, task_config):
-        task_class = import_class(class_path)
+        task_class = import_global(class_path)
         task_config = self._parse_task_options(options, task_class, task_config)
         return task_class, task_config
 

--- a/cumulusci/tasks/release_notes/generator.py
+++ b/cumulusci/tasks/release_notes/generator.py
@@ -1,6 +1,6 @@
 import github3.exceptions
 
-from cumulusci.core.utils import import_class
+from cumulusci.core.utils import import_global
 from cumulusci.tasks.release_notes.exceptions import CumulusCIException
 from cumulusci.tasks.release_notes.parser import ChangeNotesLinesParser
 from cumulusci.tasks.release_notes.parser import IssuesParser
@@ -121,7 +121,7 @@ class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator):
 
     def _init_parsers(self):
         for cfg in self.parser_config:
-            parser_class = import_class(cfg["class_path"])
+            parser_class = import_global(cfg["class_path"])
             self.parsers.append(parser_class(self, cfg["title"]))
 
     def _init_change_notes(self):

--- a/cumulusci/utils.py
+++ b/cumulusci/utils.py
@@ -368,14 +368,14 @@ def zip_clean_metaxml(zip_src, logger=None):
 
 def doc_task(task_name, task_config, project_config=None, org_config=None):
     """ Document a (project specific) task configuration in RST format. """
-    from cumulusci.core.utils import import_class
+    from cumulusci.core.utils import import_global
 
     doc = []
     doc.append("{}\n==========================================\n".format(task_name))
     doc.append("**Description:** {}\n".format(task_config.description))
     doc.append("**Class::** {}\n".format(task_config.class_path))
 
-    task_class = import_class(task_config.class_path)
+    task_class = import_global(task_config.class_path)
     task_docs = textwrap.dedent(task_class.task_docs.strip("\n"))
     if task_docs:
         doc.append(task_docs + "\n")


### PR DESCRIPTION
This involves adding a general mechanism for a service to configure a validator. If configured, the `cci service connect` command will call the validator passing the service attributes that were input, and abort if the validator raises an exception.

I also renamed cumulusci.core.utils.import_class to import_global since it can import anything from a module's globals. import_class remains as an alias for backwards-compatibility.

# Critical Changes

# Changes

# Issues Closed
Fixes #909 