### PR TITLE
Deploy org settings using the project API version

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -905,7 +905,7 @@ project:
         namespace:
         install_class:
         uninstall_class:
-        api_version: '46.0'
+        api_version: '47.0'
     git:
         default_branch: master
         prefix_feature: feature/

--- a/cumulusci/tasks/salesforce/org_settings.py
+++ b/cumulusci/tasks/salesforce/org_settings.py
@@ -19,7 +19,7 @@ PACKAGE_XML = """<?xml version="1.0" encoding="UTF-8"?>
         <members>*</members>
         <name>Settings</name>
     </types>
-    <version>46.0</version>
+    <version>{api_version}</version>
 </Package>"""
 
 
@@ -27,7 +27,8 @@ class DeployOrgSettings(Deploy):
     task_doc = """Deploys org settings from an sfdx scratch org definition file."""
 
     task_options = {
-        "definition_file": {"description": "sfdx scratch org definition file"}
+        "definition_file": {"description": "sfdx scratch org definition file"},
+        "api_version": {"description": "API version used to deploy the settings"},
     }
 
     def _run_task(self):
@@ -65,8 +66,12 @@ class DeployOrgSettings(Deploy):
             )
             with open(settings_file, "w") as f:
                 f.write(SETTINGS_XML.format(settingsName=settings_name, values=values))
+        api_version = (
+            self.options.get("api_version")
+            or self.project_config.project__package__api_version
+        )
         with open("package.xml", "w") as f:
-            f.write(PACKAGE_XML)
+            f.write(PACKAGE_XML.format(api_version=api_version))
 
 
 def capitalize(s):

--- a/cumulusci/tasks/salesforce/tests/test_org_settings.py
+++ b/cumulusci/tasks/salesforce/tests/test_org_settings.py
@@ -39,7 +39,7 @@ class TestDeployOrgSettings:
         <members>*</members>
         <name>Settings</name>
     </types>
-    <version>46.0</version>
+    <version>47.0</version>
 </Package>"""
         )
         assert (

--- a/cumulusci/tasks/salesforce/tests/test_sourcetracking.py
+++ b/cumulusci/tasks/salesforce/tests/test_sourcetracking.py
@@ -189,7 +189,7 @@ class TestRetrieveChanges(unittest.TestCase):
         <members>Object2</members>
         <name>CustomObject</name>
     </types>
-    <version>46.0</version>
+    <version>47.0</version>
 </Package>""",
                 package_xml,
             )


### PR DESCRIPTION
Instead of a hardcoded version. The settings are part of a scratch org definition file stored in the project repository, so may use different versions depending on when they were written.

# Critical Changes

# Changes

# Issues Closed
