### PR TITLE
Don't use persistent connections for MDAPI posts

### DIFF
--- a/cumulusci/__init__.py
+++ b/cumulusci/__init__.py
@@ -3,7 +3,7 @@ import sys
 
 __import__("pkg_resources").declare_namespace("cumulusci")
 
-__version__ = "3.0.3.dev0"
+__version__ = "3.0.3.dev1"
 
 __location__ = os.path.dirname(os.path.realpath(__file__))
 

--- a/cumulusci/__init__.py
+++ b/cumulusci/__init__.py
@@ -3,7 +3,7 @@ import sys
 
 __import__("pkg_resources").declare_namespace("cumulusci")
 
-__version__ = "3.0.3.dev1"
+__version__ = "3.0.3.dev2"
 
 __location__ = os.path.dirname(os.path.realpath(__file__))
 

--- a/cumulusci/salesforce_api/metadata.py
+++ b/cumulusci/salesforce_api/metadata.py
@@ -33,7 +33,6 @@ from urllib3.contrib import pyopenssl
 pyopenssl.extract_from_urllib3()
 
 retry_policy = Retry(backoff_factor=0.3)
-http_adapter = HTTPAdapter(max_retries=retry_policy)
 
 
 class BaseMetadataApiCall(object):
@@ -111,6 +110,7 @@ class BaseMetadataApiCall(object):
         session_id = self.task.org_config.access_token
         auth_envelope = envelope.replace("###SESSION_ID###", session_id)
         session = requests.Session()
+        http_adapter = HTTPAdapter(max_retries=retry_policy)
         session.mount("https://", http_adapter)
         response = session.post(
             self._build_endpoint_url(),

--- a/cumulusci/salesforce_api/metadata.py
+++ b/cumulusci/salesforce_api/metadata.py
@@ -28,6 +28,10 @@ from cumulusci.salesforce_api.exceptions import MetadataComponentFailure
 from cumulusci.salesforce_api.exceptions import MetadataParseError
 from cumulusci.salesforce_api.exceptions import MetadataApiError
 
+from urllib3.contrib import pyopenssl
+
+pyopenssl.extract_from_urllib3()
+
 retry_policy = Retry(backoff_factor=0.3)
 http_adapter = HTTPAdapter(max_retries=retry_policy)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 
-current_version = 3.0.3.dev1
+current_version = 3.0.3.dev2
 
 commit = True
 tag = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 
-current_version = 3.0.3.dev0
+current_version = 3.0.3.dev1
 
 commit = True
 tag = False

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("requirements_dev.txt") as dev_requirements_file:
 
 setup(
     name="cumulusci",
-    version="3.0.3.dev1",
+    version="3.0.3.dev2",
     description="Build and release tools for Salesforce developers",
     long_description=readme + u"\n\n" + history,
     long_description_content_type="text/x-rst",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("requirements_dev.txt") as dev_requirements_file:
 
 setup(
     name="cumulusci",
-    version="3.0.3.dev0",
+    version="3.0.3.dev1",
     description="Build and release tools for Salesforce developers",
     long_description=readme + u"\n\n" + history,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed
* Disabled use of PyOpenSSL by the Python requests library, since it is no longer needed in the versions of Python we support.
* Fixed an issue where posts to the Metadata API could reuse an existing connection and get a connection reset error if Salesforce had closed the connection.
