### PR TITLE
Add task for deploying org settings from a scratch org definition file

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -187,6 +187,10 @@ tasks:
         description: Publish a release to the MetaDeploy web installer
         class_path: cumulusci.tasks.metadeploy.Publish
         group: Release Management
+    org_settings:
+        description: Apply org settings from a scratch org definition file
+        class_path: cumulusci.tasks.salesforce.org_settings.DeployOrgSettings
+        group: Salesforce DX
     publish_community:
         description: Publishes a Community in the target org using the Connect API
         class_path: cumulusci.tasks.salesforce.PublishCommunity

--- a/cumulusci/tasks/salesforce/org_settings.py
+++ b/cumulusci/tasks/salesforce/org_settings.py
@@ -1,0 +1,75 @@
+import json
+import os
+
+from cumulusci.tasks.salesforce import Deploy
+from cumulusci.utils import temporary_dir
+
+
+SETTINGS_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<{settingsName} xmlns="http://soap.sforce.com/2006/04/metadata">
+    {values}
+</{settingsName}>"""
+ORGPREF = """<preferences>
+    <settingName>{name}</settingName>
+    <settingValue>{value}</settingValue>
+</preferences>"""
+PACKAGE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>*</members>
+        <name>Settings</name>
+    </types>
+    <version>46.0</version>
+</Package>"""
+
+
+class DeployOrgSettings(Deploy):
+    task_doc = """Deploys org settings from an sfdx scratch org definition file."""
+
+    task_options = {
+        "definition_file": {"description": "sfdx scratch org definition file"}
+    }
+
+    def _run_task(self):
+        with open(self.options["definition_file"], "r") as f:
+            scratch_org_definition = json.load(f)
+
+        settings = scratch_org_definition.get("settings", {})
+        if not settings:
+            return
+
+        with temporary_dir() as path:
+            self._generate_package(settings)
+            self.options["path"] = path
+            return super()._run_task()
+
+    def _generate_package(self, settings):
+        os.mkdir("settings")
+        for section, section_settings in settings.items():
+            settings_name = capitalize(section)
+            if section == "orgPreferenceSettings":
+                values = "\n    ".join(
+                    ORGPREF.format(name=capitalize(k), value=v)
+                    for k, v in section_settings.items()
+                )
+            else:
+                values = "\n    ".join(
+                    f"<{k}>{v}</{k}>" for k, v in section_settings.items()
+                )
+            # e.g. AccountSettings -> settings/Account.settings
+            settings_file = os.path.join(
+                "settings", settings_name[: -len("Settings")] + ".settings"
+            )
+            with open(settings_file, "w") as f:
+                f.write(SETTINGS_XML.format(settingsName=settings_name, values=values))
+        with open("package.xml", "w") as f:
+            f.write(PACKAGE_XML)
+
+
+def capitalize(s):
+    """
+    Just capitalize first letter (different from .title, as it preserves
+    the rest of the case).
+    e.g. accountSettings -> AccountSettings
+    """
+    return s[0].upper() + s[1:]

--- a/cumulusci/tasks/salesforce/org_settings.py
+++ b/cumulusci/tasks/salesforce/org_settings.py
@@ -49,8 +49,11 @@ class DeployOrgSettings(Deploy):
             settings_name = capitalize(section)
             if section == "orgPreferenceSettings":
                 values = "\n    ".join(
-                    ORGPREF.format(name=capitalize(k), value=v)
-                    for k, v in section_settings.items()
+                    line
+                    for line in "\n".join(
+                        ORGPREF.format(name=capitalize(k), value=v)
+                        for k, v in section_settings.items()
+                    ).splitlines()
                 )
             else:
                 values = "\n    ".join(

--- a/cumulusci/tasks/salesforce/tests/test_org_settings.py
+++ b/cumulusci/tasks/salesforce/tests/test_org_settings.py
@@ -1,0 +1,72 @@
+from unittest.mock import Mock
+import base64
+import io
+import json
+import os
+import zipfile
+
+from cumulusci.tasks.salesforce.org_settings import DeployOrgSettings
+from cumulusci.utils import temporary_dir
+from .util import create_task
+
+
+class TestDeployOrgSettings:
+    def test_run_task(self):
+        with temporary_dir() as d:
+            with open("dev.json", "w") as f:
+                json.dump(
+                    {
+                        "settings": {
+                            "orgPreferenceSettings": {"s1DesktopEnabled": True},
+                            "communitiesSettings": {"enableNetworksEnabled": True},
+                        }
+                    },
+                    f,
+                )
+            path = os.path.join(d, "dev.json")
+            task_options = {"definition_file": path}
+            task = create_task(DeployOrgSettings, task_options)
+            task.api_class = Mock()
+            task()
+
+        package_zip = task.api_class.call_args[0][1]
+        zf = zipfile.ZipFile(io.BytesIO(base64.b64decode(package_zip)), "r")
+        assert (
+            zf.read("package.xml")
+            == b"""<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>*</members>
+        <name>Settings</name>
+    </types>
+    <version>46.0</version>
+</Package>"""
+        )
+        assert (
+            zf.read("settings/OrgPreference.settings")
+            == b"""<?xml version="1.0" encoding="UTF-8"?>
+<OrgPreferenceSettings xmlns="http://soap.sforce.com/2006/04/metadata">
+    <preferences>
+        <settingName>S1DesktopEnabled</settingName>
+        <settingValue>True</settingValue>
+    </preferences>
+</OrgPreferenceSettings>"""
+        )
+        assert (
+            zf.read("settings/Communities.settings")
+            == b"""<?xml version="1.0" encoding="UTF-8"?>
+<CommunitiesSettings xmlns="http://soap.sforce.com/2006/04/metadata">
+    <enableNetworksEnabled>True</enableNetworksEnabled>
+</CommunitiesSettings>"""
+        )
+
+    def test_run_task__no_settings(self):
+        with temporary_dir() as d:
+            with open("dev.json", "w") as f:
+                f.write("{}")
+            path = os.path.join(d, "dev.json")
+            task_options = {"definition_file": path}
+            task = create_task(DeployOrgSettings, task_options)
+            task.api_class = Mock()
+            task()
+            assert not task.api_class.called

--- a/cumulusci/tasks/salesforce/tests/test_org_settings.py
+++ b/cumulusci/tasks/salesforce/tests/test_org_settings.py
@@ -32,8 +32,8 @@ class TestDeployOrgSettings:
         package_zip = task.api_class.call_args[0][1]
         zf = zipfile.ZipFile(io.BytesIO(base64.b64decode(package_zip)), "r")
         assert (
-            zf.read("package.xml")
-            == b"""<?xml version="1.0" encoding="UTF-8"?>
+            readtext(zf, "package.xml")
+            == """<?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <types>
         <members>*</members>
@@ -43,8 +43,8 @@ class TestDeployOrgSettings:
 </Package>"""
         )
         assert (
-            zf.read("settings/OrgPreference.settings")
-            == b"""<?xml version="1.0" encoding="UTF-8"?>
+            readtext(zf, "settings/OrgPreference.settings")
+            == """<?xml version="1.0" encoding="UTF-8"?>
 <OrgPreferenceSettings xmlns="http://soap.sforce.com/2006/04/metadata">
     <preferences>
         <settingName>S1DesktopEnabled</settingName>
@@ -53,8 +53,8 @@ class TestDeployOrgSettings:
 </OrgPreferenceSettings>"""
         )
         assert (
-            zf.read("settings/Communities.settings")
-            == b"""<?xml version="1.0" encoding="UTF-8"?>
+            readtext(zf, "settings/Communities.settings")
+            == """<?xml version="1.0" encoding="UTF-8"?>
 <CommunitiesSettings xmlns="http://soap.sforce.com/2006/04/metadata">
     <enableNetworksEnabled>True</enableNetworksEnabled>
 </CommunitiesSettings>"""
@@ -70,3 +70,8 @@ class TestDeployOrgSettings:
             task.api_class = Mock()
             task()
             assert not task.api_class.called
+
+
+def readtext(zf, name):
+    with zf.open(name, "r") as f:
+        return io.TextIOWrapper(f).read()

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -1,4 +1,3 @@
-Checking the version!
 ==========================================
 Tasks Reference
 ==========================================
@@ -311,9 +310,9 @@ parent's pull request.
 When given the branch_name option, this task will: (1) check if the base branch
 of the corresponding pull request starts with the feature branch prefix and if so (2) attempt
 to query for a pull request corresponding to this parent feature branch. (3) if a pull request
-isn't found, one is created and the build_notes_label is applied to it.
+isn't found, the task exits and no actions are taken.
 
-If the build_notes_label is present on the pull request, then all notes from the 
+If the build_notes_label is present on the pull request, then all notes from the
 child pull request are aggregated into the parent pull request. if the build_notes_label
 is not detected on the parent pull request then a link to the child pull request
 is placed under the "Unaggregated Pull Requests" header.
@@ -326,9 +325,9 @@ from child pull requests are re-aggregated and the body of the parent is replace
 Options:
 ------------------------------------------
 
-* **branch_name**: Name of branch with a pull request
-* **parent_branch_name**: name of the parent branch to rebuild change notes for
+* **branch_name** *(required)*: Name of branch to check for parent status, and if so, reaggregate change notes from child branches.
 * **build_notes_label** *(required)*: Name of the label that indicates that change notes on parent pull requests should be reaggregated when a child branch pull request is created.
+* **force**: force rebuilding of change notes from child branches in the given branch.
 
 github_clone_tag
 ==========================================
@@ -549,6 +548,18 @@ Options:
 * **tag** *(required)*: Name of the git tag to publish
 * **plan**: Name of the plan(s) to publish. This refers to the `plans` section of cumulusci.yml. By default, all plans will be published.
 * **dry_run**: If True, print steps without publishing.
+
+org_settings
+==========================================
+
+**Description:** Apply org settings from a scratch org definition file
+
+**Class::** cumulusci.tasks.salesforce.org_settings.DeployOrgSettings
+
+Options:
+------------------------------------------
+
+* **definition_file**: sfdx scratch org definition file
 
 publish_community
 ==========================================
@@ -833,6 +844,7 @@ Options:
 * **name**: Sets the name of the top level test suite
 * **pdb**: If true, run the Python debugger when tests fail.
 * **verbose**: If true, log each keyword as it runs.
+* **debug**: If true, enable the `breakpoint` keyword to enable the robot debugger
 
 robot_libdoc
 ==========================================
@@ -844,7 +856,7 @@ robot_libdoc
 Options:
 ------------------------------------------
 
-* **path** *(required)*: The path to the robot library to be documented.  Can be single a python file or a .robot file, or a comma separated list of those files. The order of the files will be preserved in the generated documentation. **Default: ['cumulusci.robotframework.CumulusCI', 'cumulusci.robotframework.PageObjects', 'cumulusci.robotframework.Salesforce', 'cumulusci/robotframework/Salesforce.robot']**
+* **path** *(required)*: The path to one or more keyword libraries to be documented. The path can be single a python file, a .robot file, a python module (eg: cumulusci.robotframework.Salesforce) or a comma separated list of any of those. Glob patterns are supported for filenames (eg: robot/SAL/doc/*PageObject.py). The order of the files will be preserved in the generated documentation. The result of pattern expansion will be sorted **Default: ['cumulusci.robotframework.CumulusCI', 'cumulusci.robotframework.PageObjects', 'cumulusci.robotframework.Salesforce', 'cumulusci/robotframework/Salesforce.robot']**
 * **output** *(required)*: The output file where the documentation will be written **Default: docs/robot/Keywords.html**
 * **title**: A string to use as the title of the generated output **Default: CumulusCI Robot Framework Keywords**
 


### PR DESCRIPTION
Moving this here from MetaShare. Useful when creating scratch orgs directly using ScratchOrgInfo instead of using sfdx.

# Critical Changes

# Changes
* Added an `org_settings` task which can deploy scratch org settings from a scratch org definition file.

# Issues Closed
