### PR TITLE
Fixes to deprecation warnings for Python 3.8 Collections

### DIFF
--- a/cumulusci/core/tests/test_tasks.py
+++ b/cumulusci/core/tests/test_tasks.py
@@ -89,7 +89,7 @@ class TestBaseTaskCallable(MockLoggerMixin, unittest.TestCase):
             self.project_config, self.task_config, self.org_config
         )
 
-        self.assertIsInstance(task, collections.Callable)
+        self.assertIsInstance(task, collections.abc.Callable)
 
     def test_option_overrides(self):
         task = self.__class__.task_class(

--- a/cumulusci/core/tests/utils.py
+++ b/cumulusci/core/tests/utils.py
@@ -43,7 +43,7 @@ class MockLoggingHandler(logging.Handler):
             self.release()
 
 
-class EnvironmentVarGuard(collections.MutableMapping):
+class EnvironmentVarGuard(collections.abc.MutableMapping):
 
     """Class to help protect the environment variable properly.  Can be used as
     a context manager."""


### PR DESCRIPTION
# Critical Changes
Changes package name on collections abstract classes for 3.8 deprecation of old package name.

# Changes
`test_tasks.py` and `utils.py`. Only Utils was throwing the warning in the test runner, but test_task has the same concern.

# Issues Closed
Fixes #1273