### PR TITLE
Fix color escapes on Windows

### DIFF
--- a/cumulusci/cli/logger.py
+++ b/cumulusci/cli/logger.py
@@ -23,7 +23,7 @@ def init_logger(log_requests=False):
     for handler in logger.handlers:  # pragma: nocover
         logger.removeHandler(handler)
 
-    if os.name == "nt" and "colorama" in sys.modules:
+    if os.name == "nt" and "colorama" in sys.modules:  # pragma: nocover
         colorama.init()
 
     formatter = coloredlogs.ColoredFormatter(fmt="%(asctime)s: %(message)s")

--- a/cumulusci/cli/logger.py
+++ b/cumulusci/cli/logger.py
@@ -2,9 +2,18 @@
 from __future__ import unicode_literals
 
 import logging
+import os
+import sys
+
+import requests
 
 import coloredlogs
-import requests
+
+try:
+    import colorama
+except ImportError:
+    # coloredlogs only installs colorama on Windows
+    pass
 
 
 def init_logger(log_requests=False):
@@ -13,6 +22,9 @@ def init_logger(log_requests=False):
     logger = logging.getLogger(__name__.split(".")[0])
     for handler in logger.handlers:  # pragma: nocover
         logger.removeHandler(handler)
+
+    if os.name == "nt" and "colorama" in sys.modules:
+        colorama.init()
 
     formatter = coloredlogs.ColoredFormatter(fmt="%(asctime)s: %(message)s")
     handler = logging.StreamHandler()


### PR DESCRIPTION
Before:
![ps_bad_color](https://user-images.githubusercontent.com/748532/59569623-30f2c000-9041-11e9-8475-58cc5a51614a.PNG)
![cmd_bad_color](https://user-images.githubusercontent.com/748532/59569619-1e788680-9041-11e9-9d3e-94ac50e5b7b7.PNG)

After:
![ps_good_color](https://user-images.githubusercontent.com/748532/59569629-3fd97280-9041-11e9-8a65-a7ae25d4aeee.PNG)
![cmd_good_color](https://user-images.githubusercontent.com/748532/59569627-3bad5500-9041-11e9-9673-e2d3e8a39bf2.PNG)


# Critical Changes

# Changes
- Log colors now display correctly on Windows.
# Issues Closed
Fixes #813
