### PR TITLE
Feature/robot community keywords

### DIFF
--- a/cumulusci/core/github.py
+++ b/cumulusci/core/github.py
@@ -45,7 +45,7 @@ def get_github_api_for_repo(keychain, owner, repo):
     if APP_ID and APP_KEY:
         installation = INSTALLATIONS.get((owner, repo))
         if installation is None:
-            gh.login_as_app(APP_KEY, APP_ID)
+            gh.login_as_app(APP_KEY, APP_ID, expire_in=120)
             try:
                 installation = gh.app_installation_for_repository(owner, repo)
             except github3.exceptions.NotFoundError:

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -954,3 +954,51 @@ class TestOrgConfig(unittest.TestCase):
         self.assertEqual("Enterprise Edition", config.org_type)
         self.assertEqual(False, config.is_sandbox)
         self.assertIsNotNone(config.organization_sobject)
+
+    @mock.patch("cumulusci.core.config.OrgConfig._fetch_community_info")
+    def test_community_info(self, mock_fetch):
+        """Verify that get_community_info returns data from the cache"""
+        config = OrgConfig({}, "test")
+        config._community_info_cache = {"Kōkua": {"name": "Kōkua"}}
+        info = config.get_community_info("Kōkua")
+        self.assertEquals(info["name"], "Kōkua")
+        mock_fetch.assert_not_called()
+
+    @mock.patch("cumulusci.core.config.OrgConfig._fetch_community_info")
+    def test_community_info_auto_refresh_cache(self, mock_fetch):
+        """Verify that the internal cache is automatically refreshed
+
+        The cache should be refreshed automatically if the requested community
+        is not in the cache.
+        """
+        mock_fetch.return_value = {"Kōkua": {"name": "Kōkua"}}
+
+        config = OrgConfig({}, "test")
+        config._community_info_cache = {}
+        info = config.get_community_info("Kōkua")
+        mock_fetch.assert_called()
+        self.assertEqual(info["name"], "Kōkua")
+
+    @mock.patch("cumulusci.core.config.OrgConfig._fetch_community_info")
+    def test_community_info_force_refresh(self, mock_fetch):
+        """Verify that the force_refresh parameter has an effect"""
+        mock_fetch.return_value = {"Kōkua": {"name": "Kōkua"}}
+        config = OrgConfig({}, "test")
+
+        # With the cache seeded with the target community, first
+        # verify that the cache isn't refreshed automatically
+        config._community_info_cache = {"Kōkua": {"name": "Kōkua"}}
+        config.get_community_info("Kōkua")
+        mock_fetch.assert_not_called()
+
+        # Now, set force_refresh and make sure it is refreshed
+        config.get_community_info("Kōkua", force_refresh=True)
+        mock_fetch.assert_called()
+
+    @mock.patch("cumulusci.core.config.OrgConfig._fetch_community_info")
+    def test_community_info_exception(self, mock_fetch):
+        """Verify an exception is thrown when the community doesn't exist"""
+        config = OrgConfig({}, "test")
+        expected_exception = "Unable to find community information for 'bogus'"
+        with self.assertRaisesRegexp(Exception, expected_exception):
+            config.get_community_info("bogus")

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 import os
 import unittest

--- a/cumulusci/robotframework/CumulusCI.py
+++ b/cumulusci/robotframework/CumulusCI.py
@@ -131,7 +131,8 @@ class CumulusCI(object):
         - If a key is given, only the value for that key will be returned.
 
         Some of the supported keys include name, siteUrl, and
-        loginUrl. For a comprehensive list see the API documentation,
+        loginUrl. For a comprehensive list see the
+        [https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_responses_community.htm|API documentation],
         or call this keyword without the key argument and examine the
         results.
 

--- a/cumulusci/robotframework/tests/cumulusci/communities.robot
+++ b/cumulusci/robotframework/tests/cumulusci/communities.robot
@@ -5,7 +5,7 @@ Library   Collections
 Suite Setup  run keywords
      # Note: the first community name intentionally includes a unicode
      # character to make sure we can handle it.
-...  Insure community exists       Kōkua   kokua
+...  Ensure community exists       Kōkua   kokua
 ...  AND  Insure community exists  Ohana   ohana
 
 *** Keywords ***

--- a/cumulusci/robotframework/tests/cumulusci/communities.robot
+++ b/cumulusci/robotframework/tests/cumulusci/communities.robot
@@ -6,7 +6,7 @@ Suite Setup  run keywords
      # Note: the first community name intentionally includes a unicode
      # character to make sure we can handle it.
 ...  Ensure community exists       Kōkua   kokua
-...  AND  Insure community exists  Ohana   ohana
+...  AND  Ensure community exists  Ohana   ohana
 
 *** Keywords ***
 Ensure community exists

--- a/cumulusci/robotframework/tests/cumulusci/communities.robot
+++ b/cumulusci/robotframework/tests/cumulusci/communities.robot
@@ -1,0 +1,56 @@
+*** Settings ***
+Resource  cumulusci/robotframework/CumulusCI.robot
+Library   Collections
+
+Suite Setup  run keywords
+...  # Note: the first community name intentionally includes a unicode
+...  # character to make sure we can handle it.
+...  Insure community exists       Kōkua   kokua
+...  AND  Insure community exists  Ohana   ohana
+
+*** Keywords ***
+Insure community exists
+    [Arguments]      ${community name}  ${url prefix}
+    [Documentation]  Creates a community with the given name if it doesn't exist
+
+    ${passed}=  run keyword and return status
+    ...  get community info  ${community name}
+
+    run keyword if  not $passed  run task  create_community
+    ...  template=VF Template
+    ...  name=${community name}
+    ...  url_path_prefix=${url prefix}
+
+*** Test Cases ***
+Get community info for specific community
+    # we'll just spot-check a few keys. I don't see a point
+    # in testing them all, since the API is either going to
+    # return everything or nothing
+    ${info}=  get community info               Kōkua
+    Dictionary should contain key  ${info}     name
+    Dictionary should contain key  ${info}     loginUrl
+    Dictionary should contain key  ${info}     siteUrl
+    Should be equal  ${info['name']}           Kōkua
+    Should be equal  ${info['urlPathPrefix']}  kokua
+
+    # now get info for another community, to make sure
+    # it doesn't return the data from the previous community
+    ${info}=  get community info  Ohana
+    Should be equal  ${info['name']}  Ohana
+    Should be equal  ${info['urlPathPrefix']}  ohana
+
+Get community info for non-existing community throws error
+    [Documentation]  Verify that an unknown community name throws a reasonable error message
+    run keyword and expect error
+    ...  Unable to find community information for 'bōgusCommunity'
+    ...  get community info  bōgusCommunity
+
+Get community info with key
+    [Documentation]  Verify we can Fetch data for a single key
+    ${loginUrl}=  get community info  Kōkua  loginUrl
+    Should match regexp  ${loginUrl}  https://.*/kokua/login
+
+Get community info with unknown key throws error
+    [Documentation]  Verify that an unknown key throws a reasonable error message
+    run keyword and expect error  Invalid key 'bōgus'
+    ...  get community info  Kōkua  bōgus

--- a/cumulusci/robotframework/tests/cumulusci/communities.robot
+++ b/cumulusci/robotframework/tests/cumulusci/communities.robot
@@ -3,8 +3,8 @@ Resource  cumulusci/robotframework/CumulusCI.robot
 Library   Collections
 
 Suite Setup  run keywords
-...  # Note: the first community name intentionally includes a unicode
-...  # character to make sure we can handle it.
+     # Note: the first community name intentionally includes a unicode
+     # character to make sure we can handle it.
 ...  Insure community exists       Kōkua   kokua
 ...  AND  Insure community exists  Ohana   ohana
 

--- a/cumulusci/robotframework/tests/cumulusci/communities.robot
+++ b/cumulusci/robotframework/tests/cumulusci/communities.robot
@@ -9,7 +9,7 @@ Suite Setup  run keywords
 ...  AND  Insure community exists  Ohana   ohana
 
 *** Keywords ***
-Insure community exists
+Ensure community exists
     [Arguments]      ${community name}  ${url prefix}
     [Documentation]  Creates a community with the given name if it doesn't exist
 

--- a/docs/robot/Keywords.html
+++ b/docs/robot/Keywords.html
@@ -189,7 +189,7 @@ Library  cumulusci.robotframework.CumulusCI  ${ORG}
 <li>If no key is given, all of the information returned by the API will be returned by this keyword in the form of a dictionary</li>
 <li>If a key is given, only the value for that key will be returned.</li>
 </ul>
-<p>Some of the supported keys include name, siteUrl, and loginUrl. For a comprehensive list see the API documentation, or call this keyword without the key argument and examine the results.</p>
+<p>Some of the supported keys include name, siteUrl, and loginUrl. For a comprehensive list see the <a href="https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_responses_community.htm">API documentation</a>, or call this keyword without the key argument and examine the results.</p>
 <p>An API call will be made the first time this keyword is used, and the return values will be cached. Subsequent calls will not call the API unless the requested community name is not in the cached results, or unless the force_refresh parameter is set to True.</p></td>
               </tr>
               
@@ -1216,7 +1216,7 @@ Library  cumulusci.robotframework.PageObjects
       
     </div>
     <div class="footer">
-      Generated on Monday August 05, 06:25 PM - cumulusci v2.5.5
+      Generated on Thursday August 08, 11:04 AM - cumulusci v2.5.5
     </div>
   </body>
 </html>

--- a/docs/robot/Keywords.html
+++ b/docs/robot/Keywords.html
@@ -170,6 +170,29 @@ Library  cumulusci.robotframework.CumulusCI  ${ORG}
                 <td class="kwdoc"><p>Pauses execution and enters the Python debugger.</p></td>
               </tr>
               
+              <tr class="kwrow" id="CumulusCI.Get Community Info">
+                <td class="kwname">
+                  Get Community Info
+                </td>
+                <td class="kwargs">
+                  
+                  <i>community_name</i>, 
+                  
+                  <i>key=None</i>, 
+                  
+                  <i>force_refresh=False</i>
+                  
+                </td>
+                <td class="kwdoc"><p>This keyword uses the Salesforce API to get information about a community.</p>
+<p>This keyword requires the exact community name as its first argumment.</p>
+<ul>
+<li>If no key is given, all of the information returned by the API will be returned by this keyword in the form of a dictionary</li>
+<li>If a key is given, only the value for that key will be returned.</li>
+</ul>
+<p>Some of the supported keys include name, siteUrl, and loginUrl. For a comprehensive list see the API documentation, or call this keyword without the key argument and examine the results.</p>
+<p>An API call will be made the first time this keyword is used, and the return values will be cached. Subsequent calls will not call the API unless the requested community name is not in the cached results, or unless the force_refresh parameter is set to True.</p></td>
+              </tr>
+              
               <tr class="kwrow" id="CumulusCI.Get Namespace Prefix">
                 <td class="kwname">
                   Get Namespace Prefix
@@ -1193,7 +1216,7 @@ Library  cumulusci.robotframework.PageObjects
       
     </div>
     <div class="footer">
-      Generated on Friday June 21, 05:17 PM - cumulusci v2.5.2
+      Generated on Monday August 05, 06:25 PM - cumulusci v2.5.5
     </div>
   </body>
 </html>

--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -1,11 +1,15 @@
 {
   "orgName": "CumulusCI - Dev Workspace",
   "edition": "Developer",
+    "features": [
+        "Communities"
+    ],
   "settings": {
     "orgPreferenceSettings": {
       "s1DesktopEnabled": true
       , "chatterEnabled": true
       , "translation": true
+      ,  "networksEnabled": true
     }
   }
 }


### PR DESCRIPTION
This adds a new keyword to the CumulusCI library, `Get Community Info`. It can be used to get information about a community by name via the Salesforce API.

This also includes some robot tests, and tweaks orgs/dev.json so that communities can be enabled. 

This keyword solves the immediate need another team has for writing page object keywords that need to get the URL for a community. I started down the path of providing a more specialized `get community site url` keyword, but decided to go with a more general-purpose keyword. I'm open to hearing other opinions on this. 

# Critical Changes

# Changes

# Issues Closed
