### PR TITLE
Python 3.8 Updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,15 +39,15 @@ jobs:
       - run:
           name: Run Python tests
           command: |
-            mkdir -p testresults/py3
-            venv/bin/tox -e py36 -- --junitxml=testresults/py3/junit.xml
-            mv .coverage .coverage.py3
+            mkdir -p testresults/py36
+            venv/bin/tox -e py36 -- --junitxml=testresults/py36/junit.xml
+            mv .coverage .coverage.py36
       - store_test_results:
           path: testresults
       - persist_to_workspace:
           root: .
           paths:
-            - .coverage.py3
+            - .coverage.py36
   
   test_py37:
     <<: *defaults
@@ -61,15 +61,15 @@ jobs:
       - run:
           name: Run Python tests
           command: |
-            mkdir -p testresults/py3
-            venv/bin/tox -e py37 -- --junitxml=testresults/py3/junit.xml
-            mv .coverage .coverage.py3
+            mkdir -p testresults/py37
+            venv/bin/tox -e py37 -- --junitxml=testresults/py37/junit.xml
+            mv .coverage .coverage.py37
       - store_test_results:
           path: testresults
       - persist_to_workspace:
           root: .
           paths:
-            - .coverage.py3
+            - .coverage.py37
 
   test_robot:
     <<: *defaults
@@ -221,6 +221,7 @@ workflows:
       - test_release
       - report:
           requires:
-            - test_py3
+            - test_py36
+            - test_py37
             - test_robot
             - test_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,7 +215,8 @@ workflows:
   build_test_report:
     jobs:
       - lint
-      - test_py3
+      - test_py36
+      - test_py37
       - test_robot
       - test_release
       - report:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
           name: Run Python tests
           command: |
             mkdir -p testresults/py3
-            venv/bin/tox -e py37 -- --junitxml=testresults/py3/junit.xml
+            venv/bin/tox -e py38 -- --junitxml=testresults/py3/junit.xml
             mv .coverage .coverage.py3
       - store_test_results:
           path: testresults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,30 @@ jobs:
           root: .
           paths:
             - .coverage.py37
+  
+  test_py38:
+    <<: *defaults
+    docker:
+      - image: circleci/python:3.8
+    steps:
+      - checkout
+      - run:
+          name: Install Python dependencies
+          command: |
+            virtualenv venv
+            venv/bin/pip install tox
+      - run:
+          name: Run Python tests
+          command: |
+            mkdir -p testresults/py38
+            venv/bin/tox -e py38 -- --junitxml=testresults/py38/junit.xml
+            mv .coverage .coverage.py38
+      - store_test_results:
+          path: testresults
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .coverage.py38
 
   test_robot:
     <<: *defaults
@@ -219,11 +243,13 @@ workflows:
       - lint
       - test_py36
       - test_py37
+      - test_py38
       - test_robot
       - test_release
       - report:
           requires:
             - test_py36
             - test_py37
+            - test_py38
             - test_robot
             - test_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           command: |
             venv/bin/black --check --diff .
 
-  test_py3:
+  test_py36:
     <<: *defaults
     steps:
       - checkout
@@ -40,7 +40,29 @@ jobs:
           name: Run Python tests
           command: |
             mkdir -p testresults/py3
-            venv/bin/tox -e py38 -- --junitxml=testresults/py3/junit.xml
+            venv/bin/tox -e py36 -- --junitxml=testresults/py3/junit.xml
+            mv .coverage .coverage.py3
+      - store_test_results:
+          path: testresults
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .coverage.py3
+  
+  test_py37:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Install Python dependencies
+          command: |
+            virtualenv venv
+            venv/bin/pip install tox
+      - run:
+          name: Run Python tests
+          command: |
+            mkdir -p testresults/py3
+            venv/bin/tox -e py37 -- --junitxml=testresults/py3/junit.xml
             mv .coverage .coverage.py3
       - store_test_results:
           path: testresults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,8 @@ jobs:
 
   test_py36:
     <<: *defaults
+    docker:
+      - image: circleci/python:3.6
     steps:
       - checkout
       - run:

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,7 @@ CumulusCI
 
 CumulusCI is a command line tool belt and set of reusable Python classes useful in the development and release process of building a Salesforce Managed Package application.
 
+
 Key Features
 ------------
 
@@ -26,6 +27,9 @@ For more information, read the `full documentation`_.
 
 If you just want a quick intro, watch this screencast demo of using CumulusCI to configure a Salesforce project from a GitHub repository:
 https://asciinema.org/a/91555
+
+Supported Python Versions: 3.6, 3.7, 3.8
+
 
 CumulusCI 1.0 (Ant based) Users, **PLEASE READ**
 ================================================

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     test_suite="cumulusci.core.tests",
     tests_require=test_requirements,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37
+envlist = py36, py37, py38
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38
+envlist = py36, py37
 
 [testenv]
 setenv =


### PR DESCRIPTION
* tox.ini updated to include 3.8.0
* We now have three separate jobs for python tests that will run in circleci for py versionse: 3.6, 3.7, and 3.8.