### PR TITLE
Make circleci run all tests and preserve output even if some fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,14 +102,15 @@ jobs:
             # we need to modify our task to make it easier to save the
             # output.xml file with a unique name. Until then, we have
             # to manually preserve each file under a different name
-            venv/bin/coverage run --append venv/bin/cci task run robot -o name "CumulusCI" -o suites cumulusci/robotframework/tests/cumulusci  -o xunit robot_results/robot/cumulusci.xml
+            venv/bin/coverage run --append venv/bin/cci task run robot -o name "CumulusCI" -o suites cumulusci/robotframework/tests/cumulusci  -o xunit robot_results/robot/cumulusci.xml || true
             mv output.xml robot_results/robot/cumulusci-output.xml
-            venv/bin/coverage run --append venv/bin/cci task run robot -o name "Salesforce API" -o suites cumulusci/robotframework/tests/salesforce -o include api -o xunit robot_results/robot/salesforce_api.xml
+            venv/bin/coverage run --append venv/bin/cci task run robot -o name "Salesforce API" -o suites cumulusci/robotframework/tests/salesforce -o include api -o xunit robot_results/robot/salesforce_api.xml || true
             mv output.xml robot_results/robot/salesforce_api-output.xml
-            venv/bin/coverage run --append venv/bin/cci task run robot -o name "Salesforce UI Chrome" -o suites cumulusci/robotframework/tests/salesforce -o exclude api -o xunit robot_results/robot/salesforce_ui_chrome.xml
+            venv/bin/coverage run --append venv/bin/cci task run robot -o name "Salesforce UI Chrome" -o suites cumulusci/robotframework/tests/salesforce -o exclude api -o xunit robot_results/robot/salesforce_ui_chrome.xml || true
             mv output.xml robot_results/robot/salesforce_ui_chrome-output.xml
-            venv/bin/coverage run --append venv/bin/cci task run robot -o name "Salesforce UI Firefox" -o suites cumulusci/robotframework/tests/salesforce -o exclude api -o vars BROWSER:headlessfirefox -o xunit robot_results/robot/salesforce_ui_firefox.xml
+            venv/bin/coverage run --append venv/bin/cci task run robot -o name "Salesforce UI Firefox" -o suites cumulusci/robotframework/tests/salesforce -o exclude api -o vars BROWSER:headlessfirefox -o xunit robot_results/robot/salesforce_ui_firefox.xml || true
             mv output.xml robot_results/robot/salesforce_ui_firefox-output.xml
+            mv selenium-screenshot-* robot_results/robot || true
       - run:
           name: Consolidate robot outputs into a single report and log
           when: always


### PR DESCRIPTION
- added || true to every robot step, so all robot tests run even if some fail.
- screenshots are copied to the output directory

# Critical Changes

# Changes

# Issues Closed
