### PR TITLE
Feature/more forgiving batch wait

### DIFF
--- a/cumulusci/tasks/apex/batch.py
+++ b/cumulusci/tasks/apex/batch.py
@@ -49,7 +49,7 @@ class BatchApexWait(BaseSalesforceApiTask):
             self.logger.info("There have been some batch failures.")
             self.logger.info("Error values:")
             self.logger.info(repr(vals))
-            raise SalesforceException("There were import errors", vals)
+            raise SalesforceException("There were import errors: %s" % repr(vals))
         elif not self.done_for_sure:
             self.logger.info("The final record counts do not add up.")
             self.logger.info("This is probably related to W-1132237")

--- a/cumulusci/tasks/apex/batch.py
+++ b/cumulusci/tasks/apex/batch.py
@@ -36,14 +36,14 @@ class BatchApexWait(BaseSalesforceApiTask):
             key: value
             for key, value in self.batch.items()
             if key
-            in [
+            in {
                 "Id",
                 "Status",
                 "ExtendedStatus",
                 "NumberOfErrors",
                 "JobItemsProcessed",
                 "TotalJobItems",
-            ]
+            }
         }
         if not self.success:
             self.logger.info("There have been some batch failures.")

--- a/cumulusci/tasks/apex/batch.py
+++ b/cumulusci/tasks/apex/batch.py
@@ -1,6 +1,5 @@
 """ a task for waiting on a Batch Apex job to complete """
 
-import datetime
 from cumulusci.utils import parse_api_datetime
 from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 from cumulusci.core.exceptions import SalesforceException
@@ -33,9 +32,28 @@ class BatchApexWait(BaseSalesforceApiTask):
 
         self.logger.info("Job is complete.")
 
+        vals = {
+            key: value
+            for key, value in self.batch.items()
+            if key
+            in [
+                "Id",
+                "Status",
+                "ExtendedStatus",
+                "NumberOfErrors",
+                "JobItemsProcessed",
+                "TotalJobItems",
+            ]
+        }
         if not self.success:
-            self.logger.info("There were some batch failures.")
-            raise SalesforceException(self.batch["ExtendedStatus"])
+            self.logger.info("There have been some batch failures.")
+            self.logger.info("Error values:")
+            self.logger.info(repr(vals))
+            raise SalesforceException("There were import errors", vals)
+        elif not self.done_for_sure:
+            self.logger.info("The final record counts do not add up.")
+            self.logger.info("This is probably related to W-1132237")
+            self.logger.info(repr(vals))
 
         self.logger.info(
             "%s took %d seconds to process %d batches.",
@@ -66,9 +84,13 @@ class BatchApexWait(BaseSalesforceApiTask):
 
     @property
     def success(self):
-        """ returns True if all batches succeeded """
-        return (self.batch["JobItemsProcessed"] is self.batch["TotalJobItems"]) and (
-            self.batch["NumberOfErrors"] is 0
+        return self.batch["NumberOfErrors"] == 0
+
+    @property
+    def done_for_sure(self):
+        """ returns True if all batches were counted and succeeded """
+        return (self.batch["JobItemsProcessed"] == self.batch["TotalJobItems"]) and (
+            self.batch["NumberOfErrors"] == 0
         )
 
     @property

--- a/cumulusci/tasks/apex/tests/test_apex_tasks.py
+++ b/cumulusci/tasks/apex/tests/test_apex_tasks.py
@@ -609,9 +609,7 @@ class TestRunBatchApex(MockLoggerMixin, unittest.TestCase):
         responses.add(responses.GET, url, json=response)
         task()
 
-        self.assertIn("The final record counts do not add up.", self.task_log["info"]),
-        #     mock.call("This is probably related to W-1132237"),
-        # ]
+        self.assertIn("The final record counts do not add up.", self.task_log["info"])
 
     @responses.activate
     def test_run_batch_apex_status_ok(self):

--- a/cumulusci/tasks/apex/tests/test_apex_tasks.py
+++ b/cumulusci/tasks/apex/tests/test_apex_tasks.py
@@ -598,7 +598,7 @@ class TestRunBatchApex(MockLoggerMixin, unittest.TestCase):
         with self.assertRaises(SalesforceException) as cm:
             task()
         err = cm.exception
-        self.assertIn("Bad Status", err.args[1].values())
+        self.assertIn("Bad Status", err.args[0])
 
     @responses.activate
     def test_run_batch_apex_number_mismatch(self):

--- a/cumulusci/tasks/apex/tests/test_apex_tasks.py
+++ b/cumulusci/tasks/apex/tests/test_apex_tasks.py
@@ -28,6 +28,7 @@ from cumulusci.core.exceptions import (
 from cumulusci.tasks.apex.anon import AnonymousApexTask
 from cumulusci.tasks.apex.batch import BatchApexWait
 from cumulusci.tasks.apex.testrunner import RunApexTests
+from cumulusci.core.tests.utils import MockLoggerMixin
 
 
 @patch(
@@ -515,7 +516,7 @@ class TestAnonymousApexTask(unittest.TestCase):
     "cumulusci.tasks.salesforce.BaseSalesforceTask._update_credentials",
     MagicMock(return_value=None),
 )
-class TestRunBatchApex(unittest.TestCase):
+class TestRunBatchApex(MockLoggerMixin, unittest.TestCase):
     def setUp(self):
         self.api_version = 42.0
         self.global_config = BaseGlobalConfig(
@@ -545,6 +546,7 @@ class TestRunBatchApex(unittest.TestCase):
         self.base_tooling_url = "{}/services/data/v{}/tooling/".format(
             self.org_config.instance_url, self.api_version
         )
+        self.task_log = self._task_log_handler.messages
 
     def _get_query_resp(self):
         return {
@@ -596,7 +598,20 @@ class TestRunBatchApex(unittest.TestCase):
         with self.assertRaises(SalesforceException) as cm:
             task()
         err = cm.exception
-        self.assertEqual(err.args[0], "Bad Status")
+        self.assertIn("Bad Status", err.args[1].values())
+
+    @responses.activate
+    def test_run_batch_apex_number_mismatch(self):
+        task, url = self._get_url_and_task()
+        response = self._get_query_resp()
+        response["records"][0]["JobItemsProcessed"] = 1
+        response["records"][0]["TotalJobItems"] = 3
+        responses.add(responses.GET, url, json=response)
+        task()
+
+        self.assertIn("The final record counts do not add up.", self.task_log["info"]),
+        #     mock.call("This is probably related to W-1132237"),
+        # ]
 
     @responses.activate
     def test_run_batch_apex_status_ok(self):


### PR DESCRIPTION
# Critical Changes

# Changes

Previously, CCI would check that a batch job was completed correctly based on whether it both reported no error message and also had a TotalJobItems=JobItemsProcessed. On extremely large jobs with lots of Ajax, this seems like too conservative of a strategy. Sometimes the Salesforce Platform returns JobItemsProcessed<TotalJobItems but otherwise it seems that job succeeds and there is no serious reason to be concerned. In this case, CCI will now report a warning rather than an error and other processes can continue.

# Issues Closed
