### PR TITLE
Feature/more flexible format str

### DIFF
--- a/cumulusci/core/template_utils.py
+++ b/cumulusci/core/template_utils.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from faker import Faker
 
 from jinja2 import Template
 
@@ -35,11 +36,9 @@ class FakerTemplateLibrary:
 
     _faker = None
 
-    @property
-    def faker(self):
-        """Defer loading heavy faker library until actually needed"""
-        self._faker = self._faker or __import__("faker").Faker()
-        return self._faker
+    def __init__(self, locale=None):
+        self.locale = locale
+        self.faker = Faker(self.locale)
 
     def __getattr__(self, name):
         return StringGenerator(
@@ -52,8 +51,8 @@ faker_template_library = FakerTemplateLibrary()
 Template = lru_cache(512)(Template)
 
 
-def format_str(value, variables={}):
+def format_str(value, variables={}, fake=faker_template_library):
     if isinstance(value, str) and "{" in value:
-        value = Template(value).render(fake=faker_template_library, **variables)
+        value = Template(value).render(fake=fake, **variables)
 
     return value

--- a/cumulusci/core/template_utils.py
+++ b/cumulusci/core/template_utils.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 from jinja2 import Template
 
 
@@ -47,9 +49,11 @@ class FakerTemplateLibrary:
 
 faker_template_library = FakerTemplateLibrary()
 
+Template = lru_cache(512)(Template)
+
 
 def format_str(value, **kwargs):
-    if isinstance(value, str):
+    if isinstance(value, str) and "{" in value:
         value = Template(value).render(fake=faker_template_library, **kwargs)
 
     return value

--- a/cumulusci/core/template_utils.py
+++ b/cumulusci/core/template_utils.py
@@ -52,8 +52,8 @@ faker_template_library = FakerTemplateLibrary()
 Template = lru_cache(512)(Template)
 
 
-def format_str(value, **kwargs):
+def format_str(value, variables={}):
     if isinstance(value, str) and "{" in value:
-        value = Template(value).render(fake=faker_template_library, **kwargs)
+        value = Template(value).render(fake=faker_template_library, **variables)
 
     return value

--- a/cumulusci/core/template_utils.py
+++ b/cumulusci/core/template_utils.py
@@ -51,7 +51,8 @@ faker_template_library = FakerTemplateLibrary()
 Template = lru_cache(512)(Template)
 
 
-def format_str(value, variables={}, fake=faker_template_library):
+def format_str(value, variables=None, fake=faker_template_library):
+    variables = variables or {}
     if isinstance(value, str) and "{" in value:
         value = Template(value).render(fake=fake, **variables)
 

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -564,7 +564,7 @@ class Salesforce(object):
 
         for i in range(int(number_to_create)):
             formatted_fields = {
-                name: format_str(value, i) for name, value in fields.items()
+                name: format_str(value, number=i) for name, value in fields.items()
             }
             newobj = self._salesforce_generate_object(obj_name, **formatted_fields)
             objs.append(newobj)

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -564,7 +564,7 @@ class Salesforce(object):
 
         for i in range(int(number_to_create)):
             formatted_fields = {
-                name: format_str(value, number=i) for name, value in fields.items()
+                name: format_str(value, {"number": i}) for name, value in fields.items()
             }
             newobj = self._salesforce_generate_object(obj_name, **formatted_fields)
             objs.append(newobj)

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -16,7 +16,7 @@ from cumulusci.robotframework.utils import selenium_retry
 from SeleniumLibrary.errors import ElementNotFound, NoOpenBrowser
 from urllib3.exceptions import ProtocolError
 
-from cumulusci.robotframework.template_utils import format_str
+from cumulusci.core.template_utils import format_str
 
 OID_REGEX = r"^(%2F)?([a-zA-Z0-9]{15,18})$"
 STATUS_KEY = ("status",)

--- a/cumulusci/robotframework/template_utils.py
+++ b/cumulusci/robotframework/template_utils.py
@@ -48,8 +48,8 @@ class FakerTemplateLibrary:
 faker_template_library = FakerTemplateLibrary()
 
 
-def format_str(value, i):
+def format_str(value, **kwargs):
     if isinstance(value, str):
-        value = Template(value).render(number=i, fake=faker_template_library)
+        value = Template(value).render(fake=faker_template_library, **kwargs)
 
     return value

--- a/cumulusci/robotframework/tests/test_template_util.py
+++ b/cumulusci/robotframework/tests/test_template_util.py
@@ -13,7 +13,12 @@ class TemplateUtils(unittest.TestCase):
     def test_faker_library(self):
         fake = template_utils.FakerTemplateLibrary()
         assert fake.first_name
-        assert fake.email(domain="salesforce.com")
+        assert "example.com" in fake.email(domain="example.com")
+
+    def test_faker_languages(self):
+        fake = template_utils.FakerTemplateLibrary("no_NO")
+        assert fake.first_name
+        assert "example.com" in fake.email(domain="example.com")
 
     def test_format_str(self):
         assert template_utils.format_str("abc") == "abc"
@@ -29,3 +34,21 @@ class TemplateUtils(unittest.TestCase):
             template_utils.format_str("{% raw %}{}{% endraw %}", {"count": "15"})
             == "{}"
         )
+
+    def test_format_str_languages(self):
+        norwegian_faker = template_utils.FakerTemplateLibrary("no_NO")
+
+        val = template_utils.format_str(
+            "{{vikingfake.first_name}} {{abc}}",
+            {"abc": 5, "vikingfake": norwegian_faker},
+        )
+        assert "5" in val
+
+        def cosmopolitan_faker(language):
+            return template_utils.FakerTemplateLibrary(language)
+
+        val = template_utils.format_str(
+            "{{fakei18n('ne_NP').first_name}} {{abc}}",
+            {"abc": 5, "fakei18n": cosmopolitan_faker, "type": type},
+        )
+        assert "5" in val

--- a/cumulusci/robotframework/tests/test_template_util.py
+++ b/cumulusci/robotframework/tests/test_template_util.py
@@ -17,12 +17,15 @@ class TemplateUtils(unittest.TestCase):
 
     def test_format_str(self):
         assert template_utils.format_str("abc") == "abc"
-        assert template_utils.format_str("{{abc}}", abc=5) == "5"
+        assert template_utils.format_str("{{abc}}", {"abc": 5}) == "5"
         assert len(template_utils.format_str("{{fake.first_name}}"))
         assert "15" in template_utils.format_str(
-            "{{fake.first_name}} {{count}}", count=15
+            "{{fake.first_name}} {{count}}", {"count": 15}
         )
         assert "15" in template_utils.format_str(
-            "{{fake.first_name}} {{count}}", count="15"
+            "{{fake.first_name}} {{count}}", {"count": "15"}
         )
-        assert template_utils.format_str("{% raw %}{}{% endraw %}", count="15") == "{}"
+        assert (
+            template_utils.format_str("{% raw %}{}{% endraw %}", {"count": "15"})
+            == "{}"
+        )

--- a/cumulusci/robotframework/tests/test_template_util.py
+++ b/cumulusci/robotframework/tests/test_template_util.py
@@ -1,5 +1,5 @@
 import unittest
-from cumulusci.robotframework import template_utils
+from cumulusci.core import template_utils
 
 
 class TemplateUtils(unittest.TestCase):
@@ -14,3 +14,15 @@ class TemplateUtils(unittest.TestCase):
         fake = template_utils.FakerTemplateLibrary()
         assert fake.first_name
         assert fake.email(domain="salesforce.com")
+
+    def test_format_str(self):
+        assert template_utils.format_str("abc") == "abc"
+        assert template_utils.format_str("{{abc}}", abc=5) == "5"
+        assert len(template_utils.format_str("{{fake.first_name}}"))
+        assert "15" in template_utils.format_str(
+            "{{fake.first_name}} {{count}}", count=15
+        )
+        assert "15" in template_utils.format_str(
+            "{{fake.first_name}} {{count}}", count="15"
+        )
+        assert template_utils.format_str("{% raw %}{}{% endraw %}", count="15") == "{}"


### PR DESCRIPTION
Internal reorganization of this code.

Allow callers to pass arbitrary keyword arguments to this Jinja function.

Make the function more globally visible by moving the file

