### PR TITLE
Include option for including links to PRs with no release notes

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -717,6 +717,7 @@ flows:
                     link_pr: True
                     publish: True
                     tag: ^^github_release.tag_name
+                    include_empty: True
             4:
                 task: github_master_to_feature
 

--- a/cumulusci/tasks/release_notes/generator.py
+++ b/cumulusci/tasks/release_notes/generator.py
@@ -12,6 +12,7 @@ from cumulusci.tasks.release_notes.provider import GithubChangeNotesProvider
 class BaseReleaseNotesGenerator(object):
     def __init__(self):
         self.change_notes = []
+        self.empty_pull_requests = []
         self.init_parsers()
         self.init_change_notes()
 
@@ -45,9 +46,16 @@ class BaseReleaseNotesGenerator(object):
 
     def _parse_change_note(self, change_note):
         """ Parses an individual change note through all parsers in
-        self.parsers """
+        self.parsers. If no lines were added then appends the change
+        note to the list of empty PRs"""
+        line_added_by_parsers = False
         for parser in self.parsers:
-            parser.parse(change_note)
+            line_added = parser.parse(change_note)
+            if not line_added_by_parsers:
+                line_added_by_parsers = line_added
+
+        if not line_added_by_parsers:
+            self.empty_pull_requests.append(change_note)
 
     def render(self):
         """ Returns the rendered release notes from all parsers as a string """
@@ -98,6 +106,7 @@ class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator):
         link_pr=False,
         publish=False,
         has_issues=True,
+        include_empty=False,
     ):
         self.github = github
         self.github_info = github_info
@@ -107,6 +116,7 @@ class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator):
         self.link_pr = link_pr
         self.do_publish = publish
         self.has_issues = has_issues
+        self.include_empty_pull_requests = include_empty
         self.lines_parser_class = None
         self.issues_parser_class = None
         super(GithubReleaseNotesGenerator, self).__init__()
@@ -135,6 +145,21 @@ class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator):
             raise CumulusCIException(
                 "Release not found for tag: {}".format(self.current_tag)
             )
+
+    def _render_empty_pr_section(self):
+        section_lines = []
+        if self.empty_pull_requests:
+            section_lines.append("\n# Pull requests with no release notes")
+            for content in self.empty_pull_requests:
+                section_lines.append(
+                    "\n* {}".format(self._mark_down_link_to_pr(content))
+                )
+
+        return section_lines
+
+    def _mark_down_link_to_pr(self, pull_request):
+        if pull_request:
+            return " [[PR{}]({})]".format(pull_request.number, pull_request.html_url)
 
     def _update_release_content(self, release, content):
         """Merge existing and new release content."""
@@ -186,8 +211,10 @@ class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator):
                 if parser_content and not parser.replaced:
                     new_body.append(parser_content + "\r\n")
 
-            content = u"\r\n".join(new_body)
-
+        # add empty PRs section
+        if self.include_empty_pull_requests:
+            new_body.extend(self._render_empty_pr_section())
+        content = u"\r\n".join(new_body)
         return content
 
     def get_repo(self):

--- a/cumulusci/tasks/release_notes/generator.py
+++ b/cumulusci/tasks/release_notes/generator.py
@@ -150,16 +150,17 @@ class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator):
         section_lines = []
         if self.empty_change_notes:
             section_lines.append("\n# Pull requests with no release notes")
-            for content in self.empty_change_notes:
+            for change_note in self.empty_change_notes:
                 section_lines.append(
-                    "\n* {}".format(self._mark_down_link_to_pr(content))
+                    "\n* {}".format(self._mark_down_link_to_pr(change_note))
                 )
 
         return section_lines
 
-    def _mark_down_link_to_pr(self, pull_request):
-        if pull_request:
-            return "[[PR{}]({})]".format(pull_request.number, pull_request.html_url)
+    def _mark_down_link_to_pr(self, change_note):
+        return "{} [[PR{}]({})]".format(
+            change_note.title, change_note.number, change_note.html_url
+        )
 
     def _update_release_content(self, release, content):
         """Merge existing and new release content."""

--- a/cumulusci/tasks/release_notes/generator.py
+++ b/cumulusci/tasks/release_notes/generator.py
@@ -164,8 +164,8 @@ class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator):
 
     def _update_release_content(self, release, content):
         """Merge existing and new release content."""
+        new_body = []
         if release.body:
-            new_body = []
             current_parser = None
             is_start_line = False
             for parser in self.parsers:
@@ -212,7 +212,10 @@ class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator):
                 if parser_content and not parser.replaced:
                     new_body.append(parser_content + "\r\n")
 
-        # add empty PRs section
+        else:  # no release.body
+            new_body.append(content)
+
+        # add empty PR section
         if self.include_empty_pull_requests:
             new_body.extend(self._render_empty_pr_section())
         content = u"\r\n".join(new_body)

--- a/cumulusci/tasks/release_notes/generator.py
+++ b/cumulusci/tasks/release_notes/generator.py
@@ -12,7 +12,7 @@ from cumulusci.tasks.release_notes.provider import GithubChangeNotesProvider
 class BaseReleaseNotesGenerator(object):
     def __init__(self):
         self.change_notes = []
-        self.empty_pull_requests = []
+        self.empty_change_notes = []
         self.init_parsers()
         self.init_change_notes()
 
@@ -55,7 +55,7 @@ class BaseReleaseNotesGenerator(object):
                 line_added_by_parsers = line_added
 
         if not line_added_by_parsers:
-            self.empty_pull_requests.append(change_note)
+            self.empty_change_notes.append(change_note)
 
     def render(self):
         """ Returns the rendered release notes from all parsers as a string """
@@ -148,9 +148,9 @@ class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator):
 
     def _render_empty_pr_section(self):
         section_lines = []
-        if self.empty_pull_requests:
+        if self.empty_change_notes:
             section_lines.append("\n# Pull requests with no release notes")
-            for content in self.empty_pull_requests:
+            for content in self.empty_change_notes:
                 section_lines.append(
                     "\n* {}".format(self._mark_down_link_to_pr(content))
                 )

--- a/cumulusci/tasks/release_notes/generator.py
+++ b/cumulusci/tasks/release_notes/generator.py
@@ -159,7 +159,7 @@ class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator):
 
     def _mark_down_link_to_pr(self, pull_request):
         if pull_request:
-            return " [[PR{}]({})]".format(pull_request.number, pull_request.html_url)
+            return "[[PR{}]({})]".format(pull_request.number, pull_request.html_url)
 
     def _update_release_content(self, release, content):
         """Merge existing and new release content."""

--- a/cumulusci/tasks/release_notes/parser.py
+++ b/cumulusci/tasks/release_notes/parser.py
@@ -32,6 +32,8 @@ class ChangeNotesLinesParser(BaseChangeNotesParser):
         self.h2_title = None  # has value when in h2 section
 
     def parse(self, change_note):
+        """Returns True if a line was added to self._add_line was called, False otherwise"""
+        line_added = False
         change_note = self._process_change_note(change_note)
         for line in change_note.splitlines():
             line = self._process_line(line)
@@ -60,8 +62,10 @@ class ChangeNotesLinesParser(BaseChangeNotesParser):
                     continue
 
                 self._add_line(line)
+                line_added = True
 
         self._in_section = False
+        return line_added
 
     def _process_change_note(self, change_note):
         # subclasses override this if some manipulation is needed

--- a/cumulusci/tasks/release_notes/task.py
+++ b/cumulusci/tasks/release_notes/task.py
@@ -25,6 +25,9 @@ class GithubReleaseNotes(BaseGithubTask):
             )
         },
         "publish": {"description": "Publish to GitHub release if True (default=False)"},
+        "include_empty": {
+            "description": "If True, include links to PRs that have no release notes (default=False)"
+        },
     }
 
     def _run_task(self):
@@ -47,6 +50,7 @@ class GithubReleaseNotes(BaseGithubTask):
             process_bool_arg(self.options.get("link_pr", False)),
             process_bool_arg(self.options.get("publish", False)),
             self.get_repo().has_issues,
+            process_bool_arg(self.options.get("include_empty", False)),
         )
 
         release_notes = generator()

--- a/cumulusci/tasks/release_notes/tests/test_generator.py
+++ b/cumulusci/tasks/release_notes/tests/test_generator.py
@@ -131,7 +131,7 @@ class TestGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTestMixin):
             self.gh, github_info, PARSER_CONFIG, self.current_tag, self.last_tag
         )
         actual_link = generator._mark_down_link_to_pr(pr)
-        expected_link = "[[PR{}]({})]".format(pr.number, pr.html_url)
+        expected_link = "{} [[PR{}]({})]".format(pr.title, pr.number, pr.html_url)
         self.assertEquals(expected_link, actual_link)
 
 

--- a/cumulusci/tasks/release_notes/tests/test_generator.py
+++ b/cumulusci/tasks/release_notes/tests/test_generator.py
@@ -183,6 +183,12 @@ class TestGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTestMixin):
             split_content[3],
         )
 
+    def _create_generator(self):
+        generator = GithubReleaseNotesGenerator(
+            self.gh, self.github_info.copy(), PARSER_CONFIG, self.current_tag
+        )
+        return generator
+
 class TestPublishingGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTestMixin):
     def setUp(self):
         self.init_github()

--- a/cumulusci/tasks/release_notes/tests/test_generator.py
+++ b/cumulusci/tasks/release_notes/tests/test_generator.py
@@ -122,6 +122,18 @@ class TestGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTestMixin):
         self.assertEqual(generator.change_notes.current_tag, self.current_tag)
         self.assertEqual(generator.change_notes._last_tag, self.last_tag)
 
+    @responses.activate
+    def test_mark_down_link_to_pr(self):
+        pr = mock.Mock(number=1, html_url="http://pr", body="# Changes\r\n\r\nfoo")
+        github_info = self.github_info.copy()
+        self.mock_util.mock_get_repo()
+        generator = GithubReleaseNotesGenerator(
+            self.gh, github_info, PARSER_CONFIG, self.current_tag, self.last_tag
+        )
+        actual_link = generator._mark_down_link_to_pr(pr)
+        expected_link = "[[PR{}]({})]".format(pr.number, pr.html_url)
+        self.assertEquals(expected_link, actual_link)
+
 
 class TestPublishingGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTestMixin):
     def setUp(self):

--- a/cumulusci/tasks/release_notes/tests/test_parser.py
+++ b/cumulusci/tasks/release_notes/tests/test_parser.py
@@ -54,61 +54,70 @@ class TestChangeNotesLinesParser(unittest.TestCase):
     def test_parse_no_start_line(self):
         change_note = "foo\r\nbar\r\n"
         parser = ChangeNotesLinesParser(None, self.title)
-        parser.parse(change_note)
+        line_added = parser.parse(change_note)
         self.assertEqual(parser.content, [])
+        self.assertFalse(line_added)
 
     def test_parse_start_line_no_content(self):
         change_note = "# {}\r\n\r\n".format(self.title)
         parser = ChangeNotesLinesParser(None, self.title)
-        parser.parse(change_note)
+        line_added = parser.parse(change_note)
         self.assertEqual(parser.content, [])
+        self.assertFalse(line_added)
 
     def test_parse_start_line_no_end_line(self):
         change_note = "# {}\r\nfoo\r\nbar".format(self.title)
         parser = ChangeNotesLinesParser(None, self.title)
-        parser.parse(change_note)
+        line_added = parser.parse(change_note)
         self.assertEqual(parser.content, ["foo", "bar"])
+        self.assertEquals(True, line_added)
 
     def test_parse_start_line_end_at_header(self):
         change_note = "# {}\r\nfoo\r\n# Another Header\r\nbar".format(self.title)
         parser = ChangeNotesLinesParser(None, self.title)
-        parser.parse(change_note)
+        line_added = parser.parse(change_note)
         self.assertEqual(parser.content, ["foo"])
+        self.assertTrue(line_added)
 
     def test_parse_start_line_no_content_no_end_line(self):
         change_note = "# {}".format(self.title)
         parser = ChangeNotesLinesParser(None, self.title)
-        parser.parse(change_note)
+        line_added = parser.parse(change_note)
         self.assertEqual(parser.content, [])
+        self.assertFalse(line_added)
 
     def test_parse_multiple_start_lines_without_end_lines(self):
         change_note = "# {0}\r\nfoo\r\n# {0}\r\nbar\r\n".format(self.title)
         parser = ChangeNotesLinesParser(None, self.title)
-        parser.parse(change_note)
+        line_added = parser.parse(change_note)
         self.assertEqual(parser.content, ["foo", "bar"])
+        self.assertTrue(line_added)
 
     def test_parse_multiple_start_lines_with_end_lines(self):
         change_note = "# {0}\r\nfoo\r\n\r\n# {0}\r\nbar\r\n\r\nincluded\r\n\r\n# not included".format(
             self.title
         )
         parser = ChangeNotesLinesParser(None, self.title)
-        parser.parse(change_note)
+        line_added = parser.parse(change_note)
         self.assertEqual(parser.content, ["foo", "bar", "included"])
+        self.assertTrue(line_added)
 
     def test_parse_multi_level_indent(self):
         change_note = "# {0}\r\nfoo \r\n    bar  \r\n        baz \r\n".format(
             self.title
         )
         parser = ChangeNotesLinesParser(None, self.title)
-        parser.parse(change_note)
+        line_added = parser.parse(change_note)
         self.assertEqual(parser.content, ["foo", "    bar", "        baz"])
+        self.assertTrue(line_added)
 
     def test_parse_subheading(self):
         change_note = "# {0}\r\n## Subheading\r\nfoo".format(self.title)
         parser = ChangeNotesLinesParser(None, self.title)
-        parser.parse(change_note)
+        line_added = parser.parse(change_note)
         self.assertEqual([], parser.content)
         self.assertEqual({"Subheading": ["foo"]}, parser.h2)
+        self.assertTrue(line_added)
 
     def test_render_no_content(self):
         parser = ChangeNotesLinesParser(None, self.title)


### PR DESCRIPTION
# Changes
* The `github_release_notes` task now has an `include_empty` option to for the ability to include links to PRs that have no release notes.


