### PR TITLE
Feature/libdoc for pageobjects

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -18,9 +18,10 @@ tasks:
             title: CumulusCI Robot Framework Keywords
             output: docs/robot/Keywords.html
             path:
-              - cumulusci/robotframework/Salesforce.py
+              - cumulusci.robotframework.CumulusCI
+              - cumulusci.robotframework.PageObjects
+              - cumulusci.robotframework.Salesforce
               - cumulusci/robotframework/Salesforce.robot
-              - cumulusci/robotframework/CumulusCI.py
 
 flows:
     robot_docs:

--- a/cumulusci/core/tests/test_pageobjects.py
+++ b/cumulusci/core/tests/test_pageobjects.py
@@ -104,7 +104,7 @@ class TestPageObjects(unittest.TestCase):
         )
         self.assertEqual(po.bar_keyword_1("hello"), "bar keyword 1: hello")
 
-    @mock.patch("robot.libraries.BuiltIn.BuiltIn.log")
+    @mock.patch("robot.api.logger.info")
     def test_log_page_object_keywords(
         self, log_mock, get_context_mock, get_library_instance_mock
     ):

--- a/cumulusci/robotframework/pageobjects/PageObjects.py
+++ b/cumulusci/robotframework/pageobjects/PageObjects.py
@@ -1,5 +1,5 @@
 from robot.api import logger
-from robot.libraries.BuiltIn import BuiltIn, RobotNotRunningError
+from robot.libraries.BuiltIn import BuiltIn
 from .baseobjects import BasePage
 import inspect
 import robot.utils
@@ -38,10 +38,7 @@ class PageObjects(object):
 
         # Start with this library at the front of the library search order;
         # that may change as page objects are loaded.
-        try:
-            BuiltIn().set_library_search_order("PageObjects")
-        except RobotNotRunningError:
-            pass
+        BuiltIn().set_library_search_order("PageObjects")
 
     @classmethod
     def _reset(cls):
@@ -52,16 +49,12 @@ class PageObjects(object):
         for pobj in cls.registry.values():
             if pobj.__module__ in sys.modules:
                 del sys.modules[pobj.__module__]
-            del pobj
         cls.registry = {}
         cls.cache = {}
 
     @property
     def selenium(self):
-        try:
-            return BuiltIn().get_library_instance("SeleniumLibrary")
-        except RobotNotRunningError:
-            return None
+        return BuiltIn().get_library_instance("SeleniumLibrary")
 
     def __getattr__(self, name):
         """Return the keyword from the current page object

--- a/cumulusci/robotframework/pageobjects/PageObjects.py
+++ b/cumulusci/robotframework/pageobjects/PageObjects.py
@@ -44,7 +44,7 @@ class PageObjects(object):
             pass
 
     @classmethod
-    def reset(cls):
+    def _reset(cls):
         """Reset the internal data structures used to manage page objects
 
         This is to aid testing. It probably shouldn't be used at any other time.

--- a/cumulusci/robotframework/pageobjects/PageObjects.py
+++ b/cumulusci/robotframework/pageobjects/PageObjects.py
@@ -25,7 +25,7 @@ class PageObjects(object):
     cache = {}
 
     def __init__(self, *args):
-        logger.info("initializing PageObjects...", "DEBUG")
+        logger.debug("initializing PageObjects...")
         importer = robot.utils.Importer()
 
         for file_path in args:

--- a/cumulusci/robotframework/pageobjects/PageObjects.py
+++ b/cumulusci/robotframework/pageobjects/PageObjects.py
@@ -1,22 +1,36 @@
 from robot.api import logger
-from robot.libraries.BuiltIn import BuiltIn
-from .baseobjects import BasePage
+from robot.libraries.BuiltIn import BuiltIn, RobotNotRunningError
+from cumulusci.robotframework.pageobjects.baseobjects import BasePage
 import inspect
 import robot.utils
 import os
 import sys
 
 
+def get_keyword_names(obj):
+    """Returns a list of method names for the given object
+
+    This excludes methods that begin with an underscore, and
+    also excludes the special method `get_keyword_names`.
+    """
+    names = [
+        member[0]
+        for member in inspect.getmembers(obj, inspect.isroutine)
+        if (not member[0].startswith("_")) and member[0] != "get_keyword_names"
+    ]
+    return names
+
+
 class PageObjects(object):
-    """Dynamic robot library for importing and using page objects
+    """Keyword library for importing and using page objects
 
     When importing, you can include one or more paths to python
     files that define page objects. For example, if you have a set
     of classes in robot/HEDA/resources/PageObjects.py, you can import
     this library into a test case like this:
 
-        Library  cumulusci.robotframework.PageObjects
-        ...  robot/HEDA/resources/PageObjects.py
+    | Library  cumulusci.robotframework.PageObjects
+    | ...  robot/HEDA/resources/PageObjects.py
 
     """
 
@@ -38,7 +52,13 @@ class PageObjects(object):
 
         # Start with this library at the front of the library search order;
         # that may change as page objects are loaded.
-        BuiltIn().set_library_search_order("PageObjects")
+        try:
+            BuiltIn().set_library_search_order("PageObjects")
+        except RobotNotRunningError:
+            # this should only happen when trying to load this library
+            # via the robot_libdoc task, in which case we don't care
+            # whether this throws an error or not.
+            pass
 
     @classmethod
     def _reset(cls):
@@ -69,29 +89,16 @@ class PageObjects(object):
         """
         This method is required by robot's dynamic library api
         """
-        names = [name for name in dir(self) if self._is_keyword(name, self)]
+        names = get_keyword_names(self)
         if self.current_page_object is not None:
-            names = names + [
-                name
-                for name in dir(self.current_page_object)
-                if self._is_keyword(name, self.current_page_object)
-            ]
+            names = names + get_keyword_names(self.current_page_object)
         return names
-
-    def _is_keyword(self, name, source):
-        return (
-            not name.startswith("_")
-            and name != "get_keyword_names"
-            and inspect.isroutine(getattr(source, name))
-        )
 
     def log_page_object_keywords(self):
         """Logs page objects and their keywords for all page objects which have been imported"""
         for key in sorted(self.registry.keys()):
             pobj = self.registry[key]
-            keywords = sorted(
-                [method for method in dir(pobj) if self._is_keyword(method, pobj)]
-            )
+            keywords = get_keyword_names(pobj)
             logger.info("{}: {}".format(key, ", ".join(keywords)))
 
     def _get_page_object(self, page_type, object_name):

--- a/cumulusci/tasks/robotframework/libdoc.py
+++ b/cumulusci/tasks/robotframework/libdoc.py
@@ -76,7 +76,7 @@ class RobotLibDoc(BaseTask):
                         os.path.abspath(input_file)
                     )
 
-                    for pobj_name in sorted(PageObjects.registry.keys()):
+                    for pobj_name, pobj in sorted(PageObjects.registry.items()):
                         pobj = PageObjects.registry[pobj_name]
                         libname = "{}.{}".format(pobj.__module__, pobj.__name__)
                         libdoc = LibraryDocBuilder().build(libname)

--- a/cumulusci/tasks/robotframework/libdoc.py
+++ b/cumulusci/tasks/robotframework/libdoc.py
@@ -71,7 +71,7 @@ class RobotLibDoc(BaseTask):
             kwfile = KeywordFile(input_file)
             try:
                 if self.is_pageobject_library(input_file):
-                    PageObjects.reset()
+                    PageObjects._reset()
                     Importer().import_class_or_module_by_path(
                         os.path.abspath(input_file)
                     )

--- a/cumulusci/tasks/robotframework/stylesheet.css
+++ b/cumulusci/tasks/robotframework/stylesheet.css
@@ -40,7 +40,8 @@ body {
     padding: 4px;
 }
 .section {
-    margin-bottom: 10px;
+    margin-bottom: 2em;
+    margin-left: 2em;
 }
 .kwtable {
     box-shadow: 7px 7px 9px #d4d4d4;
@@ -75,4 +76,14 @@ body {
 }
 .library-documentation {
     margin-bottom: 2em;
+    margin-left: 2em;
+}
+
+.pageobject-header {
+    font-size: 1.2em;
+    font-weight: bold;
+}
+
+.object_name, .page_type {
+    padding: 2px 10px ;
 }

--- a/cumulusci/tasks/robotframework/stylesheet.css
+++ b/cumulusci/tasks/robotframework/stylesheet.css
@@ -9,15 +9,22 @@ body {
 }
 .header {
     display: flex;
-    border-bottom: 1px solid #aaa;
     align-items: bottom;
 }
-.header .title {
-    font-size: 2em;
+.header h1 {
+    margin-top: 0px;
 }
 .header search {
     align-self: flex-end;
     margin-bottom: 0px;
+}
+.file-header: {
+    margin-bottom: 10em;
+}
+.file-header h2 {
+    padding-bottom: 4px;
+    margin-bottom: 4px;
+    border-bottom: 1px solid #127a9a
 }
 .right {
     margin-left: auto;
@@ -43,6 +50,15 @@ body {
     margin-bottom: 2em;
     margin-left: 2em;
 }
+.description {
+    margin-top: .5em;
+    margin-bottom: 1em;
+    background: #f4f6f9;
+    padding-left: 1em;
+    padding-top: .5em;
+    padding-bottom: 1em;
+}
+
 .kwtable {
     box-shadow: 7px 7px 9px #d4d4d4;
     border-collapse: collapse;
@@ -78,12 +94,10 @@ body {
     margin-bottom: 2em;
     margin-left: 2em;
 }
-
 .pageobject-header {
     font-size: 1.2em;
     font-weight: bold;
 }
-
 .object_name, .page_type {
     padding: 2px 10px ;
 }

--- a/cumulusci/tasks/robotframework/template.html
+++ b/cumulusci/tasks/robotframework/template.html
@@ -35,30 +35,39 @@
         <div class="title">{{title}}</div>
         <div class="search right">search: <input id="search" type="search"></input></div>
       </div>
-      {% for library in libraries %}
-      <div class="section" id="library-{{library.name}}">
-        <h1>{{library.src}}</h1>
-        <div class="library-documentation">
-        {{library.doc|robot_html}}
-        </div>
-        <table class="kwtable">
-          <tbody>
-            <tr><th>Keyword</th><th>Arguments</th><th>Documentation</th></tr>
-            {% for keyword in library.keywords %}
-            <tr class="kwrow" id="{{library.src}}.{{keyword.name}}">
-              <td class="kwname">
-                {{keyword.name}}
-              </td>
-              <td class="kwargs">
+
+      {% for kwfile in libraries %}
+      <div class="file" id="file-{{kwfile.path}}">
+        <h1 title='{{kwfile.path}}'>{{kwfile.filename}}</h1>
+        {% for pageobject, library in kwfile.keywords.items() %}
+        <div class="section" pageobject="{{pageobject|join('-')}}">
+          {% if pageobject %}
+          <div class='pageobject-header'>
+            Page Object: <span class='page_type'>{{pageobject[0]}}</span>
+            <span class='object_name'>{{pageobject[1]}}</span>
+          </div>
+          {% endif %}
+          <div class='description'>{{library.doc|robot_html}}</div>
+          <table class="kwtable">
+            <tbody>
+              <tr><th>Keyword</th><th>Arguments</th><th>Documentation</th></tr>
+              {% for keyword in library.keywords %}
+              <tr class="kwrow" id="{{kwfile.filename}}.{{keyword.name}}">
+                <td class="kwname">
+                  {{keyword.name}}
+                </td>
+                <td class="kwargs">
                   {% for arg in keyword.args %}
                   <i>{{arg}}</i>{% if not loop.last %}, {% endif %}
                   {% endfor %}
-              </td>
-              <td class="kwdoc">{{keyword.doc|robot_html}}</td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
+                </td>
+                <td class="kwdoc">{{keyword.doc|robot_html}}</td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div> {# class="library-whatever" #}
+        {% endfor %}
       </div>
       {% endfor %}
     </div>

--- a/cumulusci/tasks/robotframework/template.html
+++ b/cumulusci/tasks/robotframework/template.html
@@ -6,10 +6,10 @@
       crossorigin="anonymous">
     </script>
     <script>
-      function search() {
-          var search_string = $("#search").val().toLowerCase();
+      function filter() {
+          var filter_string = $("#filter").val().toLowerCase();
           $(".kwtable .kwname").each(function() {
-              if ($(this).text().toLowerCase().indexOf(search_string) !== -1) {
+              if ($(this).text().toLowerCase().indexOf(filter_string) !== -1) {
                   $(this).parent().show();
               } else {
                   $(this).parent().hide();
@@ -17,11 +17,11 @@
           })
       }
       $(document).ready(function() {
-          $("#search").on("input", function() {
-              search()
+          $("#filter").on("input", function() {
+              filter()
           })
-          $("#search").keyup(function() {
-              search()
+          $("#filter").keyup(function() {
+              filter()
           })
       });
     </script>
@@ -33,7 +33,7 @@
     <div class="container">
       <div class="header">
         <div class="title">{{title}}</div>
-        <div class="search right">search: <input id="search" type="search"></input></div>
+        <div class="filter right">filter: <input id="filter" type="filter"></input></div>
       </div>
 
       {% for kwfile in libraries %}

--- a/cumulusci/tasks/robotframework/template.html
+++ b/cumulusci/tasks/robotframework/template.html
@@ -32,13 +32,16 @@
   <body>
     <div class="container">
       <div class="header">
-        <div class="title">{{title}}</div>
+        <h1 class="title">{{title}}</h1>
         <div class="filter right">filter: <input id="filter" type="filter"></input></div>
       </div>
 
       {% for kwfile in libraries %}
       <div class="file" id="file-{{kwfile.path}}">
-        <h1 title='{{kwfile.path}}'>{{kwfile.filename}}</h1>
+        <div class='file-header'>
+          <h2 title='{{kwfile.path}}'>{{kwfile.filename}}</h2>
+          <div class='file-path'>{{kwfile.path}}</div>
+        </div>
         {% for pageobject, library in kwfile.keywords.items() %}
         <div class="section" pageobject="{{pageobject|join('-')}}">
           {% if pageobject %}

--- a/cumulusci/tasks/robotframework/tests/TestPageObjects.py
+++ b/cumulusci/tasks/robotframework/tests/TestPageObjects.py
@@ -1,0 +1,26 @@
+from cumulusci.robotframework.pageobjects import pageobject, ListingPage, DetailPage
+
+
+@pageobject(page_type="Listing", object_name="Something__c")
+class SomethingListingPage(ListingPage):
+    """Description of SomethingListingPage"""
+
+    def keyword_one(self):
+        pass
+
+    def keyword_two(self):
+        pass
+
+
+@pageobject(page_type="Detail", object_name="Something__c")
+class SomethingDetailPage(DetailPage):
+    """Description of SomethingDetailPage"""
+
+    def keyword_one(self):
+        pass
+
+    def keyword_two(self):
+        pass
+
+    def keyword_three(self):
+        pass

--- a/cumulusci/tasks/robotframework/tests/test_robotframework.py
+++ b/cumulusci/tasks/robotframework/tests/test_robotframework.py
@@ -114,7 +114,7 @@ class TestRobotLibDocOutput(unittest.TestCase):
     def test_output_title(self):
         """Verify the document has the expected title"""
         title_element = self.html_body.find(
-            ".//div[@class='header']/div[@class='title']"
+            ".//div[@class='header']/h1[@class='title']"
         )
         assert title_element is not None
         assert title_element.text.strip() == "Keyword Documentation, yo."
@@ -135,7 +135,9 @@ class TestRobotLibDocOutput(unittest.TestCase):
     def test_output_sections(self):
         """Verify that the output has a section for each file"""
         sections = self.html_body.findall(".//div[@class='file']")
-        section_titles = [x.find("h1").text for x in sections]
+        section_titles = [
+            x.find(".//div[@class='file-header']/h2").text for x in sections
+        ]
         assert len(sections) == 2, "expected to find 2 sections, found {}".format(
             len(sections)
         )

--- a/docs/robot/Keywords.html
+++ b/docs/robot/Keywords.html
@@ -6,10 +6,10 @@
       crossorigin="anonymous">
     </script>
     <script>
-      function search() {
-          var search_string = $("#search").val().toLowerCase();
+      function filter() {
+          var filter_string = $("#filter").val().toLowerCase();
           $(".kwtable .kwname").each(function() {
-              if ($(this).text().toLowerCase().indexOf(search_string) !== -1) {
+              if ($(this).text().toLowerCase().indexOf(filter_string) !== -1) {
                   $(this).parent().show();
               } else {
                   $(this).parent().hide();
@@ -17,11 +17,11 @@
           })
       }
       $(document).ready(function() {
-          $("#search").on("input", function() {
-              search()
+          $("#filter").on("input", function() {
+              filter()
           })
-          $("#search").keyup(function() {
-              search()
+          $("#filter").keyup(function() {
+              filter()
           })
       });
     </script>
@@ -122,7 +122,7 @@
     <div class="container">
       <div class="header">
         <div class="title">CumulusCI Robot Framework Keywords</div>
-        <div class="search right">search: <input id="search" type="search"></input></div>
+        <div class="filter right">filter: <input id="filter" type="filter"></input></div>
       </div>
 
       
@@ -1086,7 +1086,7 @@ Library  cumulusci.robotframework.CumulusCI  ${ORG}
       
     </div>
     <div class="footer">
-      Generated on Monday June 17, 09:32 PM - cumulusci v2.5.2
+      Generated on Tuesday June 18, 06:12 PM - cumulusci v2.5.2
     </div>
   </body>
 </html>

--- a/docs/robot/Keywords.html
+++ b/docs/robot/Keywords.html
@@ -37,15 +37,22 @@
 }
 .header {
     display: flex;
-    border-bottom: 1px solid #aaa;
     align-items: bottom;
 }
-.header .title {
-    font-size: 2em;
+.header h1 {
+    margin-top: 0px;
 }
 .header search {
     align-self: flex-end;
     margin-bottom: 0px;
+}
+.file-header: {
+    margin-bottom: 10em;
+}
+.file-header h2 {
+    padding-bottom: 4px;
+    margin-bottom: 4px;
+    border-bottom: 1px solid #127a9a
 }
 .right {
     margin-left: auto;
@@ -71,6 +78,15 @@
     margin-bottom: 2em;
     margin-left: 2em;
 }
+.description {
+    margin-top: .5em;
+    margin-bottom: 1em;
+    background: #f4f6f9;
+    padding-left: 1em;
+    padding-top: .5em;
+    padding-bottom: 1em;
+}
+
 .kwtable {
     box-shadow: 7px 7px 9px #d4d4d4;
     border-collapse: collapse;
@@ -106,12 +122,10 @@
     margin-bottom: 2em;
     margin-left: 2em;
 }
-
 .pageobject-header {
     font-size: 1.2em;
     font-weight: bold;
 }
-
 .object_name, .page_type {
     padding: 2px 10px ;
 }
@@ -121,22 +135,266 @@
   <body>
     <div class="container">
       <div class="header">
-        <div class="title">CumulusCI Robot Framework Keywords</div>
+        <h1 class="title">CumulusCI Robot Framework Keywords</h1>
         <div class="filter right">filter: <input id="filter" type="filter"></input></div>
       </div>
 
       
-      <div class="file" id="file-cumulusci/robotframework/Salesforce.py">
-        <h1 title='cumulusci/robotframework/Salesforce.py'>Salesforce.py</h1>
+      <div class="file" id="file-cumulusci.robotframework.CumulusCI">
+        <div class='file-header'>
+          <h2 title='cumulusci.robotframework.CumulusCI'>CumulusCI</h2>
+          <div class='file-path'>cumulusci.robotframework.CumulusCI</div>
+        </div>
         
         <div class="section" pageobject="">
           
-          <div class='description'><p>Documentation for library <code>Salesforce</code>.</p></div>
+          <div class='description'><p>Library for accessing CumulusCI for the local git project</p>
+<p>This library allows Robot Framework tests to access credentials to a Salesforce org created by CumulusCI, including Scratch Orgs.  It also exposes the core logic of CumulusCI including interactions with the Salesforce API's and project specific configuration including custom and customized tasks and flows.</p>
+<p>Initialization requires a single argument, the org name for the target CumulusCI org.  If running your tests via cci's robot task (recommended), you can initialize the library in your tests taking advantage of the variable set by the robot task:</p>
+<pre>
+<code>*** Settings ***</code>
+
+Library  cumulusci.robotframework.CumulusCI  ${ORG}
+</pre></div>
           <table class="kwtable">
             <tbody>
               <tr><th>Keyword</th><th>Arguments</th><th>Documentation</th></tr>
               
-              <tr class="kwrow" id="Salesforce.py.Click Header Field Link">
+              <tr class="kwrow" id="CumulusCI.Debug">
+                <td class="kwname">
+                  Debug
+                </td>
+                <td class="kwargs">
+                  
+                </td>
+                <td class="kwdoc"><p>Pauses execution and enters the Python debugger.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="CumulusCI.Get Namespace Prefix">
+                <td class="kwname">
+                  Get Namespace Prefix
+                </td>
+                <td class="kwargs">
+                  
+                  <i>package=None</i>
+                  
+                </td>
+                <td class="kwdoc"><p>Returns the namespace prefix (including __) for the specified package name. (Defaults to project__package__name_managed from the current project config.)</p>
+<p>Returns an empty string if the package is not installed as a managed package.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="CumulusCI.Get Org Info">
+                <td class="kwname">
+                  Get Org Info
+                </td>
+                <td class="kwargs">
+                  
+                </td>
+                <td class="kwdoc"><p>Returns a dictionary of the org information for the current target Salesforce org</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="CumulusCI.Login Url">
+                <td class="kwname">
+                  Login Url
+                </td>
+                <td class="kwargs">
+                  
+                  <i>org=None</i>
+                  
+                </td>
+                <td class="kwdoc"><p>Returns the login url which will automatically log into the target Salesforce org.  By default, the org_name passed to the library constructor is used but this can be overridden with the org option to log into a different org.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="CumulusCI.Run Task">
+                <td class="kwname">
+                  Run Task
+                </td>
+                <td class="kwargs">
+                  
+                  <i>task_name</i>, 
+                  
+                  <i>**options</i>
+                  
+                </td>
+                <td class="kwdoc"><p>Runs a named CumulusCI task for the current project with optional support for overriding task options via kwargs.</p>
+<p>Examples:</p>
+<table border="1">
+<tr>
+<th>Keyword</th>
+<th>task_name</th>
+<th>task_options</th>
+<th>comment</th>
+</tr>
+<tr>
+<td>Run Task</td>
+<td>deploy</td>
+<td></td>
+<td>Run deploy with standard options</td>
+</tr>
+<tr>
+<td>Run Task</td>
+<td>deploy</td>
+<td>path=path/to/some/metadata</td>
+<td>Run deploy with custom path</td>
+</tr>
+</table></td>
+              </tr>
+              
+              <tr class="kwrow" id="CumulusCI.Run Task Class">
+                <td class="kwname">
+                  Run Task Class
+                </td>
+                <td class="kwargs">
+                  
+                  <i>class_path</i>, 
+                  
+                  <i>**options</i>
+                  
+                </td>
+                <td class="kwdoc"><p>Runs a CumulusCI task class with task options via kwargs.</p>
+<p>Use this keyword to run logic from CumulusCI tasks which have not been configured in the project's cumulusci.yml file.  This is most useful in cases where a test needs to use task logic for logic unique to the test and thus not worth making into a named task for the project</p>
+<p>Examples:</p>
+<table border="1">
+<tr>
+<th>Keyword</th>
+<th>task_class</th>
+<th>task_options</th>
+</tr>
+<tr>
+<td>Run Task Class</td>
+<td>cumulusci.task.utils.DownloadZip</td>
+<td>url=http://test.com/test.zip dir=test_zip</td>
+</tr>
+</table></td>
+              </tr>
+              
+              <tr class="kwrow" id="CumulusCI.Set Login Url">
+                <td class="kwname">
+                  Set Login Url
+                </td>
+                <td class="kwargs">
+                  
+                </td>
+                <td class="kwdoc"><p>Sets the LOGIN_URL variable in the suite scope which will automatically log into the target Salesforce org.</p>
+<p>Typically, this is run during Suite Setup</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="CumulusCI.Set Project Config">
+                <td class="kwname">
+                  Set Project Config
+                </td>
+                <td class="kwargs">
+                  
+                  <i>project_config</i>
+                  
+                </td>
+                <td class="kwdoc"></td>
+              </tr>
+              
+            </tbody>
+          </table>
+        </div> 
+        
+      </div>
+      
+      <div class="file" id="file-cumulusci.robotframework.PageObjects">
+        <div class='file-header'>
+          <h2 title='cumulusci.robotframework.PageObjects'>PageObjects</h2>
+          <div class='file-path'>cumulusci.robotframework.PageObjects</div>
+        </div>
+        
+        <div class="section" pageobject="">
+          
+          <div class='description'><p>Keyword library for importing and using page objects</p>
+<p>When importing, you can include one or more paths to python files that define page objects. For example, if you have a set of classes in robot/HEDA/resources/PageObjects.py, you can import this library into a test case like this:</p>
+<pre>
+Library  cumulusci.robotframework.PageObjects
+...  robot/HEDA/resources/PageObjects.py
+</pre></div>
+          <table class="kwtable">
+            <tbody>
+              <tr><th>Keyword</th><th>Arguments</th><th>Documentation</th></tr>
+              
+              <tr class="kwrow" id="PageObjects.Current Page Should Be">
+                <td class="kwname">
+                  Current Page Should Be
+                </td>
+                <td class="kwargs">
+                  
+                  <i>page_type</i>, 
+                  
+                  <i>object_name</i>, 
+                  
+                  <i>**kwargs</i>
+                  
+                </td>
+                <td class="kwdoc"><p>Verifies that the page appears to be the requested page</p>
+<p>If this is the expected page, the keywords for this page object will be loaded.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="PageObjects.Go To Page">
+                <td class="kwname">
+                  Go To Page
+                </td>
+                <td class="kwargs">
+                  
+                  <i>page_type</i>, 
+                  
+                  <i>object_name</i>, 
+                  
+                  <i>**kwargs</i>
+                  
+                </td>
+                <td class="kwdoc"><p>Go to the page of the given page object.</p>
+<p>Different pages support different additional arguments. For example, a Listing page supports the keyword argument `filter_name`.</p>
+<p>If this keyword is able to navigate to a page, the keywords for this page object will be loaded.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="PageObjects.Load Page Object">
+                <td class="kwname">
+                  Load Page Object
+                </td>
+                <td class="kwargs">
+                  
+                  <i>page_type</i>, 
+                  
+                  <i>object_name=None</i>
+                  
+                </td>
+                <td class="kwdoc"><p>Load the keywords for the page object identified by the type and object name</p>
+<p>The page type / object name pair must have been registered using the cumulusci.robotframework.pageobject decorator.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="PageObjects.Log Page Object Keywords">
+                <td class="kwname">
+                  Log Page Object Keywords
+                </td>
+                <td class="kwargs">
+                  
+                </td>
+                <td class="kwdoc"><p>Logs page objects and their keywords for all page objects which have been imported</p></td>
+              </tr>
+              
+            </tbody>
+          </table>
+        </div> 
+        
+      </div>
+      
+      <div class="file" id="file-cumulusci.robotframework.Salesforce">
+        <div class='file-header'>
+          <h2 title='cumulusci.robotframework.Salesforce'>Salesforce</h2>
+          <div class='file-path'>cumulusci.robotframework.Salesforce</div>
+        </div>
+        
+        <div class="section" pageobject="">
+          
+          <div class='description'><p>Documentation for library <code>cumulusci.robotframework.Salesforce</code>.</p></div>
+          <table class="kwtable">
+            <tbody>
+              <tr><th>Keyword</th><th>Arguments</th><th>Documentation</th></tr>
+              
+              <tr class="kwrow" id="Salesforce.Click Header Field Link">
                 <td class="kwname">
                   Click Header Field Link
                 </td>
@@ -148,7 +406,7 @@
                 <td class="kwdoc"><p>Clicks a link in record header.</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Click Modal Button">
+              <tr class="kwrow" id="Salesforce.Click Modal Button">
                 <td class="kwname">
                   Click Modal Button
                 </td>
@@ -160,7 +418,7 @@
                 <td class="kwdoc"><p>Clicks a button in a Lightning modal.</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Click Object Button">
+              <tr class="kwrow" id="Salesforce.Click Object Button">
                 <td class="kwname">
                   Click Object Button
                 </td>
@@ -172,7 +430,7 @@
                 <td class="kwdoc"><p>Clicks a button in an object's actions.</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Click Related Item Link">
+              <tr class="kwrow" id="Salesforce.Click Related Item Link">
                 <td class="kwname">
                   Click Related Item Link
                 </td>
@@ -186,7 +444,7 @@
                 <td class="kwdoc"><p>Clicks a link in the related list with the specified heading.</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Click Related Item Popup Link">
+              <tr class="kwrow" id="Salesforce.Click Related Item Popup Link">
                 <td class="kwname">
                   Click Related Item Popup Link
                 </td>
@@ -203,7 +461,7 @@
 <p>heading specifies the name of the list, title specifies the name of the item, and link specifies the name of the link</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Click Related List Button">
+              <tr class="kwrow" id="Salesforce.Click Related List Button">
                 <td class="kwname">
                   Click Related List Button
                 </td>
@@ -218,7 +476,7 @@
 <p>Waits for a modal to open after clicking the button.</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Close Modal">
+              <tr class="kwrow" id="Salesforce.Close Modal">
                 <td class="kwname">
                   Close Modal
                 </td>
@@ -228,7 +486,7 @@
                 <td class="kwdoc"><p>Closes the open modal</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Create Webdriver With Retry">
+              <tr class="kwrow" id="Salesforce.Create Webdriver With Retry">
                 <td class="kwname">
                   Create Webdriver With Retry
                 </td>
@@ -243,7 +501,7 @@
 <p>Retry on connection resets which can happen if custom domain propagation is slow.</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Current App Should Be">
+              <tr class="kwrow" id="Salesforce.Current App Should Be">
                 <td class="kwname">
                   Current App Should Be
                 </td>
@@ -255,7 +513,7 @@
                 <td class="kwdoc"><p>Validates the currently selected Salesforce App</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Delete Session Records">
+              <tr class="kwrow" id="Salesforce.Delete Session Records">
                 <td class="kwname">
                   Delete Session Records
                 </td>
@@ -266,7 +524,7 @@
 <p>(Only records specifically recorded using the Store Session Record keyword are deleted.)</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Get Active Browser Ids">
+              <tr class="kwrow" id="Salesforce.Get Active Browser Ids">
                 <td class="kwname">
                   Get Active Browser Ids
                 </td>
@@ -276,7 +534,7 @@
                 <td class="kwdoc"><p>Return the id of all open browser ids</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Get Current Record Id">
+              <tr class="kwrow" id="Salesforce.Get Current Record Id">
                 <td class="kwname">
                   Get Current Record Id
                 </td>
@@ -286,7 +544,7 @@
                 <td class="kwdoc"><p>Parses the current url to get the object id of the current record. Expects url format like: [a-zA-Z0-9]{15,18}</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Get Field Value">
+              <tr class="kwrow" id="Salesforce.Get Field Value">
                 <td class="kwname">
                   Get Field Value
                 </td>
@@ -298,7 +556,7 @@
                 <td class="kwdoc"><p>Return the current value of a form field based on the field label</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Get Locator">
+              <tr class="kwrow" id="Salesforce.Get Locator">
                 <td class="kwname">
                   Get Locator
                 </td>
@@ -314,7 +572,7 @@
                 <td class="kwdoc"><p>Returns a rendered locator string from the Salesforce lex_locators dictionary.  This can be useful if you want to use an element in a different way than the built in keywords allow.</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Get Record Type Id">
+              <tr class="kwrow" id="Salesforce.Get Record Type Id">
                 <td class="kwname">
                   Get Record Type Id
                 </td>
@@ -328,7 +586,7 @@
                 <td class="kwdoc"><p>Returns the Record Type Id for a record type name</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Get Related List Count">
+              <tr class="kwrow" id="Salesforce.Get Related List Count">
                 <td class="kwname">
                   Get Related List Count
                 </td>
@@ -340,7 +598,7 @@
                 <td class="kwdoc"><p>Returns the number of items indicated for a related list.</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Go To Object Home">
+              <tr class="kwrow" id="Salesforce.Go To Object Home">
                 <td class="kwname">
                   Go To Object Home
                 </td>
@@ -352,7 +610,7 @@
                 <td class="kwdoc"><p>Navigates to the Home view of a Salesforce Object</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Go To Object List">
+              <tr class="kwrow" id="Salesforce.Go To Object List">
                 <td class="kwname">
                   Go To Object List
                 </td>
@@ -366,7 +624,7 @@
                 <td class="kwdoc"><p>Navigates to the Home view of a Salesforce Object</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Go To Record Home">
+              <tr class="kwrow" id="Salesforce.Go To Record Home">
                 <td class="kwname">
                   Go To Record Home
                 </td>
@@ -378,7 +636,7 @@
                 <td class="kwdoc"><p>Navigates to the Home view of a Salesforce Object</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Go To Setup Home">
+              <tr class="kwrow" id="Salesforce.Go To Setup Home">
                 <td class="kwname">
                   Go To Setup Home
                 </td>
@@ -388,7 +646,7 @@
                 <td class="kwdoc"><p>Navigates to the Home tab of Salesforce Setup</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Go To Setup Object Manager">
+              <tr class="kwrow" id="Salesforce.Go To Setup Object Manager">
                 <td class="kwname">
                   Go To Setup Object Manager
                 </td>
@@ -398,7 +656,7 @@
                 <td class="kwdoc"><p>Navigates to the Object Manager tab of Salesforce Setup</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Header Field Should Be Checked">
+              <tr class="kwrow" id="Salesforce.Header Field Should Be Checked">
                 <td class="kwname">
                   Header Field Should Be Checked
                 </td>
@@ -410,7 +668,7 @@
                 <td class="kwdoc"><p>Validates that a checkbox field in the record header is checked</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Header Field Should Be Unchecked">
+              <tr class="kwrow" id="Salesforce.Header Field Should Be Unchecked">
                 <td class="kwname">
                   Header Field Should Be Unchecked
                 </td>
@@ -422,7 +680,7 @@
                 <td class="kwdoc"><p>Validates that a checkbox field in the record header is unchecked</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Header Field Should Have Link">
+              <tr class="kwrow" id="Salesforce.Header Field Should Have Link">
                 <td class="kwname">
                   Header Field Should Have Link
                 </td>
@@ -434,7 +692,7 @@
                 <td class="kwdoc"><p>Validates that a field in the record header has a link as its value</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Header Field Should Have Value">
+              <tr class="kwrow" id="Salesforce.Header Field Should Have Value">
                 <td class="kwname">
                   Header Field Should Have Value
                 </td>
@@ -446,7 +704,7 @@
                 <td class="kwdoc"><p>Validates that a field in the record header has a text value. NOTE: Use other keywords for non-string value types</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Header Field Should Not Have Link">
+              <tr class="kwrow" id="Salesforce.Header Field Should Not Have Link">
                 <td class="kwname">
                   Header Field Should Not Have Link
                 </td>
@@ -458,7 +716,7 @@
                 <td class="kwdoc"><p>Validates that a field in the record header does not have a link as its value</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Header Field Should Not Have Value">
+              <tr class="kwrow" id="Salesforce.Header Field Should Not Have Value">
                 <td class="kwname">
                   Header Field Should Not Have Value
                 </td>
@@ -470,7 +728,7 @@
                 <td class="kwdoc"><p>Validates that a field in the record header does not have a value. NOTE: Use other keywords for non-string value types</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Load Related List">
+              <tr class="kwrow" id="Salesforce.Load Related List">
                 <td class="kwname">
                   Load Related List
                 </td>
@@ -482,7 +740,7 @@
                 <td class="kwdoc"><p>Scrolls down until the specified related list loads.</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Open App Launcher">
+              <tr class="kwrow" id="Salesforce.Open App Launcher">
                 <td class="kwname">
                   Open App Launcher
                 </td>
@@ -492,7 +750,7 @@
                 <td class="kwdoc"><p>Opens the Saleforce App Launcher</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Populate Field">
+              <tr class="kwrow" id="Salesforce.Populate Field">
                 <td class="kwname">
                   Populate Field
                 </td>
@@ -507,7 +765,7 @@
 <p>Any existing value will be replaced.</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Populate Form">
+              <tr class="kwrow" id="Salesforce.Populate Form">
                 <td class="kwname">
                   Populate Form
                 </td>
@@ -519,7 +777,7 @@
                 <td class="kwdoc"><p>Enters multiple values from a mapping into form fields.</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Populate Lookup Field">
+              <tr class="kwrow" id="Salesforce.Populate Lookup Field">
                 <td class="kwname">
                   Populate Lookup Field
                 </td>
@@ -533,7 +791,7 @@
                 <td class="kwdoc"><p>Enters a value into a lookup field.</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Remove Session Record">
+              <tr class="kwrow" id="Salesforce.Remove Session Record">
                 <td class="kwname">
                   Remove Session Record
                 </td>
@@ -547,7 +805,7 @@
                 <td class="kwdoc"><p>Remove a record from the list of records that should be automatically removed.</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Salesforce Delete">
+              <tr class="kwrow" id="Salesforce.Salesforce Delete">
                 <td class="kwname">
                   Salesforce Delete
                 </td>
@@ -561,7 +819,7 @@
                 <td class="kwdoc"><p>Deletes a Saleforce object by id and returns the dict result</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Salesforce Get">
+              <tr class="kwrow" id="Salesforce.Salesforce Get">
                 <td class="kwname">
                   Salesforce Get
                 </td>
@@ -575,7 +833,7 @@
                 <td class="kwdoc"><p>Gets a Salesforce object by id and returns the dict result</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Salesforce Insert">
+              <tr class="kwrow" id="Salesforce.Salesforce Insert">
                 <td class="kwname">
                   Salesforce Insert
                 </td>
@@ -589,7 +847,7 @@
                 <td class="kwdoc"><p>Inserts a Salesforce object setting fields using kwargs and returns the id</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Salesforce Query">
+              <tr class="kwrow" id="Salesforce.Salesforce Query">
                 <td class="kwname">
                   Salesforce Query
                 </td>
@@ -603,7 +861,7 @@
                 <td class="kwdoc"><p>Constructs and runs a simple SOQL query and returns the dict results</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Salesforce Update">
+              <tr class="kwrow" id="Salesforce.Salesforce Update">
                 <td class="kwname">
                   Salesforce Update
                 </td>
@@ -619,7 +877,7 @@
                 <td class="kwdoc"><p>Updates a Salesforce object by id and returns the dict results</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Select App Launcher App">
+              <tr class="kwrow" id="Salesforce.Select App Launcher App">
                 <td class="kwname">
                   Select App Launcher App
                 </td>
@@ -631,7 +889,7 @@
                 <td class="kwdoc"><p>Navigates to a Salesforce App via the App Launcher</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Select App Launcher Tab">
+              <tr class="kwrow" id="Salesforce.Select App Launcher Tab">
                 <td class="kwname">
                   Select App Launcher Tab
                 </td>
@@ -643,7 +901,7 @@
                 <td class="kwdoc"><p>Navigates to a tab via the App Launcher</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Select Record Type">
+              <tr class="kwrow" id="Salesforce.Select Record Type">
                 <td class="kwname">
                   Select Record Type
                 </td>
@@ -655,7 +913,7 @@
                 <td class="kwdoc"><p>Selects a record type while adding an object.</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Selenium Execute With Retry">
+              <tr class="kwrow" id="Salesforce.Selenium Execute With Retry">
                 <td class="kwname">
                   Selenium Execute With Retry
                 </td>
@@ -672,7 +930,7 @@
 <p>The retry happens for certain errors that are likely to be resolved by retrying.</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Soql Query">
+              <tr class="kwrow" id="Salesforce.Soql Query">
                 <td class="kwname">
                   Soql Query
                 </td>
@@ -684,7 +942,7 @@
                 <td class="kwdoc"><p>Runs a simple SOQL query and returns the dict results</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Store Session Record">
+              <tr class="kwrow" id="Salesforce.Store Session Record">
                 <td class="kwname">
                   Store Session Record
                 </td>
@@ -698,7 +956,7 @@
                 <td class="kwdoc"><p>Stores a Salesforce record's id for use in the Delete Session Records keyword</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Wait For Aura">
+              <tr class="kwrow" id="Salesforce.Wait For Aura">
                 <td class="kwname">
                   Wait For Aura
                 </td>
@@ -709,7 +967,7 @@
 <p>This script polls Aura via $A in Javascript to determine when all in-flight XHTTP requests have completed before continuing.</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Wait Until Loading Is Complete">
+              <tr class="kwrow" id="Salesforce.Wait Until Loading Is Complete">
                 <td class="kwname">
                   Wait Until Loading Is Complete
                 </td>
@@ -722,7 +980,7 @@
 <p>(We're actually waiting for the actions ribbon to appear.)</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Wait Until Modal Is Closed">
+              <tr class="kwrow" id="Salesforce.Wait Until Modal Is Closed">
                 <td class="kwname">
                   Wait Until Modal Is Closed
                 </td>
@@ -732,7 +990,7 @@
                 <td class="kwdoc"><p>Wait for modal to close</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Wait Until Modal Is Open">
+              <tr class="kwrow" id="Salesforce.Wait Until Modal Is Open">
                 <td class="kwname">
                   Wait Until Modal Is Open
                 </td>
@@ -742,7 +1000,7 @@
                 <td class="kwdoc"><p>Wait for modal to open</p></td>
               </tr>
               
-              <tr class="kwrow" id="Salesforce.py.Wait Until Salesforce Is Ready">
+              <tr class="kwrow" id="Salesforce.Wait Until Salesforce Is Ready">
                 <td class="kwname">
                   Wait Until Salesforce Is Ready
                 </td>
@@ -767,7 +1025,10 @@
       </div>
       
       <div class="file" id="file-cumulusci/robotframework/Salesforce.robot">
-        <h1 title='cumulusci/robotframework/Salesforce.robot'>Salesforce.robot</h1>
+        <div class='file-header'>
+          <h2 title='cumulusci/robotframework/Salesforce.robot'>Salesforce.robot</h2>
+          <div class='file-path'>cumulusci/robotframework/Salesforce.robot</div>
+        </div>
         
         <div class="section" pageobject="">
           
@@ -930,163 +1191,9 @@
         
       </div>
       
-      <div class="file" id="file-cumulusci/robotframework/CumulusCI.py">
-        <h1 title='cumulusci/robotframework/CumulusCI.py'>CumulusCI.py</h1>
-        
-        <div class="section" pageobject="">
-          
-          <div class='description'><p>Library for accessing CumulusCI for the local git project</p>
-<p>This library allows Robot Framework tests to access credentials to a Salesforce org created by CumulusCI, including Scratch Orgs.  It also exposes the core logic of CumulusCI including interactions with the Salesforce API's and project specific configuration including custom and customized tasks and flows.</p>
-<p>Initialization requires a single argument, the org name for the target CumulusCI org.  If running your tests via cci's robot task (recommended), you can initialize the library in your tests taking advantage of the variable set by the robot task:</p>
-<pre>
-<code>*** Settings ***</code>
-
-Library  cumulusci.robotframework.CumulusCI  ${ORG}
-</pre></div>
-          <table class="kwtable">
-            <tbody>
-              <tr><th>Keyword</th><th>Arguments</th><th>Documentation</th></tr>
-              
-              <tr class="kwrow" id="CumulusCI.py.Debug">
-                <td class="kwname">
-                  Debug
-                </td>
-                <td class="kwargs">
-                  
-                </td>
-                <td class="kwdoc"><p>Pauses execution and enters the Python debugger.</p></td>
-              </tr>
-              
-              <tr class="kwrow" id="CumulusCI.py.Get Namespace Prefix">
-                <td class="kwname">
-                  Get Namespace Prefix
-                </td>
-                <td class="kwargs">
-                  
-                  <i>package=None</i>
-                  
-                </td>
-                <td class="kwdoc"><p>Returns the namespace prefix (including __) for the specified package name. (Defaults to project__package__name_managed from the current project config.)</p>
-<p>Returns an empty string if the package is not installed as a managed package.</p></td>
-              </tr>
-              
-              <tr class="kwrow" id="CumulusCI.py.Get Org Info">
-                <td class="kwname">
-                  Get Org Info
-                </td>
-                <td class="kwargs">
-                  
-                </td>
-                <td class="kwdoc"><p>Returns a dictionary of the org information for the current target Salesforce org</p></td>
-              </tr>
-              
-              <tr class="kwrow" id="CumulusCI.py.Login Url">
-                <td class="kwname">
-                  Login Url
-                </td>
-                <td class="kwargs">
-                  
-                  <i>org=None</i>
-                  
-                </td>
-                <td class="kwdoc"><p>Returns the login url which will automatically log into the target Salesforce org.  By default, the org_name passed to the library constructor is used but this can be overridden with the org option to log into a different org.</p></td>
-              </tr>
-              
-              <tr class="kwrow" id="CumulusCI.py.Run Task">
-                <td class="kwname">
-                  Run Task
-                </td>
-                <td class="kwargs">
-                  
-                  <i>task_name</i>, 
-                  
-                  <i>**options</i>
-                  
-                </td>
-                <td class="kwdoc"><p>Runs a named CumulusCI task for the current project with optional support for overriding task options via kwargs.</p>
-<p>Examples:</p>
-<table border="1">
-<tr>
-<th>Keyword</th>
-<th>task_name</th>
-<th>task_options</th>
-<th>comment</th>
-</tr>
-<tr>
-<td>Run Task</td>
-<td>deploy</td>
-<td></td>
-<td>Run deploy with standard options</td>
-</tr>
-<tr>
-<td>Run Task</td>
-<td>deploy</td>
-<td>path=path/to/some/metadata</td>
-<td>Run deploy with custom path</td>
-</tr>
-</table></td>
-              </tr>
-              
-              <tr class="kwrow" id="CumulusCI.py.Run Task Class">
-                <td class="kwname">
-                  Run Task Class
-                </td>
-                <td class="kwargs">
-                  
-                  <i>class_path</i>, 
-                  
-                  <i>**options</i>
-                  
-                </td>
-                <td class="kwdoc"><p>Runs a CumulusCI task class with task options via kwargs.</p>
-<p>Use this keyword to run logic from CumulusCI tasks which have not been configured in the project's cumulusci.yml file.  This is most useful in cases where a test needs to use task logic for logic unique to the test and thus not worth making into a named task for the project</p>
-<p>Examples:</p>
-<table border="1">
-<tr>
-<th>Keyword</th>
-<th>task_class</th>
-<th>task_options</th>
-</tr>
-<tr>
-<td>Run Task Class</td>
-<td>cumulusci.task.utils.DownloadZip</td>
-<td>url=http://test.com/test.zip dir=test_zip</td>
-</tr>
-</table></td>
-              </tr>
-              
-              <tr class="kwrow" id="CumulusCI.py.Set Login Url">
-                <td class="kwname">
-                  Set Login Url
-                </td>
-                <td class="kwargs">
-                  
-                </td>
-                <td class="kwdoc"><p>Sets the LOGIN_URL variable in the suite scope which will automatically log into the target Salesforce org.</p>
-<p>Typically, this is run during Suite Setup</p></td>
-              </tr>
-              
-              <tr class="kwrow" id="CumulusCI.py.Set Project Config">
-                <td class="kwname">
-                  Set Project Config
-                </td>
-                <td class="kwargs">
-                  
-                  <i>project_config</i>
-                  
-                </td>
-                <td class="kwdoc"></td>
-              </tr>
-              
-            </tbody>
-          </table>
-        </div> 
-        
-      </div>
-      
     </div>
     <div class="footer">
-      Generated on Tuesday June 18, 06:12 PM - cumulusci v2.5.2
+      Generated on Friday June 21, 05:17 PM - cumulusci v2.5.2
     </div>
   </body>
 </html>

--- a/docs/robot/Keywords.html
+++ b/docs/robot/Keywords.html
@@ -68,7 +68,8 @@
     padding: 4px;
 }
 .section {
-    margin-bottom: 10px;
+    margin-bottom: 2em;
+    margin-left: 2em;
 }
 .kwtable {
     box-shadow: 7px 7px 9px #d4d4d4;
@@ -103,6 +104,16 @@
 }
 .library-documentation {
     margin-bottom: 2em;
+    margin-left: 2em;
+}
+
+.pageobject-header {
+    font-size: 1.2em;
+    font-weight: bold;
+}
+
+.object_name, .page_type {
+    padding: 2px 10px ;
 }
 
     </style>
@@ -113,71 +124,73 @@
         <div class="title">CumulusCI Robot Framework Keywords</div>
         <div class="search right">search: <input id="search" type="search"></input></div>
       </div>
+
       
-      <div class="section" id="library-Salesforce">
-        <h1>Salesforce.py</h1>
-        <div class="library-documentation">
-        <p>Documentation for library <code>Salesforce</code>.</p>
-        </div>
-        <table class="kwtable">
-          <tbody>
-            <tr><th>Keyword</th><th>Arguments</th><th>Documentation</th></tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Click Header Field Link">
-              <td class="kwname">
-                Click Header Field Link
-              </td>
-              <td class="kwargs">
+      <div class="file" id="file-cumulusci/robotframework/Salesforce.py">
+        <h1 title='cumulusci/robotframework/Salesforce.py'>Salesforce.py</h1>
+        
+        <div class="section" pageobject="">
+          
+          <div class='description'><p>Documentation for library <code>Salesforce</code>.</p></div>
+          <table class="kwtable">
+            <tbody>
+              <tr><th>Keyword</th><th>Arguments</th><th>Documentation</th></tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Click Header Field Link">
+                <td class="kwname">
+                  Click Header Field Link
+                </td>
+                <td class="kwargs">
                   
                   <i>label</i>
                   
-              </td>
-              <td class="kwdoc"><p>Clicks a link in record header.</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Click Modal Button">
-              <td class="kwname">
-                Click Modal Button
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Clicks a link in record header.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Click Modal Button">
+                <td class="kwname">
+                  Click Modal Button
+                </td>
+                <td class="kwargs">
                   
                   <i>title</i>
                   
-              </td>
-              <td class="kwdoc"><p>Clicks a button in a Lightning modal.</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Click Object Button">
-              <td class="kwname">
-                Click Object Button
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Clicks a button in a Lightning modal.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Click Object Button">
+                <td class="kwname">
+                  Click Object Button
+                </td>
+                <td class="kwargs">
                   
                   <i>title</i>
                   
-              </td>
-              <td class="kwdoc"><p>Clicks a button in an object's actions.</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Click Related Item Link">
-              <td class="kwname">
-                Click Related Item Link
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Clicks a button in an object's actions.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Click Related Item Link">
+                <td class="kwname">
+                  Click Related Item Link
+                </td>
+                <td class="kwargs">
                   
                   <i>heading</i>, 
                   
                   <i>title</i>
                   
-              </td>
-              <td class="kwdoc"><p>Clicks a link in the related list with the specified heading.</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Click Related Item Popup Link">
-              <td class="kwname">
-                Click Related Item Popup Link
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Clicks a link in the related list with the specified heading.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Click Related Item Popup Link">
+                <td class="kwname">
+                  Click Related Item Popup Link
+                </td>
+                <td class="kwargs">
                   
                   <i>heading</i>, 
                   
@@ -185,101 +198,111 @@
                   
                   <i>link</i>
                   
-              </td>
-              <td class="kwdoc"><p>Clicks a link in the popup menu for a related list item.</p>
+                </td>
+                <td class="kwdoc"><p>Clicks a link in the popup menu for a related list item.</p>
 <p>heading specifies the name of the list, title specifies the name of the item, and link specifies the name of the link</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Click Related List Button">
-              <td class="kwname">
-                Click Related List Button
-              </td>
-              <td class="kwargs">
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Click Related List Button">
+                <td class="kwname">
+                  Click Related List Button
+                </td>
+                <td class="kwargs">
                   
                   <i>heading</i>, 
                   
                   <i>button_title</i>
                   
-              </td>
-              <td class="kwdoc"><p>Clicks a button in the heading of a related list.</p>
+                </td>
+                <td class="kwdoc"><p>Clicks a button in the heading of a related list.</p>
 <p>Waits for a modal to open after clicking the button.</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Close Modal">
-              <td class="kwname">
-                Close Modal
-              </td>
-              <td class="kwargs">
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Close Modal">
+                <td class="kwname">
+                  Close Modal
+                </td>
+                <td class="kwargs">
                   
-              </td>
-              <td class="kwdoc"><p>Closes the open modal</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Create Webdriver With Retry">
-              <td class="kwname">
-                Create Webdriver With Retry
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Closes the open modal</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Create Webdriver With Retry">
+                <td class="kwname">
+                  Create Webdriver With Retry
+                </td>
+                <td class="kwargs">
                   
                   <i>*args</i>, 
                   
                   <i>**kwargs</i>
                   
-              </td>
-              <td class="kwdoc"><p>Call the Create Webdriver keyword.</p>
+                </td>
+                <td class="kwdoc"><p>Call the Create Webdriver keyword.</p>
 <p>Retry on connection resets which can happen if custom domain propagation is slow.</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Current App Should Be">
-              <td class="kwname">
-                Current App Should Be
-              </td>
-              <td class="kwargs">
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Current App Should Be">
+                <td class="kwname">
+                  Current App Should Be
+                </td>
+                <td class="kwargs">
                   
                   <i>app_name</i>
                   
-              </td>
-              <td class="kwdoc"><p>Validates the currently selected Salesforce App</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Delete Session Records">
-              <td class="kwname">
-                Delete Session Records
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Validates the currently selected Salesforce App</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Delete Session Records">
+                <td class="kwname">
+                  Delete Session Records
+                </td>
+                <td class="kwargs">
                   
-              </td>
-              <td class="kwdoc"><p>Deletes records that were created while running this test case.</p>
+                </td>
+                <td class="kwdoc"><p>Deletes records that were created while running this test case.</p>
 <p>(Only records specifically recorded using the Store Session Record keyword are deleted.)</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Get Current Record Id">
-              <td class="kwname">
-                Get Current Record Id
-              </td>
-              <td class="kwargs">
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Get Active Browser Ids">
+                <td class="kwname">
+                  Get Active Browser Ids
+                </td>
+                <td class="kwargs">
                   
-              </td>
-              <td class="kwdoc"><p>Parses the current url to get the object id of the current record. Expects url format like: [a-zA-Z0-9]{15,18}</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Get Field Value">
-              <td class="kwname">
-                Get Field Value
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Return the id of all open browser ids</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Get Current Record Id">
+                <td class="kwname">
+                  Get Current Record Id
+                </td>
+                <td class="kwargs">
+                  
+                </td>
+                <td class="kwdoc"><p>Parses the current url to get the object id of the current record. Expects url format like: [a-zA-Z0-9]{15,18}</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Get Field Value">
+                <td class="kwname">
+                  Get Field Value
+                </td>
+                <td class="kwargs">
                   
                   <i>label</i>
                   
-              </td>
-              <td class="kwdoc"><p>Return the current value of a form field based on the field label</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Get Locator">
-              <td class="kwname">
-                Get Locator
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Return the current value of a form field based on the field label</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Get Locator">
+                <td class="kwname">
+                  Get Locator
+                </td>
+                <td class="kwargs">
                   
                   <i>path</i>, 
                   
@@ -287,304 +310,304 @@
                   
                   <i>**kwargs</i>
                   
-              </td>
-              <td class="kwdoc"><p>Returns a rendered locator string from the Salesforce lex_locators dictionary.  This can be useful if you want to use an element in a different way than the built in keywords allow.</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Get Record Type Id">
-              <td class="kwname">
-                Get Record Type Id
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Returns a rendered locator string from the Salesforce lex_locators dictionary.  This can be useful if you want to use an element in a different way than the built in keywords allow.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Get Record Type Id">
+                <td class="kwname">
+                  Get Record Type Id
+                </td>
+                <td class="kwargs">
                   
                   <i>obj_type</i>, 
                   
                   <i>developer_name</i>
                   
-              </td>
-              <td class="kwdoc"><p>Returns the Record Type Id for a record type name</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Get Related List Count">
-              <td class="kwname">
-                Get Related List Count
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Returns the Record Type Id for a record type name</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Get Related List Count">
+                <td class="kwname">
+                  Get Related List Count
+                </td>
+                <td class="kwargs">
                   
                   <i>heading</i>
                   
-              </td>
-              <td class="kwdoc"><p>Returns the number of items indicated for a related list.</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Go To Object Home">
-              <td class="kwname">
-                Go To Object Home
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Returns the number of items indicated for a related list.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Go To Object Home">
+                <td class="kwname">
+                  Go To Object Home
+                </td>
+                <td class="kwargs">
                   
                   <i>obj_name</i>
                   
-              </td>
-              <td class="kwdoc"><p>Navigates to the Home view of a Salesforce Object</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Go To Object List">
-              <td class="kwname">
-                Go To Object List
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Navigates to the Home view of a Salesforce Object</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Go To Object List">
+                <td class="kwname">
+                  Go To Object List
+                </td>
+                <td class="kwargs">
                   
                   <i>obj_name</i>, 
                   
                   <i>filter_name=None</i>
                   
-              </td>
-              <td class="kwdoc"><p>Navigates to the Home view of a Salesforce Object</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Go To Record Home">
-              <td class="kwname">
-                Go To Record Home
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Navigates to the Home view of a Salesforce Object</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Go To Record Home">
+                <td class="kwname">
+                  Go To Record Home
+                </td>
+                <td class="kwargs">
                   
                   <i>obj_id</i>
                   
-              </td>
-              <td class="kwdoc"><p>Navigates to the Home view of a Salesforce Object</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Go To Setup Home">
-              <td class="kwname">
-                Go To Setup Home
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Navigates to the Home view of a Salesforce Object</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Go To Setup Home">
+                <td class="kwname">
+                  Go To Setup Home
+                </td>
+                <td class="kwargs">
                   
-              </td>
-              <td class="kwdoc"><p>Navigates to the Home tab of Salesforce Setup</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Go To Setup Object Manager">
-              <td class="kwname">
-                Go To Setup Object Manager
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Navigates to the Home tab of Salesforce Setup</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Go To Setup Object Manager">
+                <td class="kwname">
+                  Go To Setup Object Manager
+                </td>
+                <td class="kwargs">
                   
-              </td>
-              <td class="kwdoc"><p>Navigates to the Object Manager tab of Salesforce Setup</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Header Field Should Be Checked">
-              <td class="kwname">
-                Header Field Should Be Checked
-              </td>
-              <td class="kwargs">
-                  
-                  <i>label</i>
-                  
-              </td>
-              <td class="kwdoc"><p>Validates that a checkbox field in the record header is checked</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Header Field Should Be Unchecked">
-              <td class="kwname">
-                Header Field Should Be Unchecked
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Navigates to the Object Manager tab of Salesforce Setup</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Header Field Should Be Checked">
+                <td class="kwname">
+                  Header Field Should Be Checked
+                </td>
+                <td class="kwargs">
                   
                   <i>label</i>
                   
-              </td>
-              <td class="kwdoc"><p>Validates that a checkbox field in the record header is unchecked</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Header Field Should Have Link">
-              <td class="kwname">
-                Header Field Should Have Link
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Validates that a checkbox field in the record header is checked</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Header Field Should Be Unchecked">
+                <td class="kwname">
+                  Header Field Should Be Unchecked
+                </td>
+                <td class="kwargs">
                   
                   <i>label</i>
                   
-              </td>
-              <td class="kwdoc"><p>Validates that a field in the record header has a link as its value</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Header Field Should Have Value">
-              <td class="kwname">
-                Header Field Should Have Value
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Validates that a checkbox field in the record header is unchecked</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Header Field Should Have Link">
+                <td class="kwname">
+                  Header Field Should Have Link
+                </td>
+                <td class="kwargs">
                   
                   <i>label</i>
                   
-              </td>
-              <td class="kwdoc"><p>Validates that a field in the record header has a text value. NOTE: Use other keywords for non-string value types</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Header Field Should Not Have Link">
-              <td class="kwname">
-                Header Field Should Not Have Link
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Validates that a field in the record header has a link as its value</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Header Field Should Have Value">
+                <td class="kwname">
+                  Header Field Should Have Value
+                </td>
+                <td class="kwargs">
                   
                   <i>label</i>
                   
-              </td>
-              <td class="kwdoc"><p>Validates that a field in the record header does not have a link as its value</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Header Field Should Not Have Value">
-              <td class="kwname">
-                Header Field Should Not Have Value
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Validates that a field in the record header has a text value. NOTE: Use other keywords for non-string value types</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Header Field Should Not Have Link">
+                <td class="kwname">
+                  Header Field Should Not Have Link
+                </td>
+                <td class="kwargs">
                   
                   <i>label</i>
                   
-              </td>
-              <td class="kwdoc"><p>Validates that a field in the record header does not have a value. NOTE: Use other keywords for non-string value types</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Load Related List">
-              <td class="kwname">
-                Load Related List
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Validates that a field in the record header does not have a link as its value</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Header Field Should Not Have Value">
+                <td class="kwname">
+                  Header Field Should Not Have Value
+                </td>
+                <td class="kwargs">
+                  
+                  <i>label</i>
+                  
+                </td>
+                <td class="kwdoc"><p>Validates that a field in the record header does not have a value. NOTE: Use other keywords for non-string value types</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Load Related List">
+                <td class="kwname">
+                  Load Related List
+                </td>
+                <td class="kwargs">
                   
                   <i>heading</i>
                   
-              </td>
-              <td class="kwdoc"><p>Scrolls down until the specified related list loads.</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Open App Launcher">
-              <td class="kwname">
-                Open App Launcher
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Scrolls down until the specified related list loads.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Open App Launcher">
+                <td class="kwname">
+                  Open App Launcher
+                </td>
+                <td class="kwargs">
                   
-              </td>
-              <td class="kwdoc"><p>Opens the Saleforce App Launcher</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Populate Field">
-              <td class="kwname">
-                Populate Field
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Opens the Saleforce App Launcher</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Populate Field">
+                <td class="kwname">
+                  Populate Field
+                </td>
+                <td class="kwargs">
                   
                   <i>name</i>, 
                   
                   <i>value</i>
                   
-              </td>
-              <td class="kwdoc"><p>Enters a value into a text field.</p>
+                </td>
+                <td class="kwdoc"><p>Enters a value into a text field.</p>
 <p>Any existing value will be replaced.</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Populate Form">
-              <td class="kwname">
-                Populate Form
-              </td>
-              <td class="kwargs">
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Populate Form">
+                <td class="kwname">
+                  Populate Form
+                </td>
+                <td class="kwargs">
                   
                   <i>**kwargs</i>
                   
-              </td>
-              <td class="kwdoc"><p>Enters multiple values from a mapping into form fields.</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Populate Lookup Field">
-              <td class="kwname">
-                Populate Lookup Field
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Enters multiple values from a mapping into form fields.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Populate Lookup Field">
+                <td class="kwname">
+                  Populate Lookup Field
+                </td>
+                <td class="kwargs">
                   
                   <i>name</i>, 
                   
                   <i>value</i>
                   
-              </td>
-              <td class="kwdoc"><p>Enters a value into a lookup field.</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Remove Session Record">
-              <td class="kwname">
-                Remove Session Record
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Enters a value into a lookup field.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Remove Session Record">
+                <td class="kwname">
+                  Remove Session Record
+                </td>
+                <td class="kwargs">
                   
                   <i>obj_type</i>, 
                   
                   <i>obj_id</i>
                   
-              </td>
-              <td class="kwdoc"><p>Remove a record from the list of records that should be automatically removed.</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Salesforce Delete">
-              <td class="kwname">
-                Salesforce Delete
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Remove a record from the list of records that should be automatically removed.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Salesforce Delete">
+                <td class="kwname">
+                  Salesforce Delete
+                </td>
+                <td class="kwargs">
                   
                   <i>obj_name</i>, 
                   
                   <i>obj_id</i>
                   
-              </td>
-              <td class="kwdoc"><p>Deletes a Saleforce object by id and returns the dict result</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Salesforce Get">
-              <td class="kwname">
-                Salesforce Get
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Deletes a Saleforce object by id and returns the dict result</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Salesforce Get">
+                <td class="kwname">
+                  Salesforce Get
+                </td>
+                <td class="kwargs">
                   
                   <i>obj_name</i>, 
                   
                   <i>obj_id</i>
                   
-              </td>
-              <td class="kwdoc"><p>Gets a Salesforce object by id and returns the dict result</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Salesforce Insert">
-              <td class="kwname">
-                Salesforce Insert
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Gets a Salesforce object by id and returns the dict result</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Salesforce Insert">
+                <td class="kwname">
+                  Salesforce Insert
+                </td>
+                <td class="kwargs">
                   
                   <i>obj_name</i>, 
                   
                   <i>**kwargs</i>
                   
-              </td>
-              <td class="kwdoc"><p>Inserts a Salesforce object setting fields using kwargs and returns the id</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Salesforce Query">
-              <td class="kwname">
-                Salesforce Query
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Inserts a Salesforce object setting fields using kwargs and returns the id</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Salesforce Query">
+                <td class="kwname">
+                  Salesforce Query
+                </td>
+                <td class="kwargs">
                   
                   <i>obj_name</i>, 
                   
                   <i>**kwargs</i>
                   
-              </td>
-              <td class="kwdoc"><p>Constructs and runs a simple SOQL query and returns the dict results</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Salesforce Update">
-              <td class="kwname">
-                Salesforce Update
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Constructs and runs a simple SOQL query and returns the dict results</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Salesforce Update">
+                <td class="kwname">
+                  Salesforce Update
+                </td>
+                <td class="kwargs">
                   
                   <i>obj_name</i>, 
                   
@@ -592,51 +615,51 @@
                   
                   <i>**kwargs</i>
                   
-              </td>
-              <td class="kwdoc"><p>Updates a Salesforce object by id and returns the dict results</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Select App Launcher App">
-              <td class="kwname">
-                Select App Launcher App
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Updates a Salesforce object by id and returns the dict results</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Select App Launcher App">
+                <td class="kwname">
+                  Select App Launcher App
+                </td>
+                <td class="kwargs">
                   
                   <i>app_name</i>
                   
-              </td>
-              <td class="kwdoc"><p>Navigates to a Salesforce App via the App Launcher</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Select App Launcher Tab">
-              <td class="kwname">
-                Select App Launcher Tab
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Navigates to a Salesforce App via the App Launcher</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Select App Launcher Tab">
+                <td class="kwname">
+                  Select App Launcher Tab
+                </td>
+                <td class="kwargs">
                   
                   <i>tab_name</i>
                   
-              </td>
-              <td class="kwdoc"><p>Navigates to a tab via the App Launcher</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Select Record Type">
-              <td class="kwname">
-                Select Record Type
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Navigates to a tab via the App Launcher</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Select Record Type">
+                <td class="kwname">
+                  Select Record Type
+                </td>
+                <td class="kwargs">
                   
                   <i>label</i>
                   
-              </td>
-              <td class="kwdoc"><p>Selects a record type while adding an object.</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Selenium Execute With Retry">
-              <td class="kwname">
-                Selenium Execute With Retry
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Selects a record type while adding an object.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Selenium Execute With Retry">
+                <td class="kwname">
+                  Selenium Execute With Retry
+                </td>
+                <td class="kwargs">
                   
                   <i>execute</i>, 
                   
@@ -644,143 +667,174 @@
                   
                   <i>params</i>
                   
-              </td>
-              <td class="kwdoc"><p>Run a single selenium command and retry once.</p>
+                </td>
+                <td class="kwdoc"><p>Run a single selenium command and retry once.</p>
 <p>The retry happens for certain errors that are likely to be resolved by retrying.</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Soql Query">
-              <td class="kwname">
-                Soql Query
-              </td>
-              <td class="kwargs">
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Soql Query">
+                <td class="kwname">
+                  Soql Query
+                </td>
+                <td class="kwargs">
                   
                   <i>query</i>
                   
-              </td>
-              <td class="kwdoc"><p>Runs a simple SOQL query and returns the dict results</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Store Session Record">
-              <td class="kwname">
-                Store Session Record
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Runs a simple SOQL query and returns the dict results</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Store Session Record">
+                <td class="kwname">
+                  Store Session Record
+                </td>
+                <td class="kwargs">
                   
                   <i>obj_type</i>, 
                   
                   <i>obj_id</i>
                   
-              </td>
-              <td class="kwdoc"><p>Stores a Salesforce record's id for use in the Delete Session Records keyword</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Wait For Aura">
-              <td class="kwname">
-                Wait For Aura
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Stores a Salesforce record's id for use in the Delete Session Records keyword</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Wait For Aura">
+                <td class="kwname">
+                  Wait For Aura
+                </td>
+                <td class="kwargs">
                   
-              </td>
-              <td class="kwdoc"><p>Run the WAIT_FOR_AURA_SCRIPT.</p>
+                </td>
+                <td class="kwdoc"><p>Run the WAIT_FOR_AURA_SCRIPT.</p>
 <p>This script polls Aura via $A in Javascript to determine when all in-flight XHTTP requests have completed before continuing.</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Wait Until Loading Is Complete">
-              <td class="kwname">
-                Wait Until Loading Is Complete
-              </td>
-              <td class="kwargs">
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Wait Until Loading Is Complete">
+                <td class="kwname">
+                  Wait Until Loading Is Complete
+                </td>
+                <td class="kwargs">
                   
                   <i>locator=None</i>
                   
-              </td>
-              <td class="kwdoc"><p>Wait for LEX page to load.</p>
+                </td>
+                <td class="kwdoc"><p>Wait for LEX page to load.</p>
 <p>(We're actually waiting for the actions ribbon to appear.)</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Wait Until Modal Is Closed">
-              <td class="kwname">
-                Wait Until Modal Is Closed
-              </td>
-              <td class="kwargs">
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Wait Until Modal Is Closed">
+                <td class="kwname">
+                  Wait Until Modal Is Closed
+                </td>
+                <td class="kwargs">
                   
-              </td>
-              <td class="kwdoc"><p>Wait for modal to close</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.py.Wait Until Modal Is Open">
-              <td class="kwname">
-                Wait Until Modal Is Open
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Wait for modal to close</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Wait Until Modal Is Open">
+                <td class="kwname">
+                  Wait Until Modal Is Open
+                </td>
+                <td class="kwargs">
                   
-              </td>
-              <td class="kwdoc"><p>Wait for modal to open</p></td>
-            </tr>
-            
-          </tbody>
-        </table>
+                </td>
+                <td class="kwdoc"><p>Wait for modal to open</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.py.Wait Until Salesforce Is Ready">
+                <td class="kwname">
+                  Wait Until Salesforce Is Ready
+                </td>
+                <td class="kwargs">
+                  
+                  <i>locator=None</i>, 
+                  
+                  <i>timeout=None</i>, 
+                  
+                  <i>interval=5</i>
+                  
+                </td>
+                <td class="kwdoc"><p>Waits until we are able to render the initial salesforce landing page</p>
+<p>It will continue to refresh the page until we land on a lightning page or until a timeout has been reached. The timeout can be specified in any time string supported by robot (eg: number of seconds, "3 minutes", etc.). If not specified, the default selenium timeout will be used.</p>
+<p>This keyword will wait a few seconds between each refresh, as well as wait after each refresh for the page to fully render (ie: it calls wait_for_aura())</p></td>
+              </tr>
+              
+            </tbody>
+          </table>
+        </div> 
+        
       </div>
       
-      <div class="section" id="library-Salesforce">
-        <h1>Salesforce.robot</h1>
-        <div class="library-documentation">
-        <p>Documentation for resource file <code>Salesforce</code>.</p>
-        </div>
-        <table class="kwtable">
-          <tbody>
-            <tr><th>Keyword</th><th>Arguments</th><th>Documentation</th></tr>
-            
-            <tr class="kwrow" id="Salesforce.robot.Chrome Set Binary">
-              <td class="kwname">
-                Chrome Set Binary
-              </td>
-              <td class="kwargs">
+      <div class="file" id="file-cumulusci/robotframework/Salesforce.robot">
+        <h1 title='cumulusci/robotframework/Salesforce.robot'>Salesforce.robot</h1>
+        
+        <div class="section" pageobject="">
+          
+          <div class='description'><p>Documentation for resource file <code>Salesforce</code>.</p></div>
+          <table class="kwtable">
+            <tbody>
+              <tr><th>Keyword</th><th>Arguments</th><th>Documentation</th></tr>
+              
+              <tr class="kwrow" id="Salesforce.robot.Chrome Set Binary">
+                <td class="kwname">
+                  Chrome Set Binary
+                </td>
+                <td class="kwargs">
                   
                   <i>options</i>
                   
-              </td>
-              <td class="kwdoc"></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.robot.Chrome Set Headless">
-              <td class="kwname">
-                Chrome Set Headless
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.robot.Chrome Set Headless">
+                <td class="kwname">
+                  Chrome Set Headless
+                </td>
+                <td class="kwargs">
                   
                   <i>options</i>
                   
-              </td>
-              <td class="kwdoc"></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.robot.Delete Records and Close Browser">
-              <td class="kwname">
-                Delete Records and Close Browser
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.robot.Delete Records and Close Browser">
+                <td class="kwname">
+                  Delete Records and Close Browser
+                </td>
+                <td class="kwargs">
                   
-              </td>
-              <td class="kwdoc"></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.robot.Get Chrome Options">
-              <td class="kwname">
-                Get Chrome Options
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>This will close all open browser windows and then delete all records created with the Salesforce API during this testing session.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.robot.Get Chrome Options">
+                <td class="kwname">
+                  Get Chrome Options
+                </td>
+                <td class="kwargs">
                   
-              </td>
-              <td class="kwdoc"></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.robot.Locate Element By Text">
-              <td class="kwname">
-                Locate Element By Text
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.robot.Initialize Location Strategies">
+                <td class="kwname">
+                  Initialize Location Strategies
+                </td>
+                <td class="kwargs">
+                  
+                </td>
+                <td class="kwdoc"><p>Initialize the Salesforce location strategies 'text' and 'title'</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.robot.Locate Element By Text">
+                <td class="kwname">
+                  Locate Element By Text
+                </td>
+                <td class="kwargs">
                   
                   <i>browser</i>, 
                   
@@ -790,15 +844,15 @@
                   
                   <i>constraints</i>
                   
-              </td>
-              <td class="kwdoc"></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.robot.Locate Element By Title">
-              <td class="kwname">
-                Locate Element By Title
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.robot.Locate Element By Title">
+                <td class="kwname">
+                  Locate Element By Title
+                </td>
+                <td class="kwargs">
                   
                   <i>browser</i>, 
                   
@@ -808,133 +862,148 @@
                   
                   <i>constraints</i>
                   
-              </td>
-              <td class="kwdoc"></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.robot.Open Test Browser">
-              <td class="kwname">
-                Open Test Browser
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.robot.Open Test Browser">
+                <td class="kwname">
+                  Open Test Browser
+                </td>
+                <td class="kwargs">
                   
-              </td>
-              <td class="kwdoc"></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.robot.Open Test Browser Chrome">
-              <td class="kwname">
-                Open Test Browser Chrome
-              </td>
-              <td class="kwargs">
+                  <i>size=${DEFAULT BROWSER SIZE}</i>, 
                   
-                  <i>login_url</i>
+                  <i>alias=${NONE}</i>
                   
-              </td>
-              <td class="kwdoc"></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.robot.Open Test Browser Firefox">
-              <td class="kwname">
-                Open Test Browser Firefox
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Opens a test browser to the org.</p>
+<p>The variable ${BROWSER} determines which browser should open. The following four browsers are explicitly supported: chrome, firefox, headlesschrome, and headlessfirefox. Any other value will be passed directly to the SeleniumLibrary 'Open Browser' keyword.</p>
+<p>Once the browser has been opened, it will be set to the given size (default=${DEFAULT BROWSER SIZE})</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.robot.Open Test Browser Chrome">
+                <td class="kwname">
+                  Open Test Browser Chrome
+                </td>
+                <td class="kwargs">
                   
-                  <i>login_url</i>
+                  <i>login_url</i>, 
                   
-              </td>
-              <td class="kwdoc"></td>
-            </tr>
-            
-            <tr class="kwrow" id="Salesforce.robot.Open Test Browser Headless Firefox">
-              <td class="kwname">
-                Open Test Browser Headless Firefox
-              </td>
-              <td class="kwargs">
+                  <i>alias=${NONE}</i>
                   
-                  <i>login_url</i>
+                </td>
+                <td class="kwdoc"></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.robot.Open Test Browser Firefox">
+                <td class="kwname">
+                  Open Test Browser Firefox
+                </td>
+                <td class="kwargs">
                   
-              </td>
-              <td class="kwdoc"></td>
-            </tr>
-            
-          </tbody>
-        </table>
+                  <i>login_url</i>, 
+                  
+                  <i>alias=${NONE}</i>
+                  
+                </td>
+                <td class="kwdoc"></td>
+              </tr>
+              
+              <tr class="kwrow" id="Salesforce.robot.Open Test Browser Headless Firefox">
+                <td class="kwname">
+                  Open Test Browser Headless Firefox
+                </td>
+                <td class="kwargs">
+                  
+                  <i>login_url</i>, 
+                  
+                  <i>alias=${NONE}</i>
+                  
+                </td>
+                <td class="kwdoc"></td>
+              </tr>
+              
+            </tbody>
+          </table>
+        </div> 
+        
       </div>
       
-      <div class="section" id="library-CumulusCI">
-        <h1>CumulusCI.py</h1>
-        <div class="library-documentation">
-        <p>Library for accessing CumulusCI for the local git project</p>
+      <div class="file" id="file-cumulusci/robotframework/CumulusCI.py">
+        <h1 title='cumulusci/robotframework/CumulusCI.py'>CumulusCI.py</h1>
+        
+        <div class="section" pageobject="">
+          
+          <div class='description'><p>Library for accessing CumulusCI for the local git project</p>
 <p>This library allows Robot Framework tests to access credentials to a Salesforce org created by CumulusCI, including Scratch Orgs.  It also exposes the core logic of CumulusCI including interactions with the Salesforce API's and project specific configuration including custom and customized tasks and flows.</p>
 <p>Initialization requires a single argument, the org name for the target CumulusCI org.  If running your tests via cci's robot task (recommended), you can initialize the library in your tests taking advantage of the variable set by the robot task:</p>
 <pre>
 <code>*** Settings ***</code>
 
 Library  cumulusci.robotframework.CumulusCI  ${ORG}
-</pre>
-        </div>
-        <table class="kwtable">
-          <tbody>
-            <tr><th>Keyword</th><th>Arguments</th><th>Documentation</th></tr>
-            
-            <tr class="kwrow" id="CumulusCI.py.Debug">
-              <td class="kwname">
-                Debug
-              </td>
-              <td class="kwargs">
+</pre></div>
+          <table class="kwtable">
+            <tbody>
+              <tr><th>Keyword</th><th>Arguments</th><th>Documentation</th></tr>
+              
+              <tr class="kwrow" id="CumulusCI.py.Debug">
+                <td class="kwname">
+                  Debug
+                </td>
+                <td class="kwargs">
                   
-              </td>
-              <td class="kwdoc"><p>Pauses execution and enters the Python debugger.</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="CumulusCI.py.Get Namespace Prefix">
-              <td class="kwname">
-                Get Namespace Prefix
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Pauses execution and enters the Python debugger.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="CumulusCI.py.Get Namespace Prefix">
+                <td class="kwname">
+                  Get Namespace Prefix
+                </td>
+                <td class="kwargs">
                   
                   <i>package=None</i>
                   
-              </td>
-              <td class="kwdoc"><p>Returns the namespace prefix (including __) for the specified package name. (Defaults to project__package__name_managed from the current project config.)</p>
+                </td>
+                <td class="kwdoc"><p>Returns the namespace prefix (including __) for the specified package name. (Defaults to project__package__name_managed from the current project config.)</p>
 <p>Returns an empty string if the package is not installed as a managed package.</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="CumulusCI.py.Get Org Info">
-              <td class="kwname">
-                Get Org Info
-              </td>
-              <td class="kwargs">
+              </tr>
+              
+              <tr class="kwrow" id="CumulusCI.py.Get Org Info">
+                <td class="kwname">
+                  Get Org Info
+                </td>
+                <td class="kwargs">
                   
-              </td>
-              <td class="kwdoc"><p>Returns a dictionary of the org information for the current target Salesforce org</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="CumulusCI.py.Login Url">
-              <td class="kwname">
-                Login Url
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Returns a dictionary of the org information for the current target Salesforce org</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="CumulusCI.py.Login Url">
+                <td class="kwname">
+                  Login Url
+                </td>
+                <td class="kwargs">
                   
                   <i>org=None</i>
                   
-              </td>
-              <td class="kwdoc"><p>Returns the login url which will automatically log into the target Salesforce org.  By default, the org_name passed to the library constructor is used but this can be overridden with the org option to log into a different org.</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="CumulusCI.py.Run Task">
-              <td class="kwname">
-                Run Task
-              </td>
-              <td class="kwargs">
+                </td>
+                <td class="kwdoc"><p>Returns the login url which will automatically log into the target Salesforce org.  By default, the org_name passed to the library constructor is used but this can be overridden with the org option to log into a different org.</p></td>
+              </tr>
+              
+              <tr class="kwrow" id="CumulusCI.py.Run Task">
+                <td class="kwname">
+                  Run Task
+                </td>
+                <td class="kwargs">
                   
                   <i>task_name</i>, 
                   
                   <i>**options</i>
                   
-              </td>
-              <td class="kwdoc"><p>Runs a named CumulusCI task for the current project with optional support for overriding task options via kwargs.</p>
+                </td>
+                <td class="kwdoc"><p>Runs a named CumulusCI task for the current project with optional support for overriding task options via kwargs.</p>
 <p>Examples:</p>
 <table border="1">
 <tr>
@@ -956,20 +1025,20 @@ Library  cumulusci.robotframework.CumulusCI  ${ORG}
 <td>Run deploy with custom path</td>
 </tr>
 </table></td>
-            </tr>
-            
-            <tr class="kwrow" id="CumulusCI.py.Run Task Class">
-              <td class="kwname">
-                Run Task Class
-              </td>
-              <td class="kwargs">
+              </tr>
+              
+              <tr class="kwrow" id="CumulusCI.py.Run Task Class">
+                <td class="kwname">
+                  Run Task Class
+                </td>
+                <td class="kwargs">
                   
                   <i>class_path</i>, 
                   
                   <i>**options</i>
                   
-              </td>
-              <td class="kwdoc"><p>Runs a CumulusCI task class with task options via kwargs.</p>
+                </td>
+                <td class="kwdoc"><p>Runs a CumulusCI task class with task options via kwargs.</p>
 <p>Use this keyword to run logic from CumulusCI tasks which have not been configured in the project's cumulusci.yml file.  This is most useful in cases where a test needs to use task logic for logic unique to the test and thus not worth making into a named task for the project</p>
 <p>Examples:</p>
 <table border="1">
@@ -984,38 +1053,40 @@ Library  cumulusci.robotframework.CumulusCI  ${ORG}
 <td>url=http://test.com/test.zip dir=test_zip</td>
 </tr>
 </table></td>
-            </tr>
-            
-            <tr class="kwrow" id="CumulusCI.py.Set Login Url">
-              <td class="kwname">
-                Set Login Url
-              </td>
-              <td class="kwargs">
+              </tr>
+              
+              <tr class="kwrow" id="CumulusCI.py.Set Login Url">
+                <td class="kwname">
+                  Set Login Url
+                </td>
+                <td class="kwargs">
                   
-              </td>
-              <td class="kwdoc"><p>Sets the LOGIN_URL variable in the suite scope which will automatically log into the target Salesforce org.</p>
+                </td>
+                <td class="kwdoc"><p>Sets the LOGIN_URL variable in the suite scope which will automatically log into the target Salesforce org.</p>
 <p>Typically, this is run during Suite Setup</p></td>
-            </tr>
-            
-            <tr class="kwrow" id="CumulusCI.py.Set Project Config">
-              <td class="kwname">
-                Set Project Config
-              </td>
-              <td class="kwargs">
+              </tr>
+              
+              <tr class="kwrow" id="CumulusCI.py.Set Project Config">
+                <td class="kwname">
+                  Set Project Config
+                </td>
+                <td class="kwargs">
                   
                   <i>project_config</i>
                   
-              </td>
-              <td class="kwdoc"></td>
-            </tr>
-            
-          </tbody>
-        </table>
+                </td>
+                <td class="kwdoc"></td>
+              </tr>
+              
+            </tbody>
+          </table>
+        </div> 
+        
       </div>
       
     </div>
     <div class="footer">
-      Generated on Friday April 26, 10:17 AM - cumulusci v2.4.2
+      Generated on Monday June 17, 09:32 PM - cumulusci v2.5.2
     </div>
   </body>
 </html>


### PR DESCRIPTION
This updates our robot_libdoc task to handle page object files. The main goal is for the product teams to be able to generate documentation for their own page object libraries. 

I've fixed the issue with not being able to generate documentation for the PageObjects.py library. This includes a commit of a new Keywords.html file which contains the documentation for that library.

This code will not generate documentation for our base classes. For one, they don't actually have any keywords in them yet, and for another I haven't figured out the best way to do that since the base libraries themselves aren't directly usable from robot tests. I've created a separate work item [#W-033984](https://foundation.lightning.force.com/lightning/r/agf__ADM_Work__c/a2x1E000001C6idQAC/view) related to generating documentation for the base classes. 

# Critical Changes

# Changes

# Issues Closed
