### PR TITLE
Add method for cleanly asking if an org is alive

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -968,7 +968,9 @@ def org_list(config, plain):
                 domain = urlparse(instance_url).hostname or ""
                 if domain:
                     domain = domain.replace(".my.salesforce.com", "")
-            row.extend([org_days, not org_config.alive, org_config.config_name, domain])
+            row.extend(
+                [org_days, not org_config.active, org_config.config_name, domain]
+            )
             scratch_data.append(row)
         else:
             username = org_config.config.get(

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -959,7 +959,7 @@ def org_list(config, plain):
         row = [org, org_config.default]
         if isinstance(org_config, ScratchOrgConfig):
             org_days = org_config.format_org_days()
-            row.extend([org_days, org_config.expired, org_config.config_name])
+            row.extend([org_days, not org_config.alive, org_config.config_name])
             scratch_data.append(row)
         else:
             username = org_config.config.get(
@@ -968,11 +968,7 @@ def org_list(config, plain):
             row.append(username)
             persistent_data.append(row)
 
-    rows_to_dim = [
-        row_index
-        for row_index, row in enumerate(scratch_data)
-        if row[3] or not org_configs[row[0]].date_created
-    ]
+    rows_to_dim = [row_index for row_index, row in enumerate(scratch_data) if row[3]]
     scratch_table = CliTable(
         scratch_data, title="Scratch Orgs", bool_cols=["Default"], dim_rows=rows_to_dim
     )

--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -142,8 +142,12 @@ class ScratchOrgConfig(OrgConfig):
         return self.config.setdefault("days", 1)
 
     @property
+    def alive(self):
+        return self.date_created and not self.expired
+
+    @property
     def expired(self):
-        return self.expires and self.expires < datetime.datetime.now()
+        return bool(self.expires) and self.expires < datetime.datetime.now()
 
     @property
     def expires(self):

--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -142,7 +142,7 @@ class ScratchOrgConfig(OrgConfig):
         return self.config.setdefault("days", 1)
 
     @property
-    def alive(self):
+    def active(self):
         """Check if an org is alive"""
         return self.date_created and not self.expired
 

--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -143,10 +143,12 @@ class ScratchOrgConfig(OrgConfig):
 
     @property
     def alive(self):
+        """Check if an org is alive"""
         return self.date_created and not self.expired
 
     @property
     def expired(self):
+        """Check if an org has already expired"""
         return bool(self.expires) and self.expires < datetime.datetime.now()
 
     @property

--- a/cumulusci/core/tests/test_config_expensive.py
+++ b/cumulusci/core/tests/test_config_expensive.py
@@ -467,18 +467,18 @@ class TestScratchOrgConfig(unittest.TestCase):
         config.date_created = datetime.now()
         self.assertEqual(config.days_alive, 1)
 
-    def test_alive(self, Command):
+    def test_active(self, Command):
         config = ScratchOrgConfig({}, "test")
         config.date_created = None
-        self.assertFalse(config.alive)
+        self.assertFalse(config.active)
 
         config = ScratchOrgConfig({}, "test")
         config.date_created = datetime.now()
-        self.assertTrue(config.alive)
+        self.assertTrue(config.active)
 
         config = ScratchOrgConfig({}, "test")
         config.date_created = datetime.now() - timedelta(days=10)
-        self.assertFalse(config.alive)
+        self.assertFalse(config.active)
 
     def test_create_org(self, Command):
         out = b"Successfully created scratch org: ORG_ID, username: USERNAME"

--- a/cumulusci/core/tests/test_config_expensive.py
+++ b/cumulusci/core/tests/test_config_expensive.py
@@ -458,7 +458,6 @@ class TestScratchOrgConfig(unittest.TestCase):
         self.assertEqual(config.expires, now + timedelta(days=1))
 
         config = ScratchOrgConfig({"days": 1}, "test")
-        now = datetime.now()
         config.date_created = None
         self.assertIsNone(config.expires)
 

--- a/cumulusci/core/tests/test_config_expensive.py
+++ b/cumulusci/core/tests/test_config_expensive.py
@@ -457,10 +457,28 @@ class TestScratchOrgConfig(unittest.TestCase):
         config.date_created = now
         self.assertEqual(config.expires, now + timedelta(days=1))
 
+        config = ScratchOrgConfig({"days": 1}, "test")
+        now = datetime.now()
+        config.date_created = None
+        self.assertIsNone(config.expires)
+
     def test_days_alive(self, Command):
         config = ScratchOrgConfig({}, "test")
         config.date_created = datetime.now()
         self.assertEqual(config.days_alive, 1)
+
+    def test_alive(self, Command):
+        config = ScratchOrgConfig({}, "test")
+        config.date_created = None
+        self.assertFalse(config.alive)
+
+        config = ScratchOrgConfig({}, "test")
+        config.date_created = datetime.now()
+        self.assertTrue(config.alive)
+
+        config = ScratchOrgConfig({}, "test")
+        config.date_created = datetime.now() - timedelta(days=10)
+        self.assertFalse(config.alive)
 
     def test_create_org(self, Command):
         out = b"Successfully created scratch org: ORG_ID, username: USERNAME"


### PR DESCRIPTION
Clean up scratch org aliveness testing, per your suggestion.

None of these functions are used as often as I would have guessed so it wasn't a big deal yet. Cleaning up the API now will avoid that as the code base grows.