### PR TITLE
Expand `cci version` info

### DIFF
--- a/cumulusci/__init__.py
+++ b/cumulusci/__init__.py
@@ -2,5 +2,5 @@ from __future__ import unicode_literals
 import os
 
 __import__("pkg_resources").declare_namespace("cumulusci")
-__version__ = "2.5.4"
+__version__ = "2.5.5"
 __location__ = os.path.dirname(os.path.realpath(__file__))

--- a/cumulusci/__init__.py
+++ b/cumulusci/__init__.py
@@ -2,5 +2,5 @@ from __future__ import unicode_literals
 import os
 
 __import__("pkg_resources").declare_namespace("cumulusci")
-__version__ = "2.5.5"
+__version__ = "2.5.4"
 __location__ = os.path.dirname(os.path.realpath(__file__))

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -248,7 +248,36 @@ def main():
 
 @click.command(name="version", help="Print the current version of CumulusCI")
 def version():
-    click.echo(cumulusci.__version__)
+    click.echo("CumulusCI version: ", nl=False)
+    click.echo(click.style(cumulusci.__version__, bold=True), nl=False)
+    click.echo(" ({})".format(sys.argv[0]))
+    click.echo("Python version: {}".format(sys.version.split()[0]), nl=False)
+    click.echo(" ({})".format(sys.executable))
+
+    current_version = get_installed_version()
+    latest_version = get_latest_final_version()
+    if latest_version > current_version:
+        click.echo()
+        click.echo(
+            "There is a newer version of CumulusCI available ({}).".format(
+                str(latest_version)
+            )
+        )
+        click.echo("To upgrade, run `{}`".format(get_cci_upgrade_command()))
+        click.echo(
+            "Release notes: https://github.com/SFDO-Tooling/CumulusCI/releases/tag/v{}".format(
+                str(latest_version)
+            )
+        )
+
+    if sys.version_info.major == 2:
+        click.echo()
+        click.echo("WARNING: You are running CumulusCI using Python 2.")
+        click.echo("Soon CumulusCI will only support Python 3.")
+        click.echo("To reinstall CumulusCI on Python 3, follow these instructions:")
+        click.echo("https://cumulusci.readthedocs.io/en/latest/tutorial.html")
+
+    click.echo()
 
 
 @click.command(name="shell", help="Drop into a Python shell")

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -246,7 +246,7 @@ def main():
     init_logger(log_requests=log_requests)
 
 
-@click.command(name="version", help="Print the current version of CumulusCI")
+@main.command(name="version", help="Print the current version of CumulusCI")
 def version():
     click.echo("CumulusCI version: ", nl=False)
     click.echo(click.style(cumulusci.__version__, bold=True), nl=False)
@@ -282,7 +282,7 @@ def version():
     click.echo()
 
 
-@click.command(name="shell", help="Drop into a Python shell")
+@main.command(name="shell", help="Drop into a Python shell")
 def shell():
     try:
         config = load_config(load_project_config=True, load_keychain=True)

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -239,8 +239,9 @@ def main():
     This runs as the first step in processing any CLI command.
     """
     # Avoid checking for updates if we've been asked to output JSON,
-    # because we don't want to pollute the output
-    if "--json" not in sys.argv:
+    # or if we're going to check anyway as part of the `version` command.
+    is_version_command = len(sys.argv) > 1 and sys.argv[1] == "version"
+    if "--json" not in sys.argv and not is_version_command:
         check_latest_version()
     log_requests = "--debug" in sys.argv
     init_logger(log_requests=log_requests)
@@ -254,10 +255,10 @@ def version():
     click.echo("Python version: {}".format(sys.version.split()[0]), nl=False)
     click.echo(" ({})".format(sys.executable))
 
+    click.echo()
     current_version = get_installed_version()
     latest_version = get_latest_final_version()
     if latest_version > current_version:
-        click.echo()
         click.echo(
             "There is a newer version of CumulusCI available ({}).".format(
                 str(latest_version)
@@ -269,13 +270,15 @@ def version():
                 str(latest_version)
             )
         )
+    else:
+        click.echo("You have the latest version of CumulusCI.")
 
     if sys.version_info.major == 2:
         click.echo()
         click.echo("WARNING: You are running CumulusCI using Python 2.")
         click.echo("Soon CumulusCI will only support Python 3.")
         click.echo("To reinstall CumulusCI on Python 3, follow these instructions:")
-        click.echo("https://cumulusci.readthedocs.io/en/latest/tutorial.html")
+        click.echo("https://cumulusci.readthedocs.io/en/latest/install.html")
 
     click.echo()
 

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -191,10 +191,14 @@ class TestCCI(unittest.TestCase):
         check_latest_version.assert_called_once()
         init_logger.assert_called_once()
 
+    @mock.patch(
+        "cumulusci.cli.cci.get_latest_final_version",
+        mock.Mock(return_value=pkg_resources.parse_version("100")),
+    )
     @mock.patch("click.echo")
     def test_version(self, echo):
         run_click_command(cci.version)
-        echo.assert_called_once_with(cumulusci.__version__)
+        assert cumulusci.__version__ in echo.call_args_list[1][0][0]
 
     @mock.patch("code.interact")
     def test_shell(self, interact):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Contents:
    :maxdepth: 2
 
    why_cumulusci
+   install
    tutorial
    features
    robotframework

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,0 +1,71 @@
+..  _`installing CumulusCI`:
+
+--------------------
+Installing CumulusCI
+--------------------
+
+macOS/Linux
+^^^^^^^^^^^
+
+On macOS and Linux, the easiest way to install CumulusCI is using `homebrew <https://docs.brew.sh/>`_ :
+
+.. code:: console
+
+   $ brew tap SFDO-Tooling/homebrew-sfdo
+   $ brew install cumulusci
+
+Windows
+^^^^^^^
+
+Python
+~~~~~~
+
+First, install Python 3: https://www.python.org/downloads/windows/
+
+In the installer, be sure to check the "Add Python to PATH" checkbox.
+
+pipx
+~~~~
+
+On Windows 10, the easiest way to install CumulusCI is using
+`pipx <https://github.com/pipxproject/pipx>`_. In a new command prompt, run:
+
+.. code:: powershell
+
+   python -m pip install --user pipx
+
+Add the following paths to your ``PATH`` environment variable:
+
+1. ``%USERPROFILE%\AppData\Roaming\Python\Python37\Scripts``
+2. ``%USERPROFILE%\.local\bin``
+
+.. note::
+
+   From the `Python
+   documentation <https://docs.python.org/3/using/windows.html#excursus-setting-environment-variables>`_:
+   To permanently modify the default environment variables, click Start and
+   search for ‘edit environment variables’, or open System properties,
+   Advanced system settings and click the Environment Variables button. In
+   this dialog, you can add or modify User and System variables. To change
+   System variables, you need non-restricted access to your machine (i.e.
+   Administrator rights)
+
+In a new command prompt, run: ``pipx install cumulusci``
+
+.. code:: powershell
+
+   pipx install cumulusci
+
+Verify CumulusCI
+^^^^^^^^^^^^^^^^
+
+In a new terminal window or command prompt you can verify that CumulusCI
+is installed correctly by running ``cci version``:
+
+.. code:: console
+
+   $ cci version
+   Checking the version!
+   2.5.5
+
+Still need help? Search issues on CumulusCI GitHub https://github.com/SFDO-Tooling/CumulusCI/issues

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -7,74 +7,7 @@ This tutorial is for macOS. Linux and Windows are not yet officially supported b
 Part 1: Installing CumulusCI
 ============================
 
-Install CumulusCI
------------------
-
-macOS/Linux
-^^^^^^^^^^^
-
-On macOS and Linux, the easiest way to install CumulusCI is using `homebrew <https://docs.brew.sh/>`_ :
-
-.. code:: console
-
-   $ brew tap SFDO-Tooling/homebrew-sfdo
-   $ brew install cumulusci
-
-Windows
-^^^^^^^
-
-Python
-~~~~~~
-
-First, install Python 3: https://www.python.org/downloads/windows/
-
-In the installer, be sure to check the "Add Python to PATH" checkbox.
-
-pipx
-~~~~
-
-On Windows 10, the easiest way to install CumulusCI is using
-`pipx <https://github.com/pipxproject/pipx>`_. In a new command prompt, run:
-
-.. code:: powershell
-
-   python -m pip install --user pipx
-
-Add the following paths to your ``PATH`` environment variable:
-
-1. ``%USERPROFILE%\AppData\Roaming\Python\Python37\Scripts``
-2. ``%USERPROFILE%\.local\bin``
-
-.. note::
-
-   From the `Python
-   documentation <https://docs.python.org/3/using/windows.html#excursus-setting-environment-variables>`_:
-   To permanently modify the default environment variables, click Start and
-   search for ‘edit environment variables’, or open System properties,
-   Advanced system settings and click the Environment Variables button. In
-   this dialog, you can add or modify User and System variables. To change
-   System variables, you need non-restricted access to your machine (i.e.
-   Administrator rights)
-
-In a new command prompt, run: ``pipx install cumulusci``
-
-.. code:: powershell
-
-   pipx install cumulusci
-
-Verify CumulusCI
-^^^^^^^^^^^^^^^^
-
-In a new terminal window or command prompt you can verify that CumulusCI
-is installed correctly by running ``cci version``:
-
-.. code:: console
-
-   $ cci version
-   Checking the version!
-   2.5.5
-
-Still need help? Search issues on CumulusCI GitHub https://github.com/SFDO-Tooling/CumulusCI/issues
+Before starting the tutorial, make sure you've completed :ref:`installing CumulusCI`.
 
 Part 2: Project Configuration
 =============================


### PR DESCRIPTION
I also moved the install docs to their own page so it's easier to link to them without including the whole tutorial.

# Critical Changes

# Changes
* Add additional info to the `cci version` command, including the Python version, an upgrade check, and a warning on Python 2.

# Issues Closed
