### PR TITLE
Automatically retry UNABLE_TO_LOCK_ROW Apex test failures

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -287,6 +287,11 @@ tasks:
         description: Runs all apex tests
         class_path: cumulusci.tasks.apex.testrunner.RunApexTests
         group: Salesforce
+        options:
+            retry_errors:
+                - "unable to obtain exclusive access to this record"
+                - "UNABLE_TO_LOCK_ROW"
+
     uninstall_managed:
         description: Uninstalls the managed version of the package
         class_path: cumulusci.tasks.salesforce.UninstallPackage

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -291,11 +291,6 @@ tasks:
         description: Runs all apex tests
         class_path: cumulusci.tasks.apex.testrunner.RunApexTests
         group: Salesforce
-        options:
-            retry_errors:
-                - "unable to obtain exclusive access to this record"
-                - "UNABLE_TO_LOCK_ROW"
-
     uninstall_managed:
         description: Uninstalls the managed version of the package
         class_path: cumulusci.tasks.salesforce.UninstallPackage

--- a/cumulusci/tasks/apex/testrunner.py
+++ b/cumulusci/tasks/apex/testrunner.py
@@ -119,13 +119,13 @@ class RunApexTests(BaseSalesforceApiTask):
         "json_output": {
             "description": "File name for json output.  Defaults to test_results.json"
         },
-        "retry_errors": {
+        "retry_failures": {
             "description": "A list of regular expression patterns to match against "
             "test failures. If failures match, the failing tests are retried in "
             "serial mode."
         },
         "retry_always": {
-            "description": "By default, all failures must match retry_errors to perform "
+            "description": "By default, all failures must match retry_failures to perform "
             "a retry. Set retry_always to True to retry all failed tests if any failure matches."
         },
     }
@@ -158,11 +158,11 @@ class RunApexTests(BaseSalesforceApiTask):
 
         self.options["managed"] = process_bool_arg(self.options.get("managed", False))
 
-        self.options["retry_errors"] = process_list_arg(
-            self.options.get("retry_errors", [])
+        self.options["retry_failures"] = process_list_arg(
+            self.options.get("retry_failures", [])
         )
         compiled_res = []
-        for regex in self.options["retry_errors"]:
+        for regex in self.options["retry_failures"]:
             try:
                 compiled_res.append(re.compile(regex))
             except re.error as e:
@@ -171,7 +171,7 @@ class RunApexTests(BaseSalesforceApiTask):
                         regex, e
                     )
                 )
-        self.options["retry_errors"] = compiled_res
+        self.options["retry_failures"] = compiled_res
         self.options["retry_always"] = process_bool_arg(
             self.options.get("retry_always", False)
         )
@@ -236,7 +236,7 @@ class RunApexTests(BaseSalesforceApiTask):
             [
                 reg.search(test_result["Message"] or "")
                 or reg.search(test_result["StackTrace"] or "")
-                for reg in self.options["retry_errors"]
+                for reg in self.options["retry_failures"]
             ]
         )
 

--- a/cumulusci/tasks/apex/testrunner.py
+++ b/cumulusci/tasks/apex/testrunner.py
@@ -184,7 +184,7 @@ class RunApexTests(BaseSalesforceApiTask):
         self.job_id = None
         self.results_by_class_name = {}
         self.result = None
-        self.retries = None
+        self.retry_details = None
 
     def _get_namespace_filter(self):
         if self.options["managed"]:

--- a/cumulusci/tasks/apex/tests/test_apex_tasks.py
+++ b/cumulusci/tasks/apex/tests/test_apex_tasks.py
@@ -229,7 +229,7 @@ class TestRunApexTests(unittest.TestCase):
             "junit_output": "results_junit.xml",
             "poll_interval": 1,
             "test_name_match": "%_TEST",
-            "retry_errors": ["UNABLE_TO_LOCK_ROW"],
+            "retry_failures": ["UNABLE_TO_LOCK_ROW"],
         }
         task = RunApexTests(self.project_config, task_config, self.org_config)
         task()
@@ -250,7 +250,7 @@ class TestRunApexTests(unittest.TestCase):
             "junit_output": "results_junit.xml",
             "poll_interval": 1,
             "test_name_match": "%_TEST",
-            "retry_errors": ["UNABLE_TO_LOCK_ROW"],
+            "retry_failures": ["UNABLE_TO_LOCK_ROW"],
         }
         task = RunApexTests(self.project_config, task_config, self.org_config)
         with self.assertRaises(ApexTestException):
@@ -262,7 +262,7 @@ class TestRunApexTests(unittest.TestCase):
             "junit_output": "results_junit.xml",
             "poll_interval": 1,
             "test_name_match": "%_TEST",
-            "retry_errors": [
+            "retry_failures": [
                 "UNABLE_TO_LOCK_ROW",
                 "unable to obtain exclusive access to this record",
             ],
@@ -313,13 +313,13 @@ class TestRunApexTests(unittest.TestCase):
             "junit_output": "results_junit.xml",
             "poll_interval": 1,
             "test_name_match": "%_TEST",
-            "retry_errors": ["UNABLE_TO_LOCK_ROW"],
+            "retry_failures": ["UNABLE_TO_LOCK_ROW"],
         }
         task = RunApexTests(self.project_config, task_config, self.org_config)
         task._init_options(task_config.config["options"])
 
         self.assertIsNotNone(
-            task.options["retry_errors"][0].search("UNABLE_TO_LOCK_ROW: test failed")
+            task.options["retry_failures"][0].search("UNABLE_TO_LOCK_ROW: test failed")
         )
 
     def test_init_options__bad_regexes(self):
@@ -328,7 +328,7 @@ class TestRunApexTests(unittest.TestCase):
             "junit_output": "results_junit.xml",
             "poll_interval": 1,
             "test_name_match": "%_TEST",
-            "retry_errors": ["("],
+            "retry_failures": ["("],
         }
         with self.assertRaises(TaskOptionsError):
             task = RunApexTests(self.project_config, task_config, self.org_config)

--- a/cumulusci/tasks/apex/tests/test_apex_tasks.py
+++ b/cumulusci/tasks/apex/tests/test_apex_tasks.py
@@ -3,7 +3,6 @@ from future import standard_library
 standard_library.install_aliases()
 import http.client
 import os
-import re
 import shutil
 import tempfile
 import unittest
@@ -319,7 +318,9 @@ class TestRunApexTests(unittest.TestCase):
         task = RunApexTests(self.project_config, task_config, self.org_config)
         task._init_options(task_config.config["options"])
 
-        self.assertIsInstance(task.options["retry_errors"][0], re.Pattern)
+        self.assertIsNotNone(
+            task.options["retry_errors"][0].search("UNABLE_TO_LOCK_ROW: test failed")
+        )
 
     def test_init_options__bad_regexes(self):
         task_config = TaskConfig()

--- a/cumulusci/tasks/apex/tests/test_apex_tasks.py
+++ b/cumulusci/tasks/apex/tests/test_apex_tasks.py
@@ -216,20 +216,6 @@ class TestRunApexTests(unittest.TestCase):
             task()
 
     @responses.activate
-    def test_init_options__regexes(self):
-        task_config = TaskConfig()
-        task_config.config["options"] = {
-            "junit_output": "results_junit.xml",
-            "poll_interval": 1,
-            "test_name_match": "%_TEST",
-            "retry_errors": ["UNABLE_TO_LOCK_ROW"],
-        }
-        task = RunApexTests(self.project_config, task_config, self.org_config)
-        task._init_options(task_config.config["options"])
-
-        self.assertIsInstance(task.options["retry_errors"][0], re.Pattern)
-
-    @responses.activate
     def test_run_task__retry_tests(self):
         self._mock_apex_class_query()
         self._mock_run_tests()
@@ -321,6 +307,31 @@ class TestRunApexTests(unittest.TestCase):
                 }
             )
         )
+
+    def test_init_options__regexes(self):
+        task_config = TaskConfig()
+        task_config.config["options"] = {
+            "junit_output": "results_junit.xml",
+            "poll_interval": 1,
+            "test_name_match": "%_TEST",
+            "retry_errors": ["UNABLE_TO_LOCK_ROW"],
+        }
+        task = RunApexTests(self.project_config, task_config, self.org_config)
+        task._init_options(task_config.config["options"])
+
+        self.assertIsInstance(task.options["retry_errors"][0], re.Pattern)
+
+    def test_init_options__bad_regexes(self):
+        task_config = TaskConfig()
+        task_config.config["options"] = {
+            "junit_output": "results_junit.xml",
+            "poll_interval": 1,
+            "test_name_match": "%_TEST",
+            "retry_errors": ["("],
+        }
+        with self.assertRaises(TaskOptionsError):
+            task = RunApexTests(self.project_config, task_config, self.org_config)
+            task._init_options(task_config.config["options"])
 
     def test_get_namespace_filter__managed(self):
         task_config = TaskConfig({"options": {"managed": True, "namespace": "testns"}})


### PR DESCRIPTION
To test this PR against an org, make sure it is generated _without_ the org setting `DisableParallelApexTesting`.

# Critical Changes

# Changes

- The `run_tests` task now supports a `retry_errors` parameter. When all unit test failures' message or stack trace match one of the regular expressions specified there, the failing tests will be retried serially. By default, this will happen only when all unit test failures are due to row locking errors.
- Existing retry options have been removed from `run_tests`; these options controlled retrying result queries.

# Issues Closed
