### PR TITLE
Feature/factory task base

### DIFF
--- a/cumulusci/tasks/bulkdata/base_generate_data_task.py
+++ b/cumulusci/tasks/bulkdata/base_generate_data_task.py
@@ -70,4 +70,3 @@ class BaseGenerateDataTask(BaseTask):
     def generate_data(self, session, engine, base, num_records):
         """Abstract methods for base classes to really generate
            the data into an open session."""
-        pass

--- a/cumulusci/tasks/bulkdata/factory_utils.py
+++ b/cumulusci/tasks/bulkdata/factory_utils.py
@@ -1,0 +1,117 @@
+from abc import ABC, abstractmethod
+from importlib import import_module
+
+from factory import enums, base
+
+from .base_generate_data_task import BaseGenerateDataTask
+
+
+#  Factoryboy uses "__" and Salesforce uses "__". Luckily Factoryboy makes
+#  theirs easy to override!
+enums.SPLITTER = "____"
+
+
+# More flexible than FactoryBoy's sequences because you can create and
+# destroy them where-ever you want.
+class Adder:
+    def __init__(self, x=0):
+        self.x = x
+
+    def __call__(self, value):
+        self.x += value
+        return int(self.x)
+
+    def reset(self, x):
+        self.x = x
+
+
+# Thin collector for the factories and a place to try to achieve better
+# scalability than the create_batch function from FactoryBoy.
+class Factories:
+    def __init__(self, session, orm_classes, collection):
+        """Add a session to factories and then store them."""
+
+        self.factory_classes = {
+            key: self.add_session(value, session, orm_classes)
+            for key, value in collection.items()
+        }
+
+    @staticmethod
+    def add_session(fact, session, orm_classes):
+        "Attach the session to the factory"
+        fact._meta.sqlalchemy_session = session
+        fact._meta.sqlalchemy_session_persistence = "commit"
+
+        # if the model is just a string name, find a real class that matches
+        # that name
+        if isinstance(fact._meta.model, str):
+            try:
+                fact._meta.model = orm_classes[fact._meta.model]
+            except KeyError:
+                raise KeyError(
+                    f"ORM Class not found matching {fact._meta.model}. Check mapping.yml"
+                )
+
+        return fact
+
+    def create_batch(self, classname, batchsize, **kwargs):
+        cls = self.factory_classes.get(classname, None)
+        assert (
+            cls
+        ), f"Cannot find a factory class named {classname}. Did you misspell it?"
+        for _ in range(batchsize):
+            cls.create(**kwargs)
+
+    def __getitem__(self, name):
+        return self.factory_classes[name]
+
+
+class BaseDataFactory(BaseGenerateDataTask, ABC):
+    """Abstract base class for any FactoryBoy based generator"""
+
+    def generate_data(self, session, engine, base, num_records):
+        raw_factories = self.make_factories(base.classes)
+        factories = Factories(session, base.classes, raw_factories)
+        self.make_records(num_records, factories)
+
+    @abstractmethod
+    def make_factories(self, classes):
+        pass
+
+    @abstractmethod
+    def make_records(self, num_records, factories):
+        pass
+
+
+class ModuleDataFactory(BaseDataFactory):
+    datafactory_classes_module = None
+    # override to nominate a module to serve as the collection of modules
+
+    def make_factories(self, classes):
+        if not self.datafactory_classes_module:
+            # by default look for classes in the same place that the derived class came from
+            self.datafactory_classes_module = self.__module__
+        module = import_module(self.datafactory_classes_module)
+        module_contents = vars(module)
+
+        # filter out other cruft from the file
+        factories = {
+            name: f
+            for name, f in module_contents.items()
+            if isinstance(f, base.FactoryMetaClass)
+        }
+
+        return factories
+
+
+class _Models:
+    """Stand in for the models module of a framework like Django"""
+
+    def __getattr__(self, name):
+        # Instead of returning model objects, return strings as stand-ins.
+        # Later we'll replace the strings with real model objects after
+        # doing the mapping.yml introspection.
+        return name
+
+
+Models = _Models()

--- a/cumulusci/tasks/bulkdata/factory_utils.py
+++ b/cumulusci/tasks/bulkdata/factory_utils.py
@@ -94,11 +94,11 @@ class BaseDataFactory(BaseGenerateDataTask):
 
     @abstractmethod
     def make_factories(self, classes):
-        pass
+        """Subclass to generate factory classes based on ORM classes."""
 
     @abstractmethod
     def make_records(self, num_records, factories):
-        pass
+        """Subclass to make db records using factories."""
 
 
 class ModuleDataFactory(BaseDataFactory):

--- a/cumulusci/tasks/bulkdata/factory_utils.py
+++ b/cumulusci/tasks/bulkdata/factory_utils.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from importlib import import_module
 
 from factory import enums, base
@@ -82,7 +82,7 @@ class Factories:
         return self.factory_classes[name]
 
 
-class BaseDataFactory(BaseGenerateDataTask, ABC):
+class BaseDataFactory(BaseGenerateDataTask, ABCMeta):
     """Abstract base class for any FactoryBoy based generator"""
 
     def generate_data(self, session, engine, base, num_records):

--- a/cumulusci/tasks/bulkdata/factory_utils.py
+++ b/cumulusci/tasks/bulkdata/factory_utils.py
@@ -82,8 +82,10 @@ class Factories:
         return self.factory_classes[name]
 
 
-class BaseDataFactory(BaseGenerateDataTask, ABCMeta):
+class BaseDataFactory(BaseGenerateDataTask):
     """Abstract base class for any FactoryBoy based generator"""
+
+    __metaclass__ = ABCMeta
 
     def generate_data(self, session, engine, base, num_records):
         raw_factories = self.make_factories(base.classes)

--- a/cumulusci/tasks/bulkdata/factory_utils.py
+++ b/cumulusci/tasks/bulkdata/factory_utils.py
@@ -11,9 +11,22 @@ from .base_generate_data_task import BaseGenerateDataTask
 enums.SPLITTER = "____"
 
 
-# More flexible than FactoryBoy's sequences because you can create and
-# destroy them where-ever you want.
 class Adder:
+    """A more flexible alternative to Factoryboy sequences. You can create and
+        destroy them wherever you want.
+
+    >>> x = Adder(10)
+    >>> x(1)
+    11
+    >>> x(1)
+    12
+    >>> x.reset(5)
+    >>> x(2)
+    7
+    >>> x(2)
+    9
+    """
+
     def __init__(self, x=0):
         self.x = x
 
@@ -25,9 +38,11 @@ class Adder:
         self.x = x
 
 
-# Thin collector for the factories and a place to try to achieve better
-# scalability than the create_batch function from FactoryBoy.
 class Factories:
+    """Thin collector for the factories and a place to experiment with
+    techniques for better scalability than the create_batch function
+    from FactoryBoy."""
+
     def __init__(self, session, orm_classes, collection):
         """Add a session to factories and then store them."""
 
@@ -49,16 +64,17 @@ class Factories:
                 fact._meta.model = orm_classes[fact._meta.model]
             except KeyError:
                 raise KeyError(
-                    f"ORM Class not found matching {fact._meta.model}. Check mapping.yml"
+                    "ORM Class not found matching %s. Check mapping.yml"
+                    % fact._meta.model
                 )
 
         return fact
 
     def create_batch(self, classname, batchsize, **kwargs):
         cls = self.factory_classes.get(classname, None)
-        assert (
-            cls
-        ), f"Cannot find a factory class named {classname}. Did you misspell it?"
+        assert cls, (
+            "Cannot find a factory class named %s. Did you misspell it?" % classname
+        )
         for _ in range(batchsize):
             cls.create(**kwargs)
 

--- a/cumulusci/tasks/bulkdata/tests/dummy_data_factory.py
+++ b/cumulusci/tasks/bulkdata/tests/dummy_data_factory.py
@@ -1,14 +1,5 @@
-from datetime import date, datetime
-
 import factory
 from cumulusci.tasks.bulkdata.factory_utils import ModuleDataFactory, Models
-
-
-def now():
-    return datetime.now().date()
-
-
-START_DATE = date(2019, 1, 1)  # Per https://salesforce.quip.com/gLfGAPtqVzUS
 
 
 class GenerateDummyData(ModuleDataFactory):

--- a/cumulusci/tasks/bulkdata/tests/dummy_data_factory.py
+++ b/cumulusci/tasks/bulkdata/tests/dummy_data_factory.py
@@ -12,7 +12,7 @@ START_DATE = date(2019, 1, 1)  # Per https://salesforce.quip.com/gLfGAPtqVzUS
 
 
 class GenerateDummyData(ModuleDataFactory):
-    """Generate data specific to a particular use case"""
+    """Generate data based on test mapping.yml"""
 
     def make_records(self, num_records, factories):
         factories.create_batch("Contact", 10)

--- a/cumulusci/tasks/bulkdata/tests/dummy_data_factory.py
+++ b/cumulusci/tasks/bulkdata/tests/dummy_data_factory.py
@@ -1,0 +1,41 @@
+from datetime import date, datetime
+
+import factory
+from cumulusci.tasks.bulkdata.factory_utils import ModuleDataFactory, Models
+
+
+def now():
+    return datetime.now().date()
+
+
+START_DATE = date(2019, 1, 1)  # Per https://salesforce.quip.com/gLfGAPtqVzUS
+
+
+class GenerateDummyData(ModuleDataFactory):
+    """Generate data specific to a particular use case"""
+
+    def make_records(self, num_records, factories):
+        factories.create_batch("Contact", 10)
+        factories.create_batch("Household", 5)
+
+
+class Household(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = Models.households
+
+    name = factory.sequence(lambda i: f"Household {i}")
+
+
+class Contact(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = Models.contacts
+        exclude = [
+            "household"
+        ]  # don't try to attach the household to the Contact directly
+
+    id = factory.Sequence(lambda n: n + 1)
+    household = factory.SubFactory(Household)  # create households automatically
+    first_name = factory.sequence(lambda i: f"Gordon {i}")
+    last_name = factory.sequence(lambda i: f"Everyman {i}")
+    email = factory.sequence(lambda i: f"gevm{i}@example.com")
+    household_id = factory.LazyAttribute(lambda o: o.household.id)

--- a/cumulusci/tasks/bulkdata/tests/dummy_data_factory.py
+++ b/cumulusci/tasks/bulkdata/tests/dummy_data_factory.py
@@ -7,6 +7,7 @@ class GenerateDummyData(ModuleDataFactory):
 
     def make_records(self, num_records, factories):
         factories.create_batch("Contact", 10)
+        factories["Contact"].create_batch(5)
         factories.create_batch("Household", 5)
 
 

--- a/cumulusci/tasks/bulkdata/tests/dummy_data_factory.py
+++ b/cumulusci/tasks/bulkdata/tests/dummy_data_factory.py
@@ -23,7 +23,7 @@ class Household(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = Models.households
 
-    name = factory.sequence(lambda i: f"Household {i}")
+    name = factory.sequence(lambda i: "Household %d" % i)
 
 
 class Contact(factory.alchemy.SQLAlchemyModelFactory):
@@ -35,7 +35,7 @@ class Contact(factory.alchemy.SQLAlchemyModelFactory):
 
     id = factory.Sequence(lambda n: n + 1)
     household = factory.SubFactory(Household)  # create households automatically
-    first_name = factory.sequence(lambda i: f"Gordon {i}")
-    last_name = factory.sequence(lambda i: f"Everyman {i}")
-    email = factory.sequence(lambda i: f"gevm{i}@example.com")
+    first_name = factory.sequence(lambda i: "Gordon %d" % i)
+    last_name = factory.sequence(lambda i: "Everyman %d" % i)
+    email = factory.sequence(lambda i: "gevm%d@example.com" % i)
     household_id = factory.LazyAttribute(lambda o: o.household.id)

--- a/cumulusci/tasks/bulkdata/tests/test_factory_utils.py
+++ b/cumulusci/tasks/bulkdata/tests/test_factory_utils.py
@@ -1,10 +1,12 @@
 import unittest
 import os
 
-from cumulusci.utils import temporary_dir
+import factory
 
+from cumulusci.utils import temporary_dir
 from cumulusci.tasks.bulkdata.tests.test_bulkdata import _make_task
-from cumulusci.tasks.bulkdata.tests.dummy_data_factory import GenerateDummyData
+from cumulusci.tasks.bulkdata.tests.dummy_data_factory import GenerateDummyData, Contact
+from cumulusci.tasks.bulkdata import factory_utils
 
 
 class TestFactoryUtils(unittest.TestCase):
@@ -25,3 +27,30 @@ class TestFactoryUtils(unittest.TestCase):
                 },
             )
             task()
+
+
+class TestAdder(unittest.TestCase):
+    def test_adder(self):
+        a = factory_utils.Adder(10)
+        b = a(20)
+        assert b == 30
+        c = a(0)
+        assert c == 30
+        d = a(-5)
+        assert d == 25
+        a.reset(3)
+        assert a(0) == 3
+
+
+class TestFactories(unittest.TestCase):
+    def test_factories(self):
+        class Broken(factory.alchemy.SQLAlchemyModelFactory):
+            class Meta:
+                model = "xyzzy"
+
+        try:
+            factory_utils.Factories(None, {}, {"A": Contact, "B": Broken})
+        except KeyError as e:
+            assert "not found" in repr(e)
+            return
+        assert False, "Should not get to this point"

--- a/cumulusci/tasks/bulkdata/tests/test_factory_utils.py
+++ b/cumulusci/tasks/bulkdata/tests/test_factory_utils.py
@@ -48,9 +48,5 @@ class TestFactories(unittest.TestCase):
             class Meta:
                 model = "xyzzy"
 
-        try:
+        with self.assertRaises(KeyError):
             factory_utils.Factories(None, {}, {"A": Contact, "B": Broken})
-        except KeyError as e:
-            assert "not found" in repr(e)
-            return
-        assert False, "Should not get to this point"

--- a/cumulusci/tasks/bulkdata/tests/test_factory_utils.py
+++ b/cumulusci/tasks/bulkdata/tests/test_factory_utils.py
@@ -1,0 +1,27 @@
+import unittest
+import os
+
+from cumulusci.utils import temporary_dir
+
+from cumulusci.tasks.bulkdata.tests.test_bulkdata import _make_task
+from cumulusci.tasks.bulkdata.tests.dummy_data_factory import GenerateDummyData
+
+
+class TestFactoryUtils(unittest.TestCase):
+    def test_factory(self):
+        mapping_file = os.path.join(os.path.dirname(__file__), "mapping_v2.yml")
+
+        with temporary_dir() as d:
+            tmp_db_path = os.path.join(d, "temp.db")
+            dburl = "sqlite:///" + tmp_db_path
+            task = _make_task(
+                GenerateDummyData,
+                {
+                    "options": {
+                        "num_records": 10,
+                        "mapping": mapping_file,
+                        "database_url": dburl,
+                    }
+                },
+            )
+            task()


### PR DESCRIPTION
A base class for Factory-boy derived data generators.

Look at tests/dummy_data_factory.py to see what the API looks like from a consumer's point of view.

The gist is that you have one class derived from ModuleDataFactory with a make_records method and a series of FactoryBoy classes inheriting from factory.alchemy.SQLAlchemyModelFactory for individual tables.

The extra classes are picked up with some introspection magic so you don't need to "register" them.

There is also some magic which attaches them to the right session dynamically.
