### PR TITLE
Feature/log instead of error

### DIFF
--- a/cumulusci/core/github.py
+++ b/cumulusci/core/github.py
@@ -135,3 +135,9 @@ def get_pull_requests_by_commit(github, repo, commit_sha):
 def is_pull_request_merged(pull_request):
     """Takes a github3.pulls.ShortPullRequest object"""
     return pull_request.merged_at is not None
+
+
+def markdown_link_to_pr(change_note):
+    return "{} [[PR{}]({})]".format(
+        change_note.title, change_note.number, change_note.html_url
+    )

--- a/cumulusci/core/tests/test_github.py
+++ b/cumulusci/core/tests/test_github.py
@@ -19,6 +19,7 @@ from cumulusci.core.github import (
     get_github_api,
     validate_service,
     create_pull_request,
+    markdown_link_to_pr,
     is_pull_request_merged,
     get_github_api_for_repo,
     is_label_on_pull_request,
@@ -243,3 +244,11 @@ class TestGithub(GithubApiTestMixin):
 
         assert is_pull_request_merged(merged_pull_request)
         assert not is_pull_request_merged(unmerged_pull_request)
+
+    def test_markdown_link_to_pr(self, gh_api):
+        self.init_github()
+        pr = ShortPullRequest(self._get_expected_pull_request(1, 1), gh_api)
+        actual_link = markdown_link_to_pr(pr)
+        expected_link = "{} [[PR{}]({})]".format(pr.title, pr.number, pr.html_url)
+
+        assert expected_link == actual_link

--- a/cumulusci/tasks/release_notes/tests/test_task.py
+++ b/cumulusci/tasks/release_notes/tests/test_task.py
@@ -178,6 +178,7 @@ class TestParentPullRequestNotes(GithubApiTestMixin):
         )
         task.repo = mock.Mock()
         task.repo.owner.login = "SFDO-Tooling"
+        task._update_unaggregated_pr_header = mock.Mock()
 
         pull_request = ShortPullRequest(
             self._get_expected_pull_request(1, 1, "Body"), gh_api
@@ -187,7 +188,7 @@ class TestParentPullRequestNotes(GithubApiTestMixin):
 
         label_found.return_value = False
         task._run_task()
-        task.generator.update_unaggregated_pr_header.assert_called_once_with(
+        task._update_unaggregated_pr_header.assert_called_once_with(
             pull_request, child_branch_name
         )
         assert not task.generator.aggregate_child_change_notes.called
@@ -273,3 +274,108 @@ class TestParentPullRequestNotes(GithubApiTestMixin):
             pull_request
         )
         assert not task.generator.update_unaggregated_pr_header.called
+
+    @mock.patch("cumulusci.tasks.release_notes.task.get_pull_requests_with_base_branch")
+    def test_update_unaggregated_pr_header__one_pr_returned(
+        self, get_pr, task_factory, gh_api, project_config
+    ):
+        self.init_github()
+        self.project_config = project_config
+
+        to_link = ShortPullRequest(self._get_expected_pull_request(2, 2), gh_api)
+        get_pr.return_value = [to_link]
+
+        task = task_factory(self.PARENT_BRANCH_OPTIONS)
+        task._add_link_to_pr = mock.Mock()
+        to_update = ShortPullRequest(self._get_expected_pull_request(1, 1), gh_api)
+
+        task._update_unaggregated_pr_header(to_update, "feature/test-branch")
+        task._add_link_to_pr.assert_called_once_with(to_update, to_link)
+
+    @mock.patch("cumulusci.tasks.release_notes.task.get_pull_requests_with_base_branch")
+    def test_update_unaggregated_pr_header__no_prs_returned(
+        self, get_pr, task_factory, gh_api, project_config
+    ):
+        self.init_github()
+        self.project_config = project_config
+
+        get_pr.return_value = []
+
+        task = task_factory(self.PARENT_BRANCH_OPTIONS)
+        task._add_link_to_pr = mock.Mock()
+        task.logger = mock.Mock(error=mock.Mock())
+        to_update = ShortPullRequest(self._get_expected_pull_request(1, 1), gh_api)
+
+        branch_name = "feature/test-branch"
+        task._update_unaggregated_pr_header(to_update, branch_name)
+        task.logger.error.assert_called_once_with(
+            f"No pull request for branch {branch_name} found."
+        )
+
+    @mock.patch("cumulusci.tasks.release_notes.task.get_pull_requests_with_base_branch")
+    def test_update_unaggregated_pr_header__multiple_prs_returned(
+        self, get_pr, task_factory, gh_api, project_config
+    ):
+        self.init_github()
+        self.project_config = project_config
+
+        get_pr.return_value = [
+            ShortPullRequest(self._get_expected_pull_request(1, 1), gh_api),
+            ShortPullRequest(self._get_expected_pull_request(2, 2), gh_api),
+        ]
+
+        task = task_factory(self.PARENT_BRANCH_OPTIONS)
+        task._add_link_to_pr = mock.Mock()
+        task.logger = mock.Mock(error=mock.Mock())
+        to_update = ShortPullRequest(self._get_expected_pull_request(3, 3), gh_api)
+
+        branch_name = "feature/test-branch"
+        task._update_unaggregated_pr_header(to_update, branch_name)
+        task.logger.error.assert_called_once_with(
+            f"Expected one pull request, found 2 for branch {branch_name}"
+        )
+
+    def test_add_header(self, task_factory, gh_api, project_config):
+        self.init_github()
+        self.project_config = project_config
+        task = task_factory(self.PARENT_BRANCH_OPTIONS)
+        pull_request = ShortPullRequest(self._get_expected_pull_request(1, 1), gh_api)
+
+        task._add_header(pull_request)
+        assert task.UNAGGREGATED_PR_HEADER in pull_request.body
+
+        task._add_header(pull_request)  # header shouldn't be added again
+        assert pull_request.body.count(task.UNAGGREGATED_PR_HEADER) == 1
+
+    @mock.patch("cumulusci.tasks.release_notes.task.markdown_link_to_pr")
+    def test_add_link_to_pr(self, link_to_pr, task_factory, gh_api, project_config):
+        self.init_github()
+        self.project_config = project_config
+        task = task_factory(self.PARENT_BRANCH_OPTIONS)
+        to_update = mock.Mock(update=mock.Mock(), body="Pull request body.")
+        to_link = mock.Mock()
+
+        link = "This is a link to a pull request."
+        link_to_pr.return_value = link
+
+        task._add_link_to_pr(to_update, to_link)
+        expected_body = to_update.body + f"\r\n* {link}"
+        to_update.update.assert_called_once_with(body=expected_body)
+
+    @mock.patch("cumulusci.tasks.release_notes.task.markdown_link_to_pr")
+    def test_add_link_to_pr_should_not_add_duplicate_link(
+        self, link_to_pr, task_factory, gh_api, project_config
+    ):
+        self.init_github()
+        self.project_config = project_config
+        task = task_factory(self.PARENT_BRANCH_OPTIONS)
+        to_update = mock.Mock(update=mock.Mock(), body="Pull request body.")
+        to_link = mock.Mock()
+
+        link = "This is a link to a pull request."
+        link_to_pr.return_value = link
+        expected_body = to_update.body + f"\r\n* {link}"
+        to_update.body = expected_body
+
+        task._add_link_to_pr(to_update, to_link)
+        assert to_update.update.call_count == 0


### PR DESCRIPTION
* Added `markdown_link_to_pr()` method to `cumulusci.core.github`
* Moved `_unaggregated_pr_header()` from `cumulusci.tasks.release_notes.generator.py` into `cumulusci.tasks.release_notes.task.py`

# Changes
* We now log an error instead of throwing an exception when a pull request is not found (or when more than one is found) when attempting to aggregate change notes from child branches in flow `github_parent_pr_notes`