### PR TITLE
Use Click's UsageError when flow/task is not found

### DIFF
--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -21,7 +21,6 @@ from cumulusci.core.tasks import BaseTask
 from cumulusci.core.exceptions import OrgNotFound
 from cumulusci.core.exceptions import ScratchOrgException
 from cumulusci.core.exceptions import ServiceNotConfigured
-from cumulusci.core.exceptions import TaskNotFoundError
 from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.cli import cci
 from cumulusci.cli.config import CliRuntime
@@ -823,7 +822,7 @@ test_task   Test Task""",
         config.get_org.return_value = (None, None)
         config.project_config.tasks__test = None
 
-        with self.assertRaises(TaskNotFoundError):
+        with self.assertRaises(click.UsageError):
             run_click_command(
                 cci.task_run,
                 config=config,

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -1016,7 +1016,7 @@ test_flow  Test Flow""",
 
     def test_flow_info__not_found(self):
         config = mock.Mock()
-        config.project_config.get_flow.return_value = FlowNotFoundError
+        config.project_config.get_flow.side_effect = FlowNotFoundError
         with self.assertRaises(click.UsageError):
             run_click_command(cci.flow_info, config=config, flow_name="test")
 

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -19,6 +19,7 @@ from cumulusci.core.config import OrgConfig
 from cumulusci.core.config import FlowConfig
 from cumulusci.core.config import TaskConfig
 from cumulusci.core.tasks import BaseTask
+from cumulusci.core.exceptions import FlowNotFoundError
 from cumulusci.core.exceptions import OrgNotFound
 from cumulusci.core.exceptions import ScratchOrgException
 from cumulusci.core.exceptions import ServiceNotConfigured
@@ -1012,6 +1013,12 @@ test_flow  Test Flow""",
         run_click_command(cci.flow_info, config=config, flow_name="test")
 
         echo.assert_called_with("\x1b[1mdescription:\x1b[0m Test Flow")
+
+    def test_flow_info__not_found(self):
+        config = mock.Mock()
+        config.project_config.get_flow.return_value = FlowNotFoundError
+        with self.assertRaises(click.UsageError):
+            run_click_command(cci.flow_info, config=config, flow_name="test")
 
     def test_flow_run(self):
         org_config = mock.Mock(scratch=True, config={})

--- a/cumulusci/core/config/BaseTaskFlowConfig.py
+++ b/cumulusci/core/config/BaseTaskFlowConfig.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from difflib import get_close_matches
 
 from cumulusci.core.config import BaseConfig
 from cumulusci.core.config import FlowConfig
@@ -33,7 +34,9 @@ class BaseTaskFlowConfig(BaseConfig):
         """ Returns a TaskConfig """
         config = getattr(self, "tasks__{}".format(name))
         if not config:
-            raise TaskNotFoundError("Task not found: {}".format(name))
+            error_msg = "Task not found: {}".format(name)
+            suggestion = self.get_suggested_name(name, self.tasks)
+            raise TaskNotFoundError(error_msg + suggestion)
         return TaskConfig(config)
 
     def list_flows(self):
@@ -44,5 +47,17 @@ class BaseTaskFlowConfig(BaseConfig):
         """ Returns a FlowConfig """
         config = getattr(self, "flows__{}".format(name))
         if not config:
-            raise FlowNotFoundError("Flow not found: {}".format(name))
+            error_msg = "Flow not found: {}".format(name)
+            suggestion = self.get_suggested_name(name, self.flows)
+            raise FlowNotFoundError(error_msg + suggestion)
         return FlowConfig(config)
+
+    def get_suggested_name(self, name, steps):
+        """
+        Given a name that cannot be resolved and a list of tasks/flow dicts, returns the nearest match.
+        """
+        match_list = get_close_matches(name, steps.keys(), n=1)
+        if match_list:
+            return '. Did you mean "{}"?'.format(match_list[0])
+        else:
+            return ""

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -874,6 +874,12 @@ class TestBaseTaskFlowConfig(unittest.TestCase):
         coffee = [flow for flow in flows if flow["name"] == "coffee"][0]
         self.assertEqual(coffee["description"], "Coffee Flow")
 
+    def test_suggested_name(self):
+        flows = self.task_flow_config.flows
+        self.assertEqual(len(flows), 2)
+        error_msg = self.task_flow_config.get_suggested_name("bofee", flows)
+        self.assertIn("coffee", error_msg)
+
 
 class TestOrgConfig(unittest.TestCase):
     @mock.patch("cumulusci.core.config.OrgConfig.SalesforceOAuth2")


### PR DESCRIPTION
Before:
```console
$ cci flow info derpendencies
Traceback (most recent call last):
[...]
  File "/Users/jestevez/.pyenv/versions/3.7.1/envs/cci-prod/lib/python3.7/site-packages/cumulusci/core/config/BaseTaskFlowConfig.py", line 47, in get_flow
    raise FlowNotFoundError("Flow not found: {}".format(name))
cumulusci.core.exceptions.FlowNotFoundError: Flow not found: derpendencies
```

After:
```console
$ cci flow info derpendencies
Checking the version!
Usage: cci flow info [OPTIONS] FLOW_NAME

Error: Flow not found: derpendencies. Did you mean "dependencies"?
```
# Critical Changes

# Changes
- `cci` no longer prints tracebacks when a flow or task is not found. Additionally, it will suggest a name if a close enough match can be found.
# Issues Closed
#960 