### PR TITLE
Fix UpdateAdminProfile when used in a cross-project flow

### DIFF
--- a/cumulusci/tasks/salesforce/UpdateAdminProfile.py
+++ b/cumulusci/tasks/salesforce/UpdateAdminProfile.py
@@ -55,6 +55,13 @@ class UpdateAdminProfile(Deploy):
         }
 
     def _run_task(self):
+        self.tempdir = tempfile.mkdtemp()
+        self._retrieve_unpackaged()
+        self._process_metadata()
+        self._deploy_metadata()
+        shutil.rmtree(self.tempdir)
+
+    def _retrieve_unpackaged(self):
         path = self.options.get("package_xml") or os.path.join(
             CUMULUSCI_PATH, "cumulusci", "files", "admin_profile.xml"
         )
@@ -64,14 +71,6 @@ class UpdateAdminProfile(Deploy):
         self._package_xml_content = self._package_xml_content.format(
             **self.namespace_prefixes
         )
-
-        self.tempdir = tempfile.mkdtemp()
-        self._retrieve_unpackaged()
-        self._process_metadata()
-        self._deploy_metadata()
-        shutil.rmtree(self.tempdir)
-
-    def _retrieve_unpackaged(self):
         self.logger.info(
             "Retrieving metadata using {}".format(
                 self.options.get("package_xml", "default package.xml")

--- a/cumulusci/tasks/salesforce/UpdateAdminProfile.py
+++ b/cumulusci/tasks/salesforce/UpdateAdminProfile.py
@@ -8,8 +8,6 @@ from cumulusci.core.utils import process_bool_arg
 from cumulusci.tasks.salesforce import Deploy
 from cumulusci.utils import CUMULUSCI_PATH
 from cumulusci.utils import elementtree_parse_file
-from cumulusci.utils import findReplace
-from cumulusci.utils import findReplaceRegex
 
 
 class UpdateAdminProfile(Deploy):
@@ -56,6 +54,7 @@ class UpdateAdminProfile(Deploy):
             else "",
         }
 
+    def _run_task(self):
         path = self.options.get("package_xml") or os.path.join(
             CUMULUSCI_PATH, "cumulusci", "files", "admin_profile.xml"
         )
@@ -66,7 +65,6 @@ class UpdateAdminProfile(Deploy):
             **self.namespace_prefixes
         )
 
-    def _run_task(self):
         self.tempdir = tempfile.mkdtemp()
         self._retrieve_unpackaged()
         self._process_metadata()


### PR DESCRIPTION
This moves use of the path option into _run_task instead of _init_options so that it happens when CumulusCI has already changed to the correct project directory.

# Critical Changes

# Changes

# Issues Closed
