### PR TITLE
Set a shorter expiration for the JWT used for getting an app installation token

### DIFF
--- a/cumulusci/core/github.py
+++ b/cumulusci/core/github.py
@@ -45,7 +45,7 @@ def get_github_api_for_repo(keychain, owner, repo):
     if APP_ID and APP_KEY:
         installation = INSTALLATIONS.get((owner, repo))
         if installation is None:
-            gh.login_as_app(APP_KEY, APP_ID)
+            gh.login_as_app(APP_KEY, APP_ID, expire_in=120)
             try:
                 installation = gh.app_installation_for_repository(owner, repo)
             except github3.exceptions.NotFoundError:


### PR DESCRIPTION
The default gave us an occasional error
"AuthenticationFailed: 401 'Expiration time' claim ('exp') is too far in the future"
possibly due to rounding errors.


# Critical Changes

# Changes

# Issues Closed
