### PR TITLE
Refactor to support interacting with github as a github app

### DIFF
--- a/cumulusci/core/github.py
+++ b/cumulusci/core/github.py
@@ -4,6 +4,7 @@ from future import standard_library
 
 standard_library.install_aliases()
 from builtins import str
+from future.utils import native_str_to_bytes
 from cumulusci.core.exceptions import CumulusCIFailure
 from github3 import GitHub
 from github3 import login
@@ -14,10 +15,6 @@ import os
 
 retries = Retry(status_forcelist=(502, 503, 504), backoff_factor=0.3)
 adapter = HTTPAdapter(max_retries=retries)
-APP_KEY = os.environ.get("GITHUB_APP_KEY")
-if isinstance(APP_KEY, str):
-    APP_KEY = APP_KEY.encode("utf-8")
-APP_ID = os.environ.get("GITHUB_APP_ID")
 
 
 def get_github_api(username=None, password=None):
@@ -40,6 +37,8 @@ def get_github_api_for_repo(keychain, owner, repo):
     gh.session.mount("http://", adapter)
     gh.session.mount("https://", adapter)
 
+    APP_KEY = native_str_to_bytes(os.environ.get("GITHUB_APP_KEY", ""))
+    APP_ID = os.environ.get("GITHUB_APP_ID")
     if APP_ID and APP_KEY:
         installation = INSTALLATIONS.get((owner, repo))
         if installation is None:

--- a/cumulusci/core/tests/test_github.py
+++ b/cumulusci/core/tests/test_github.py
@@ -5,7 +5,7 @@ import unittest
 import mock
 import responses
 
-from cumulusci.core.exceptions import GithubException
+from cumulusci.core.exceptions import CumulusCIFailure
 from cumulusci.core.github import get_github_api
 from cumulusci.core.github import validate_service
 
@@ -45,6 +45,6 @@ class TestGithub(unittest.TestCase):
 
     @responses.activate
     def test_validate_service(self):
-        responses.add("GET", "/rate_limit", status=401)
-        with self.assertRaises(GithubException):
+        responses.add("GET", "https://api.github.com/rate_limit", status=401)
+        with self.assertRaises(CumulusCIFailure):
             validate_service({"username": "BOGUS", "password": "BOGUS"})

--- a/cumulusci/core/tests/test_github.py
+++ b/cumulusci/core/tests/test_github.py
@@ -1,12 +1,17 @@
+from datetime import datetime
 from http.client import HTTPMessage
 import io
+import os
 import unittest
 
+from github3.session import AppInstallationTokenAuth
 import mock
 import responses
 
 from cumulusci.core.exceptions import CumulusCIFailure
+from cumulusci.core import github
 from cumulusci.core.github import get_github_api
+from cumulusci.core.github import get_github_api_for_repo
 from cumulusci.core.github import validate_service
 
 
@@ -27,6 +32,10 @@ class MockHttpResponse(mock.Mock):
 
 
 class TestGithub(unittest.TestCase):
+    def tearDown(self):
+        # clear cached repo -> installation mapping
+        github.INSTALLATIONS.clear()
+
     @mock.patch("urllib3.connectionpool.HTTPConnectionPool._make_request")
     def test_github_api_retries(self, _make_request):
         gh = get_github_api("TestUser", "TestPass")
@@ -42,6 +51,58 @@ class TestGithub(unittest.TestCase):
 
         gh.octocat("meow")
         self.assertEqual(_make_request.call_count, 2)
+
+    @responses.activate
+    @mock.patch("github3.apps.create_token")
+    def test_get_github_api_for_repo(self, create_token):
+        create_token.return_value = "ATOKEN"
+        responses.add(
+            "GET",
+            "https://api.github.com/repos/TestOwner/TestRepo/installation",
+            json={
+                "id": 1,
+                "access_tokens_url": "",
+                "account": "",
+                "app_id": "",
+                "created_at": "",
+                "events": "",
+                "html_url": "",
+                "permissions": "",
+                "repositories_url": "",
+                "repository_selection": "",
+                "single_file_name": "",
+                "target_id": "",
+                "target_type": "",
+                "updated_at": "",
+            },
+        )
+        responses.add(
+            "POST",
+            "https://api.github.com/app/installations/1/access_tokens",
+            status=201,
+            json={"token": "ITOKEN", "expires_at": datetime.now().isoformat()},
+        )
+
+        with mock.patch.dict(
+            os.environ, {"GITHUB_APP_KEY": "bogus", "GITHUB_APP_ID": "1234"}
+        ):
+            gh = get_github_api_for_repo(None, "TestOwner", "TestRepo")
+            assert isinstance(gh.session.auth, AppInstallationTokenAuth)
+
+    @responses.activate
+    @mock.patch("github3.apps.create_token")
+    def test_get_github_api_for_repo__not_installed(self, create_token):
+        create_token.return_value = "ATOKEN"
+        responses.add(
+            "GET",
+            "https://api.github.com/repos/TestOwner/TestRepo/installation",
+            status=404,
+        )
+        with mock.patch.dict(
+            os.environ, {"GITHUB_APP_KEY": "bogus", "GITHUB_APP_ID": "1234"}
+        ):
+            with self.assertRaises(CumulusCIFailure):
+                get_github_api_for_repo(None, "TestOwner", "TestRepo")
 
     @responses.activate
     def test_validate_service(self):

--- a/cumulusci/tasks/github/base.py
+++ b/cumulusci/tasks/github/base.py
@@ -1,12 +1,14 @@
-from cumulusci.core.github import get_github_api
+from cumulusci.core.github import get_github_api_for_repo
 from cumulusci.core.tasks import BaseTask
 
 
 class BaseGithubTask(BaseTask):
     def _init_task(self):
         self.github_config = self.project_config.keychain.get_service("github")
-        self.github = get_github_api(
-            username=self.github_config.username, password=self.github_config.password
+        self.github = get_github_api_for_repo(
+            self.project_config.keychain,
+            self.project_config.repo_owner,
+            self.project_config.repo_name,
         )
 
     def get_repo(self):

--- a/cumulusci/tasks/github/tests/test_commit.py
+++ b/cumulusci/tasks/github/tests/test_commit.py
@@ -9,7 +9,7 @@ from cumulusci.tasks.github import CommitApexDocs
 from cumulusci.tests.util import create_project_config
 
 
-@mock.patch("cumulusci.tasks.github.base.get_github_api", mock.Mock())
+@mock.patch("cumulusci.tasks.github.base.get_github_api_for_repo", mock.Mock())
 class TestCommitApexDocs(unittest.TestCase):
     def setUp(self):
         self.project_config = create_project_config()

--- a/cumulusci/tasks/github/tests/test_pull_request.py
+++ b/cumulusci/tasks/github/tests/test_pull_request.py
@@ -7,7 +7,7 @@ from cumulusci.tasks.github import PullRequests
 from cumulusci.tests.util import create_project_config
 
 
-@mock.patch("cumulusci.tasks.github.base.get_github_api", mock.Mock())
+@mock.patch("cumulusci.tasks.github.base.get_github_api_for_user", mock.Mock())
 class TestPullRequests(unittest.TestCase):
     project_config = create_project_config()
     project_config.keychain.set_service(

--- a/cumulusci/tasks/github/tests/test_pull_request.py
+++ b/cumulusci/tasks/github/tests/test_pull_request.py
@@ -7,24 +7,24 @@ from cumulusci.tasks.github import PullRequests
 from cumulusci.tests.util import create_project_config
 
 
-@mock.patch("cumulusci.tasks.github.base.get_github_api_for_user", mock.Mock())
 class TestPullRequests(unittest.TestCase):
-    project_config = create_project_config()
-    project_config.keychain.set_service(
-        "github",
-        ServiceConfig(
-            {
-                "username": "TestUser",
-                "password": "TestPass",
-                "email": "testuser@testdomain.com",
-            }
-        ),
-    )
-    task_config = TaskConfig()
-    task = PullRequests(project_config, task_config)
-    repo = mock.Mock()
-    repo.pull_requests.return_value = [mock.Mock(number=1, title="Test PR")]
-    task.get_repo = mock.Mock(return_value=repo)
-    task.logger = mock.Mock()
-    task()
-    task.logger.info.assert_called_with("#1: Test PR")
+    def test_run_task(self):
+        project_config = create_project_config()
+        project_config.keychain.set_service(
+            "github",
+            ServiceConfig(
+                {
+                    "username": "TestUser",
+                    "password": "TestPass",
+                    "email": "testuser@testdomain.com",
+                }
+            ),
+        )
+        task_config = TaskConfig()
+        task = PullRequests(project_config, task_config)
+        repo = mock.Mock()
+        repo.pull_requests.return_value = [mock.Mock(number=1, title="Test PR")]
+        task.get_repo = mock.Mock(return_value=repo)
+        task.logger = mock.Mock()
+        task()
+        task.logger.info.assert_called_with("#1: Test PR")

--- a/cumulusci/tasks/github/tests/util_github_api.py
+++ b/cumulusci/tasks/github/tests/util_github_api.py
@@ -1,9 +1,4 @@
-import random
-
 from datetime import datetime
-from datetime import timedelta
-
-import responses
 
 from cumulusci.tests.util import random_sha
 
@@ -347,7 +342,7 @@ class GithubApiTestMixin(object):
             "mergeable": not merged_date,
             "mergeable_state": "clean",
             "merged_at": merged_date,
-            "merged": merged_date != None,
+            "merged": merged_date is not None,
             "merged_by": None,
             "number": issue_number,
             "patch_url": "",
@@ -367,9 +362,9 @@ class GithubApiTestMixin(object):
         return pr
 
     def _get_expected_issue(self, issue_number, owner=None, repo=None):
-        if owner == None:
+        if owner is None:
             owner = "TestOwner"
-        if repo == None:
+        if repo is None:
             repo = "TestRepo"
         now = datetime.now().isoformat()
         response_body = {

--- a/cumulusci/tasks/release_notes/tests/test_generator.py
+++ b/cumulusci/tasks/release_notes/tests/test_generator.py
@@ -1,7 +1,5 @@
 # coding=utf-8
 
-import datetime
-import json
 import mock
 import os
 import unittest
@@ -335,4 +333,4 @@ class TestPublishingGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTest
             status=404,
         )
         with self.assertRaises(CumulusCIException):
-            result = generator()
+            generator()

--- a/cumulusci/tasks/release_notes/tests/test_provider.py
+++ b/cumulusci/tasks/release_notes/tests/test_provider.py
@@ -11,7 +11,6 @@ import tempfile
 import unittest
 
 from cumulusci.core.github import get_github_api
-import requests
 import responses
 
 from cumulusci.core.exceptions import GithubApiError
@@ -21,7 +20,6 @@ from cumulusci.tasks.release_notes.provider import BaseChangeNotesProvider
 from cumulusci.tasks.release_notes.provider import StaticChangeNotesProvider
 from cumulusci.tasks.release_notes.provider import DirectoryChangeNotesProvider
 from cumulusci.tasks.release_notes.provider import GithubChangeNotesProvider
-from cumulusci.tasks.release_notes.exceptions import LastReleaseTagNotFoundError
 from cumulusci.tasks.github.tests.util_github_api import GithubApiTestMixin
 from cumulusci.tasks.release_notes.tests.utils import MockUtil
 

--- a/cumulusci/tasks/salesforce/UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/UpdateDependencies.py
@@ -235,8 +235,11 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
                         dependency["repo_name"],
                     )
                 )
+                gh_for_repo = self.project_config.get_github_api(
+                    dependency["repo_owner"], dependency["repo_name"]
+                )
                 package_zip = self._download_extract_github(
-                    self.project_config.get_github_api(),
+                    gh_for_repo,
                     dependency["repo_owner"],
                     dependency["repo_name"],
                     dependency["subfolder"],


### PR DESCRIPTION
This adds a new function `get_github_api_for_repo` for getting an authenticated github API client, and updates to use it throughout the codebase. The new function will authenticate as an app instead of the user configured in the CumulusCI keychain if the GITHUB_APP_ID and GITHUB_APP_KEY environment variables are set. The reason for the new function is that authenticating as an app requires specifying the id of that app's installation for a particular user/org, so we need to know which repository the caller is intending to interact with.

# Critical Changes

# Changes
- CumulusCI can now authenticate for GitHub API calls as either a user or an app. The latter is for use when CumulusCI is used as part of a hosted service.

# Issues Closed
