### PR TITLE
Feature/robot locators 47

### DIFF
--- a/cumulusci/core/tests/test_salesforce_locators.py
+++ b/cumulusci/core/tests/test_salesforce_locators.py
@@ -37,7 +37,7 @@ class TestLocators(unittest.TestCase):
         # we expect the library to still be instantiated, but with the latest
         # version of the locators.
         sf = Salesforce()
-        expected = "cumulusci.robotframework.locators_46"
+        expected = "cumulusci.robotframework.locators_47"
         actual = sf.locators_module.__name__
         message = "expected to load '{}', actually loaded '{}'".format(expected, actual)
         self.assertEqual(expected, actual, message)

--- a/cumulusci/robotframework/locators_47.py
+++ b/cumulusci/robotframework/locators_47.py
@@ -1,0 +1,5 @@
+from cumulusci.robotframework import locators_46
+
+lex_locators = locators_46.lex_locators.copy()
+
+# At the moment, there are no changes to the locators.


### PR DESCRIPTION
This adds a locators file for Winter '20. There are no changes to the locators, but our code expects the file to exist. I want a better long term solution, but this simple fix seemed best in order to get a new release cut before we go to the offsite summit.

I chose not to consolidate locators_45.py and locators_46.py at this time just to make the smallest change necessary to allow people to test on the prerelease. I'll clean those files up when I can come up with a better long term solution.

# Critical Changes

# Changes

# Issues Closed
