### PR TITLE
Bulk Data: sObject Updates

### DIFF
--- a/cumulusci/tasks/bulkdata/extract.py
+++ b/cumulusci/tasks/bulkdata/extract.py
@@ -193,7 +193,7 @@ class ExtractData(BulkJobTaskMixin, BaseSalesforceApiTask):
         writer_ids = unicodecsv.writer(f_ids)
         for row in unicodecsv.reader(data_file):
             writer_values.writerow(row[1:])
-            writer_ids.writerow([row[:1]])
+            writer_ids.writerow(row[:1])
         f_values.seek(0)
         f_ids.seek(0)
         return f_values, f_ids

--- a/cumulusci/tasks/bulkdata/generate.py
+++ b/cumulusci/tasks/bulkdata/generate.py
@@ -13,7 +13,7 @@ class GenerateMapping(BaseSalesforceApiTask):
     mapping suitable for extracting data in packaged and custom objects as well as
     customized standard objects.
 
-    Mappings must be serializable, and hence must resolvereference cycles - situations
+    Mappings must be serializable, and hence must resolve reference cycles - situations
     where Object A refers to B, and B also refers to A. Mapping generation will stop
     and request user input to resolve such cycles by identifying the correct load order.
     Alternately, specify the `ignore` option with the name of one of the
@@ -172,7 +172,7 @@ class GenerateMapping(BaseSalesforceApiTask):
                     # First, determine what manner of lookup we have here.
                     referenceTo = self.schema[obj][field]["referenceTo"]
 
-                    if len(referenceTo) > 1:  # Polymorphiy lookup
+                    if len(referenceTo) > 1:  # Polymorphic lookup
                         self.logger.warning(
                             "Field {}.{} is a polymorphic lookup, which is not supported".format(
                                 obj, field

--- a/cumulusci/tasks/bulkdata/generate.py
+++ b/cumulusci/tasks/bulkdata/generate.py
@@ -215,7 +215,7 @@ class GenerateMapping(BaseSalesforceApiTask):
 
             if not objs_without_deps:
                 self.logger.info(
-                    "CCI needs help to complete the mapping; the schema contains reference cycles and unresolved dependencies."
+                    "CumulusCI needs help to complete the mapping; the schema contains reference cycles and unresolved dependencies."
                 )
                 self.logger.info("Mapped objects: {}".format(", ".join(stack)))
                 self.logger.info("Remaining objects:")

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -146,10 +146,11 @@ class LoadData(BulkJobTaskMixin, BaseSalesforceApiTask):
             pkey = row[0]
             row = list(row[1:]) + statics
             row = [self._convert(value) for value in row]
-            if mapping["action"] == "update" and all([f is None for f in row]):
-                # Skip update rows that contain no values
-                total_rows -= 1
-                continue
+            if mapping["action"] == "update":
+                if len(row) > 1 and all([f is None for f in row[1:]]):
+                    # Skip update rows that contain no values
+                    total_rows -= 1
+                    continue
 
             writer.writerow(row)
             batch_ids.append(pkey)

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -86,7 +86,6 @@ class LoadData(BulkJobTaskMixin, BaseSalesforceApiTask):
             if self.after_steps[name]:
                 for after_name, after_step in self.after_steps[name].items():
                     self.logger.info("Running post-load step: {}".format(after_name))
-                    self.logger.info("{}".format(after_step))
                     result = self._load_mapping(after_step)
                     # FIXME: we need to pull the results and check for successes
                     if result != "Completed":
@@ -422,7 +421,7 @@ class LoadData(BulkJobTaskMixin, BaseSalesforceApiTask):
                     }
                     mapping["lookups"]["Id"] = {
                         "table": step["table"],
-                        "key_field": "sf_id",
+                        "key_field": step["fields"]["Id"],
                     }
                     for l in lookups:
                         mapping["lookups"][l] = lookups[l].copy()

--- a/cumulusci/tasks/bulkdata/tests/mapping_after.yml
+++ b/cumulusci/tasks/bulkdata/tests/mapping_after.yml
@@ -1,0 +1,32 @@
+Insert Accounts:
+    sf_object: Account
+    action: insert
+    table: accounts
+    fields:
+        Id: sf_id
+    lookups:
+        ParentId: 
+            after: Insert Accounts
+            table: accounts
+        Primary_Contact__c:
+            after: Insert Contacts
+            table: contacts
+Insert Contacts:
+    sf_object: Contact
+    action: insert
+    table: contacts
+    fields:
+        Id: sf_id
+    lookups:
+        ReportsToId:
+            after: Insert Contacts
+            table: contacts
+Insert Opportunities:
+    sf_object: Opportunity
+    action: insert
+    table: opportunities
+    fields:
+        Id: sf_id
+    lookups: 
+        AccountId:
+            table: accounts

--- a/cumulusci/tasks/bulkdata/tests/test_bulkdata.py
+++ b/cumulusci/tasks/bulkdata/tests/test_bulkdata.py
@@ -1103,7 +1103,7 @@ class TestExtractDataWithoutSFIds(unittest.TestCase):
         self.assertEqual("TestHousehold", household.name)
         self.assertEqual("HH_Account", household.record_type)
         contact = task.session.query(task.models["contacts"]).one()
-        self.assertEqual("foo", contact.household_id)
+        self.assertEqual("1", contact.household_id)
 
 
 class TestMappingGenerator(unittest.TestCase):

--- a/cumulusci/tasks/bulkdata/tests/test_bulkdata.py
+++ b/cumulusci/tasks/bulkdata/tests/test_bulkdata.py
@@ -463,7 +463,7 @@ class TestLoadDataWithSFIds(unittest.TestCase):
 
         task._query_db = mock.Mock()
         task._query_db.return_value.yield_per = mock.Mock(
-            return_value=[["001000000001", None]]
+            return_value=[["001000000001", "001000000002", None]]
         )
         task._start_batch = mock.Mock(return_value=(batch_file, writer, batch_ids))
         batches = list(task._get_batches(mapping))
@@ -1050,9 +1050,6 @@ class TestExtractDataWithSFIds(unittest.TestCase):
         )
         with self.assertRaises(BulkDataException):
             task()
-
-            # FIXME: skipping no-updates is not working
-            # FIXME: import fails if no fields besides Id
 
 
 class TestExtractDataWithoutSFIds(unittest.TestCase):

--- a/cumulusci/tasks/bulkdata/tests/test_bulkdata.py
+++ b/cumulusci/tasks/bulkdata/tests/test_bulkdata.py
@@ -304,9 +304,12 @@ class TestLoadDataWithSFIds(unittest.TestCase):
         task.mapping = OrderedDict()
         task.mapping["Insert Households"] = 1
         task.mapping["Insert Contacts"] = 2
+        households_steps = OrderedDict()
+        households_steps["four"] = 4
+        households_steps["five"] = 5
         task.after_steps = {
             "Insert Contacts": OrderedDict(three=3),
-            "Insert Households": OrderedDict(four=4, five=5),
+            "Insert Households": households_steps,
         }
         task._load_mapping = mock.Mock(return_value="Completed")
         task()
@@ -339,31 +342,31 @@ class TestLoadDataWithSFIds(unittest.TestCase):
             ],
             list(task.after_steps["Insert Contacts"].keys()),
         )
+        lookups = OrderedDict()
+        lookups["Id"] = {"table": "accounts", "key_field": "sf_id"}
+        lookups["Primary_Contact__c"] = OrderedDict({"table": "contacts"})
         self.assertEqual(
             {
                 "sf_object": "Account",
                 "action": "update",
                 "table": "accounts",
-                "lookups": OrderedDict(
-                    Id={"table": "accounts", "key_field": "sf_id"},
-                    Primary_Contact__c=OrderedDict({"table": "contacts"}),
-                ),
+                "lookups": lookups,
                 "fields": {},
             },
             task.after_steps["Insert Contacts"][
                 "Update Account Dependencies After Insert Contacts"
             ],
         )
+        lookups = OrderedDict()
+        lookups["Id"] = {"table": "contacts", "key_field": "sf_id"}
+        lookups["ReportsToId"] = OrderedDict({"table": "contacts"})
         self.assertEqual(
             {
                 "sf_object": "Contact",
                 "action": "update",
                 "table": "contacts",
                 "fields": {},
-                "lookups": OrderedDict(
-                    Id={"table": "contacts", "key_field": "sf_id"},
-                    ReportsToId=OrderedDict({"table": "contacts"}),
-                ),
+                "lookups": lookups,
             },
             task.after_steps["Insert Contacts"][
                 "Update Contact Dependencies After Insert Contacts"
@@ -373,16 +376,16 @@ class TestLoadDataWithSFIds(unittest.TestCase):
             ["Update Account Dependencies After Insert Accounts"],
             list(task.after_steps["Insert Accounts"].keys()),
         )
+        lookups = OrderedDict()
+        lookups["Id"] = {"table": "accounts", "key_field": "sf_id"}
+        lookups["ParentId"] = OrderedDict({"table": "accounts"})
         self.assertEqual(
             {
                 "sf_object": "Account",
                 "action": "update",
                 "table": "accounts",
                 "fields": {},
-                "lookups": OrderedDict(
-                    Id={"table": "accounts", "key_field": "sf_id"},
-                    ParentId=OrderedDict({"table": "accounts"}),
-                ),
+                "lookups": lookups,
             },
             task.after_steps["Insert Accounts"][
                 "Update Account Dependencies After Insert Accounts"
@@ -472,13 +475,17 @@ class TestLoadDataWithSFIds(unittest.TestCase):
             {"options": {"database_url": "sqlite://", "mapping": "test.yml"}},
         )
 
+        fields = OrderedDict()
+        fields["Id"] = "sf_id"
+        fields["Name"] = "Name"
+
         self.assertEqual(
             ["Name", "Industry", "RecordTypeId"],
             task._get_columns(
                 OrderedDict(
                     sf_object="Account",
                     action="insert",
-                    fields=OrderedDict(Id="sf_id", Name="Name"),
+                    fields=fields,
                     static=OrderedDict(Industry="Technology"),
                     record_type="Organization",
                 )
@@ -490,7 +497,7 @@ class TestLoadDataWithSFIds(unittest.TestCase):
                 OrderedDict(
                     sf_object="Account",
                     action="update",
-                    fields=OrderedDict(Id="sf_id", Name="Name"),
+                    fields=fields,
                     static=OrderedDict(Industry="Technology"),
                     record_type="Organization",
                 )


### PR DESCRIPTION
# Critical Changes

# Changes

 - `LoadData` now supports the key `action: update` to perform a Bulk API update job
 - `LoadData` now supports an `after: <step name>` on a lookup entry to defer updating that lookup until a dependent sObject step is completed.
 - `GenerateMapping` now handles self-lookups and reference cycles by generating `after:` markers wherever needed. 
- A small issue in `QueryData` affecting mappings using `oid_as_pk: False` has been fixed.

# Issues Closed
