### PR TITLE
Update command task with examples.

### DIFF
--- a/cumulusci/tasks/command.py
+++ b/cumulusci/tasks/command.py
@@ -19,6 +19,17 @@ from cumulusci.core.utils import process_bool_arg
 class Command(BaseTask):
     """ Execute a shell command in a subprocess """
 
+    task_docs = """
+        **Example Command-line Usage::** cci task run command -o command "echo 'Hello command task!'"
+
+        **Example Task to Run Command::**
+        hello_world:
+            description: Says hello world
+            class_path: cumulusci.tasks.command.Command
+            options:
+            command: echo 'Hello World!'
+    """
+
     task_options = {
         "command": {"description": "The command to execute", "required": True},
         "dir": {

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -22,6 +22,15 @@ command
 
 **Class::** cumulusci.tasks.command.Command
 
+**Example Command-line Usage::** cci task run command -o command "echo 'Hello command task!'"
+
+**Example Task to Run Command::**
+  hello_world:
+    description: Says hello world
+    class_path: cumulusci.tasks.command.Command
+    options:
+      command: echo 'Hello World!'
+
 Options:
 ------------------------------------------
 

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -31,6 +31,7 @@ command
     options:
       command: echo 'Hello World!'
 
+
 Options:
 ------------------------------------------
 
@@ -554,9 +555,11 @@ metadeploy_publish
 Options:
 ------------------------------------------
 
-* **tag** *(required)*: Name of the git tag to publish
+* **tag**: Name of the git tag to publish
+* **commit**: Commit hash to publish
 * **plan**: Name of the plan(s) to publish. This refers to the `plans` section of cumulusci.yml. By default, all plans will be published.
 * **dry_run**: If True, print steps without publishing.
+* **publish**: If True, set is_listed to True on the version. Default: False
 
 org_settings
 ==========================================


### PR DESCRIPTION
Updated current documentation for the Command task to include a couple examples: (1) Running an arbitrary shell command, and (2) simple custom command task.