### PR TITLE
Make CreateUnmanagedEESrc remove Protected settings on Custom Objects

### DIFF
--- a/cumulusci/tasks/metadata/ee_src.py
+++ b/cumulusci/tasks/metadata/ee_src.py
@@ -18,7 +18,7 @@ class CreateUnmanagedEESrc(BaseTask):
         },
     }
 
-    elements = ["*.object:availableFields"]
+    elements = ["*.object:availableFields", "*.object:visibility[.='Protected']"]
 
     def _run_task(self):
         # Check that path exists

--- a/cumulusci/tasks/metadata/tests/test_ee_src.py
+++ b/cumulusci/tasks/metadata/tests/test_ee_src.py
@@ -26,8 +26,11 @@ class TestCreateUnmanagedEESrc(unittest.TestCase):
             )
             task = CreateUnmanagedEESrc(project_config, task_config)
             task()
-            removeXmlElement.assert_called_once_with(
-                "availableFields", path, "*.object"
+            removeXmlElement.assert_has_calls(
+                [
+                    mock.call("availableFields", path, "*.object"),
+                    mock.call("visibility[.='Protected']", path, "*.object"),
+                ]
             )
 
     def test_run_task__path_not_found(self):


### PR DESCRIPTION
# Critical Changes

# Changes

- The `CreateUnmanagedEESrc` task has been revised to remove the Protected setting on Custom Objects, to ensure that source is deployable to an Enterprise Edition.

# Issues Closed
