### PR TITLE
Add PreflightFlowCoordinator to evaluate preflight checks

### DIFF
--- a/cumulusci/core/flowrunner.py
+++ b/cumulusci/core/flowrunner.py
@@ -202,7 +202,7 @@ class TaskRunner(object):
 
         # Resolve ^^task_name.return_value style option syntax
         task_config = self.step.task_config.copy()
-        task_config["options"] = task_config["options"].copy()
+        task_config["options"] = task_config.get("options", {}).copy()
         self.flow.resolve_return_value_options(task_config["options"])
 
         task_config["options"].update(options)

--- a/cumulusci/core/flowrunner.py
+++ b/cumulusci/core/flowrunner.py
@@ -60,6 +60,7 @@ except ImportError:  # pragma: no cover
 
 import copy
 import logging
+from collections import defaultdict
 from collections import namedtuple
 from distutils.version import LooseVersion
 from operator import attrgetter
@@ -180,8 +181,6 @@ class FlowCallback(object):
 
 class TaskRunner(object):
     """ TaskRunner encapsulates the job of instantiating and running a task.
-
-    TODO: Abstract out how "step" gets passed in, so that TaskRunner can run a task on the cli, only one step.
     """
 
     def __init__(self, project_config, step, org_config, flow=None):
@@ -194,7 +193,7 @@ class TaskRunner(object):
     def from_flow(cls, flow, step):
         return cls(flow.project_config, step, flow.org_config, flow=flow)
 
-    def run_step(self):
+    def run_step(self, **options):
         """
         Run a step.
 
@@ -206,17 +205,19 @@ class TaskRunner(object):
         task_config["options"] = task_config["options"].copy()
         self.flow.resolve_return_value_options(task_config["options"])
 
+        task_config["options"].update(options)
+
+        task = self.step.task_class(
+            self.project_config,
+            TaskConfig(task_config),
+            org_config=self.org_config,
+            name=self.step.task_name,
+            stepnum=self.step.step_num,
+            flow=self.flow,
+        )
+        self._log_options(task)
         exc = None
         try:
-            task = self.step.task_class(
-                self.project_config,
-                TaskConfig(task_config),
-                org_config=self.org_config,
-                name=self.step.task_name,
-                stepnum=self.step.step_num,
-                flow=self.flow,
-            )
-            self._log_options(task)
             task()
         except Exception as e:
             self.flow.logger.exception(
@@ -238,9 +239,8 @@ class TaskRunner(object):
             return
         for key, info in task.task_options.items():
             value = task.options.get(key)
-            if value is None:
-                continue
-            task.logger.info("  {}: {}".format(key, value))
+            if value is not None:
+                task.logger.info("  {}: {}".format(key, value))
 
 
 class FlowCoordinator(object):
@@ -275,7 +275,7 @@ class FlowCoordinator(object):
 
     @classmethod
     def from_steps(cls, project_config, steps, name=None, callbacks=None):
-        instance = FlowCoordinator(
+        instance = cls(
             project_config,
             flow_config=FlowConfig({"steps": {}}),
             name=name,
@@ -470,6 +470,11 @@ class FlowCoordinator(object):
             step_ui_overrides.update(step_config.get("ui_options", {}))
             task_config["ui_options"].update(step_ui_overrides)
 
+            # merge checks from task config and flow step
+            if "checks" not in task_config:
+                task_config["checks"] = []
+            task_config["checks"].extend(step_config.get("checks", []))
+
             # merge runtime options
             if name in self.runtime_options:
                 task_config["options"].update(self.runtime_options[name])
@@ -581,3 +586,96 @@ class FlowCoordinator(object):
             if result.path[-len(path) :] == path:
                 return result
         raise NameError("Path not found: {}".format(path))
+
+
+class PreflightFlowCoordinator(FlowCoordinator):
+    """Coordinates running preflight checks instead of the actual flow steps.
+    """
+
+    def run(self, org_config):
+        self.org_config = org_config
+        self.callbacks.pre_flow(self)
+
+        self._init_org()
+        self._rule(fill="-")
+        self.logger.info("Organization:")
+        self.logger.info("  {}: {}".format("Username", org_config.username))
+        self.logger.info("  {}: {}".format("  Org Id", org_config.org_id))
+        self._rule(fill="-", new_line=True)
+
+        self.logger.info("Running preflight checks...")
+        self._rule(new_line=True)
+
+        self.jinja2_context = {
+            "tasks": TaskCache(self, self.project_config, org_config),
+            "project_config": self.project_config,
+            "org_config": self.org_config,
+        }
+
+        self.preflight_results = defaultdict(list)
+        try:
+            # flow-level checks
+            for check in self.flow_config.checks or []:
+                result = self.evaluate_check(check)
+                if result:
+                    self.preflight_results[None].append(result)
+
+            # Step-level checks
+            for step in self.steps:
+                for check in step.task_config.get("checks", []):
+                    result = self.evaluate_check(check)
+                    if result:
+                        self.preflight_results[step.path].append(result)
+        finally:
+            self.callbacks.post_flow(self)
+
+    def evaluate_check(self, check):
+        self.logger.info("Evaluating check: {}".format(check["when"]))
+        expr = jinja2_env.compile_expression(check["when"])
+        value = bool(expr(**self.jinja2_context))
+        self.logger.info("Check result: {}".format(value))
+        if value:
+            return {"status": check["action"], "message": check.get("message")}
+
+
+class TaskCache(object):
+    """Provides access to named tasks and caches their results.
+
+    This is intended for use in a jinja2 expression context
+    so that multiple expressions evaluated in the same context
+    can avoid running a task more than once with the same options.
+    """
+
+    def __init__(self, flow, project_config, org_config):
+        self.flow = flow
+        self.project_config = project_config
+        self.org_config = org_config
+        self.results = {}
+
+    def __getattr__(self, task_name):
+        return CachedTaskRunner(self, task_name)
+
+
+class CachedTaskRunner(object):
+    """Runs a task and caches the result in a TaskCache"""
+
+    def __init__(self, cache, task_name):
+        self.cache = cache
+        self.task_name = task_name
+
+    def __call__(self, **options):
+        cache_key = (self.task_name, tuple(options.items()))
+        if cache_key in self.cache.results:
+            return self.cache.results[cache_key]
+
+        task_config = self.cache.project_config.tasks[self.task_name]
+        task_class = import_global(task_config["class_path"])
+        step = StepSpec(1, self.task_name, task_config, task_class)
+        self.cache.flow.callbacks.pre_task(step)
+        result = TaskRunner(
+            self.cache.project_config, step, self.cache.org_config, self.cache.flow
+        ).run_step(**options)
+        self.cache.flow.callbacks.post_task(step, result)
+
+        self.cache.results[cache_key] = result
+        return result.return_values

--- a/cumulusci/core/tasks.py
+++ b/cumulusci/core/tasks.py
@@ -235,9 +235,7 @@ class BaseTask(object):
             "is_required": True,
         }
         ui_step.update(self.task_config.config.get("ui_options", {}))
-        task_config = {"options": self.options}
-        if self.task_config.checks:
-            task_config["checks"] = self.task_config.checks
+        task_config = {"options": self.options, "checks": self.task_config.checks or []}
         ui_step.update(
             {
                 "path": step.path,

--- a/cumulusci/core/tasks.py
+++ b/cumulusci/core/tasks.py
@@ -235,12 +235,15 @@ class BaseTask(object):
             "is_required": True,
         }
         ui_step.update(self.task_config.config.get("ui_options", {}))
+        task_config = {"options": self.options}
+        if self.task_config.checks:
+            task_config["checks"] = self.task_config.checks
         ui_step.update(
             {
                 "path": step.path,
                 "step_num": str(step.step_num),
                 "task_class": self.task_config.class_path,
-                "task_config": {"options": self.options},
+                "task_config": task_config,
             }
         )
         return [ui_step]

--- a/cumulusci/tasks/metadeploy.py
+++ b/cumulusci/tasks/metadeploy.py
@@ -121,27 +121,27 @@ class Publish(BaseMetaDeployTask):
             product, plan_name, plan_config
         )
 
+        plan_json = {
+            "is_listed": plan_config.get("is_listed", True),
+            "plan_template": plan_template["url"],
+            "post_install_message_additional": plan_config.get(
+                "post_install_message_additional", ""
+            ),
+            "preflight_message_additional": plan_config.get(
+                "preflight_message_additional", ""
+            ),
+            "steps": steps,
+            "tier": plan_config["tier"],
+            "title": plan_config["title"],
+            "version": version["url"],
+            # Use same AllowedList as the product, if any
+            "visible_to": product.get("visible_to"),
+        }
+        if plan_config.get("checks"):
+            plan_json["preflight_checks"] = plan_config["checks"]
+
         # Create Plan
-        plan = self._call_api(
-            "POST",
-            "/plans",
-            json={
-                "is_listed": plan_config.get("is_listed", True),
-                "plan_template": plan_template["url"],
-                "post_install_message_additional": plan_config.get(
-                    "post_install_message_additional", ""
-                ),
-                "preflight_message_additional": plan_config.get(
-                    "preflight_message_additional", ""
-                ),
-                "steps": steps,
-                "tier": plan_config["tier"],
-                "title": plan_config["title"],
-                "version": version["url"],
-                # Use same AllowedList as the product, if any
-                "visible_to": product.get("visible_to"),
-            },
-        )
+        plan = self._call_api("POST", "/plans", json=plan_json)
         self.logger.info("Created Plan {}".format(plan["url"]))
 
     def _freeze_steps(self, project_config, plan_config):

--- a/cumulusci/tasks/salesforce/BaseSalesforceMetadataApiTask.py
+++ b/cumulusci/tasks/salesforce/BaseSalesforceMetadataApiTask.py
@@ -10,5 +10,8 @@ class BaseSalesforceMetadataApiTask(BaseSalesforceTask):
 
     def _run_task(self):
         api = self._get_api()
+        result = None
         if api:
-            return api()
+            result = api()
+            self.return_values = result
+        return result

--- a/cumulusci/tasks/salesforce/DeployBundles.py
+++ b/cumulusci/tasks/salesforce/DeployBundles.py
@@ -63,9 +63,10 @@ class DeployBundles(Deploy):
                     "subfolder": subpath,
                 }
             )
-            task_config = {"options": {"dependencies": [dependency]}}
-            if self.task_config.checks:
-                task_config["checks"] = self.task_config.checks
+            task_config = {
+                "options": {"dependencies": [dependency]},
+                "checks": self.task_config.checks or [],
+            }
             ui_step = {
                 "name": "Deploy {}".format(subpath),
                 "kind": "metadata",

--- a/cumulusci/tasks/salesforce/DeployBundles.py
+++ b/cumulusci/tasks/salesforce/DeployBundles.py
@@ -64,6 +64,8 @@ class DeployBundles(Deploy):
                 }
             )
             task_config = {"options": {"dependencies": [dependency]}}
+            if self.task_config.checks:
+                task_config["checks"] = self.task_config.checks
             ui_step = {
                 "name": "Deploy {}".format(subpath),
                 "kind": "metadata",

--- a/cumulusci/tasks/salesforce/InstallPackageVersion.py
+++ b/cumulusci/tasks/salesforce/InstallPackageVersion.py
@@ -94,6 +94,9 @@ class InstallPackageVersion(Deploy):
         options = self.options.copy()
         options["version"] = str(options["version"])
         name = options.pop("name")
+        task_config = {"options": options}
+        if self.task_config.checks:
+            task_config["checks"] = self.task_config.checks
         ui_step = {
             "name": "Install {} {}".format(name, options["version"]),
             "kind": "managed",
@@ -105,7 +108,7 @@ class InstallPackageVersion(Deploy):
                 "path": step.path,
                 "step_num": str(step.step_num),
                 "task_class": self.task_config.class_path,
-                "task_config": {"options": options},
+                "task_config": task_config,
             }
         )
         return [ui_step]

--- a/cumulusci/tasks/salesforce/InstallPackageVersion.py
+++ b/cumulusci/tasks/salesforce/InstallPackageVersion.py
@@ -94,9 +94,7 @@ class InstallPackageVersion(Deploy):
         options = self.options.copy()
         options["version"] = str(options["version"])
         name = options.pop("name")
-        task_config = {"options": options}
-        if self.task_config.checks:
-            task_config["checks"] = self.task_config.checks
+        task_config = {"options": options, "checks": self.task_config.checks or []}
         ui_step = {
             "name": "Install {} {}".format(name, options["version"]),
             "kind": "managed",

--- a/cumulusci/tasks/salesforce/UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/UpdateDependencies.py
@@ -325,9 +325,10 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
             else:
                 kind = "metadata"
                 name = name or "Deploy {}".format(dependency["subfolder"])
-            task_config = {"options": self.options.copy()}
-            if self.task_config.checks:
-                task_config["checks"] = self.task_config.checks
+            task_config = {
+                "options": self.options.copy(),
+                "checks": self.task_config.checks or [],
+            }
             task_config["options"]["dependencies"] = [dependency]
             ui_step = {"name": name, "kind": kind, "is_required": True}
             ui_step.update(ui_options.get(i, {}))

--- a/cumulusci/tasks/salesforce/UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/UpdateDependencies.py
@@ -300,6 +300,8 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
                 kind = "metadata"
                 name = name or "Deploy {}".format(dependency["subfolder"])
             task_config = {"options": self.options.copy()}
+            if self.task_config.checks:
+                task_config["checks"] = self.task_config.checks
             task_config["options"]["dependencies"] = [dependency]
             ui_step = {"name": name, "kind": kind, "is_required": True}
             ui_step.update(ui_options.get(i, {}))

--- a/cumulusci/tasks/salesforce/tests/test_DeployBundles.py
+++ b/cumulusci/tasks/salesforce/tests/test_DeployBundles.py
@@ -53,7 +53,8 @@ class TestDeployBundles(unittest.TestCase):
                                         "subfolder": "unpackaged/test",
                                     }
                                 ]
-                            }
+                            },
+                            "checks": [],
                         },
                     }
                 ],

--- a/cumulusci/tasks/salesforce/tests/test_UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/tests/test_UpdateDependencies.py
@@ -282,7 +282,8 @@ class TestUpdateDependencies(unittest.TestCase):
                             "purge_on_delete": True,
                             "allow_newer": True,
                             "allow_uninstalls": False,
-                        }
+                        },
+                        "checks": [],
                     },
                 },
                 {
@@ -307,7 +308,8 @@ class TestUpdateDependencies(unittest.TestCase):
                             "purge_on_delete": True,
                             "allow_newer": True,
                             "allow_uninstalls": False,
-                        }
+                        },
+                        "checks": [],
                     },
                 },
             ],

--- a/cumulusci/tasks/tests/test_metadeploy.py
+++ b/cumulusci/tasks/tests/test_metadeploy.py
@@ -67,6 +67,7 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
                 "slug": "install",
                 "tier": "primary",
                 "steps": {1: {"flow": "install_prod"}},
+                "checks": [],
             }
         }
         project_config.keychain.set_service(
@@ -169,7 +170,8 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
                             "retry_interval": 5,
                             "retry_interval_add": 30,
                             "version": "1.0",
-                        }
+                        },
+                        "checks": [],
                     },
                 },
                 {
@@ -180,7 +182,8 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
                     "step_num": "1.3.2",
                     "task_class": "cumulusci.tasks.salesforce.UpdateAdminProfile",
                     "task_config": {
-                        "options": {"managed": True, "namespaced_org": False}
+                        "options": {"managed": True, "namespaced_org": False},
+                        "checks": [],
                     },
                 },
             ],


### PR DESCRIPTION
Preflight checks can be defined in the `checks` list at either the flow or step level. The PreflightFlowCoordinator contains the logic to evaluate them and produce `preflight_results`, which MetaDeploy will make use of.

Each check consists of:

- `when`: a jinja2 expression. Evaluated in a context that has access to `project_config`, `org_config`, and `tasks` which is a way of accessing tasks in a way that will cache their results so that multiple checks using the same task will only run the task once (for example if there are multiple checks making use of a task that gets the current installed package versions)
- `action`: a string that will be set as the `status` in the preflight result if the `when` condition evaluates to true
- `message`: a string that will be set as the `message` in the preflight result if the `when` condition evaluates to true

# Critical Changes

# Changes

# Issues Closed
