### PR TITLE
Add cci org shell command

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -38,15 +38,19 @@ from cumulusci.core.exceptions import CumulusCIUsageError
 from cumulusci.core.exceptions import OrgNotFound
 from cumulusci.core.exceptions import ScratchOrgException
 from cumulusci.core.exceptions import ServiceNotConfigured
+from cumulusci.core.exceptions import ServiceNotValid
 from cumulusci.core.exceptions import FlowNotFoundError
+
 from cumulusci.core.utils import import_global
 from cumulusci.cli.config import CliRuntime
 from cumulusci.cli.config import get_installed_version
 from cumulusci.utils import doc_task
 from cumulusci.utils import get_cci_upgrade_command
 from cumulusci.oauth.salesforce import CaptureSalesforceOAuth
+
 from .logger import init_logger
 import re
+import simple_salesforce
 
 
 @contextmanager
@@ -1009,6 +1013,38 @@ def org_scratch_delete(config, org_name):
     config.keychain.set_org(org_config)
 
 
+@click.command(
+    name="shell",
+    help="Drop into a Python shell with a simple_salesforce connection in `sf`",
+)
+@click.argument("org_name", required=False)
+@pass_config
+def org_shell(config, org_name):
+    org_name, org_config = config.get_org(org_name)
+    org_config.refresh_oauth_token(config.keychain)
+
+    sf = simple_salesforce.Salesforce(
+        instance_url=org_config.instance_url,
+        session_id=org_config.access_token,
+        api_version=config.project_config.project__package__api_version,
+    )
+    try:
+        app = config.project_config.keychain.get_service("connectedapp")
+        client_name = app.client_id
+    except (ServiceNotValid, ServiceNotConfigured):
+        client_name = "CumulusCI/{}".format(cumulusci.__version__)
+
+    sf.headers.setdefault("Sforce-Call-Options", "client={}".format(client_name))
+
+    code.interact(
+        banner="Use `sf` to access org `{}` via simple_salesforce".format(org_name),
+        local=dict(globals(), **locals()),
+    )
+
+    # Save the org config in case it was modified
+    config.keychain.set_org(org_config)
+
+
 org.add_command(org_browser)
 org.add_command(org_connect)
 org.add_command(org_default)
@@ -1018,6 +1054,7 @@ org.add_command(org_list)
 org.add_command(org_remove)
 org.add_command(org_scratch)
 org.add_command(org_scratch_delete)
+org.add_command(org_shell)
 
 
 # Commands for group: task

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1026,7 +1026,7 @@ def org_shell(config, org_name):
     sf = simple_salesforce.Salesforce(
         instance_url=org_config.instance_url,
         session_id=org_config.access_token,
-        api_version=config.project_config.project__package__api_version,
+        version=config.project_config.project__package__api_version,
     )
     try:
         app = config.project_config.keychain.get_service("connectedapp")

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1014,7 +1014,8 @@ def org_scratch_delete(config, org_name):
 
 @click.command(
     name="shell",
-    help="Drop into a Python shell with a simple_salesforce connection in `sf`",
+    help="Drop into a Python shell with a simple_salesforce connection in `sf`, "
+    "as well as the `org_config` and `project_config`.",
 )
 @click.argument("org_name", required=False)
 @pass_config
@@ -1026,7 +1027,11 @@ def org_shell(config, org_name):
 
     code.interact(
         banner="Use `sf` to access org `{}` via simple_salesforce".format(org_name),
-        local=dict(globals(), **locals()),
+        local={
+            "sf": sf,
+            "org_config": org_config,
+            "project_config": config.project_config,
+        },
     )
 
     # Save the org config in case it was modified

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -785,7 +785,7 @@ test2                                     dev          test2@example.com""",
         mock_sf.assert_called_once_with(
             instance_url=org_config.instance_url,
             session_id=org_config.access_token,
-            api_version=config.project_config.project__package__api_version,
+            version=config.project_config.project__package__api_version,
         )
         config.keychain.set_org.assert_called_once_with(org_config)
 

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -772,6 +772,41 @@ test2                                     dev          test2@example.com""",
         with self.assertRaises(click.UsageError):
             run_click_command(cci.org_scratch_delete, config=config, org_name="test")
 
+    @mock.patch("simple_salesforce.Salesforce")
+    @mock.patch("code.interact")
+    def test_org_shell(self, mock_code, mock_sf):
+        org_config = mock.Mock()
+        config = mock.Mock()
+        config.get_org.return_value = ("test", org_config)
+
+        run_click_command(cci.org_shell, config=config, org_name="test")
+
+        org_config.refresh_oauth_token.assert_called_once()
+        mock_sf.assert_called_once_with(
+            instance_url=org_config.instance_url,
+            session_id=org_config.access_token,
+            api_version=config.project_config.project__package__api_version,
+        )
+        config.keychain.set_org.assert_called_once_with(org_config)
+
+        mock_code.assert_called_once()
+        self.assertIn("sf", mock_code.call_args[1]["local"])
+
+    @mock.patch("simple_salesforce.Salesforce")
+    @mock.patch("code.interact")
+    def test_org_shell__no_connected_app(self, mock_code, mock_sf):
+        org_config = mock.Mock()
+        config = mock.Mock()
+        config.get_org.return_value = ("test", org_config)
+        config.project_config.keychain.get_service.side_effect = ServiceNotConfigured
+
+        run_click_command(cci.org_shell, config=config, org_name="test")
+
+        mock_sf.return_value.headers.setdefault.assert_called_once_with(
+            "Sforce-Call-Options",
+            "client={}".format("CumulusCI/{}".format(cumulusci.__version__)),
+        )
+
     @mock.patch("click.echo")
     def test_task_list(self, echo):
         config = mock.Mock()

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -772,40 +772,23 @@ test2                                     dev          test2@example.com""",
         with self.assertRaises(click.UsageError):
             run_click_command(cci.org_scratch_delete, config=config, org_name="test")
 
-    @mock.patch("simple_salesforce.Salesforce")
+    @mock.patch("cumulusci.cli.cci.get_simple_salesforce_connection")
     @mock.patch("code.interact")
     def test_org_shell(self, mock_code, mock_sf):
         org_config = mock.Mock()
+        org_config.instance_url = "https://salesforce.com"
+        org_config.access_token = "TEST"
         config = mock.Mock()
         config.get_org.return_value = ("test", org_config)
 
         run_click_command(cci.org_shell, config=config, org_name="test")
 
         org_config.refresh_oauth_token.assert_called_once()
-        mock_sf.assert_called_once_with(
-            instance_url=org_config.instance_url,
-            session_id=org_config.access_token,
-            version=config.project_config.project__package__api_version,
-        )
+        mock_sf.assert_called_once_with(config.project_config, org_config)
         config.keychain.set_org.assert_called_once_with(org_config)
 
         mock_code.assert_called_once()
         self.assertIn("sf", mock_code.call_args[1]["local"])
-
-    @mock.patch("simple_salesforce.Salesforce")
-    @mock.patch("code.interact")
-    def test_org_shell__no_connected_app(self, mock_code, mock_sf):
-        org_config = mock.Mock()
-        config = mock.Mock()
-        config.get_org.return_value = ("test", org_config)
-        config.project_config.keychain.get_service.side_effect = ServiceNotConfigured
-
-        run_click_command(cci.org_shell, config=config, org_name="test")
-
-        mock_sf.return_value.headers.setdefault.assert_called_once_with(
-            "Sforce-Call-Options",
-            "client={}".format("CumulusCI/{}".format(cumulusci.__version__)),
-        )
 
     @mock.patch("click.echo")
     def test_task_list(self, echo):

--- a/cumulusci/salesforce_api/tests/test_utils.py
+++ b/cumulusci/salesforce_api/tests/test_utils.py
@@ -1,0 +1,58 @@
+import unittest
+from unittest.mock import Mock, patch
+from cumulusci.salesforce_api.utils import get_simple_salesforce_connection
+from cumulusci.core.exceptions import ServiceNotConfigured
+from cumulusci import __version__
+
+
+class TestSalesforceApiUtils(unittest.TestCase):
+    @patch("simple_salesforce.Salesforce")
+    def test_connection(self, mock_sf):
+        org_config = Mock()
+        proj_config = Mock()
+        service_mock = Mock()
+        service_mock.client_id = "TEST"
+        proj_config.keychain.get_service.return_value = service_mock
+
+        get_simple_salesforce_connection(proj_config, org_config)
+        mock_sf.assert_called_once_with(
+            instance_url=org_config.instance_url,
+            session_id=org_config.access_token,
+            version=proj_config.project__package__api_version,
+        )
+
+        mock_sf.return_value.headers.setdefault.assert_called_once_with(
+            "Sforce-Call-Options", "client={}".format(service_mock.client_id)
+        )
+
+    @patch("simple_salesforce.Salesforce")
+    def test_connection__explicit_api_version(self, mock_sf):
+        org_config = Mock()
+        proj_config = Mock()
+        service_mock = Mock()
+        service_mock.client_id = "TEST"
+        proj_config.keychain.get_service.return_value = service_mock
+
+        get_simple_salesforce_connection(proj_config, org_config, api_version="42.0")
+        mock_sf.assert_called_once_with(
+            instance_url=org_config.instance_url,
+            session_id=org_config.access_token,
+            version="42.0",
+        )
+
+        mock_sf.return_value.headers.setdefault.assert_called_once_with(
+            "Sforce-Call-Options", "client={}".format(service_mock.client_id)
+        )
+
+    @patch("simple_salesforce.Salesforce")
+    def test_connection__no_connected_app(self, mock_sf):
+        org_config = Mock()
+        proj_config = Mock()
+        proj_config.keychain.get_service.side_effect = ServiceNotConfigured
+
+        get_simple_salesforce_connection(proj_config, org_config)
+
+        mock_sf.return_value.headers.setdefault.assert_called_once_with(
+            "Sforce-Call-Options",
+            "client={}".format("CumulusCI/{}".format(__version__)),
+        )

--- a/cumulusci/salesforce_api/tests/test_utils.py
+++ b/cumulusci/salesforce_api/tests/test_utils.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from mock import Mock, patch
 from cumulusci.salesforce_api.utils import get_simple_salesforce_connection
 from cumulusci.core.exceptions import ServiceNotConfigured
 from cumulusci import __version__

--- a/cumulusci/salesforce_api/utils.py
+++ b/cumulusci/salesforce_api/utils.py
@@ -1,0 +1,24 @@
+import simple_salesforce
+
+from cumulusci import __version__
+from cumulusci.core.exceptions import ServiceNotConfigured
+from cumulusci.core.exceptions import ServiceNotValid
+
+CALL_OPTS_HEADER_KEY = "Sforce-Call-Options"
+
+
+def get_simple_salesforce_connection(project_config, org_config, api_version=None):
+    sf = simple_salesforce.Salesforce(
+        instance_url=org_config.instance_url,
+        session_id=org_config.access_token,
+        version=api_version or project_config.project__package__api_version,
+    )
+    try:
+        app = project_config.keychain.get_service("connectedapp")
+        client_name = app.client_id
+    except (ServiceNotValid, ServiceNotConfigured):
+        client_name = "CumulusCI/{}".format(__version__)
+
+    sf.headers.setdefault(CALL_OPTS_HEADER_KEY, "client={}".format(client_name))
+
+    return sf

--- a/cumulusci/tasks/salesforce/BaseSalesforceApiTask.py
+++ b/cumulusci/tasks/salesforce/BaseSalesforceApiTask.py
@@ -1,9 +1,7 @@
 from salesforce_bulk import SalesforceBulk
-from simple_salesforce import Salesforce
 
 from cumulusci.tasks.salesforce import BaseSalesforceTask
-
-CALL_OPTS_HEADER_KEY = "Sforce-Call-Options"
+from cumulusci.salesforce_api.utils import get_simple_salesforce_connection
 
 
 class BaseSalesforceApiTask(BaseSalesforceTask):
@@ -17,22 +15,11 @@ class BaseSalesforceApiTask(BaseSalesforceTask):
         self._init_class()
 
     def _init_api(self, base_url=None):
-        if self.api_version:
-            api_version = self.api_version
-        else:
-            api_version = self.project_config.project__package__api_version
-
-        rv = Salesforce(
-            instance_url=self.org_config.instance_url,
-            session_id=self.org_config.access_token,
-            version=api_version,
+        rv = get_simple_salesforce_connection(
+            self.project_config, self.org_config, api_version=self.api_version
         )
         if base_url is not None:
             rv.base_url += base_url
-
-        rv.headers.setdefault(
-            CALL_OPTS_HEADER_KEY, "client={}".format(self._get_client_name())
-        )
 
         return rv
 


### PR DESCRIPTION
# Critical Changes

# Changes

 - Add the `cci org shell` command, which opens a Python shell pre-populated with a `simple_salesforce` session on the selected org (as `sf`).

# Issues Closed
