### PR TITLE
Provide access to the Organization sobject data on OrgConfig

### DIFF
--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -91,13 +91,17 @@ class OrgConfig(BaseConfig):
 
     def _load_orginfo(self):
         headers = {"Authorization": "Bearer " + self.access_token}
-        org_info = requests.get(
+        self._org_sobject = requests.get(
             self.instance_url
             + "/services/data/v45.0/sobjects/Organization/{}".format(self.org_id),
             headers=headers,
         ).json()
         result = {
-            "org_type": org_info["OrganizationType"],
-            "is_sandbox": org_info["IsSandbox"],
+            "org_type": self._org_sobject["OrganizationType"],
+            "is_sandbox": self._org_sobject["IsSandbox"],
         }
         self.config.update(result)
+
+    @property
+    def organization_sobject(self):
+        return self._org_sobject

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -953,3 +953,4 @@ class TestOrgConfig(unittest.TestCase):
 
         self.assertEqual("Enterprise Edition", config.org_type)
         self.assertEqual(False, config.is_sandbox)
+        self.assertIsNotNone(config.organization_sobject)


### PR DESCRIPTION
When CumulusCI connects to an org, it fetches the Organization sObject and stores some information from it in the org config that gets saved to the keychain. This makes a change to also cache the returned data on the org config instance (i.e. more temporarily than the keychain) so that it can be accessed by tasks. The immediate need is access to SignupCountryIsoCode to enforce a regional restriction on where an installer can be used.

With this in place we should be able to configure a preflight check like this:

```
{
    "when": "org_config.organization_sobject['SignupCountryIsoCode'] != 'US'",
    "action": "error",
    "message": "Sorry, this product is not available in your region."
}
```

# Critical Changes

# Changes

# Issues Closed
