### PR TITLE
Updates to persistent org connections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
             ./sfdx/install
             cd CumulusCI-Test
             echo $SFDX_HUB_KEY_BASE64 | base64 --decode > sfdx.key
-            echo "export SFDX_HUB_KEY=$(echo $SFDX_HUB_KEY_BASE64 | base64 --decode)" >> $BASH_ENV
+            echo 'export SFDX_HUB_KEY="$(echo $SFDX_HUB_KEY_BASE64 | base64 --decode)"' >> $BASH_ENV
             sfdx force:auth:jwt:grant --clientid $SFDX_CLIENT_ID --jwtkeyfile sfdx.key --username $SFDX_HUB_USERNAME --setdefaultdevhubusername -a hub
       - run:
           name: Run ci_feature flow

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
       - run:
           name: Create scratch org
           command: |
-            echo $SFDX_HUB_KEY | base64 --decode > sfdx.key
+            echo $SFDX_HUB_KEY_BASE64 | base64 --decode > sfdx.key
             sfdx force:auth:jwt:grant --clientid $SFDX_CLIENT_ID --jwtkeyfile sfdx.key --username $SFDX_HUB_USERNAME --setdefaultdevhubusername -a hub
             venv/bin/cci org info dev > org_info.txt
             venv/bin/cci org default dev
@@ -164,7 +164,8 @@ jobs:
             wget -qO- https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz | tar xJ -C sfdx --strip-components 1
             ./sfdx/install
             cd CumulusCI-Test
-            echo $SFDX_HUB_KEY | base64 --decode > sfdx.key
+            echo $SFDX_HUB_KEY_BASE64 | base64 --decode > sfdx.key
+            echo "export SFDX_HUB_KEY=$(echo $SFDX_HUB_KEY_BASE64 | base64 --decode)" >> $BASH_ENV
             sfdx force:auth:jwt:grant --clientid $SFDX_CLIENT_ID --jwtkeyfile sfdx.key --username $SFDX_HUB_USERNAME --setdefaultdevhubusername -a hub
       - run:
           name: Run ci_feature flow

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
           name: Create scratch org
           command: |
             echo $SFDX_HUB_KEY | base64 --decode > sfdx.key
-            sfdx force:auth:jwt:grant --clientid $SFDX_CLIENT_KEY --jwtkeyfile sfdx.key --username $SFDX_HUB_USERNAME --setdefaultdevhubusername -a hub
+            sfdx force:auth:jwt:grant --clientid $SFDX_CLIENT_ID --jwtkeyfile sfdx.key --username $SFDX_HUB_USERNAME --setdefaultdevhubusername -a hub
             venv/bin/cci org info dev > org_info.txt
             venv/bin/cci org default dev
       - run:
@@ -165,7 +165,7 @@ jobs:
             ./sfdx/install
             cd CumulusCI-Test
             echo $SFDX_HUB_KEY | base64 --decode > sfdx.key
-            sfdx force:auth:jwt:grant --clientid $SFDX_CLIENT_KEY --jwtkeyfile sfdx.key --username $SFDX_HUB_USERNAME --setdefaultdevhubusername -a hub
+            sfdx force:auth:jwt:grant --clientid $SFDX_CLIENT_ID --jwtkeyfile sfdx.key --username $SFDX_HUB_USERNAME --setdefaultdevhubusername -a hub
       - run:
           name: Run ci_feature flow
           command: |

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -824,15 +824,7 @@ def org_browser(config, org_name):
 def org_connect(config, org_name, sandbox, login_url, default, global_org):
     config.check_org_overwrite(org_name)
 
-    try:
-        connected_app = config.keychain.get_service("connected_app")
-    except ServiceNotConfigured:
-        raise ServiceNotConfigured(
-            "Connected App is required but not configured. "
-            + "Configure the Connected App service:\n"
-            + "http://cumulusci.readthedocs.io/en/latest/"
-            + "tutorial.html#configuring-the-project-s-connected-app"
-        )
+    connected_app = config.keychain.get_service("connected_app")
     if sandbox:
         login_url = "https://test.salesforce.com"
 

--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -9,8 +9,6 @@ from cumulusci.core.exceptions import SalesforceCredentialsException
 from cumulusci.oauth.salesforce import SalesforceOAuth2
 from cumulusci.oauth.salesforce import jwt_session
 
-SFDX_CLIENT_ID = os.environ.get("SFDX_CLIENT_ID")
-SFDX_HUB_KEY = os.environ.get("SFDX_HUB_KEY")
 
 class OrgConfig(BaseConfig):
     """ Salesforce org configuration (i.e. org credentials) """
@@ -24,8 +22,14 @@ class OrgConfig(BaseConfig):
         super(OrgConfig, self).__init__(config)
 
     def refresh_oauth_token(self, keychain, connected_app=None):
+        SFDX_CLIENT_ID = os.environ.get("SFDX_CLIENT_ID")
+        SFDX_HUB_KEY = os.environ.get("SFDX_HUB_KEY")
         if SFDX_CLIENT_ID and SFDX_HUB_KEY:
-            login_url = "https://test.salesforce.com" if self.is_sandbox else "https://login.salesforce.com"
+            login_url = (
+                "https://test.salesforce.com"
+                if self.is_sandbox
+                else "https://login.salesforce.com"
+            )
             info = jwt_session(SFDX_CLIENT_ID, SFDX_HUB_KEY, self.username, login_url)
         else:
             info = self._refresh_token(keychain, connected_app)

--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -1,11 +1,16 @@
 from __future__ import unicode_literals
 
+import os
+
 import requests
 
 from cumulusci.core.config import BaseConfig
 from cumulusci.core.exceptions import SalesforceCredentialsException
 from cumulusci.oauth.salesforce import SalesforceOAuth2
+from cumulusci.oauth.salesforce import jwt_session
 
+SFDX_CLIENT_ID = os.environ.get("SFDX_CLIENT_ID")
+SFDX_HUB_KEY = os.environ.get("SFDX_HUB_KEY")
 
 class OrgConfig(BaseConfig):
     """ Salesforce org configuration (i.e. org credentials) """
@@ -19,6 +24,17 @@ class OrgConfig(BaseConfig):
         super(OrgConfig, self).__init__(config)
 
     def refresh_oauth_token(self, keychain, connected_app=None):
+        if SFDX_CLIENT_ID and SFDX_HUB_KEY:
+            login_url = "https://test.salesforce.com" if self.is_sandbox else "https://login.salesforce.com"
+            info = jwt_session(SFDX_CLIENT_ID, SFDX_HUB_KEY, self.username, login_url)
+        else:
+            info = self._refresh_token(keychain, connected_app)
+        if info != self.config:
+            self.config.update(info)
+        self._load_userinfo()
+        self._load_orginfo()
+
+    def _refresh_token(self, keychain, connected_app):
         if keychain:  # it might be none'd and caller adds connected_app
             connected_app = keychain.get_service("connected_app")
         if connected_app is None:
@@ -42,11 +58,7 @@ class OrgConfig(BaseConfig):
             raise SalesforceCredentialsException(
                 "Error refreshing OAuth token: {}".format(resp.text)
             )
-        info = resp.json()
-        if info != self.config:
-            self.config.update(info)
-        self._load_userinfo()
-        self._load_orginfo()
+        return resp.json()
 
     @property
     def lightning_base_url(self):

--- a/cumulusci/core/keychain/BaseProjectKeychain.py
+++ b/cumulusci/core/keychain/BaseProjectKeychain.py
@@ -3,12 +3,20 @@ from __future__ import print_function
 import sarge
 
 from cumulusci.core.config import BaseConfig
+from cumulusci.core.config import ConnectedAppOAuthConfig
 from cumulusci.core.config import ScratchOrgConfig
 from cumulusci.core.config import ServiceConfig
 from cumulusci.core.exceptions import OrgNotFound
 from cumulusci.core.exceptions import ServiceNotConfigured
 from cumulusci.core.exceptions import ServiceNotValid
 from cumulusci.core.sfdx import sfdx
+
+
+DEFAULT_CONNECTED_APP = ConnectedAppOAuthConfig({
+    "client_id": "3MVG9i1HRpGLXp.or6OVlWVWyn8DXi9xueKNM4npq_AWh.yqswojK9sE5WY7f.biP0w7bNJIENfXc7JMDZGO1",
+    "client_secret": None,
+    "callback_url": "http://localhost:8080/callback",
+})
 
 
 class BaseProjectKeychain(BaseConfig):
@@ -215,6 +223,8 @@ class BaseProjectKeychain(BaseConfig):
         if not self.project_config.services or name not in self.project_config.services:
             self._raise_service_not_valid(name)
         if name not in self.services:
+            if name == "connected_app":
+                return DEFAULT_CONNECTED_APP
             self._raise_service_not_configured(name)
 
         return self._get_service(name)

--- a/cumulusci/core/keychain/BaseProjectKeychain.py
+++ b/cumulusci/core/keychain/BaseProjectKeychain.py
@@ -12,11 +12,13 @@ from cumulusci.core.exceptions import ServiceNotValid
 from cumulusci.core.sfdx import sfdx
 
 
-DEFAULT_CONNECTED_APP = ConnectedAppOAuthConfig({
-    "client_id": "3MVG9i1HRpGLXp.or6OVlWVWyn8DXi9xueKNM4npq_AWh.yqswojK9sE5WY7f.biP0w7bNJIENfXc7JMDZGO1",
-    "client_secret": None,
-    "callback_url": "http://localhost:8080/callback",
-})
+DEFAULT_CONNECTED_APP = ConnectedAppOAuthConfig(
+    {
+        "client_id": "3MVG9i1HRpGLXp.or6OVlWVWyn8DXi9xueKNM4npq_AWh.yqswojK9sE5WY7f.biP0w7bNJIENfXc7JMDZGO1",
+        "client_secret": None,
+        "callback_url": "http://localhost:8080/callback",
+    }
+)
 
 
 class BaseProjectKeychain(BaseConfig):

--- a/cumulusci/core/keychain/__init__.py
+++ b/cumulusci/core/keychain/__init__.py
@@ -2,6 +2,7 @@
 
 # inherit from BaseConfig
 from cumulusci.core.keychain.BaseProjectKeychain import BaseProjectKeychain
+from cumulusci.core.keychain.BaseProjectKeychain import DEFAULT_CONNECTED_APP
 
 # inherit from BaseProjectKeychain
 from cumulusci.core.keychain.BaseEncryptedProjectKeychain import (

--- a/cumulusci/tasks/connectedapp.py
+++ b/cumulusci/tasks/connectedapp.py
@@ -143,7 +143,9 @@ class CreateConnectedApp(SFDXBaseTask):
     def _validate_connect_service(self):
         if not self.options["overwrite"]:
             try:
-                connected_app = self.project_config.keychain.get_service("connected_app")
+                connected_app = self.project_config.keychain.get_service(
+                    "connected_app"
+                )
             except ServiceNotConfigured:
                 pass
             else:

--- a/cumulusci/tasks/connectedapp.py
+++ b/cumulusci/tasks/connectedapp.py
@@ -3,6 +3,7 @@ import re
 import os
 from cumulusci.core.config import ServiceConfig
 from cumulusci.core.exceptions import TaskOptionsError, ServiceNotConfigured
+from cumulusci.core.keychain import DEFAULT_CONNECTED_APP
 from cumulusci.core.utils import process_bool_arg
 from cumulusci.tasks.sfdx import SFDXBaseTask, SFDX_CLI
 from cumulusci.utils import random_alphanumeric_underscore
@@ -142,13 +143,14 @@ class CreateConnectedApp(SFDXBaseTask):
     def _validate_connect_service(self):
         if not self.options["overwrite"]:
             try:
-                self.project_config.keychain.get_service("connected_app")
+                connected_app = self.project_config.keychain.get_service("connected_app")
             except ServiceNotConfigured:
                 pass
             else:
-                raise TaskOptionsError(
-                    "The CumulusCI keychain already contains a connected_app service.  Set the 'overwrite' option to True to overwrite the existing service"
-                )
+                if connected_app is not DEFAULT_CONNECTED_APP:
+                    raise TaskOptionsError(
+                        "The CumulusCI keychain already contains a connected_app service.  Set the 'overwrite' option to True to overwrite the existing service"
+                    )
 
     def _connect_service(self):
         self.project_config.keychain.set_service(

--- a/cumulusci/tasks/tests/test_connectedapp.py
+++ b/cumulusci/tasks/tests/test_connectedapp.py
@@ -20,6 +20,7 @@ from cumulusci.core.config import (
 )
 from cumulusci.core.exceptions import ServiceNotConfigured, TaskOptionsError
 from cumulusci.core.keychain import BaseProjectKeychain
+from cumulusci.core.keychain import DEFAULT_CONNECTED_APP
 from cumulusci.core.tests.utils import MockLoggerMixin
 from cumulusci.tasks.connectedapp import CreateConnectedApp
 from cumulusci.utils import temporary_dir
@@ -240,8 +241,8 @@ class TestCreateConnectedApp(MockLoggerMixin, unittest.TestCase):
             task.options["command"],
             self.base_command + " -u {} -d {}".format(self.username, task.tempdir),
         )
-        with pytest.raises(ServiceNotConfigured):
-            self.project_config.keychain.get_service("connected_app")
+        connected_app = self.project_config.keychain.get_service("connected_app")
+        assert connected_app is DEFAULT_CONNECTED_APP
 
     @mock.patch("cumulusci.tasks.sfdx.SFDXBaseTask._run_task")
     @mock.patch("cumulusci.tasks.connectedapp.CreateConnectedApp._connect_service")

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ keyring==18.0.1  # pyup: <19
 lxml==4.4.1
 MarkupSafe==1.1.1
 pycparser==2.19
+PyJWT==1.7.1
 python-dateutil==2.8.0
 pytz==2019.2
 PyYAML==5.1.2


### PR DESCRIPTION
# Critical Changes

# Changes
* There is now a default CumulusCI global connected app that can be used to connect to persistent orgs (assuming you know the credentials) without creating a new connected app. It's still possible to configure a custom connected app using `cci service connect connected_app` if more control over the connected app settings is needed.
* When CumulusCI is being run in a non-interactive context it can now obtain an access token for a persistent org using a JWT instead of a refresh token. This approach is used if the SFDX_CLIENT_ID and SFDX_HUB_KEY environment variables are set. This makes it easier to manage persistent org connections in the context of a hosted service because it's possible to replace the connected app's certificate without needing to obtain new refresh tokens for each org.

# Issues Closed
