### PR TITLE
Don't swallow exception messages in flow_run

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1259,7 +1259,7 @@ def flow_run(config, flow_name, org, delete_org, debug, o, skip, no_prompt):
         exception = click.UsageError(str(e))
         handle_exception_debug(config, debug, throw_exception=exception)
     except (CumulusCIFailure, ScratchOrgException) as e:
-        exception = click.ClickException("Failed: {}".format(e.__class__.__name__))
+        exception = click.ClickException(str(e) or e.__class__.__name__)
         handle_exception_debug(config, debug, throw_exception=exception)
     except Exception:
         handle_exception_debug(config, debug, no_prompt=no_prompt)

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -1117,9 +1117,9 @@ test_flow  Test Flow""",
             load_keychain=False,
         )
         config.get_org = mock.Mock(return_value=("test", org_config))
-        DummyTask._run_task = mock.Mock(side_effect=ScratchOrgException)
+        DummyTask._run_task = mock.Mock(side_effect=ScratchOrgException("msg"))
 
-        with self.assertRaises(click.ClickException):
+        with self.assertRaises(click.ClickException) as e:
             run_click_command(
                 cci.flow_run,
                 config=config,
@@ -1131,6 +1131,7 @@ test_flow  Test Flow""",
                 skip=(),
                 no_prompt=True,
             )
+            assert "msg" in str(e)
 
     @mock.patch("cumulusci.cli.cci.handle_sentry_event")
     def test_flow_run_unexpected_exception(self, handle_sentry_event):


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed
- Fixed a bug in reporting scratch org creation errors encountered while running a flow.