### PR TITLE
Updates to "cci project init" template

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,4 +13,4 @@ recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
 recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif
-recursive-include cumulusci *.xml *.jar *.xsl *.txt *.properties *.sh *.py *.yml *.report *.md *.robot *.json *.css *.html
+recursive-include cumulusci *.xml *.jar *.xsl *.txt *.properties *.sh *.py *.yml *.report *.md *.robot *.json *.css *.html .gitignore

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -6,17 +6,17 @@ from past.builtins import basestring
 from builtins import str
 from collections import defaultdict
 from collections import OrderedDict
+import code
 import functools
 import json
 import operator
 import os
+import shutil
 import sys
-import webbrowser
-import code
 import time
+import webbrowser
 
 from contextlib import contextmanager
-from shutil import copyfile
 
 import click
 import pkg_resources
@@ -540,7 +540,7 @@ def project_init(config):
             "create_contact.robot",
         )
         test_dest = os.path.join(test_folder, "create_contact.robot")
-        copyfile(test_src, test_dest)
+        shutil.copyfile(test_src, test_dest)
 
     # Create pull request template
     if not os.path.isdir(".github"):
@@ -556,6 +556,13 @@ def project_init(config):
 # Issues Closed
 """
             )
+
+    # Create datasets folder
+    if not os.path.isdir("datasets"):
+        os.mkdir("datasets")
+        template = env.get_template("mapping.yml")
+        with open(os.path.join("datasets", "mapping.yml"), "w") as f:
+            f.write(template.render(**context))
 
     click.echo(
         click.style(

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -311,7 +311,7 @@ def project_init(config):
     if os.path.isfile("cumulusci.yml"):
         raise click.ClickException("This project already has a cumulusci.yml file")
 
-    context = {}
+    context = {"cci_version": cumulusci.__version__}
 
     # Prep jinja2 environment for rendering files
     env = Environment(
@@ -460,10 +460,11 @@ def project_init(config):
         test_name_match = None
     context["test_name_match"] = test_name_match
 
-    # Render the cumulusci.yml file
-    template = env.get_template("cumulusci.yml")
-    with open("cumulusci.yml", "w") as f:
-        f.write(template.render(**context))
+    # Render templates
+    for name in (".gitignore", "README.md", "cumulusci.yml"):
+        template = env.get_template(name)
+        with open(name, "w") as f:
+            f.write(template.render(**context))
 
     # Create src directory
     if not os.path.isdir("src"):
@@ -540,6 +541,21 @@ def project_init(config):
         )
         test_dest = os.path.join(test_folder, "create_contact.robot")
         copyfile(test_src, test_dest)
+
+    # Create pull request template
+    if not os.path.isdir(".github"):
+        os.mkdir(".github")
+        with open(os.path.join(".github", "PULL_REQUEST_TEMPLATE.md"), "w") as f:
+            f.write(
+                """
+
+# Critical Changes
+
+# Changes
+
+# Issues Closed
+"""
+            )
 
     click.echo(
         click.style(

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -300,6 +300,15 @@ main.add_command(service)
 # Commands for group: project
 
 
+def validate_project_name(value):
+    if not re.match(r"^[a-zA-Z0-9_-]+$", value):
+        raise click.UsageError(
+            "Invalid project name. Allowed characters: "
+            "letters, numbers, dash, and underscore"
+        )
+    return value
+
+
 @click.command(
     name="init", help="Initialize a new project for use with the cumulusci toolbelt"
 )
@@ -335,7 +344,9 @@ def project_init(config):
         "Enter the project name.  The name is usually the same as your repository name.  NOTE: Do not use spaces in the project name!"
     )
     context["project_name"] = click.prompt(
-        click.style("Project Name", bold=True), default=project_name
+        click.style("Project Name", bold=True),
+        default=project_name,
+        value_proc=validate_project_name,
     )
 
     click.echo()

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -364,6 +364,17 @@ def project_init(config):
         default=config.global_config.project__package__api_version,
     )
 
+    click.echo()
+    click.echo(
+        "Salesforce metadata can be stored using Metadata API format or DX source format. "
+        "Which do you want to use?"
+    )
+    context["source_format"] = click.prompt(
+        click.style("Source format", bold=True),
+        type=click.Choice(["sfdx", "mdapi"]),
+        default="sfdx",
+    )
+
     # Dependencies
     dependencies = []
     click.echo(click.style("# Extend Project", bold=True, fg="blue"))
@@ -466,9 +477,10 @@ def project_init(config):
         with open(name, "w") as f:
             f.write(template.render(**context))
 
-    # Create src directory
-    if not os.path.isdir("src"):
-        os.mkdir("src")
+    # Create source directory
+    source_path = "force-app" if context["source_format"] == "sfdx" else "src"
+    if not os.path.isdir(source_path):
+        os.mkdir(source_path)
 
     # Create sfdx-project.json
     if not os.path.isfile("sfdx-project.json"):

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -224,6 +224,7 @@ class TestCCI(unittest.TestCase):
                 "testpkg",  # package_name
                 "testns",  # package_namespace
                 "43.0",  # api_version
+                "mdapi",  # source_format
                 "3",  # extend other URL
                 "https://github.com/SalesforceFoundation/Cumulus",  # github_url
                 "default",  # git_default_branch
@@ -275,6 +276,7 @@ class TestCCI(unittest.TestCase):
                 "testpkg",  # package_name
                 "testns",  # package_namespace
                 "43.0",  # api_version
+                "mdapi",  # source_format
                 "3",  # extend other URL
                 "https://github.com/SalesforceFoundation/Cumulus",  # github_url
                 "default",  # git_default_branch

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -240,6 +240,10 @@ class TestCCI(unittest.TestCase):
             self.assertEqual(
                 [
                     ".git/",
+                    ".github/",
+                    ".github/PULL_REQUEST_TEMPLATE.md",
+                    ".gitignore",
+                    "README.md",
                     "cumulusci.yml",
                     "orgs/",
                     "orgs/beta.json",

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -245,6 +245,8 @@ class TestCCI(unittest.TestCase):
                     ".gitignore",
                     "README.md",
                     "cumulusci.yml",
+                    "datasets/",
+                    "datasets/mapping.yml",
                     "orgs/",
                     "orgs/beta.json",
                     "orgs/dev.json",

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -214,6 +214,10 @@ class TestCCI(unittest.TestCase):
         run_click_command(cci.service_connect)
         # no assertion; this test is for coverage of empty methods
 
+    def test_validate_project_name(self):
+        with self.assertRaises(click.UsageError):
+            cci.validate_project_name("with spaces")
+
     @mock.patch("cumulusci.cli.cci.click")
     def test_project_init(self, click):
         with temporary_dir():

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -343,6 +343,7 @@ tasks:
         description: Uploads a production release of the metadata currently in the packaging org
         class_path: cumulusci.tasks.salesforce.PackageUpload
         options:
+            name: Release
             production: True
         group: Release Management
     util_sleep:
@@ -716,8 +717,6 @@ flows:
         steps:
             1:
                 task: upload_production
-                options:
-                    name: $project_config.project__package__name
             2:
                 task: github_release
                 options:

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -342,6 +342,18 @@ tasks:
         options:
             level: info
         group: Utilities
+    extract_dataset:
+        description: Extract a sample dataset using the bulk API.
+        class_path: cumulusci.tasks.bulkdata.ExtractData
+        options:
+            database_url: 'sqlite:///datasets/sample.db'
+            mapping: 'datasets/mapping.yml'
+    load_dataset:
+        description: Load a sample dataset using the bulk API.
+        class_path: cumulusci.tasks.bulkdata.LoadData
+        options:
+            database_url: 'sqlite:///datasets/sample.db'
+            mapping: 'datasets/mapping.yml'
 
 flows:
     apex_docs:

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -62,6 +62,14 @@ tasks:
             namespace_token: '%%%NAMESPACE%%%'
             filename_token: '___NAMESPACE___'
         group: Salesforce Metadata
+    deploy_qa_config:
+        description: Deploys configuration for QA.
+        class_path: cumulusci.tasks.salesforce.Deploy
+        options:
+            namespace_inject: $project_config.project__package__namespace
+            path: unpackaged/config/qa
+            unmanaged: True
+        group: Salesforce Metadata
     dx_convert_to:
         description: Converts src directory metadata format into sfdx format under force-app
         class_path: cumulusci.tasks.sfdx.SFDXBaseTask
@@ -225,6 +233,13 @@ tasks:
         class_path: cumulusci.tasks.salesforce.sourcetracking.RetrieveChanges
         options:
             path: src
+        group: Salesforce Metadata
+    retrieve_qa_config:
+        description: Retrieves the current changes in the scratch org into unpackaged/config/qa
+        class_path: cumulusci.tasks.salesforce.sourcetracking.RetrieveChanges
+        options:
+            path: unpackaged/config/qa
+            namespace_tokenize: $project_config.project__package__namespace
         group: Salesforce Metadata
     snapshot_changes:
         description: Tell SFDX source tracking to ignore previous changes in a scratch org

--- a/cumulusci/files/templates/project/.gitignore
+++ b/cumulusci/files/templates/project/.gitignore
@@ -2,6 +2,16 @@
 .cci
 .sfdx
 /src.orig
+{% if source_format == "sfdx" %}
+/src
+{% endif %}
+{% if source_format != "sfdx" %}
+/force-app
+{% endif %}
+
+# Python
+*.pyc
+__pycache__
 
 # Robot Framework results
 robot/{{ project_name }}/results/
@@ -16,3 +26,4 @@ robot/{{ project_name }}/results/
 
 # Misc
 .DS_Store
+

--- a/cumulusci/files/templates/project/.gitignore
+++ b/cumulusci/files/templates/project/.gitignore
@@ -1,0 +1,18 @@
+# Salesforce / SFDX / CCI
+.cci
+.sfdx
+/src.orig
+
+# Robot Framework results
+robot/{{ project_name }}/results/
+
+# Editors
+*.sublime-project
+*.sublime-workspace
+.vscode
+.idea
+.project
+.settings
+
+# Misc
+.DS_Store

--- a/cumulusci/files/templates/project/README.md
+++ b/cumulusci/files/templates/project/README.md
@@ -1,0 +1,12 @@
+# {{ project_name }}
+
+Add a brief description of this project here, in Markdown format.
+It will be shown on the main page of the project's GitHub repository.
+
+## Development
+
+To work on this project in a scratch org:
+
+1. [Set up CumulusCI](https://cumulusci.readthedocs.io/en/latest/tutorial.html)
+2. Run `cci flow run dev_org --org dev` to deploy this project.
+3. Run `cci org browser dev` to open the org in your browser.

--- a/cumulusci/files/templates/project/cumulusci.yml
+++ b/cumulusci/files/templates/project/cumulusci.yml
@@ -33,11 +33,14 @@ project:
         prefix_beta: '{{ git.prefix_beta }}'{% endif %}
       {% if git.prefix_release %} 
         prefix_release: '{{ git.prefix_release }}'{% endif %}
-
     {% if test_name_match %}
     test:
         name_match: '{{ test_name_match }}'
     {% endif %}
+    {% if source_format != 'mdapi' %}
+    source_format: {{ source_format }}
+    {% endif %}
+
 tasks:
     robot:
         options:
@@ -54,3 +57,4 @@ flows:
     config_qa:
         1.1:
             task: deploy_qa_config
+

--- a/cumulusci/files/templates/project/cumulusci.yml
+++ b/cumulusci/files/templates/project/cumulusci.yml
@@ -50,6 +50,11 @@ tasks:
             path: robot/{{project_name}}/tests
             output: robot/{{project_name}}/doc/{{project_name}}_tests.html
 
+flows:
+    config_qa:
+        1.1:
+            task: deploy_qa_config
+
 {% if package_namespace %}
 orgs:
     scratch:

--- a/cumulusci/files/templates/project/cumulusci.yml
+++ b/cumulusci/files/templates/project/cumulusci.yml
@@ -54,12 +54,3 @@ flows:
     config_qa:
         1.1:
             task: deploy_qa_config
-
-{% if package_namespace %}
-orgs:
-    scratch:
-        dev_namespaced:
-            config_file: orgs/dev.json
-            days: 7
-            namespaced: True
-{% endif %}

--- a/cumulusci/files/templates/project/cumulusci.yml
+++ b/cumulusci/files/templates/project/cumulusci.yml
@@ -1,3 +1,4 @@
+minimum_cumulusci_version: '{{ cci_version }}'
 project:
     name: {{ project_name }}
     package:

--- a/cumulusci/files/templates/project/mapping.yml
+++ b/cumulusci/files/templates/project/mapping.yml
@@ -2,7 +2,6 @@ Insert Accounts:
   sf_object: Account
   table: accounts
   fields:
-    Id: sf_id
     Name: Name
     Description: Description
     BillingStreet: Street
@@ -26,7 +25,6 @@ Insert Contacts:
   sf_object: Contact
   table: contacts
   fields:
-    Id: sf_id
     Salutation: salutation
     FirstName: firstname
     LastName: lastname

--- a/cumulusci/files/templates/project/mapping.yml
+++ b/cumulusci/files/templates/project/mapping.yml
@@ -1,0 +1,47 @@
+Insert Accounts:
+  sf_object: Account
+  table: accounts
+  fields:
+    Id: sf_id
+    Name: Name
+    Description: Description
+    BillingStreet: Street
+    BillingCity: City
+    BillingState: State
+    BillingPostalCode: PostalCode
+    BillingCountry: Country
+    ShippingStreet: Street
+    ShippingCity: City
+    ShippingState: State
+    ShippingPostalCode: PostalCode
+    ShippingCountry: Country
+    Phone: Phone
+    Fax: Fax
+    Website: Website
+    NumberOfEmployees: NumberOfEmployees
+    AccountNumber: AccountNumber
+    Site: Site
+    Type: Type
+Insert Contacts:
+  sf_object: Contact
+  table: contacts
+  fields:
+    Id: sf_id
+    Salutation: salutation
+    FirstName: firstname
+    LastName: lastname
+    Email: email
+    Phone: phone
+    MobilePhone: mobile
+    OtherPhone: OtherPhone
+    HomePhone: HomePhone
+    Title: title
+    Birthdate: birthdate
+    MailingStreet: mailingstreet
+    MailingCity: mailingcity
+    MailingState: mailingstate
+    MailingPostalCode: mailingpostalcode
+    MailingCountry: mailingcountry
+  lookups:
+    AccountId:
+      table: accounts

--- a/cumulusci/tasks/bulkdata.py
+++ b/cumulusci/tasks/bulkdata.py
@@ -529,7 +529,7 @@ class LoadData(BulkJobTaskMixin, BaseSalesforceApiTask):
             self.mapping = ordered_yaml_load(f)
 
 
-class QueryData(BulkJobTaskMixin, BaseSalesforceApiTask):
+class ExtractData(BulkJobTaskMixin, BaseSalesforceApiTask):
     task_options = {
         "database_url": {
             "description": "A DATABASE_URL where the query output should be written",
@@ -546,7 +546,7 @@ class QueryData(BulkJobTaskMixin, BaseSalesforceApiTask):
     }
 
     def _init_options(self, kwargs):
-        super(QueryData, self)._init_options(kwargs)
+        super(ExtractData, self)._init_options(kwargs)
         if self.options.get("sql_path"):
             if self.options.get("database_url"):
                 raise TaskOptionsError(
@@ -795,6 +795,10 @@ class QueryData(BulkJobTaskMixin, BaseSalesforceApiTask):
         with open(path, "w") as f:
             for line in self.session.connection().connection.iterdump():
                 f.write(line + "\n")
+
+
+# For backwards-compatibility
+QueryData = ExtractData
 
 
 @contextmanager

--- a/cumulusci/tasks/tests/test_bulkdata.py
+++ b/cumulusci/tasks/tests/test_bulkdata.py
@@ -409,7 +409,7 @@ class TestLoadDataWithoutSFIds(unittest.TestCase):
 
 
 @mock.patch("cumulusci.tasks.bulkdata.time.sleep", mock.Mock())
-class TestQueryDataWithSFIds(unittest.TestCase):
+class TestExtractDataWithSFIds(unittest.TestCase):
 
     mapping_file = "mapping_v1.yml"
     HOUSEHOLD_QUERY_RESULT = b'"Id"\n1\n'
@@ -438,7 +438,7 @@ class TestQueryDataWithSFIds(unittest.TestCase):
         mapping_path = os.path.join(base_path, self.mapping_file)
 
         task = _make_task(
-            bulkdata.QueryData,
+            bulkdata.ExtractData,
             {
                 "options": {
                     "database_url": "sqlite://",  # in memory
@@ -464,7 +464,7 @@ class TestQueryDataWithSFIds(unittest.TestCase):
         base_path = os.path.dirname(__file__)
         mapping_path = os.path.join(base_path, self.mapping_file)
         task = _make_task(
-            bulkdata.QueryData,
+            bulkdata.ExtractData,
             {
                 "options": {
                     "database_url": "sqlite://",  # in memory
@@ -491,7 +491,7 @@ class TestQueryDataWithSFIds(unittest.TestCase):
         base_path = os.path.dirname(__file__)
         mapping_path = os.path.join(base_path, self.mapping_file)
         task = _make_task(
-            bulkdata.QueryData,
+            bulkdata.ExtractData,
             {"options": {"database_url": "sqlite://", "mapping": mapping_path}},
         )
         task._sql_bulk_insert_from_csv = mock.Mock()
@@ -503,7 +503,7 @@ class TestQueryDataWithSFIds(unittest.TestCase):
         base_path = os.path.dirname(__file__)
         mapping_path = os.path.join(base_path, self.mapping_file)
         task = _make_task(
-            bulkdata.QueryData,
+            bulkdata.ExtractData,
             {"options": {"database_url": "sqlite://", "mapping": mapping_path}},
         )
         task._sql_bulk_insert_from_csv = mock.Mock()
@@ -516,7 +516,7 @@ class TestQueryDataWithSFIds(unittest.TestCase):
         mapping_path = os.path.join(base_path, self.mapping_file)
         db_path = os.path.join(base_path, "testdata.db")
         task = _make_task(
-            bulkdata.QueryData,
+            bulkdata.ExtractData,
             {
                 "options": {
                     "database_url": "sqlite:///{}".format(db_path),
@@ -529,7 +529,7 @@ class TestQueryDataWithSFIds(unittest.TestCase):
 
 
 @mock.patch("cumulusci.tasks.bulkdata.time.sleep", mock.Mock())
-class TestQueryDataWithoutSFIds(unittest.TestCase):
+class TestExtractDataWithoutSFIds(unittest.TestCase):
 
     mapping_file = "mapping_v2.yml"
     HOUSEHOLD_QUERY_RESULT = b'"Id",Name\n"foo","TestHousehold"\n'
@@ -558,7 +558,7 @@ class TestQueryDataWithoutSFIds(unittest.TestCase):
         mapping_path = os.path.join(base_path, self.mapping_file)
 
         task = _make_task(
-            bulkdata.QueryData,
+            bulkdata.ExtractData,
             {
                 "options": {
                     "database_url": "sqlite://",  # in memory

--- a/docs/bulk_data.rst
+++ b/docs/bulk_data.rst
@@ -5,7 +5,7 @@ Bulk Data
 The cumulusci.tasks.bulkdata module contains three tasks for dealing with 
 test and sample data.
 
-QueryData
+ExtractData
 ^^^^^^^^^
 Runs the mapping YAML in order, from top to bottom, selecting data from the specified
 sf_object and inserting it into the local table.
@@ -41,9 +41,9 @@ Mapping File
 Salesforce OID as Primary key
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default, the QueryData and LoadData task will use an autoincrementing integer field named `id` as the primary key.  In order to make the references using an integer, the QueryData task has to do a multitable update that could impact performance when querying large data sets.
+By default, the ExtractData and LoadData task will use an autoincrementing integer field named `id` as the primary key.  In order to make the references using an integer, the ExtractData task has to do a multitable update that could impact performance when querying large data sets.
 
-If the performance of QueryData on large data sets is more important than the advantages of abstracting references to use integer ID's, you can configure a mapping to use the queried Salesforce OID's as the reference for lookup fields by adding the following to the fields section:
+If the performance of ExtractData on large data sets is more important than the advantages of abstracting references to use integer ID's, you can configure a mapping to use the queried Salesforce OID's as the reference for lookup fields by adding the following to the fields section:
 .. code-block:: yaml    
 
         fields:

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -991,7 +991,7 @@ fetch_data
 
 **Description:** None
 
-**Class::** cumulusci.tasks.bulkdata.QueryData
+**Class::** cumulusci.tasks.bulkdata.ExtractData
 
 Options:
 ------------------------------------------


### PR DESCRIPTION
# Critical Changes

# Changes
* Updates to the project template created by `cci project init`:
  * Added .gitignore
  * Added README.md
  * Added a template for GitHub pull requests
  * Added an option to store metadata in DX source format
  * Added tasks for retrieving and deploying unpackaged metadata for QA
  * Added a sample mapping.yml for the bulkdata tasks
  * Pin the minimum CumulusCI version
  * Added validation of the project name
* The bulkdata tasks are now available by default as `extract_data` and `load_data`. Renamed QueryData to ExtractData to better fit with the concept of extract-transform-load.

# Issues Closed
