### PR TITLE
Metadata mapping updates

### DIFF
--- a/cumulusci/tasks/metadata/metadata_map.yml
+++ b/cumulusci/tasks/metadata/metadata_map.yml
@@ -5,6 +5,7 @@ applications:
 appMenus:
     - type: AppMenu
       class: MetadataFilenameParser
+      extension: appMenu
 aura:
     - type: AuraDefinitionBundle
       class: BundleParser

--- a/cumulusci/tasks/metadata/metadata_map.yml
+++ b/cumulusci/tasks/metadata/metadata_map.yml
@@ -200,6 +200,14 @@ profiles:
     - type: Profile
       class: MetadataFilenameParser
       extension: profile
+profilePasswordPolicies:
+    - type: ProfilePasswordPolicy
+      class: MetadataFilenameParser
+      extension: profilePasswordPolicy
+profileSessionSettings:
+    - type: ProfileSessionSetting
+      class: MetadataFilenameParser
+      extension: profileSessionSetting
 permissionsets:
     - type: PermissionSet
       class: MetadataFilenameParser


### PR DESCRIPTION
This PR adds two metadata types to metadata_map.yml. This is to fix an issue where `retrieve_changes` will throw an exception after updating a profile.

# Critical Changes

# Changes
- We've added support for the `ProfilePasswordPolicy` and `ProfileSessionSetting` metadata types.
# Issues Closed
