### PR TITLE
Feature/robot open test browser

### DIFF
--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -10,7 +10,7 @@ from selenium.webdriver.common.action_chains import ActionChains
 
 from simple_salesforce import SalesforceResourceNotFound
 from cumulusci.robotframework.utils import selenium_retry
-from SeleniumLibrary.errors import ElementNotFound
+from SeleniumLibrary.errors import ElementNotFound, NoOpenBrowser
 from urllib3.exceptions import ProtocolError
 
 OID_REGEX = r"^(%2F)?([a-zA-Z0-9]{15,18})$"
@@ -180,6 +180,26 @@ class Salesforce(object):
                     level="WARN",
                 )
                 self.builtin.log("      {}".format(e), level="WARN")
+
+    def get_active_browser_ids(self):
+        """Return the id of all open browser ids"""
+
+        # This relies on some private data structures, but presently
+        # there is no other way. There's been a discussion in the
+        # robot slack channels about adding a new keyword that does
+        # what this keyword does. When that happens, we can remove
+        # this keyword.
+        driver_ids = []
+        try:
+            driver_cache = self.selenium._drivers
+        except NoOpenBrowser:
+            return []
+
+        for index, driver in enumerate(driver_cache._connections):
+            if driver not in driver_cache._closed:
+                # SeleniumLibrary driver ids start at one rather than zero
+                driver_ids.append(index + 1)
+        return driver_ids
 
     def get_current_record_id(self):
         """ Parses the current url to get the object id of the current record.

--- a/cumulusci/robotframework/tests/salesforce/browsers.robot
+++ b/cumulusci/robotframework/tests/salesforce/browsers.robot
@@ -17,6 +17,20 @@ Assert active browser count
     Length should be  ${browsers}  ${expected count}
     ...  Expected to find ${expected count} open browsers, found ${actual count}
 
+Assert window size
+    [Documentation]
+    ...  Verify the actual window size is the expected size
+    ...  give or take a pixel or five.
+    [Arguments]  ${expected width}  ${expected height}
+
+    # On circleci, the browser size is sometimes off by a pixel. How rude!
+    # Since we don't so much care about the precise size as we do that
+    # we are able to change the size, we'll allow a tiny bit of wiggle room.
+    ${actual width}  ${actual height}=  Get window size
+    ${xdelta}=  evaluate  abs(int($actual_width)-int($expected_width))
+    ${ydelta}=  evaluate  abs(int($actual_height)-int($expected_height))
+    Run keyword if  $xdelta > 5 or $ydelta > 5
+    ...  Fail  Window size of ${actual width}x${actual height} is not close enough to expected ${expected width}x${expected height}
 
 *** Test Cases ***
 Open Test Browser Twice
@@ -53,16 +67,11 @@ Default browser size
     [Teardown]  Close all browsers
 
     Open test browser
-    ${width}  ${height}=  Get window size
-    Should be equal as strings  ${width}x${height}  ${DEFAULT WINDOW SIZE}
-    ...  Expected window size to be ${DEFAULT WINDOW SIZE} but it was ${width}x${height}
+    Assert window size  1280  1024
 
 Explicit browser size
     [Documentation]  Verify we can set an explicit browser size when opening the window
     [Teardown]  Close all browsers
 
     Open test browser           size=1400x1200
-
-    ${width}  ${height}=        Get window size
-    Should be equal as strings  ${width}x${height}  1400x1200
-    ...  Expected window size to be 1400x1200 but it was ${width}x${height}
+    Assert window size  1400  1200

--- a/cumulusci/robotframework/tests/salesforce/browsers.robot
+++ b/cumulusci/robotframework/tests/salesforce/browsers.robot
@@ -1,0 +1,68 @@
+*** Settings ***
+
+Resource        cumulusci/robotframework/Salesforce.robot
+Suite Teardown  Close all browsers
+
+
+*** Variables ***
+${DEFAULT WINDOW SIZE}  1280x1024
+
+*** Keywords ***
+Assert active browser count
+    [Documentation]   Assert that an expected number of browsers are active
+    [Arguments]       ${expected count}
+
+    @{browsers}=      get active browser ids
+    ${actual count}=  get length  ${browsers}
+    Length should be  ${browsers}  ${expected count}
+    ...  Expected to find ${expected count} open browsers, found ${actual count}
+
+
+*** Test Cases ***
+Open Test Browser Twice
+    [Documentation]  Verify that we can open two browsers in a single test
+    [Tags]  issue:1068
+    [Teardown]  Close all browsers
+
+    Assert active browser count  0
+    Open test browser
+    Open test browser
+    Assert active browser count  2
+
+Browser aliases
+    [Documentation]  Verify that aliases are properly handled in Open Test Browser
+    [Tags]  issue:1068
+    [Setup]  Run keywords
+    ...  Open test browser  alias=browser1
+    ...  AND  Go to  https://metadeploy.herokuapp.com/products
+    ...  AND  Open test browser  alias=browser2
+    ...  AND  Go to  https://mrbelvedereci.herokuapp.com/
+    [Teardown]  Close all browsers
+
+    Switch browser  browser1
+    Location should be  https://metadeploy.herokuapp.com/products
+    Capture page screenshot
+
+    Switch browser  browser2
+    Location should be  https://mrbelvedereci.herokuapp.com/
+    Capture page screenshot
+
+
+Default browser size
+    [Documentation]  Verify that we automatically resize browser to minimum supported size
+    [Teardown]  Close all browsers
+
+    Open test browser
+    ${width}  ${height}=  Get window size
+    Should be equal as strings  ${width}x${height}  ${DEFAULT WINDOW SIZE}
+    ...  Expected window size to be ${DEFAULT WINDOW SIZE} but it was ${width}x${height}
+
+Explicit browser size
+    [Documentation]  Verify we can set an explicit browser size when opening the window
+    [Teardown]  Close all browsers
+
+    Open test browser           size=1400x1200
+
+    ${width}  ${height}=        Get window size
+    Should be equal as strings  ${width}x${height}  1400x1200
+    ...  Expected window size to be 1400x1200 but it was ${width}x${height}

--- a/cumulusci/robotframework/tests/salesforce/browsers.robot
+++ b/cumulusci/robotframework/tests/salesforce/browsers.robot
@@ -48,17 +48,18 @@ Browser aliases
     [Tags]  issue:1068
     [Setup]  Run keywords
     ...  Open test browser  alias=browser1
-    ...  AND  Go to  https://metadeploy.herokuapp.com/products
     ...  AND  Open test browser  alias=browser2
-    ...  AND  Go to  https://mrbelvedereci.herokuapp.com/
+    ...  AND  Go to  about:blank
     [Teardown]  Close all browsers
 
+    # This also doubles as a test which verifies the default
+    # landing page is the Setup home page
     Switch browser  browser1
-    Location should be  https://metadeploy.herokuapp.com/products
+    Location should contain  /lightning/setup/SetupOneHome/home
     Capture page screenshot
 
     Switch browser  browser2
-    Location should be  https://mrbelvedereci.herokuapp.com/
+    Location should be  about:blank
     Capture page screenshot
 
 


### PR DESCRIPTION
# Critical Changes

# Changes

Updates to the keyword 'Open Test Browser':
- allows you to open more than one browser in a single test case. 
- sets the default size for the browser window to 1280x1024
- adds a new keyword argument `size` to override the default size
- adds a new keyword argument `alias` to let you assign an alias to multiple browser windows

# Issues Closed

This fixes #1068 