### PR TITLE
Fixes for homebrew formula

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ rst2ansi==0.1.5
 salesforce-bulk==2.1.0
 sarge==0.1.5.post0
 selenium==3.141.0
-simple-salesforce==0.74.3
+simple-salesforce==0.74.2  # pyup: <0.74.3
 six==1.12.0
 SQLAlchemy==1.3.6
 unicodecsv==0.14.1

--- a/utility/build-homebrew.sh
+++ b/utility/build-homebrew.sh
@@ -50,19 +50,18 @@ class Cumulusci < Formula
 $(cat "$RES_FILE")
 
   def install
-    xy = Language::Python.major_minor_version "python3"
-    site_packages = libexec/"lib/python#{xy}/site-packages"
-    ENV.prepend_create_path "PYTHONPATH", site_packages
-
-    deps = resources.map(&:name).to_set
-    deps.each do |r|
-      resource(r).stage do
-        system "python3", *Language::Python.setup_install_args(libexec)
-      end
+    venv = virtualenv_create(libexec, "python3")
+    resource("entrypoints").stage do
+      # Without removing this file, `pip` will ignore the `setup.py` file and
+      # attempt to download the [`flit`](https://github.com/takluyver/flit)
+      # build system.
+      rm_f "pyproject.toml"
+      venv.pip_install Pathname.pwd
     end
-
-    bin.install Dir["#{libexec}/bin/cci"]
-    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+    (resources.map(&:name).to_set - ["entrypoints"]).each do |r|
+      venv.pip_install resource(r)
+    end
+    venv.pip_install_and_link buildpath
   end
 
   test do


### PR DESCRIPTION
- Use an older version of simple-salesforce because the newest one doesn't have an sdist published on PyPI
- Change the install stanza that we generate for the homebrew formula to use pip as is currently recommended in docs, but with a workaround to avoid breaking on the `entrypoints` package

I've tested installation of the formula locally.

# Critical Changes

# Changes

# Issues Closed
