### PR TITLE
Catch Anon Apex gack results

### DIFF
--- a/cumulusci/tasks/apex/anon.py
+++ b/cumulusci/tasks/apex/anon.py
@@ -1,5 +1,6 @@
 from cumulusci.core.exceptions import ApexCompilationException
 from cumulusci.core.exceptions import ApexException
+from cumulusci.core.exceptions import SalesforceException
 from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 from cumulusci.utils import in_directory
@@ -99,6 +100,14 @@ class AnonymousApexTask(BaseSalesforceApiTask):
         # anon_results is an ExecuteAnonymous Result
         # https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/sforce_api_calls_executeanonymous_result.htm
         anon_results = result.json()
+
+        # A result of `None` (body == "null") with a 200 status code
+        # means that a gack occurred.
+        if anon_results is None:
+            raise SalesforceException(
+                "Anonymous Apex returned the result `null`. "
+                "This often indicates a gack occurred."
+            )
         if not anon_results["compiled"]:
             raise ApexCompilationException(
                 anon_results["line"], anon_results["compileProblem"]

--- a/cumulusci/tasks/apex/tests/test_apex_tasks.py
+++ b/cumulusci/tasks/apex/tests/test_apex_tasks.py
@@ -535,6 +535,15 @@ class TestAnonymousApexTask(unittest.TestCase):
         self.assertEqual(err.args[0], problem)
         self.assertEqual(err.args[1], trace)
 
+    @responses.activate
+    def test_run_anonymous_apex__gack(self):
+        task, url = self._get_url_and_task()
+        responses.add(responses.GET, url, status=200, body="null")
+        with self.assertRaises(SalesforceException) as cm:
+            task()
+        err = str(cm.exception)
+        assert "gack" in err
+
 
 @patch(
     "cumulusci.tasks.salesforce.BaseSalesforceTask._update_credentials",


### PR DESCRIPTION
# Critical Changes

# Changes

- `AnonymousApexTask` has been revised to detect when a gack occurred during execution.

# Issues Closed
