### PR TITLE
Start regression upgrade from latest final release instead of the previous one

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -690,8 +690,6 @@ flows:
                 flow: beta_dependencies
             2:
                 task: install_managed
-                options:
-                    version: previous
             3:
                 task: install_managed_beta
 


### PR DESCRIPTION

# Critical Changes

# Changes
- The install_regression flow now upgrades to the latest beta from the most recent final release instead of from the previous final release.

# Issues Closed
