### PR TITLE
Feature/robot libdoc enhancements

### DIFF
--- a/cumulusci/core/tests/test_utils.py
+++ b/cumulusci/core/tests/test_utils.py
@@ -68,10 +68,9 @@ class TestUtils(unittest.TestCase):
 
             # Recursive
             os.mkdir("subdir")
-            touch("subdir/baz.resource")
-            self.assertEqual(
-                ["subdir/baz.resource"], utils.process_glob_list_arg("**/*.resource")
-            )
+            filename = os.path.join("subdir", "baz.resource")
+            touch(filename)
+            self.assertEqual([filename], utils.process_glob_list_arg("**/*.resource"))
 
     def test_decode_to_unicode(self):
         self.assertEqual(u"\xfc", utils.decode_to_unicode(b"\xfc"))

--- a/cumulusci/core/tests/test_utils.py
+++ b/cumulusci/core/tests/test_utils.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import unittest
 
 import pytz
@@ -7,6 +8,7 @@ from .. import utils
 
 from collections import OrderedDict
 from cumulusci.core.exceptions import ConfigMergeError
+from cumulusci.utils import temporary_dir, touch
 
 try:
     from StringIO import StringIO
@@ -33,6 +35,43 @@ class TestUtils(unittest.TestCase):
         self.assertEqual([1, 2], utils.process_list_arg([1, 2]))
         self.assertEqual(["a", "b"], utils.process_list_arg("a, b"))
         self.assertEqual(None, utils.process_list_arg(None))
+
+    def test_process_glob_list_arg(self):
+        with temporary_dir():
+            touch("foo.py")
+            touch("bar.robot")
+
+            # Expect passing arg as list works.
+            self.assertEqual(
+                ["foo.py", "bar.robot"],
+                utils.process_glob_list_arg(["foo.py", "bar.robot"]),
+            )
+
+            # Falsy arg should return an empty list
+            self.assertEqual([], utils.process_glob_list_arg(None))
+            self.assertEqual([], utils.process_glob_list_arg(""))
+            self.assertEqual([], utils.process_glob_list_arg([]))
+
+            # Expect output to be in order given
+            self.assertEqual(
+                ["foo.py", "bar.robot"],
+                utils.process_glob_list_arg("foo.py, bar.robot"),
+            )
+
+            # Expect sorted output of glob results
+            self.assertEqual(["bar.robot", "foo.py"], utils.process_glob_list_arg("*"))
+
+            # Patterns that don't match any files
+            self.assertEqual(
+                ["*.bar", "x.y.z"], utils.process_glob_list_arg("*.bar, x.y.z")
+            )
+
+            # Recursive
+            os.mkdir("subdir")
+            touch("subdir/baz.resource")
+            self.assertEqual(
+                ["subdir/baz.resource"], utils.process_glob_list_arg("**/*.resource")
+            )
 
     def test_decode_to_unicode(self):
         self.assertEqual(u"\xfc", utils.decode_to_unicode(b"\xfc"))

--- a/cumulusci/core/utils.py
+++ b/cumulusci/core/utils.py
@@ -47,13 +47,16 @@ def process_bool_arg(arg):
 
 def process_glob_list_arg(arg):
     """Convert a list of glob patterns or filenames into a list of files
-    The initial list can take the form of a comma-separated list, or
-    a proper list.
+    The initial list can take the form of a comma-separated string or
+    a proper list. Order is preserved, but duplicates will be removed.
 
     Note: this function processes glob patterns, but doesn't validate
     that the files actually exist. For example, if the pattern is
     'foo.bar' and there is no file named 'foo.bar', the literal string
     'foo.bar' will be included in the returned files.
+
+    Similarly, if the pattern is '*.baz' and it doesn't match any files,
+    the literal string '*.baz' will be returned.
     """
     initial_list = process_list_arg(arg)
 
@@ -67,7 +70,9 @@ def process_glob_list_arg(arg):
             files += sorted(more_files)
         else:
             files.append(path)
-    return files
+    # In python 3.6+ dict is ordered, so we'll use it to weed
+    # out duplicates. We can't use a set because sets aren't ordered.
+    return list(dict.fromkeys(files))
 
 
 def process_list_arg(arg):

--- a/cumulusci/core/utils.py
+++ b/cumulusci/core/utils.py
@@ -6,6 +6,7 @@ decode_to_unicode: get unicode string from sf api """
 
 from datetime import datetime
 import copy
+import glob
 import pytz
 import time
 import yaml
@@ -42,6 +43,31 @@ def process_bool_arg(arg):
             return True
         elif arg.lower() in ["false", "0"]:
             return False
+
+
+def process_glob_list_arg(arg):
+    """Convert a list of glob patterns or filenames into a list of files
+    The initial list can take the form of a comma-separated list, or
+    a proper list.
+
+    Note: this function processes glob patterns, but doesn't validate
+    that the files actually exist. For example, if the pattern is
+    'foo.bar' and there is no file named 'foo.bar', the literal string
+    'foo.bar' will be included in the returned files.
+    """
+    initial_list = process_list_arg(arg)
+
+    if not arg:
+        return []
+
+    files = []
+    for path in initial_list:
+        more_files = glob.glob(path, recursive=True)
+        if len(more_files):
+            files += sorted(more_files)
+        else:
+            files.append(path)
+    return files
 
 
 def process_list_arg(arg):

--- a/cumulusci/tasks/robotframework/libdoc.py
+++ b/cumulusci/tasks/robotframework/libdoc.py
@@ -109,10 +109,17 @@ class RobotLibDoc(BaseTask):
                 # only print out the first line to hide most of the noise
                 self.logger.warn("unexpected error: {}".format(str(e).split("\n")[0]))
 
-        with open(self.options["output"], "w") as f:
-            html = self._render_html(kwfiles)
-            f.write(html)
-            self.logger.info("created {}".format(f.name))
+        try:
+            with open(self.options["output"], "w") as f:
+                html = self._render_html(kwfiles)
+                f.write(html)
+                self.logger.info("created {}".format(f.name))
+        except Exception as e:
+            raise TaskOptionsError(
+                "Unable to create output file '{}' ({})".format(
+                    self.options["output"], e.strerror
+                )
+            )
 
         return {"files": processed_files, "html": html}
 

--- a/cumulusci/tasks/robotframework/libdoc.py
+++ b/cumulusci/tasks/robotframework/libdoc.py
@@ -8,7 +8,7 @@ import robot.utils
 import cumulusci
 from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.core.tasks import BaseTask
-from cumulusci.core.utils import process_list_arg
+from cumulusci.core.utils import process_glob_list_arg
 from cumulusci.robotframework import PageObjects
 
 from robot.libdocpkg import DocumentationBuilder
@@ -20,7 +20,15 @@ from robot.utils import Importer
 class RobotLibDoc(BaseTask):
     task_options = {
         "path": {
-            "description": "The path to the robot library to be documented.  Can be single a python file or a .robot file, or a comma separated list of those files. The order of the files will be preserved in the generated documentation.",
+            "description": (
+                "The path to one or more keyword libraries to be documented. "
+                "The path can be single a python file, a .robot file, a python "
+                "module (eg: cumulusci.robotframework.Salesforce) or a comma "
+                "separated list of any of those. Glob patterns are supported "
+                "for filenames (eg: robot/SAL/doc/*PageObject.py). The order "
+                "of the files will be preserved in the generated documentation. "
+                "The result of pattern expansion will be sorted"
+            ),
             "required": True,
         },
         "output": {
@@ -35,14 +43,17 @@ class RobotLibDoc(BaseTask):
 
     def _validate_options(self):
         super(RobotLibDoc, self)._validate_options()
+        self.options["path"] = process_glob_list_arg(self.options["path"])
 
-        self.options["path"] = process_list_arg(self.options["path"])
-
+        # Attempt to collect all files that don't match existing
+        # files. Note: "path" could be a library module path (for example,
+        # cumulusci.robotframework.CumulusCI) so we only do this check for
+        # files that end in known library suffixes (.py, .robot, .resource).
         bad_files = []
-        for library_name in self.options["path"]:
-            name, extension = os.path.splitext(library_name)
-            if extension in (".py", ".robot") and not os.path.exists(library_name):
-                bad_files.append(library_name)
+        for path in self.options["path"]:
+            name, extension = os.path.splitext(path)
+            if extension in (".py", ".robot", ".resource") and not os.path.exists(path):
+                bad_files.append(path)
 
         if bad_files:
             if len(bad_files) == 1:

--- a/cumulusci/tasks/robotframework/stylesheet.css
+++ b/cumulusci/tasks/robotframework/stylesheet.css
@@ -97,6 +97,7 @@ body {
 .pageobject-header {
     font-size: 1.2em;
     font-weight: bold;
+    margin-top: 1em;
 }
 .object_name, .page_type {
     padding: 2px 10px ;

--- a/cumulusci/tasks/robotframework/tests/test_robotframework.py
+++ b/cumulusci/tasks/robotframework/tests/test_robotframework.py
@@ -178,6 +178,15 @@ class TestRobotLibDoc(MockLoggerMixin, unittest.TestCase):
         assert os.path.exists(output)
         assert len(task.result["files"]) == 2
 
+    def test_glob_patterns(self):
+        output = os.path.join(self.tmpdir, "index.html")
+        path = os.path.join(self.datadir, "*Library.py")
+        task = create_task(RobotLibDoc, {"path": path, "output": output})
+        task()
+        assert os.path.exists(output)
+        assert len(task.result["files"]) == 1
+        assert task.result["files"][0] == os.path.join(self.datadir, "TestLibrary.py")
+
     def test_creates_output(self):
         path = os.path.join(self.datadir, "TestLibrary.py")
         output = os.path.join(self.tmpdir, "index.html")

--- a/cumulusci/tasks/robotframework/tests/test_robotframework.py
+++ b/cumulusci/tasks/robotframework/tests/test_robotframework.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import pytest
 import os.path
+import re
 from xml.etree import ElementTree as ET
 
 from cumulusci.core.config import TaskConfig
@@ -158,7 +159,9 @@ class TestRobotLibDoc(MockLoggerMixin, unittest.TestCase):
         path = os.path.join(self.datadir, "TestLibrary.py")
         output = os.path.join(self.tmpdir, "bogus", "index.html")
         task = create_task(RobotLibDoc, {"path": path, "output": output})
-        expected = r"Unable to create output file '{}' (.*)".format(output)
+        # on windows, the output path may have backslashes which needs
+        # to be protected in the expected regex
+        expected = r"Unable to create output file '{}' (.*)".format(re.escape(output))
         with pytest.raises(TaskOptionsError, match=expected):
             task()
 

--- a/cumulusci/tasks/robotframework/tests/test_robotframework.py
+++ b/cumulusci/tasks/robotframework/tests/test_robotframework.py
@@ -150,6 +150,15 @@ class TestRobotLibDoc(MockLoggerMixin, unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 
+    def test_output_directory_not_exist(self):
+        """Verify we catch an error if the output directory doesn't exist"""
+        path = os.path.join(self.datadir, "TestLibrary.py")
+        output = os.path.join(self.tmpdir, "bogus", "index.html")
+        task = create_task(RobotLibDoc, {"path": path, "output": output})
+        expected = r"Unable to create output file '{}' (.*)".format(output)
+        with pytest.raises(TaskOptionsError, match=expected):
+            task()
+
     def test_validate_filenames(self):
         """Verify that we catch bad filenames early"""
         expected = "Unable to find the following input files: 'bogus.py', 'bogus.robot'"

--- a/cumulusci/tasks/robotframework/tests/test_robotframework.py
+++ b/cumulusci/tasks/robotframework/tests/test_robotframework.py
@@ -204,6 +204,14 @@ class TestRobotLibDoc(MockLoggerMixin, unittest.TestCase):
         assert len(task.result["files"]) == 1
         assert task.result["files"][0] == os.path.join(self.datadir, "TestLibrary.py")
 
+    def test_remove_duplicates(self):
+        output = os.path.join(self.tmpdir, "index.html")
+        path = os.path.join(self.datadir, "*Library.py")
+        task = create_task(RobotLibDoc, {"path": [path, path], "output": output})
+        task()
+        assert len(task.result["files"]) == 1
+        assert task.result["files"][0] == os.path.join(self.datadir, "TestLibrary.py")
+
     def test_creates_output(self):
         path = os.path.join(self.datadir, "TestLibrary.py")
         output = os.path.join(self.tmpdir, "index.html")

--- a/docs/robotframework.rst
+++ b/docs/robotframework.rst
@@ -449,23 +449,58 @@ CumulusCI includes two tasks for working with Robot Framework tests and keyword 
 * **robot_testdoc**: Generates html documentation of your whole robot test suite and writes to **robot/<project name>/doc/<project_name>.html**.
 * **robot_lint**: Performs static analysis of robot files (files with
   .robot and .resource), flagging issues that may reduce the quality of the code.
+* **robot_libdoc**:  This task can be wired up to generate library
+  documentation if you choose to create a library of robot keywords
+  for your project.
 
-Additionally, the **robot_libdoc** task can be wired up to generate library documentation if you choose to create a library of robot keywords for your project. For example, if you have defined a robot resource file named MyProject.resource and placed it in the **resources** folder, you would add the following to the cumulusci.yml file:
+Configuring the libdoc task
+---------------------------
+
+If you have defined a robot resource file named MyProject.resource and
+placed it in the **resources** folder, you can add the following
+configuration to your cumulusci.yml file in order to enable the
+**robot_libdoc** task to generate documentation:
 
 .. code-block:: yaml
 
    tasks:
       robot_libdoc:
-          description: Generates HTML documentation for the MyProject Robot Framework library
+          description: Generates HTML documentation for the MyProject Robot Framework Keywords
           options:
-              path: robot/MyProject/resources/MyProject.robot
+              path: robot/MyProject/resources/MyProject.resource
               output: robot/MyProject/doc/MyProject_Library.html
 
-.. note::
 
-   You can generate documentation for more than one keyword file or
-   library by giving a comma-separated list of files for the **path**
-   option.
+You can generate documentation for more than one keyword file or
+library by giving a comma-separated list of files for the **path**
+option, or by defining path as a list in cumulusci.yml.  In the
+following example, documentation will be generated for MyLibrary.py
+and MyLibrary.resource:
+
+.. code-block:: yaml
+
+   tasks:
+      robot_libdoc:
+          description: Generates HTML documentation for the MyProject Robot Framework Keywords
+          options:
+              path:
+                - robot/MyProject/resources/MyProject.resource
+                - robot/MyProject/resources/MyProject.py
+              output: robot/MyProject/doc/MyProject_Library.html
+
+You can also use basic filesystem wildcards. For example,
+to document all robot files in robot/MyProject/resources you could
+configure your yaml file like this:
+
+.. code-block:: yaml
+
+   tasks:
+      robot_libdoc:
+          description: Generates HTML documentation for the MyProject Robot Framework Keywords
+          options:
+              path: robot/MyProject/resources/*.resource
+              output: robot/MyProject/doc/MyProject_Library.html
+
 
 
 Robot Directory Structure


### PR DESCRIPTION
This change lets you use wildcards to define the path option of the robot_libdoc task. There's also a bugfix that catches errors when creating the output, where it throws a proper `TaskOptionsError` rather than just spew a traceback. 

This includes a new function in utils, `process_glob_list_arg` which works like `process_list_arg`, but goes the extra step and expands wildcards.

# Critical Changes

# Changes

# Issues Closed
