### PR TITLE
Read the scratch org display output as UTF8

### DIFF
--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -41,8 +41,8 @@ class ScratchOrgConfig(OrgConfig):
         p = sfdx("force:org:display --json", self.username)
 
         org_info = None
-        stderr_list = [line.strip() for line in io.TextIOWrapper(p.stderr)]
-        stdout_list = [line.strip() for line in io.TextIOWrapper(p.stdout)]
+        stderr_list = [line.strip() for line in io.TextIOWrapper(p.stderr, encoding='utf8')]
+        stdout_list = [line.strip() for line in io.TextIOWrapper(p.stdout, encoding='utf8')]
 
         if p.returncode:
             self.logger.error("Return code: {}".format(p.returncode))

--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -4,6 +4,7 @@ import io
 import json
 import os
 import re
+import sys
 
 import sarge
 from simple_salesforce import Salesforce
@@ -41,8 +42,8 @@ class ScratchOrgConfig(OrgConfig):
         p = sfdx("force:org:display --json", self.username)
 
         org_info = None
-        stderr_list = [line.strip() for line in io.TextIOWrapper(p.stderr, encoding='utf8')]
-        stdout_list = [line.strip() for line in io.TextIOWrapper(p.stdout, encoding='utf8')]
+        stderr_list = [line.strip() for line in io.TextIOWrapper(p.stderr, encoding=sys.stdout.encoding)]
+        stdout_list = [line.strip() for line in io.TextIOWrapper(p.stdout, encoding=sys.stdout.encoding)]
 
         if p.returncode:
             self.logger.error("Return code: {}".format(p.returncode))


### PR DESCRIPTION
Fixes: CCI unable to import scratch orgs with names containing emojis.

Incidentally, this is also proposed to become default behaviour ([PEP 597](https://www.python.org/dev/peps/pep-0597/)).


# Critical Changes

# Changes

# Issues Closed
