### PR TITLE
Make jwt_session use a specific instance URL for sandboxes

### DIFF
--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -23,12 +23,9 @@ class OrgConfig(BaseConfig):
         SFDX_CLIENT_ID = os.environ.get("SFDX_CLIENT_ID")
         SFDX_HUB_KEY = os.environ.get("SFDX_HUB_KEY")
         if SFDX_CLIENT_ID and SFDX_HUB_KEY:
-            login_url = (
-                "https://test.salesforce.com"
-                if self.is_sandbox
-                else "https://login.salesforce.com"
+            info = jwt_session(
+                SFDX_CLIENT_ID, SFDX_HUB_KEY, self.username, self.instance_url
             )
-            info = jwt_session(SFDX_CLIENT_ID, SFDX_HUB_KEY, self.username, login_url)
         else:
             info = self._refresh_token(keychain, connected_app)
         if info != self.config:

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -932,6 +932,27 @@ class TestOrgConfig(unittest.TestCase):
             config.refresh_oauth_token(None)
             assert config.access_token == "TOKEN"
 
+    @mock.patch("jwt.encode", mock.Mock(return_value="JWT"))
+    @responses.activate
+    def test_refresh_oauth_token_jwt_sandbox(self):
+        responses.add(
+            "POST",
+            "https://cs00.salesforce.com/services/oauth2/token",
+            json={
+                "access_token": "TOKEN",
+                "instance_url": "https://cs00.salesforce.com",
+            },
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"SFDX_CLIENT_ID": "some client id", "SFDX_HUB_KEY": "some private key"},
+        ):
+            config = OrgConfig({"instance_url": "https://cs00.salesforce.com"}, "test")
+            config._load_userinfo = mock.Mock()
+            config._load_orginfo = mock.Mock()
+            config.refresh_oauth_token(None)
+            assert config.access_token == "TOKEN"
+
     def test_lightning_base_url(self):
         config = OrgConfig({"instance_url": "https://na01.salesforce.com"}, "test")
         self.assertEqual("https://na01.lightning.force.com", config.lightning_base_url)


### PR DESCRIPTION
While working on MetaShare I discovered that for scratch orgs it's more reliable to use a specific instance URL for the auth endpoint instead of test.salesforce.com

# Critical Changes

# Changes

# Issues Closed
* Added a workaround for an issue where refreshing the access token for a sandbox or scratch org could fail if the user's credentials were new and not fully propagated.