### PR TITLE
Log the new step summary before running a flow

### DIFF
--- a/cumulusci/core/flowrunner.py
+++ b/cumulusci/core/flowrunner.py
@@ -350,8 +350,8 @@ class FlowCoordinator(object):
 
         self._rule(fill="-")
         self.logger.info("Steps:")
-        for step in self.steps:
-            self.logger.info(step.for_display)
+        for line in self.get_summary().splitlines():
+            self.logger.info(line)
         self._rule(fill="-", new_line=True)
 
         self.logger.info("Starting execution")

--- a/cumulusci/core/tests/test_flowrunner.py
+++ b/cumulusci/core/tests/test_flowrunner.py
@@ -147,7 +147,7 @@ class SimpleTestFlowCoordinator(AbstractFlowCoordinatorTest, unittest.TestCase):
             + "\n    2) flow: nested_flow"
             + "\n        1) task: pass_name"
         )
-        self.assertEquals(expected_output, actual_output)
+        self.assertEqual(expected_output, actual_output)
 
     def test_init__options(self):
         """ A flow can accept task options and pass them to the task. """


### PR DESCRIPTION
Show the new tree summary of flow steps at the beginning of running a flow. This avoids showing the step_num which is meant to be an internal representation.

# Critical Changes

# Changes

# Issues Closed
