### PR TITLE
delegate sub-project config construction back to the (possibly custom) project config

### DIFF
--- a/cumulusci/__init__.py
+++ b/cumulusci/__init__.py
@@ -3,7 +3,7 @@ import sys
 
 __import__("pkg_resources").declare_namespace("cumulusci")
 
-__version__ = "3.1.1.dev0"
+__version__ = "3.1.1.dev1"
 
 __location__ = os.path.dirname(os.path.realpath(__file__))
 

--- a/cumulusci/core/config/project_config.py
+++ b/cumulusci/core/config/project_config.py
@@ -807,6 +807,12 @@ class BaseProjectConfig(BaseTaskFlowConfig):
             self.included_sources[frozenspec] = project_config
         return project_config
 
+    def construct_subproject_config(self, **kwargs):
+        """Construct another project config for an external source"""
+        return self.__class__(
+            self.global_config_obj, included_sources=self.included_sources, **kwargs
+        )
+
     def relpath(self, path):
         """Convert path to be relative to the project repo root."""
         return os.path.relpath(os.path.join(self.repo_root, path))

--- a/cumulusci/core/source/github.py
+++ b/cumulusci/core/source/github.py
@@ -101,16 +101,14 @@ class GitHubSource:
             )
             zf.extractall(path)
 
-        project_config = self.project_config.__class__(
-            self.project_config.global_config_obj,
+        project_config = self.project_config.construct_subproject_config(
             repo_info={
                 "root": os.path.realpath(path),
                 "owner": self.repo_owner,
                 "name": self.repo_name,
                 "url": self.url,
                 "commit": self.commit,
-            },
-            included_sources=self.project_config.included_sources,
+            }
         )
         return project_config
 

--- a/cumulusci/core/source/local_folder.py
+++ b/cumulusci/core/source/local_folder.py
@@ -18,10 +18,8 @@ class LocalFolderSource:
 
     def fetch(self):
         """Construct a project config referencing the specified path."""
-        project_config = self.project_config.__class__(
-            self.project_config.global_config_obj,
-            repo_info={"root": os.path.realpath(self.path)},
-            included_sources=self.project_config.included_sources,
+        project_config = self.project_config.construct_subproject_config(
+            repo_info={"root": os.path.realpath(self.path)}
         )
         return project_config
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 
-current_version = 3.1.1.dev0
+current_version = 3.1.1.dev1
 
 commit = True
 tag = False

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("requirements_dev.txt") as dev_requirements_file:
 
 setup(
     name="cumulusci",
-    version="3.1.1.dev0",
+    version="3.1.1.dev1",
     description="Build and release tools for Salesforce developers",
     long_description=readme + u"\n\n" + history,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
This will allow MetaDeploy's MetadeployProjectConfig to ensure that sub-project configs retain a reference to a MetaDeploy Plan.

# Critical Changes

# Changes

# Issues Closed
