### PR TITLE
Fix decoding subprocess output if console encoding is different from preferred file encoding

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -33,6 +33,7 @@ Issues fixed:
 * Colors in terminal output are now displayed correctly in Windows. (#813)
 * ``cci`` no longer prints tracebacks when a flow or task is not found.
   Additionally, it will suggest a name if a close enough match can be found. (#960)
+* Fixed UnicodeDecodeError when reading output from subprocesses if the console encoding is different from Python's preferred file encoding.
 * Fixes related to source tracking:
 
   * Track the max revision retrieved for each component instead of the overall max revision.

--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 import datetime
-import io
 import json
 import os
 import re
@@ -41,8 +40,8 @@ class ScratchOrgConfig(OrgConfig):
         p = sfdx("force:org:display --json", self.username)
 
         org_info = None
-        stderr_list = [line.strip() for line in io.TextIOWrapper(p.stderr)]
-        stdout_list = [line.strip() for line in io.TextIOWrapper(p.stdout)]
+        stderr_list = [line.strip() for line in p.stderr_text]
+        stdout_list = [line.strip() for line in p.stdout_text]
 
         if p.returncode:
             self.logger.error("Return code: {}".format(p.returncode))
@@ -197,8 +196,8 @@ class ScratchOrgConfig(OrgConfig):
         )
         p = sfdx(command, username=None, log_note="Creating scratch org")
 
-        stderr = [line.strip() for line in io.TextIOWrapper(p.stderr)]
-        stdout = [line.strip() for line in io.TextIOWrapper(p.stdout)]
+        stderr = [line.strip() for line in p.stderr_text]
+        stdout = [line.strip() for line in p.stdout_text]
 
         if p.returncode:
             message = "{}: \n{}\n{}".format(
@@ -239,8 +238,8 @@ class ScratchOrgConfig(OrgConfig):
             log_note="Generating scratch org user password",
         )
 
-        stderr = io.TextIOWrapper(p.stderr).readlines()
-        stdout = io.TextIOWrapper(p.stdout).readlines()
+        stderr = p.stderr_text.readlines()
+        stdout = p.stdout_text.readlines()
 
         if p.returncode:
             self.config["password_failed"] = True
@@ -266,7 +265,7 @@ class ScratchOrgConfig(OrgConfig):
         p = sfdx("force:org:delete -p", self.username, "Deleting scratch org")
 
         stdout = []
-        for line in io.TextIOWrapper(p.stdout):
+        for line in p.stdout_text:
             stdout.append(line)
             if line.startswith("An error occurred deleting this org"):
                 self.logger.error(line)
@@ -287,7 +286,7 @@ class ScratchOrgConfig(OrgConfig):
         # access_token
         p = sfdx("force:org:open -r", self.username, log_note="Refreshing OAuth token")
 
-        stdout_list = [line.strip() for line in io.TextIOWrapper(p.stdout)]
+        stdout_list = [line.strip() for line in p.stdout_text]
 
         if p.returncode:
             self.logger.error("Return code: {}".format(p.returncode))

--- a/cumulusci/core/sfdx.py
+++ b/cumulusci/core/sfdx.py
@@ -1,5 +1,7 @@
+import io
 import logging
 import sarge
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -23,4 +25,6 @@ def sfdx(command, username=None, log_note=None):
         shell=True,
     )
     p.run()
+    p.stdout_text = io.TextIOWrapper(p.stdout, encoding=sys.stdout.encoding)
+    p.stderr_text = io.TextIOWrapper(p.stderr, encoding=sys.stdout.encoding)
     return p

--- a/cumulusci/utils.py
+++ b/cumulusci/utils.py
@@ -545,6 +545,8 @@ def get_git_config(config_key):
         shell=True,
     )
     p.run()
-    config_value = io.TextIOWrapper(p.stdout).read().strip()
+    config_value = (
+        io.TextIOWrapper(p.stdout, encoding=sys.stdout.encoding).read().strip()
+    )
 
     return config_value if config_value and not p.returncode else None


### PR DESCRIPTION
TextIOWrapper's default encoding is locale.getpreferredencoding(False) which makes sense for file I/O but not for console I/O. This switches to specify the same encoding that Python determined for the parent process's stdout.

# Critical Changes

# Changes

# Issues Closed
