### PR TITLE
Add No Url Path Prefix Option to Create Community Task

### DIFF
--- a/cumulusci/tasks/salesforce/CreateCommunity.py
+++ b/cumulusci/tasks/salesforce/CreateCommunity.py
@@ -60,11 +60,11 @@ class CreateCommunity(BaseSalesforceApiTask):
             community_list = self.sf.restful("connect/communities")["communities"]
             communities = {c["name"]: c for c in community_list}
 
-            for community in communities.items():
-                if community["url_path_prefix"] is None:
+            for community_name in communities.keys():
+                if communities[community_name].get("urlPathPrefix") is None:
                     raise SalesforceException(
                         "A community without a url path prefix already exists, named {}. Try again with the url path prefix".format(
-                            community["name"]
+                            community_name
                         )
                     )
                 self.logger.info("No community without a url path prefix found.")
@@ -73,7 +73,7 @@ class CreateCommunity(BaseSalesforceApiTask):
             "name": self.options["name"],
             "description": self.options.get("description") or "",
             "templateName": self.options["template"],
-            "urlPathPrefix": self.options["url_path_prefix"] or "",
+            "urlPathPrefix": self.options.get("url_path_prefix") or "",
         }
 
         self.logger.info("Sending request to create Community")

--- a/cumulusci/tasks/salesforce/CreateCommunity.py
+++ b/cumulusci/tasks/salesforce/CreateCommunity.py
@@ -39,8 +39,6 @@ class CreateCommunity(BaseSalesforceApiTask):
     def _run_task(self):
         self.logger.info('Creating community "{}"'.format(self.options["name"]))
 
-        payload = {}
-
         # Before we can create a Community, we have to click through the "New Community"
         # button in the All Communities setup page. (This does some unknown behind-the-scenes setup).
         # Let's simulate that without actually using a browser.

--- a/cumulusci/tasks/salesforce/CreateCommunity.py
+++ b/cumulusci/tasks/salesforce/CreateCommunity.py
@@ -55,20 +55,6 @@ class CreateCommunity(BaseSalesforceApiTask):
         if r.status_code != 200:
             raise SalesforceException("Unable to prepare org for Communities")
 
-        if self.options.get("url_path_prefix") is None:
-            self.logger.info("Checking for community without a url path prefix.")
-            community_list = self.sf.restful("connect/communities")["communities"]
-            communities = {c["name"]: c for c in community_list}
-
-            for community_name in communities.keys():
-                if communities[community_name].get("urlPathPrefix") is None:
-                    raise SalesforceException(
-                        "A community without a url path prefix already exists, named {}. Try again with the url path prefix".format(
-                            community_name
-                        )
-                    )
-                self.logger.info("No community without a url path prefix found.")
-
         payload = {
             "name": self.options["name"],
             "description": self.options.get("description") or "",

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -81,7 +81,7 @@ Options:
 * **template** *(required)*: Name of the template for the community.
 * **name** *(required)*: Name of the community.
 * **description**: Description of the community.
-* **url_path_prefix** *(required)*: URL prefix for the community.
+* **url_path_prefix**: URL prefix for the community.
 * **timeout**: Time to wait, in seconds, for the community to be created
 
 create_package


### PR DESCRIPTION
# Critical Changes

# Changes
Create Community task now allows a blank url path prefix.

# Issues Closed
[1208](https://github.com/SFDO-Tooling/CumulusCI/issues/1208)