### PR TITLE
Make CCI manage the sfdx default org

### DIFF
--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -194,12 +194,13 @@ class ScratchOrgConfig(OrgConfig):
             "email": sarge.shell_format('adminEmail="{0!s}"', self.email_address)
             if self.email_address and not org_def_has_email
             else "",
+            "default": " -s" if self.default else "",
             "extraargs": os.environ.get("SFDX_ORG_CREATE_ARGS", ""),
         }
 
         # This feels a little dirty, but the use cases for extra args would mostly
         # work best with env vars
-        command = "sfdx force:org:create -f {config_file}{devhub}{namespaced}{days}{alias} {email} {extraargs}".format(
+        command = "sfdx force:org:create -f {config_file}{devhub}{namespaced}{days}{alias}{default} {email} {extraargs}".format(
             **options
         )
         self.logger.info("Creating scratch org with command {}".format(command))

--- a/cumulusci/core/keychain/BaseProjectKeychain.py
+++ b/cumulusci/core/keychain/BaseProjectKeychain.py
@@ -8,6 +8,7 @@ from cumulusci.core.config import ServiceConfig
 from cumulusci.core.exceptions import OrgNotFound
 from cumulusci.core.exceptions import ServiceNotConfigured
 from cumulusci.core.exceptions import ServiceNotValid
+from cumulusci.core.sfdx import sfdx
 
 
 class BaseProjectKeychain(BaseConfig):
@@ -157,12 +158,10 @@ class BaseProjectKeychain(BaseConfig):
         org.config["default"] = True
         self.set_org(org)
         if org.created:
-            sarge.run(
+            sfdx(
                 sarge.shell_format(
-                    "sfdx force:config:set defaultusername={}", org.sfdx_alias
-                ),
-                stdout=sarge.Capture(buffer_size=-1),
-                stderr=sarge.Capture(buffer_size=-1),
+                    "force:config:set defaultusername={}", org.sfdx_alias
+                )
             )
 
     def unset_default_org(self):
@@ -172,11 +171,7 @@ class BaseProjectKeychain(BaseConfig):
             if org_config.default:
                 del org_config.config["default"]
                 self.set_org(org_config)
-        sarge.run(
-            "sfdx force:config:set defaultusername=",
-            stdout=sarge.Capture(buffer_size=-1),
-            stderr=sarge.Capture(buffer_size=-1),
-        )
+        sfdx("force:config:set defaultusername=")
 
     def get_org(self, name):
         """ retrieve an org configuration by name key """

--- a/cumulusci/core/keychain/BaseProjectKeychain.py
+++ b/cumulusci/core/keychain/BaseProjectKeychain.py
@@ -156,13 +156,14 @@ class BaseProjectKeychain(BaseConfig):
         self.unset_default_org()
         org.config["default"] = True
         self.set_org(org)
-        sarge.run(
-            sarge.shell_format(
-                "sfdx force:config:set defaultusername={}", org.sfdx_alias
-            ),
-            stdout=sarge.Capture(buffer_size=-1),
-            stderr=sarge.Capture(buffer_size=-1),
-        )
+        if org.created:
+            sarge.run(
+                sarge.shell_format(
+                    "sfdx force:config:set defaultusername={}", org.sfdx_alias
+                ),
+                stdout=sarge.Capture(buffer_size=-1),
+                stderr=sarge.Capture(buffer_size=-1),
+            )
 
     def unset_default_org(self):
         """ unset the default orgs for tasks """

--- a/cumulusci/core/keychain/BaseProjectKeychain.py
+++ b/cumulusci/core/keychain/BaseProjectKeychain.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
 
+import sarge
+
 from cumulusci.core.config import BaseConfig
 from cumulusci.core.config import ScratchOrgConfig
 from cumulusci.core.config import ServiceConfig
@@ -154,6 +156,13 @@ class BaseProjectKeychain(BaseConfig):
         self.unset_default_org()
         org.config["default"] = True
         self.set_org(org)
+        sarge.run(
+            sarge.shell_format(
+                "sfdx force:config:set defaultusername={}", org.sfdx_alias
+            ),
+            stdout=sarge.Capture(buffer_size=-1),
+            stderr=sarge.Capture(buffer_size=-1),
+        )
 
     def unset_default_org(self):
         """ unset the default orgs for tasks """
@@ -162,6 +171,11 @@ class BaseProjectKeychain(BaseConfig):
             if org_config.default:
                 del org_config.config["default"]
                 self.set_org(org_config)
+        sarge.run(
+            "sfdx force:config:set defaultusername=",
+            stdout=sarge.Capture(buffer_size=-1),
+            stderr=sarge.Capture(buffer_size=-1),
+        )
 
     def get_org(self, name):
         """ retrieve an org configuration by name key """

--- a/cumulusci/core/sfdx.py
+++ b/cumulusci/core/sfdx.py
@@ -1,0 +1,26 @@
+import logging
+import sarge
+
+logger = logging.getLogger(__name__)
+
+
+def sfdx(command, username=None, log_note=None):
+    """Call an sfdx command and capture its output.
+
+    Be sure to quote user input that is part of the command using `sarge.shell_format`.
+
+    Returns a `sarge` Command instance with returncode, stdout, stderr
+    """
+    command = "sfdx {}".format(command)
+    if username:
+        command += sarge.shell_format(" -u {0}", username)
+    if log_note:
+        logger.info("{} with command: {}".format(log_note, command))
+    p = sarge.Command(
+        command,
+        stdout=sarge.Capture(buffer_size=-1),
+        stderr=sarge.Capture(buffer_size=-1),
+        shell=True,
+    )
+    p.run()
+    return p

--- a/cumulusci/core/tests/test_keychain.py
+++ b/cumulusci/core/tests/test_keychain.py
@@ -164,7 +164,8 @@ class ProjectKeychainTestMixin(unittest.TestCase):
         keychain = self.keychain_class(self.project_config, self.key)
         self.assertEqual(keychain.get_default_org()[1], None)
 
-    def test_set_default_org(self):
+    @mock.patch("cumulusci.core.sfdx.sfdx")
+    def test_set_default_org(self, sfdx):
         keychain = self.keychain_class(self.project_config, self.key)
         org_config = self.org_config.config.copy()
         org_config = OrgConfig(org_config, "test")
@@ -175,7 +176,8 @@ class ProjectKeychainTestMixin(unittest.TestCase):
 
         self.assertEqual(expected_org_config, keychain.get_default_org()[1].config)
 
-    def test_unset_default_org(self):
+    @mock.patch("cumulusci.core.sfdx.sfdx")
+    def test_unset_default_org(self, sfdx):
         keychain = self.keychain_class(self.project_config, self.key)
         org_config = self.org_config.config.copy()
         org_config = OrgConfig(org_config, "test")

--- a/cumulusci/core/tests/test_keychain.py
+++ b/cumulusci/core/tests/test_keychain.py
@@ -24,7 +24,6 @@ from cumulusci.core.exceptions import KeychainKeyNotFound
 from cumulusci.core.exceptions import ServiceNotConfigured
 from cumulusci.core.exceptions import ServiceNotValid
 from cumulusci.core.exceptions import OrgNotFound
-from cumulusci.core.exceptions import ProjectConfigNotFound
 
 __location__ = os.path.dirname(os.path.realpath(__file__))
 
@@ -63,17 +62,17 @@ class ProjectKeychainTestMixin(unittest.TestCase):
 
     def test_set_non_existant_service(self, project=False):
         keychain = self.keychain_class(self.project_config, self.key)
-        with self.assertRaises(ServiceNotValid) as context:
+        with self.assertRaises(ServiceNotValid):
             keychain.set_service("doesnotexist", ServiceConfig({"name": ""}), project)
 
     def test_set_invalid_service(self, project=False):
         keychain = self.keychain_class(self.project_config, self.key)
-        with self.assertRaises(ServiceNotValid) as context:
+        with self.assertRaises(ServiceNotValid):
             keychain.set_service("github", ServiceConfig({"name": ""}), project)
 
     def test_get_service_not_configured(self):
         keychain = self.keychain_class(self.project_config, self.key)
-        with self.assertRaises(ServiceNotConfigured) as context:
+        with self.assertRaises(ServiceNotConfigured):
             keychain.get_service("not_configured")
 
     def test_change_key(self):
@@ -460,14 +459,12 @@ class TestEncryptedFileProjectKeychain(ProjectKeychainTestMixin):
         self.assertIn("foo", keychain.get_org("test").config)
 
     def test_load_file(self):
-        dummy_keychain = BaseEncryptedProjectKeychain(self.project_config, self.key)
         self._write_file(os.path.join(self.tempdir_home, "config"), "foo")
         keychain = self.keychain_class(self.project_config, self.key)
         keychain._load_file(self.tempdir_home, "config", "from_file")
         self.assertEqual("foo", keychain.config["from_file"])
 
     def test_load_file__global_config(self):
-        dummy_keychain = BaseEncryptedProjectKeychain(self.global_config, self.key)
         self._write_file(os.path.join(self.tempdir_home, "config"), "foo")
         keychain = self.keychain_class(self.project_config, self.key)
         keychain._load_file(self.tempdir_home, "config", "from_file")

--- a/cumulusci/utils.py
+++ b/cumulusci/utils.py
@@ -8,7 +8,6 @@ import io
 import math
 import os
 import re
-import sarge
 import shutil
 import sys
 import tempfile
@@ -19,7 +18,7 @@ from contextlib import contextmanager
 from datetime import datetime
 
 import requests
-
+import sarge
 import xml.etree.ElementTree as ET
 
 CUMULUSCI_PATH = os.path.realpath(


### PR DESCRIPTION
This makes it so that setting a default org in CCI also updates the default org in sfdx.

Ancillary changes: pep8 fixes, factored out a util for calling sfdx

# Critical Changes

# Changes
* Setting a default org in CCI (using `cci org default` or the `--default` flag when creating a scratch org) will now also update the sfdx `defaultusername`.

# Issues Closed
Fixes #868