### PR TITLE
Bulk Data: fail loudly on load errors

### DIFF
--- a/cumulusci/tasks/bulkdata.py
+++ b/cumulusci/tasks/bulkdata.py
@@ -105,7 +105,7 @@ class BulkJobTaskMixin(object):
         self.logger.info("Job {} finished with result: {}".format(job_id, result))
         if result == "Failed":
             for state_message in messages:
-                self.logger.info("Batch failure message: {}".format(state_message))
+                self.logger.error("Batch failure message: {}".format(state_message))
 
         return result
 

--- a/cumulusci/tasks/tests/test_bulkdata.py
+++ b/cumulusci/tasks/tests/test_bulkdata.py
@@ -430,6 +430,34 @@ class TestLoadDataWithSFIds(unittest.TestCase):
 
         self.assertIn("Error on row", str(ex.exception))
 
+    def test_store_inserted_ids_for_batch__respects_silent_error_flag(self):
+        result_data = io.BytesIO(
+            b"Id,Success,Created,Error\n001111111111111,false,false,DUPLICATES_DETECTED"
+        )
+
+        base_path = os.path.dirname(__file__)
+        mapping_path = os.path.join(base_path, self.mapping_file)
+        task = _make_task(
+            bulkdata.LoadData,
+            {
+                "options": {
+                    "ignore_row_errors": True,
+                    "database_url": "sqlite://",
+                    "mapping": mapping_path,
+                }
+            },
+        )
+
+        task.metadata = mock.Mock()
+        task.metadata.tables = {"table": "test"}
+        task.session = mock.Mock()
+
+        # This is identical to the test above save the option set to ignore_row_errors
+        # We should get no exception.
+        task._store_inserted_ids_for_batch(
+            result_data, ["001111111111111"], "table", mock.Mock()
+        )
+
     def test_wait_for_job__logs_state_messages(self):
         base_path = os.path.dirname(__file__)
         mapping_path = os.path.join(base_path, self.mapping_file)


### PR DESCRIPTION
# Critical Changes

# Changes

- The `LoadData` task will throw a `BulkDataException` if any records fail during the load operation.

# Issues Closed
