### PR TITLE
[wip]:  refactor UI logic into new UI module

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 from collections import OrderedDict
 import functools
 import json
-import operator
 import os
 import sys
 import webbrowser
@@ -21,7 +20,6 @@ from shutil import copyfile
 import click
 import pkg_resources
 import requests
-from plaintable import Table
 from rst2ansi import rst2ansi
 from jinja2 import Environment
 from jinja2 import PackageLoader
@@ -42,6 +40,7 @@ from cumulusci.core.exceptions import TaskNotFoundError
 from cumulusci.core.utils import import_global
 from cumulusci.cli.config import CliRuntime
 from cumulusci.cli.config import get_installed_version
+from cumulusci.cli.ui import CliTable
 from cumulusci.utils import doc_task
 from cumulusci.utils import get_cci_upgrade_command
 from cumulusci.oauth.salesforce import CaptureSalesforceOAuth
@@ -584,22 +583,29 @@ project.add_command(project_dependencies)
 
 
 @click.command(name="list", help="List services available for configuration and use")
+@click.option("--plain", is_flag=True, help="Print the table using plain ascii.")
+@click.option("--json", "print_json", is_flag=True, help="Print a json string")
 @pass_config(allow_global_keychain=True)
-def service_list(config):
-    headers = ["service", "description", "is_configured"]
-    data = []
+def service_list(config, plain, print_json):
     services = (
         config.project_config.services
         if not config.is_global_keychain
         else config.global_config.services
     )
+    configured_services = config.keychain.list_services()
+
+    data = [["Name", "Description", "Configured"]]
     for serv, schema in services.items():
-        is_configured = ""
-        if serv in config.keychain.list_services():
-            is_configured = "* "
-        data.append((serv, schema["description"], is_configured))
-    table = Table(data, headers)
-    click.echo(table)
+        is_configured = serv in configured_services
+        data.append([serv, schema["description"], is_configured])
+
+    if print_json:
+        click.echo(json.dumps(data[1:]))
+        return None
+
+    table = CliTable(data, title="Services", wrap_cols=[1])
+    table.stringify_boolean_cols(2)
+    table.echo(plain)
 
 
 class ConnectServiceCommand(click.MultiCommand):
@@ -834,40 +840,46 @@ def org_info(config, org_name, print_json):
 
 
 @click.command(name="list", help="Lists the connected orgs for the current project")
+@click.option("--plain", is_flag=True, help="Print the table using plain ascii.")
 @pass_config
-def org_list(config):
-    data = []
-    headers = [
-        "org",
-        "default",
-        "scratch",
-        "days",
-        "expired",
-        "config_name",
-        "username",
-    ]
+def org_list(config, plain):
+    data = [["Org", "Default", "Scratch", "Days", "Expired", "Config", "Username"]]
     for org in config.project_config.keychain.list_orgs():
         org_config = config.project_config.keychain.get_org(org)
-        row = [org]
-        row.append("*" if org_config.default else "")
-        row.append("*" if org_config.scratch else "")
+
+        org_expired = org_config.scratch and org_config.expired
+        config_name = org_config.config_name if org_config.config_name else ""
+        username = org_config.config.get(
+            "username", org_config.userinfo__preferred_username
+        )
+        username = username if username else ""
         if org_config.days_alive:
-            row.append(
-                "{} of {}".format(org_config.days_alive, org_config.days)
+            org_days = (
+                "{}/{}".format(org_config.days_alive, org_config.days)
                 if org_config.scratch
                 else ""
             )
         else:
-            row.append(org_config.days if org_config.scratch else "")
-        row.append("*" if org_config.scratch and org_config.expired else "")
-        row.append(org_config.config_name if org_config.config_name else "")
-        username = org_config.config.get(
-            "username", org_config.userinfo__preferred_username
+            org_days = org_config.days if org_config.scratch else ""
+
+        data.append(
+            [
+                org,
+                org_config.default,
+                org_config.scratch,
+                org_days,
+                org_expired,
+                config_name,
+                username,
+            ]
         )
-        row.append(username if username else "")
-        data.append(row)
-    table = Table(data, headers)
-    click.echo(table)
+
+    wrap_cols = [-1] if not plain else None
+    table = CliTable(data, title="Orgs", wrap_cols=wrap_cols)
+    table.stringify_boolean_cols(
+        [data[0].index(col) for col in ["Default", "Scratch", "Expired"]]
+    )
+    table.echo(plain)
 
 
 @click.command(name="remove", help="Removes an org from the keychain")
@@ -978,24 +990,29 @@ org.add_command(org_scratch_delete)
 
 
 @click.command(name="list", help="List available tasks for the current context")
+@click.option("--plain", is_flag=True, help="Print the table using plain ascii.")
+@click.option("--json", "print_json", is_flag=True, help="Print a json string")
 @pass_config(load_keychain=False)
-def task_list(config):
-    data = []
-    headers = ["task", "description"]
+def task_list(config, plain, print_json):
     task_groups = OrderedDict()
+
     for task in config.project_config.list_tasks():
         group = task["group"] or "Other"
         if group not in task_groups:
             task_groups[group] = []
-        task_groups[group].append(task)
+        task_groups[group].append([task["name"], task["description"]])
+
+    if print_json:
+        click.echo(json.dumps(task_groups))
+        return None
+
     for group, tasks in task_groups.items():
-        data.append(("", ""))
-        data.append(("-- {} --".format(group), ""))
-        for task in sorted(tasks, key=operator.itemgetter("name")):
-            data.append((task["name"], task["description"]))
-    table = Table(data, headers)
-    click.echo(table)
-    click.echo("")
+        title = click.style(group, bold=True, underline=True)
+        data = [["Task", "Description"]]
+        data.extend(sorted(tasks))
+        table = CliTable(data, group, wrap_cols=[1])
+        table.echo(plain)
+
     click.echo(
         "Use "
         + click.style("cci task info <task_name>", bold=True)
@@ -1130,14 +1147,25 @@ task.add_command(task_run)
 
 
 @click.command(name="list", help="List available flows for the current context")
+@click.option("--plain", is_flag=True, help="Print the table using plain ascii.")
+@click.option("--json", "print_json", is_flag=True, help="Print a json string")
 @pass_config(load_keychain=False)
-def flow_list(config):
-    data = []
-    headers = ["flow", "description"]
-    for flow in config.project_config.list_flows():
-        data.append((flow["name"], flow["description"]))
-    table = Table(data, headers)
-    click.echo(table)
+def flow_list(config, plain, print_json):
+    if print_json:
+        click.echo(json.dumps(config.project_config.list_flows()))
+        return None
+
+    data = [["Name", "Description"]]
+    data.extend(
+        [
+            [flow["name"], flow["description"]]
+            for flow in config.project_config.list_flows()
+        ]
+    )
+
+    table = CliTable(data, title="Flows", wrap_cols=[1])
+    table.echo(plain=plain)
+
     click.echo("")
     click.echo(
         "Use "

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -342,13 +342,13 @@ class TestCCI(unittest.TestCase):
         config.project_config.services = {"test": {"description": "Test Service"}}
         config.keychain.list_services.return_value = ["test"]
 
-        run_click_command(cci.service_list, config=config)
+        run_click_command(
+            cci.service_list, config=config, plain=False, print_json=False
+        )
 
-        table = echo.call_args[0][0]
+        table = echo.call_args_list[0][0][0]
         self.assertEqual(
-            """service  description   is_configured
--------  ------------  -------------
-test     Test Service  *""",
+            """\x1b(0l\x1b(BServices\x1b(0qqqqqqqqqqqqqwqqqqqqqqqqqqk\x1b(B\n\x1b(0x\x1b(B Name \x1b(0x\x1b(B Description  \x1b(0x\x1b(B Configured \x1b(0x\x1b(B\n\x1b(0tqqqqqqnqqqqqqqqqqqqqqnqqqqqqqqqqqqu\x1b(B\n\x1b(0x\x1b(B test \x1b(0x\x1b(B Test Service \x1b(0x\x1b(B \x1b[32m✔\x1b[0m          \x1b(0x\x1b(B\n\x1b(0mqqqqqqvqqqqqqqqqqqqqqvqqqqqqqqqqqqj\x1b(B""",
             str(table),
         )
 
@@ -629,14 +629,12 @@ test     Test Service  *""",
             ),
         ]
 
-        run_click_command(cci.org_list, config=config)
+        run_click_command(cci.org_list, config=config, plain=False)
 
-        table = echo.call_args[0][0]
+        table = echo.call_args_list[0][0][0]
+        print(table)
         self.assertEqual(
-            """org    default  scratch  days    expired  config_name  username
------  -------  -------  ------  -------  -----------  -----------------
-test1  *        *        1 of 7           dev          test1@example.com
-test2                                     dev          test2@example.com""",
+            """\u001b(0l\u001b(BOrgs\u001b(0qqqwqqqqqqqqqwqqqqqqqqqwqqqqqqwqqqqqqqqqwqqqqqqqqwqqqqqqqqqqqqqqqqqqqk\u001b(B\n\u001b(0x\u001b(B Org   \u001b(0x\u001b(B Default \u001b(0x\u001b(B Scratch \u001b(0x\u001b(B Days \u001b(0x\u001b(B Expired \u001b(0x\u001b(B Config \u001b(0x\u001b(B Username          \u001b(0x\u001b(B\n\u001b(0tqqqqqqqnqqqqqqqqqnqqqqqqqqqnqqqqqqnqqqqqqqqqnqqqqqqqqnqqqqqqqqqqqqqqqqqqqu\u001b(B\n\u001b(0x\u001b(B test1 \u001b(0x\u001b(B \u001b[32m\u2714\u001b[0m       \u001b(0x\u001b(B \u001b[32m\u2714\u001b[0m       \u001b(0x\u001b(B 1/7  \u001b(0x\u001b(B \u001b[31m\u2718\u001b[0m       \u001b(0x\u001b(B dev    \u001b(0x\u001b(B test1@example.com \u001b(0x\u001b(B\n\u001b(0tqqqqqqqnqqqqqqqqqnqqqqqqqqqnqqqqqqnqqqqqqqqqnqqqqqqqqnqqqqqqqqqqqqqqqqqqqu\u001b(B\n\u001b(0x\u001b(B test2 \u001b(0x\u001b(B \u001b[31m\u2718\u001b[0m       \u001b(0x\u001b(B \u001b[31m\u2718\u001b[0m       \u001b(0x\u001b(B      \u001b(0x\u001b(B \u001b[31m\u2718\u001b[0m       \u001b(0x\u001b(B dev    \u001b(0x\u001b(B test2@example.com \u001b(0x\u001b(B\n\u001b(0mqqqqqqqvqqqqqqqqqvqqqqqqqqqvqqqqqqvqqqqqqqqqvqqqqqqqqvqqqqqqqqqqqqqqqqqqqj\u001b(B""",
             str(table),
         )
 
@@ -765,15 +763,11 @@ test2                                     dev          test2@example.com""",
             {"name": "test_task", "description": "Test Task", "group": "Test"}
         ]
 
-        run_click_command(cci.task_list, config=config)
+        run_click_command(cci.task_list, config=config, plain=False, print_json=False)
 
         table = echo.call_args_list[0][0][0]
         self.assertEqual(
-            """task        description
-----------  -----------
-
--- Test --
-test_task   Test Task""",
+            """\x1b(0l\x1b(BTest\x1b(0qqqqqqqwqqqqqqqqqqqqqk\x1b(B\n\x1b(0x\x1b(B Task      \x1b(0x\x1b(B Description \x1b(0x\x1b(B\n\x1b(0tqqqqqqqqqqqnqqqqqqqqqqqqqu\x1b(B\n\x1b(0x\x1b(B test_task \x1b(0x\x1b(B Test Task   \x1b(0x\x1b(B\n\x1b(0mqqqqqqqqqqqvqqqqqqqqqqqqqj\x1b(B""",
             str(table),
         )
 
@@ -973,13 +967,11 @@ test_task   Test Task""",
             {"name": "test_flow", "description": "Test Flow"}
         ]
 
-        run_click_command(cci.flow_list, config=config)
+        run_click_command(cci.flow_list, config=config, plain=False, print_json=False)
 
         table = echo.call_args_list[0][0][0]
         self.assertEqual(
-            """flow       description
----------  -----------
-test_flow  Test Flow""",
+            """\x1b(0l\x1b(BFlows\x1b(0qqqqqqwqqqqqqqqqqqqqk\x1b(B\n\x1b(0x\x1b(B Name      \x1b(0x\x1b(B Description \x1b(0x\x1b(B\n\x1b(0tqqqqqqqqqqqnqqqqqqqqqqqqqu\x1b(B\n\x1b(0x\x1b(B test_flow \x1b(0x\x1b(B Test Flow   \x1b(0x\x1b(B\n\x1b(0mqqqqqqqqqqqvqqqqqqqqqqqqqj\x1b(B""",
             str(table),
         )
 

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from collections import OrderedDict
 from datetime import date
 import io

--- a/cumulusci/cli/tests/test_ui.py
+++ b/cumulusci/cli/tests/test_ui.py
@@ -1,0 +1,135 @@
+import mock
+import pytest
+from cumulusci.cli.ui import CliTable
+
+
+@pytest.fixture
+def sample_data():
+    return {
+        "service_list": [
+            ["Name", "Description", "Configured"],
+            ["saucelabs", "Configure connection for saucelabs tasks.", False],
+            ["sentry", "Configure connection to sentry.io for error tracking", False],
+        ],
+        "org_list": [
+            ["Org", "Default", "Scratch", "Days", "Expired", "Config", "Username"],
+            ["beta", None, True, 1, None, "beta", ""],
+            ["dev", True, True, "1/7", False, "dev", "test-h8znvutwnctb@example.com"],
+            ["feature", None, True, 1, None, "feature", ""],
+        ],
+        "task_list_util": [
+            ["Task", "Description"],
+            ["command", "Run an arbitrary command"],
+            ["log", "Log a line at the info level."],
+            ["util_sleep", "Sleeps for N seconds"],
+        ],
+        "task_list_robot": [
+            ["Task", "Description"],
+            ["robot", "Runs a Robot Framework test from a .robot file"],
+            [
+                "robot_libdoc",
+                "Generates html documentation for the Salesorce and CumulusCI libraries and resource files",
+            ],
+        ],
+    }
+
+
+@pytest.fixture
+def pretty_output():
+    return {
+        "service_list": "\x1b(0lqqqqqqqqqqqwqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqwqqqqqqqqqqqqk\x1b(B\n\x1b(0x\x1b(B Name      \x1b(0x\x1b(B Description                                          \x1b(0x\x1b(B Configured \x1b(0x\x1b(B\n\x1b(0tqqqqqqqqqqqnqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqnqqqqqqqqqqqqu\x1b(B\n\x1b(0x\x1b(B saucelabs \x1b(0x\x1b(B Configure connection for saucelabs tasks.            \x1b(0x\x1b(B False      \x1b(0x\x1b(B\n\x1b(0x\x1b(B sentry    \x1b(0x\x1b(B Configure connection to sentry.io for error tracking \x1b(0x\x1b(B False      \x1b(0x\x1b(B\n\x1b(0mqqqqqqqqqqqvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqvqqqqqqqqqqqqj\x1b(B",
+        "org_list": "\x1b(0lqqqqqqqqqwqqqqqqqqqwqqqqqqqqqwqqqqqqwqqqqqqqqqwqqqqqqqqqwqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqk\x1b(B\n\x1b(0x\x1b(B Org     \x1b(0x\x1b(B Default \x1b(0x\x1b(B Scratch \x1b(0x\x1b(B Days \x1b(0x\x1b(B Expired \x1b(0x\x1b(B Config  \x1b(0x\x1b(B Username                      \x1b(0x\x1b(B\n\x1b(0tqqqqqqqqqnqqqqqqqqqnqqqqqqqqqnqqqqqqnqqqqqqqqqnqqqqqqqqqnqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqu\x1b(B\n\x1b(0x\x1b(B beta    \x1b(0x\x1b(B None    \x1b(0x\x1b(B True    \x1b(0x\x1b(B 1    \x1b(0x\x1b(B None    \x1b(0x\x1b(B beta    \x1b(0x\x1b(B                               \x1b(0x\x1b(B\n\x1b(0x\x1b(B dev     \x1b(0x\x1b(B True    \x1b(0x\x1b(B True    \x1b(0x\x1b(B 1/7  \x1b(0x\x1b(B False   \x1b(0x\x1b(B dev     \x1b(0x\x1b(B test-h8znvutwnctb@example.com \x1b(0x\x1b(B\n\x1b(0x\x1b(B feature \x1b(0x\x1b(B None    \x1b(0x\x1b(B True    \x1b(0x\x1b(B 1    \x1b(0x\x1b(B None    \x1b(0x\x1b(B feature \x1b(0x\x1b(B                               \x1b(0x\x1b(B\n\x1b(0mqqqqqqqqqvqqqqqqqqqvqqqqqqqqqvqqqqqqvqqqqqqqqqvqqqqqqqqqvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqj\x1b(B",
+        "task_list_util": "\x1b(0lqqqqqqqqqqqqwqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqk\x1b(B\n\x1b(0x\x1b(B Task       \x1b(0x\x1b(B Description                   \x1b(0x\x1b(B\n\x1b(0tqqqqqqqqqqqqnqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqu\x1b(B\n\x1b(0x\x1b(B command    \x1b(0x\x1b(B Run an arbitrary command      \x1b(0x\x1b(B\n\x1b(0x\x1b(B log        \x1b(0x\x1b(B Log a line at the info level. \x1b(0x\x1b(B\n\x1b(0x\x1b(B util_sleep \x1b(0x\x1b(B Sleeps for N seconds          \x1b(0x\x1b(B\n\x1b(0mqqqqqqqqqqqqvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqj\x1b(B",
+        "task_list_robot": "\x1b(0lqqqqqqqqqqqqqqwqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqk\x1b(B\n\x1b(0x\x1b(B Task         \x1b(0x\x1b(B Description                                                                               \x1b(0x\x1b(B\n\x1b(0tqqqqqqqqqqqqqqnqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqu\x1b(B\n\x1b(0x\x1b(B robot        \x1b(0x\x1b(B Runs a Robot Framework test from a .robot file                                            \x1b(0x\x1b(B\n\x1b(0x\x1b(B robot_libdoc \x1b(0x\x1b(B Generates html documentation for the Salesorce and CumulusCI libraries and resource files \x1b(0x\x1b(B\n\x1b(0mqqqqqqqqqqqqqqvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqj\x1b(B",
+    }
+
+
+@pytest.fixture
+def plain_output():
+    return {
+        "service_list": """+-----------+------------------------------------------------------+------------+
+| Name      | Description                                          | Configured |
++-----------+------------------------------------------------------+------------+
+| saucelabs | Configure connection for saucelabs tasks.            | False      |
++-----------+------------------------------------------------------+------------+
+| sentry    | Configure connection to sentry.io for error tracking | False      |
++-----------+------------------------------------------------------+------------+
+""",
+        "org_list": """+---------+---------+---------+------+---------+---------+-------------------------------+
+| Org     | Default | Scratch | Days | Expired | Config  | Username                      |
++---------+---------+---------+------+---------+---------+-------------------------------+
+| beta    | None    | True    | 1    | None    | beta    |                               |
++---------+---------+---------+------+---------+---------+-------------------------------+
+| dev     | True    | True    | 1/7  | False   | dev     | test-h8znvutwnctb@example.com |
++---------+---------+---------+------+---------+---------+-------------------------------+
+| feature | None    | True    | 1    | None    | feature |                               |
++---------+---------+---------+------+---------+---------+-------------------------------+
+""",
+        "task_list_util": """+------------+-------------------------------+
+| Task       | Description                   |
++------------+-------------------------------+
+| command    | Run an arbitrary command      |
++------------+-------------------------------+
+| log        | Log a line at the info level. |
++------------+-------------------------------+
+| util_sleep | Sleeps for N seconds          |
++------------+-------------------------------+
+""",
+        "task_list_robot": """+--------------+-------------------------------------------------------------------------------------------+
+| Task         | Description                                                                               |
++--------------+-------------------------------------------------------------------------------------------+
+| robot        | Runs a Robot Framework test from a .robot file                                            |
++--------------+-------------------------------------------------------------------------------------------+
+| robot_libdoc | Generates html documentation for the Salesorce and CumulusCI libraries and resource files |
++--------------+-------------------------------------------------------------------------------------------+
+""",
+    }
+
+
+@pytest.mark.parametrize(
+    "fixture_key", ["service_list", "org_list", "task_list_util", "task_list_robot"]
+)
+def test_table_pretty_output(sample_data, pretty_output, fixture_key):
+    instance = CliTable(sample_data[fixture_key])
+    assert pretty_output[fixture_key] == instance.table.table
+
+
+@pytest.mark.parametrize(
+    "fixture_key", ["service_list", "org_list", "task_list_util", "task_list_robot"]
+)
+def test_table_plain_output(sample_data, plain_output, fixture_key, capsys):
+    instance = CliTable(sample_data[fixture_key])
+    instance.ascii_table()
+    captured = capsys.readouterr()
+    assert plain_output[fixture_key] == captured.out
+
+
+@pytest.mark.parametrize(
+    "fixture_key", ["service_list", "org_list", "task_list_util", "task_list_robot"]
+)
+def test_table_plain_echo(sample_data, plain_output, fixture_key, capsys):
+    instance = CliTable(sample_data[fixture_key])
+    instance.echo(plain=True)
+    captured = capsys.readouterr()
+    assert plain_output[fixture_key] == captured.out
+
+
+def test_table_plain_fallback(sample_data, plain_output, capsys):
+    with mock.patch("cumulusci.cli.ui.CliTable.pretty_table") as pretty_table:
+        pretty_table.side_effect = UnicodeEncodeError(
+            "cp1542", "", 42, 43, "Fake exception"
+        )
+        instance = CliTable(sample_data["service_list"])
+        instance.echo(plain=False)
+        captured = capsys.readouterr()
+        # append newlines because echo adds them to account for task tables
+        assert plain_output["service_list"] + "\n\n" == captured.out
+
+
+def test_table_stringify_booleans(sample_data):
+    data = sample_data["service_list"]
+    data[1][2] = True
+    instance = CliTable(data)
+    instance.stringify_boolean_cols(2)
+    assert instance.PICTOGRAM_TRUE in instance.table.table_data[1]
+    assert instance.PICTOGRAM_FALSE in instance.table.table_data[2]

--- a/cumulusci/cli/tests/test_ui.py
+++ b/cumulusci/cli/tests/test_ui.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import mock
 import pytest
 from cumulusci.cli.ui import CliTable

--- a/cumulusci/cli/ui.py
+++ b/cumulusci/cli/ui.py
@@ -1,0 +1,89 @@
+"""Format and display CLI output.
+
+Classes:
+    CliTable: Pretty prints tabluar data to stdout, via click.echo.
+"""
+import os
+import collections
+import click
+import textwrap
+from terminaltables import AsciiTable, SingleTable
+
+
+class CliTable:
+    """Format and print data to the command line in tabular form.
+    Attributes:
+        INNER_BORDER: Boolean passed to terminaltables.inner_row_border. Defaults to True.
+        PICTOGRAM_TRUE: True boolean values are replaced with this string.
+        PICTOGRAM_FALSE = False boolean values are replaced with this string.
+    Methods:
+        echo: Print the table data to stdout using click.echo()
+        pretty_table: Table drawn using Unicode drawing characters.
+        ascii_table: Table drawn using Ascii characters.
+    """
+
+    INNER_BORDER = True
+    PICTOGRAM_TRUE = click.style("✔" if os.name == "posix" else "+", fg="green")
+    PICTOGRAM_FALSE = click.style("✘" if os.name == "posix" else "-", fg="red")
+
+    def __init__(self, data, title=None, wrap_cols=None):
+        """Constructor.
+        Args:
+            data: Required. List[List] of data to format, with the heading as 0-th member.
+            title: String to use as the table's title.
+            wrap_cols: List[int] of column indices to wrap to max width.
+
+        """
+        self._data = data
+        self._title = title
+        self.table = SingleTable(self._data, self._title)
+        if wrap_cols:
+            self._table_wrapper(self.table, wrap_cols)
+
+    def _table_wrapper(self, table, wrap_cols):
+        """Query for column width and wrap text"""
+        for index in wrap_cols:
+            width = abs(table.column_max_width(index))
+            for row in table.table_data:
+                row[index] = (
+                    textwrap.fill(row[index], width) if row[index] is not None else ""
+                )
+
+    def stringify_boolean_cols(self, col_index=None):
+        """Replace a boolean at the given index with a checkmark.
+        Args:
+            col_index: List[int] or int indicating which columns should be stringifed.
+        """
+        col_index = (
+            col_index if isinstance(col_index, collections.Iterable) else [col_index]
+        )
+        for row in self.table.table_data[1:]:
+            for index in col_index:
+                row[index] = self.PICTOGRAM_TRUE if row[index] else self.PICTOGRAM_FALSE
+
+    def echo(self, plain=False):
+        """Print this tables data using click.echo().
+
+        Automatically falls back to AsciiTable if there's an encoding error.
+        """
+        if plain:
+            self.ascii_table()
+            return None
+
+        try:
+            self.pretty_table()
+        except UnicodeEncodeError:
+            self.ascii_table()
+
+        click.echo("\n")
+
+    def pretty_table(self):
+        """Pretty prints a table."""
+        self.table.inner_row_border = self.INNER_BORDER
+        click.echo(self.table.table)
+
+    def ascii_table(self):
+        """Fallback for dumb terminals."""
+        self.plain = AsciiTable(self.table.table_data, self._title)
+        self.plain.inner_row_border = self.INNER_BORDER
+        click.echo(self.plain.table)

--- a/cumulusci/cli/ui.py
+++ b/cumulusci/cli/ui.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Format and display CLI output.
 
 Classes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ jwcrypto==0.6.0
 keyring==18.0.1  # pyup: <19
 lxml==4.3.4
 MarkupSafe==1.1.1
-plaintable==0.1.1
 pycparser==2.19
 python-dateutil==2.8.0
 pytz==2019.1
@@ -30,6 +29,7 @@ selenium==3.141.0
 simple-salesforce==0.74.2
 six==1.12.0
 SQLAlchemy==1.3.4
+terminaltables==3.1.0
 unicodecsv==0.14.1
 uritemplate==3.0.0
 urllib3==1.25.3


### PR DESCRIPTION
AKA: Add fancy tables for: 
- `flow list`
- `service list`
- `org list`
- `task list`

This PR adds a new module, `cumulusci.cli.ui` that is responsible for formatting and outputting cli data for the user. Its first class, CliTable, wraps the construction of a terminaltables.{SingleTable,AsciiTable} instance and provides utilities for formatting tables and printing them to stdout via click.echo.

In cumulusci.cli.cci, references to plaintable have been replaced with calls to CliTable. In addition, `--json` flags have been added to several commands (`service_list`, `task_list`, `flow_list`), as well as a `--plain` flag to force ascii format tables on those terminals which do not throw a UnicodeEncodeError (e.g. emacs-eshell on Linux, but not Windows, inexplicably). `--plain` also suppresses table column wrapping in org_list to allow copying and pasting usernames.

Also:
Fixes table output in emacs and other dumb terminals. Smoke tested on windows 10.

Only use emoji pictograms on posix platforms since Windows command prompt/powershell can't handle all unicode, yet still report `sys.platform == 'utf-8'`. This commit replaces the default pictogram with CP-1256-compliant ascii strings on non-POSIX platforms.

todos:
- [x] Update boolean pictograms in `org list`
- [x] Allow setting plain output via global config
- [x] Investigate using `click.style`'s `dim` parameter to dim inactive rows on `org/service list`
- [ ] Use tables for `* info` commands
- [ ] Investigate additions from #241
- [ ] Resolve #1023 


`org list`:
<img width="922" alt="screenshot_2019-06-17_13-34-39" src="https://user-images.githubusercontent.com/748532/59635101-2d287180-9105-11e9-8d0a-8ab53fc7664b.png">

`task_list`:
<img width="908" alt="screenshot_2019-06-17_13-35-06" src="https://user-images.githubusercontent.com/748532/59635146-4e895d80-9105-11e9-8ace-1c006377cca8.png">

`service list`:
<img width="919" alt="screenshot_2019-06-17_13-35-31" src="https://user-images.githubusercontent.com/748532/59635127-3f0a1480-9105-11e9-8598-beed5767cb75.png">

# Critical Changes

# Changes
- We've changed how the output of some commands are displayed in tables. For users that prefer Markdown style tables we've added a `--plain` option to approximate the previous behavior.
# Issues Closed
