### PR TITLE
We no longer need the [security] extra for requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ python-dateutil==2.8.0
 pytz==2019.2
 PyYAML==5.1.2
 raven==6.10.0
-requests[security]==2.22.0
+requests==2.22.0
 robotframework==3.1.2
 robotframework-seleniumlibrary==3.3.1  # pyup: <4
 rst2ansi==0.1.5


### PR DESCRIPTION
(It installed PyOpenSSL to handle certificate validation in Python < 2.7.9)


# Critical Changes

# Changes

# Issues Closed
