### PR TITLE
Fix a bug in printing the flow summary when there are sub-steps.

### DIFF
--- a/cumulusci/core/flowrunner.py
+++ b/cumulusci/core/flowrunner.py
@@ -302,6 +302,9 @@ class FlowCoordinator(object):
         for step in self.steps:
             parts = step.path.split(".")
             steps = str(step.step_num).split("/")
+            if len(parts) > len(steps):
+                # Sub-step generated during freeze process; skip it
+                continue
             task_name = parts.pop()
 
             i = -1


### PR DESCRIPTION
Freezing a flow to publish to MetaDeploy can generate sub-steps where one step from the original flow is split into multiple steps.
For example update_dependencies gets split into one sub-step for each package.
The sub-steps get an extra number like ".1" added to the end of the step path, which breaks the flow summary code.
This is a quick fix to just skip trying to display the sub-steps.


# Critical Changes

# Changes

# Issues Closed
