### PR TITLE
Cache the YAML loaded by BaseGlobalConfig

### DIFF
--- a/cumulusci/core/config/BaseGlobalConfig.py
+++ b/cumulusci/core/config/BaseGlobalConfig.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 
 import yaml
 
@@ -13,22 +12,14 @@ __location__ = os.path.dirname(os.path.realpath(__file__))
 class BaseGlobalConfig(BaseTaskFlowConfig):
     """ Base class for the global config which contains all configuration not specific to projects """
 
+    config = None
     config_filename = "cumulusci.yml"
     project_config_class = BaseProjectConfig
     config_local_dir = ".cumulusci"
 
     def __init__(self, config=None):
-        self.config_global_local = {}
-        self.config_global = {}
-        super(BaseGlobalConfig, self).__init__(config)
-
-    def get_project_config(self, *args, **kwargs):
-        """ Returns a ProjectConfig for the given project """
-        warnings.warn(
-            "BaseGlobalConfig.get_project_config is pending deprecation",
-            DeprecationWarning,
-        )
-        return self.project_config_class(self, *args, **kwargs)
+        self._init_logger()
+        self._load_config()
 
     @property
     def config_global_local_path(self):
@@ -50,20 +41,26 @@ class BaseGlobalConfig(BaseTaskFlowConfig):
 
     def _load_config(self):
         """ Loads the local configuration """
+        # avoid loading multiple times
+        if BaseGlobalConfig.config is not None:
+            return
+
         # load the global config
         with open(self.config_global_path, "r") as f_config:
             config = yaml.safe_load(f_config)
-        self.config_global = config
+        BaseGlobalConfig.config_global = config
 
         # Load the local config
         if self.config_global_local_path:
             with open(self.config_global_local_path, "r") as f:
                 config = yaml.safe_load(f)
-            self.config_global_local = config
+        else:
+            config = {}
+        BaseGlobalConfig.config_global_local = config
 
-        self.config = merge_config(
+        BaseGlobalConfig.config = merge_config(
             {
-                "global_config": self.config_global,
-                "global_local": self.config_global_local,
+                "global_config": BaseGlobalConfig.config_global,
+                "global_local": BaseGlobalConfig.config_global_local,
             }
         )

--- a/cumulusci/core/tests/test_config_expensive.py
+++ b/cumulusci/core/tests/test_config_expensive.py
@@ -56,6 +56,9 @@ class TestBaseGlobalConfig(unittest.TestCase):
         self._create_global_config_local(local_yaml)
         mock_class.return_value = self.tempdir_home
 
+        # clear cache
+        BaseGlobalConfig.config = None
+
         config = BaseGlobalConfig()
         with open(__location__ + "/../../cumulusci.yml", "r") as f_expected_config:
             expected_config = yaml.safe_load(f_expected_config)

--- a/cumulusci/files/templates/project/cumulusci.yml
+++ b/cumulusci/files/templates/project/cumulusci.yml
@@ -32,7 +32,8 @@ project:
       {% if git.prefix_beta %} 
         prefix_beta: '{{ git.prefix_beta }}'{% endif %}
       {% if git.prefix_release %} 
-        prefix_release: '{{ git.prefix_release }}'{% endif %}
+        prefix_release: '{{ git.prefix_release }}'
+      {% endif %}
     {% if test_name_match %}
     test:
         name_match: '{{ test_name_match }}'
@@ -52,4 +53,3 @@ tasks:
         options:
             path: robot/{{project_name}}/tests
             output: robot/{{project_name}}/doc/{{project_name}}_tests.html
-

--- a/cumulusci/tasks/tests/test_mrbelvedere.py
+++ b/cumulusci/tasks/tests/test_mrbelvedere.py
@@ -11,12 +11,14 @@ from cumulusci.core.config import TaskConfig
 from cumulusci.core.exceptions import MrbelvedereError
 from cumulusci.core.keychain import BaseProjectKeychain
 from cumulusci.tasks.mrbelvedere import MrbelvederePublish
-from cumulusci.tests.util import get_base_config
 
 
 class TestMrbelvederePublish(unittest.TestCase):
     def setUp(self):
-        self.project_config = BaseProjectConfig(BaseGlobalConfig(), get_base_config())
+        global_config = BaseGlobalConfig()
+        self.project_config = BaseProjectConfig(
+            global_config, config=global_config.config
+        )
         self.project_config.config["project"]["package"]["namespace"] = "npsp"
         self.project_config.config["project"]["dependencies"] = [
             {"namespace": "nochangedep", "version": "1.0"},

--- a/cumulusci/tests/util.py
+++ b/cumulusci/tests/util.py
@@ -1,13 +1,10 @@
-import os
+import copy
 import random
-
-import yaml
 
 from cumulusci.core.config import BaseGlobalConfig
 from cumulusci.core.config import BaseProjectConfig
 from cumulusci.core.keychain import BaseProjectKeychain
 from cumulusci.core.config import OrgConfig
-from cumulusci import __location__
 
 
 def random_sha():
@@ -15,20 +12,13 @@ def random_sha():
     return "%032x" % hash
 
 
-def get_base_config():
-    path = os.path.abspath(os.path.join(__location__, "cumulusci.yml"))
-    with open(path, "r") as f:
-        return yaml.safe_load(f)
-
-
 def create_project_config(repo_name="TestRepo", repo_owner="TestOwner"):
-    base_config = get_base_config()
-    global_config = BaseGlobalConfig(base_config)
+    global_config = BaseGlobalConfig()
     project_config = DummyProjectConfig(
         global_config=global_config,
         repo_name=repo_name,
         repo_owner=repo_owner,
-        config=base_config,
+        config=copy.deepcopy(global_config.config),
     )
     keychain = BaseProjectKeychain(project_config, None)
     project_config.set_keychain(keychain)


### PR DESCRIPTION
This speeds up the unit tests by about 10 times since they construct a lot of global config instances.

# Critical Changes

# Changes

# Issues Closed
