### PR TITLE
Rewrote the `wait until loading is complete` keyword.

### DIFF
--- a/cumulusci/robotframework/Salesforce.robot
+++ b/cumulusci/robotframework/Salesforce.robot
@@ -59,8 +59,7 @@ Open Test Browser
     ...    ELSE IF  '${BROWSER}' == 'headlesschrome'  Open Test Browser Chrome  ${login_url}  alias=${alias}
     ...    ELSE IF  '${BROWSER}' == 'headlessfirefox'  Open Test Browser Headless Firefox  ${login_url}  alias=${alias}
     ...    ELSE  Open Browser  ${login_url}  ${BROWSER}  alias=${alias}
-    Set Selenium Timeout  ${INITIAL_TIMEOUT}
-    Wait Until Loading Is Complete
+    Wait Until Loading Is Complete  timeout=180
     Set Selenium Timeout  ${TIMEOUT}
     Initialize Location Strategies
     ${width}  ${height}=  split string  ${size}  separator=x  max_split=1


### PR DESCRIPTION
This will repeatedly refresh the page in the event that a non-lightning
page comes up. Currently the timeout is set to three minutes.


# Critical Changes

# Changes

# Issues Closed
