### PR TITLE
Remove deprecated OrgPreferenceSettings

### DIFF
--- a/cumulusci/files/templates/project/scratch_def.json
+++ b/cumulusci/files/templates/project/scratch_def.json
@@ -2,12 +2,16 @@
   "orgName": "{{ package_name }} - {{ org_name }}",
   "edition": "{{ edition }}",
   "settings": {
-    "orgPreferenceSettings": {
-      "s1DesktopEnabled": true
-      , "chatterEnabled": true
-      {% if not managed %}
-      , "translation": true 
-      {% endif %}
-    }
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "chatterSettings": {
+      "enableChatter": true
+    },
+    {% if not managed %}
+    "languageSettings": {
+      "enableTranslationWorkbench": true
+    },
+    {% endif %}
   }
 }


### PR DESCRIPTION
# Critical Changes

# Changes

Salesforce is deprecating OrgPreferenceSettings; Updated scratch_def to create org definition files that compatible with Spring '20. 

# Issues Closed
