### PR TITLE
Fix returning cached preflight task results

### DIFF
--- a/cumulusci/core/flowrunner.py
+++ b/cumulusci/core/flowrunner.py
@@ -704,7 +704,7 @@ class CachedTaskRunner(object):
     def __call__(self, **options):
         cache_key = (self.task_name, tuple(options.items()))
         if cache_key in self.cache.results:
-            return self.cache.results[cache_key]
+            return self.cache.results[cache_key].return_values
 
         task_config = self.cache.flow.project_config.tasks[self.task_name]
         task_class = import_global(task_config["class_path"])

--- a/cumulusci/core/flowrunner.py
+++ b/cumulusci/core/flowrunner.py
@@ -702,7 +702,7 @@ class CachedTaskRunner(object):
         self.task_name = task_name
 
     def __call__(self, **options):
-        cache_key = (self.task_name, tuple(options.items()))
+        cache_key = (self.task_name, tuple(sorted(options.items())))
         if cache_key in self.cache.results:
             return self.cache.results[cache_key].return_values
 

--- a/cumulusci/core/tests/test_flowrunner.py
+++ b/cumulusci/core/tests/test_flowrunner.py
@@ -430,11 +430,7 @@ class PreflightFlowCoordinatorTest(AbstractFlowCoordinatorTest, unittest.TestCas
         flow_config = FlowConfig(
             {
                 "checks": [
-                    {
-                        "when": "not tasks.log(level='info', line='plan')",
-                        "action": "error",
-                        "message": "Failed plan check",
-                    }
+                    {"when": "True", "action": "error", "message": "Failed plan check"}
                 ],
                 "steps": {
                     1: {
@@ -442,10 +438,15 @@ class PreflightFlowCoordinatorTest(AbstractFlowCoordinatorTest, unittest.TestCas
                         "options": {"level": "info", "line": "step"},
                         "checks": [
                             {
+                                "when": "tasks.log(level='info', line='plan')",
+                                "action": "error",
+                                "message": "Failed step check 1",
+                            },
+                            {
                                 "when": "not tasks.log(level='info', line='plan')",
                                 "action": "error",
-                                "message": "Failed step check",
-                            }
+                                "message": "Failed step check 2",
+                            },
                         ],
                     }
                 },
@@ -457,7 +458,7 @@ class PreflightFlowCoordinatorTest(AbstractFlowCoordinatorTest, unittest.TestCas
         self.assertDictEqual(
             {
                 None: [{"status": "error", "message": "Failed plan check"}],
-                "log": [{"status": "error", "message": "Failed step check"}],
+                "log": [{"status": "error", "message": "Failed step check 2"}],
             },
             flow.preflight_results,
         )

--- a/cumulusci/core/tests/test_flowrunner.py
+++ b/cumulusci/core/tests/test_flowrunner.py
@@ -431,7 +431,7 @@ class PreflightFlowCoordinatorTest(AbstractFlowCoordinatorTest, unittest.TestCas
             {
                 "checks": [
                     {
-                        "when": "tasks.log(level='info', line='plan') or True",
+                        "when": "not tasks.log(level='info', line='plan')",
                         "action": "error",
                         "message": "Failed plan check",
                     }
@@ -442,7 +442,7 @@ class PreflightFlowCoordinatorTest(AbstractFlowCoordinatorTest, unittest.TestCas
                         "options": {"level": "info", "line": "step"},
                         "checks": [
                             {
-                                "when": "tasks.log(level='info', line='plan') or True",
+                                "when": "not tasks.log(level='info', line='plan')",
                                 "action": "error",
                                 "message": "Failed step check",
                             }
@@ -461,3 +461,6 @@ class PreflightFlowCoordinatorTest(AbstractFlowCoordinatorTest, unittest.TestCas
             },
             flow.preflight_results,
         )
+        # Make sure task result got cached
+        key = ("log", (("level", "info"), ("line", "plan")))
+        assert key in flow.jinja2_context["tasks"].results


### PR DESCRIPTION
@davidmreed This should fix the problem we saw with cached preflight task results. Do you see any easy way to improve the test so that we're actually testing for that?

# Critical Changes

# Changes

# Issues Closed
