### PR TITLE
`task_doc` shouldn't be inherited from parent classes

### DIFF
--- a/cumulusci/tests/test_utils.py
+++ b/cumulusci/tests/test_utils.py
@@ -464,3 +464,12 @@ class FunTestTask(BaseTask):
         "color": {"description": "What color"},
     }
     task_docs = "extra docs"
+
+
+class FunTestTaskChild(FunTestTask):
+    """For testing doc_task"""
+
+    task_options = {
+        "flavor": {"description": "What flavor", "required": True},
+        "color": {"description": "What color"},
+    }

--- a/cumulusci/tests/test_utils.py
+++ b/cumulusci/tests/test_utils.py
@@ -347,6 +347,17 @@ Options:
             result,
         )
 
+    def test_doc_task_not_inherited(self):
+        task_config = TaskConfig(
+            {
+                "class_path": "cumulusci.tests.test_utils.FunTestTaskChild",
+                "options": {"color": "black"},
+            }
+        )
+        result = utils.doc_task("command", task_config)
+
+        assert "extra docs" not in result
+
     def test_package_xml_from_dict(self):
         items = {"ApexClass": ["TestClass"]}
         result = utils.package_xml_from_dict(

--- a/cumulusci/utils.py
+++ b/cumulusci/utils.py
@@ -369,8 +369,8 @@ def doc_task(task_name, task_config, project_config=None, org_config=None):
     doc.append("**Class::** {}\n".format(task_config.class_path))
 
     task_class = import_global(task_config.class_path)
-    task_docs = textwrap.dedent(task_class.task_docs.strip("\n"))
-    if task_docs:
+    if "task_docs" in task_class.__dict__:
+        task_docs = textwrap.dedent(task_class.task_docs.strip("\n"))
         doc.append(task_docs + "\n")
     if task_class.task_options:
         doc.append("Options:\n------------------------------------------\n")


### PR DESCRIPTION
# Changes
* `cci task doc` now only adds task_docs when present in `class.__dict__`
