### PR TITLE
Add support for specifying latest/latest_beta/previous release in a github source spec

### DIFF
--- a/cumulusci/core/config/project_config.py
+++ b/cumulusci/core/config/project_config.py
@@ -22,6 +22,7 @@ from cumulusci.core.exceptions import (
 )
 from cumulusci.core.github import get_github_api_for_repo
 from cumulusci.core.github import find_latest_release
+from cumulusci.core.github import find_previous_release
 from cumulusci.core.source import GitHubSource
 from cumulusci.core.source import LocalFolderSource
 from cumulusci.core.source import NullSource
@@ -432,14 +433,9 @@ class BaseProjectConfig(BaseTaskFlowConfig):
         """Query GitHub releases to find the previous production release"""
         gh = self.get_github_api()
         repo = gh.repository(self.repo_owner, self.repo_name)
-        most_recent = None
-        for release in repo.releases():
-            # Return the second release that matches the release prefix
-            if release.tag_name.startswith(self.project__git__prefix_release):
-                if most_recent is None:
-                    most_recent = release
-                else:
-                    return LooseVersion(self.get_version_for_tag(release.tag_name))
+        release = find_previous_release(repo, self.project__git__prefix_release)
+        if release is not None:
+            return LooseVersion(self.get_version_for_tag(release.tag_name))
 
     @property
     def config_project_path(self):

--- a/cumulusci/core/github.py
+++ b/cumulusci/core/github.py
@@ -151,3 +151,17 @@ def find_latest_release(repo, include_beta=None):
             return repo.latest_release()
     except (github3.exceptions.NotFoundError, StopIteration):
         pass
+
+
+def find_previous_release(repo, prefix=None):
+    most_recent = None
+    for release in repo.releases():
+        if prefix and not release.tag_name.startswith(prefix):
+            continue
+        if not prefix and release.prerelease:
+            continue
+        # Return the second release
+        if most_recent is None:
+            most_recent = release
+        else:
+            return release

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -240,8 +240,8 @@ class TestBaseProjectConfig(unittest.TestCase):
             {},
             [
                 DummyRelease("release/1.1", "1.1"),
-                DummyRelease("release/1.0", "1.0"),
                 DummyRelease("beta-wrongprefix", "wrong"),
+                DummyRelease("release/1.0", "1.0"),
                 DummyRelease("beta/1.0-Beta_2", "1.0 (Beta 2)"),
                 DummyRelease("beta/1.0-Beta_1", "1.0 (Beta 1)"),
             ],


### PR DESCRIPTION

# Critical Changes

# Changes
- When including steps from an external GitHub source, it's now possible to specify `release: latest`, `release: latest_beta`, or `release: prevous` instead of a commit, branch, or tag.

# Issues Closed
