### PR TITLE
Feature/robot wait

### DIFF
--- a/cumulusci/core/tests/test_salesforce.py
+++ b/cumulusci/core/tests/test_salesforce.py
@@ -4,11 +4,29 @@ from cumulusci.robotframework.Salesforce import Salesforce
 from SeleniumLibrary.errors import ElementNotFound
 
 
-@mock.patch("robot.libraries.BuiltIn.BuiltIn._get_context")
-class TestKeyword_wait_until_loading_is_complete(unittest.TestCase):
+# _init_locators has a special code block
+class TestSeleniumLibrary(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestKeyword_wait_until_loading_is_complete, cls).setUpClass()
+        super(TestSeleniumLibrary, cls).setUpClass()
+
+    def test_init_locators(self):
+        """Verify that locators are initialized if not passed in"""
+        with mock.patch.object(Salesforce, "_init_locators"):
+            # _init_locators should NOT be called if we pass them in
+            sflib = Salesforce(locators={"body": "//whatever"})
+            assert not sflib._init_locators.called
+
+            # _init_locators SHOULD be called if we don't pass them in
+            sflib = Salesforce()
+            sflib._init_locators.assert_called_once()
+
+
+@mock.patch("robot.libraries.BuiltIn.BuiltIn._get_context")
+class TestKeyword_wait_until_salesforce_is_ready(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestKeyword_wait_until_salesforce_is_ready, cls).setUpClass()
         cls.sflib = Salesforce(locators={"body": "//whatever"})
 
     def test_successful_page_load(self, mock_robot_context):

--- a/cumulusci/core/tests/test_salesforce.py
+++ b/cumulusci/core/tests/test_salesforce.py
@@ -35,6 +35,10 @@ class TestKeyword_wait_until_loading_is_complete(unittest.TestCase):
         with mock.patch.object(Salesforce, "wait_for_aura", return_value=True):
             self.sflib.selenium.get_webelement.side_effect = ElementNotFound()
 
+            if not hasattr(self, "assertRaisesRegex"):
+                # py2 compatibility
+                self.assertRaisesRegex = self.assertRaisesRegexp
+
             with self.assertRaisesRegex(
                 Exception, "Timed out waiting for a lightning page"
             ):

--- a/cumulusci/robotframework/Salesforce.robot
+++ b/cumulusci/robotframework/Salesforce.robot
@@ -59,8 +59,7 @@ Open Test Browser
     ...    ELSE IF  '${BROWSER}' == 'headlesschrome'  Open Test Browser Chrome  ${login_url}  alias=${alias}
     ...    ELSE IF  '${BROWSER}' == 'headlessfirefox'  Open Test Browser Headless Firefox  ${login_url}  alias=${alias}
     ...    ELSE  Open Browser  ${login_url}  ${BROWSER}  alias=${alias}
-    Set Selenium Timeout  ${INITIAL_TIMEOUT}
-    Wait Until Loading Is Complete
+    Wait Until Salesforce Is Ready  timeout=180
     Set Selenium Timeout  ${TIMEOUT}
     Initialize Location Strategies
     ${width}  ${height}=  split string  ${size}  separator=x  max_split=1


### PR DESCRIPTION
This handles the DomainNotPropagated errors we sometimes see by refreshing the page. I've observed other startup problems that are not caught by these fixes, but they seem to be more rare and harder to work around.

Instead of trying to create a one-size-fits-all solution for waiting on the browser, this leaves the `wait_until_loading_is_complete` keyword alone, and creates a new keyword specifically for waiting after the browser is first opened.

# Critical Changes

# Changes

# Issues Closed
