### PR TITLE
Allow bypassing scratch org recreation prompt via option and environment variable

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -37,7 +37,7 @@ from cumulusci.core.exceptions import FlowNotFoundError
 from cumulusci.core.utils import import_global
 from cumulusci.cli.config import CliRuntime
 from cumulusci.cli.config import get_installed_version
-from cumulusci.cli.options import no_prompt_callback, plain_output_callback
+from cumulusci.cli.options import global_option_lookup, NO_PROMPT_ENV, PLAIN_OUTPUT_ENV
 from cumulusci.cli.ui import CliTable, CROSSMARK
 from cumulusci.salesforce_api.utils import get_simple_salesforce_connection
 from cumulusci.utils import doc_task
@@ -632,7 +632,8 @@ def project_dependencies(config):
     "--plain",
     is_flag=True,
     help="Print the table using plain ascii.",
-    callback=plain_output_callback,
+    callback=global_option_lookup,
+    envvar=PLAIN_OUTPUT_ENV,
 )
 @click.option("--json", "print_json", is_flag=True, help="Print a json string")
 @pass_config(allow_global_keychain=True)
@@ -738,7 +739,8 @@ def service_connect():
     "--plain",
     is_flag=True,
     help="Print the table using plain ascii.",
-    callback=plain_output_callback,
+    callback=global_option_lookup,
+    envvar=PLAIN_OUTPUT_ENV,
 )
 @pass_config(allow_global_keychain=True)
 def service_info(config, service_name, plain):
@@ -773,7 +775,8 @@ def service_info(config, service_name, plain):
     "--no-prompt",
     is_flag=True,
     help="Disables all prompts.  Set for non-interactive mode use such as calling from scripts or CI systems",
-    callback=no_prompt_callback,
+    callback=global_option_lookup,
+    envvar=NO_PROMPT_ENV,
 )
 @pass_config
 def org_browser(config, org_name, no_prompt):
@@ -891,7 +894,8 @@ def calculate_org_days(info):
     "--no-prompt",
     is_flag=True,
     help="Disables all prompts.  Set for non-interactive mode use such as calling from scripts or CI systems",
-    callback=no_prompt_callback,
+    callback=global_option_lookup,
+    envvar=NO_PROMPT_ENV,
 )
 @pass_config
 def org_info(config, org_name, print_json, no_prompt):
@@ -955,7 +959,8 @@ def org_info(config, org_name, print_json, no_prompt):
     "--plain",
     is_flag=True,
     help="Print the table using plain ascii.",
-    callback=plain_output_callback,
+    callback=global_option_lookup,
+    envvar=PLAIN_OUTPUT_ENV,
 )
 @pass_config
 def org_list(config, plain):
@@ -1132,7 +1137,8 @@ def org_shell(config, org_name):
     "--plain",
     is_flag=True,
     help="Print the table using plain ascii.",
-    callback=plain_output_callback,
+    callback=global_option_lookup,
+    envvar=PLAIN_OUTPUT_ENV,
 )
 @click.option("--json", "print_json", is_flag=True, help="Print a json string")
 @pass_config(load_keychain=False)
@@ -1222,7 +1228,8 @@ def task_info(config, task_name):
     "--no-prompt",
     is_flag=True,
     help="Disables all prompts.  Set for non-interactive mode use such as calling from scripts or CI systems",
-    callback=no_prompt_callback,
+    callback=global_option_lookup,
+    envvar=NO_PROMPT_ENV,
 )
 @pass_config
 def task_run(config, task_name, org, o, debug, debug_before, debug_after, no_prompt):
@@ -1293,7 +1300,8 @@ def task_run(config, task_name, org, o, debug, debug_before, debug_after, no_pro
     "--plain",
     is_flag=True,
     help="Print the table using plain ascii.",
-    callback=plain_output_callback,
+    callback=global_option_lookup,
+    envvar=PLAIN_OUTPUT_ENV,
 )
 @click.option("--json", "print_json", is_flag=True, help="Print a json string")
 @pass_config(load_keychain=False)
@@ -1358,7 +1366,8 @@ def flow_info(config, flow_name):
     "--no-prompt",
     is_flag=True,
     help="Disables all prompts.  Set for non-interactive mode use such as calling from scripts or CI systems",
-    callback=no_prompt_callback,
+    callback=global_option_lookup,
+    envvar=NO_PROMPT_ENV,
 )
 @pass_config
 def flow_run(config, flow_name, org, delete_org, debug, o, skip, no_prompt):

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -37,6 +37,7 @@ from cumulusci.core.exceptions import FlowNotFoundError
 from cumulusci.core.utils import import_global
 from cumulusci.cli.config import CliRuntime
 from cumulusci.cli.config import get_installed_version
+from cumulusci.cli.options import no_prompt_callback, plain_output_callback
 from cumulusci.cli.ui import CliTable, CROSSMARK
 from cumulusci.salesforce_api.utils import get_simple_salesforce_connection
 from cumulusci.utils import doc_task
@@ -627,7 +628,12 @@ def project_dependencies(config):
 
 
 @service.command(name="list", help="List services available for configuration and use")
-@click.option("--plain", is_flag=True, help="Print the table using plain ascii.")
+@click.option(
+    "--plain",
+    is_flag=True,
+    help="Print the table using plain ascii.",
+    callback=plain_output_callback,
+)
 @click.option("--json", "print_json", is_flag=True, help="Print a json string")
 @pass_config(allow_global_keychain=True)
 def service_list(config, plain, print_json):
@@ -637,7 +643,6 @@ def service_list(config, plain, print_json):
         else config.global_config.services
     )
     configured_services = config.keychain.list_services()
-    plain = plain or config.global_config.cli__plain_output
 
     data = [["Name", "Description", "Configured"]]
     for serv, schema in services.items():
@@ -729,11 +734,15 @@ def service_connect():
 
 @service.command(name="info", help="Show the details of a connected service")
 @click.argument("service_name")
-@click.option("--plain", is_flag=True, help="Print the table using plain ascii.")
+@click.option(
+    "--plain",
+    is_flag=True,
+    help="Print the table using plain ascii.",
+    callback=plain_output_callback,
+)
 @pass_config(allow_global_keychain=True)
 def service_info(config, service_name, plain):
     try:
-        plain = plain or config.global_config.cli__plain_output
         service_config = config.keychain.get_service(service_name)
         service_data = [["Key", "Value"]]
         service_data.extend(
@@ -754,16 +763,6 @@ def service_info(config, service_name, plain):
         )
 
 
-# Commands for group: org
-def get_prompt_global_config(ctx, param, value):
-    global_config = BaseGlobalConfig()
-    global_value = global_config.cli__no_prompt
-    if global_value:
-        return global_value
-    else:
-        return value
-
-
 @org.command(
     name="browser",
     help="Opens a browser window and logs into the org using the stored OAuth credentials",
@@ -773,8 +772,7 @@ def get_prompt_global_config(ctx, param, value):
     "--no-prompt",
     is_flag=True,
     help="Disables all prompts.  Set for non-interactive mode use such as calling from scripts or CI systems",
-    callback=get_prompt_global_config,
-    envvar="CUMULUSCI_NO_PROMPT",
+    callback=no_prompt_callback,
 )
 @pass_config
 def org_browser(config, org_name, no_prompt):
@@ -892,8 +890,7 @@ def calculate_org_days(info):
     "--no-prompt",
     is_flag=True,
     help="Disables all prompts.  Set for non-interactive mode use such as calling from scripts or CI systems",
-    callback=get_prompt_global_config,
-    envvar="CUMULUSCI_NO_PROMPT",
+    callback=no_prompt_callback,
 )
 @pass_config
 def org_info(config, org_name, print_json, no_prompt):
@@ -953,10 +950,14 @@ def org_info(config, org_name, print_json, no_prompt):
 
 
 @org.command(name="list", help="Lists the connected orgs for the current project")
-@click.option("--plain", is_flag=True, help="Print the table using plain ascii.")
+@click.option(
+    "--plain",
+    is_flag=True,
+    help="Print the table using plain ascii.",
+    callback=plain_output_callback,
+)
 @pass_config
 def org_list(config, plain):
-    plain = plain or config.global_config.cli__plain_output
     header = ["Name", "Default", "Username", "Expires"]
     persistent_data = [header]
     scratch_data = [header[:2] + ["Days", "Expired", "Config", "Domain"]]
@@ -1126,13 +1127,17 @@ def org_shell(config, org_name):
 
 
 @task.command(name="list", help="List available tasks for the current context")
-@click.option("--plain", is_flag=True, help="Print the table using plain ascii.")
+@click.option(
+    "--plain",
+    is_flag=True,
+    help="Print the table using plain ascii.",
+    callback=plain_output_callback,
+)
 @click.option("--json", "print_json", is_flag=True, help="Print a json string")
 @pass_config(load_keychain=False)
 def task_list(config, plain, print_json):
     task_groups = {}
     tasks = config.project_config.list_tasks()
-    plain = plain or config.global_config.cli__plain_output
 
     if print_json:
         click.echo(json.dumps(tasks))
@@ -1216,8 +1221,7 @@ def task_info(config, task_name):
     "--no-prompt",
     is_flag=True,
     help="Disables all prompts.  Set for non-interactive mode use such as calling from scripts or CI systems",
-    callback=get_prompt_global_config,
-    envvar="CUMULUSCI_NO_PROMPT",
+    callback=no_prompt_callback,
 )
 @pass_config
 def task_run(config, task_name, org, o, debug, debug_before, debug_after, no_prompt):
@@ -1284,11 +1288,15 @@ def task_run(config, task_name, org, o, debug, debug_before, debug_after, no_pro
 
 
 @flow.command(name="list", help="List available flows for the current context")
-@click.option("--plain", is_flag=True, help="Print the table using plain ascii.")
+@click.option(
+    "--plain",
+    is_flag=True,
+    help="Print the table using plain ascii.",
+    callback=plain_output_callback,
+)
 @click.option("--json", "print_json", is_flag=True, help="Print a json string")
 @pass_config(load_keychain=False)
 def flow_list(config, plain, print_json):
-    plain = plain or config.global_config.cli__plain_output
     flows = config.project_config.list_flows()
 
     if print_json:
@@ -1349,8 +1357,7 @@ def flow_info(config, flow_name):
     "--no-prompt",
     is_flag=True,
     help="Disables all prompts.  Set for non-interactive mode use such as calling from scripts or CI systems",
-    callback=get_prompt_global_config,
-    envvar="CUMULUSCI_NO_PROMPT",
+    callback=no_prompt_callback,
 )
 @pass_config
 def flow_run(config, flow_name, org, delete_org, debug, o, skip, no_prompt):

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -755,6 +755,13 @@ def service_info(config, service_name, plain):
 
 
 # Commands for group: org
+def get_prompt_global_config(ctx, param, value):
+    global_config = BaseGlobalConfig()
+    global_value = global_config.cli__no_prompt
+    if global_value:
+        return global_value
+    else:
+        return value
 
 
 @org.command(
@@ -766,6 +773,8 @@ def service_info(config, service_name, plain):
     "--no-prompt",
     is_flag=True,
     help="Disables all prompts.  Set for non-interactive mode use such as calling from scripts or CI systems",
+    callback=get_prompt_global_config,
+    envvar="CUMULUSCI_NO_PROMPT",
 )
 @pass_config
 def org_browser(config, org_name, no_prompt):
@@ -883,6 +892,8 @@ def calculate_org_days(info):
     "--no-prompt",
     is_flag=True,
     help="Disables all prompts.  Set for non-interactive mode use such as calling from scripts or CI systems",
+    callback=get_prompt_global_config,
+    envvar="CUMULUSCI_NO_PROMPT",
 )
 @pass_config
 def org_info(config, org_name, print_json, no_prompt):
@@ -1205,6 +1216,8 @@ def task_info(config, task_name):
     "--no-prompt",
     is_flag=True,
     help="Disables all prompts.  Set for non-interactive mode use such as calling from scripts or CI systems",
+    callback=get_prompt_global_config,
+    envvar="CUMULUSCI_NO_PROMPT",
 )
 @pass_config
 def task_run(config, task_name, org, o, debug, debug_before, debug_after, no_prompt):
@@ -1336,6 +1349,8 @@ def flow_info(config, flow_name):
     "--no-prompt",
     is_flag=True,
     help="Disables all prompts.  Set for non-interactive mode use such as calling from scripts or CI systems",
+    callback=get_prompt_global_config,
+    envvar="CUMULUSCI_NO_PROMPT",
 )
 @pass_config
 def flow_run(config, flow_name, org, delete_org, debug, o, skip, no_prompt):

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -763,6 +763,7 @@ def service_info(config, service_name, plain):
         )
 
 
+# Commands for group: org
 @org.command(
     name="browser",
     help="Opens a browser window and logs into the org using the stored OAuth credentials",

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -762,9 +762,14 @@ def service_info(config, service_name, plain):
     help="Opens a browser window and logs into the org using the stored OAuth credentials",
 )
 @click.argument("org_name", required=False)
+@click.option(
+    "--no-prompt",
+    is_flag=True,
+    help="Disables all prompts.  Set for non-interactive mode use such as calling from scripts or CI systems",
+)
 @pass_config
-def org_browser(config, org_name):
-    org_name, org_config = config.get_org(org_name)
+def org_browser(config, org_name, no_prompt):
+    org_name, org_config = config.get_org(org_name, no_prompt=no_prompt)
     org_config.refresh_oauth_token(config.keychain)
 
     webbrowser.open(org_config.start_url)
@@ -874,10 +879,15 @@ def calculate_org_days(info):
 @org.command(name="info", help="Display information for a connected org")
 @click.argument("org_name", required=False)
 @click.option("print_json", "--json", is_flag=True, help="Print as JSON")
+@click.option(
+    "--no-prompt",
+    is_flag=True,
+    help="Disables all prompts.  Set for non-interactive mode use such as calling from scripts or CI systems",
+)
 @pass_config
-def org_info(config, org_name, print_json):
+def org_info(config, org_name, print_json, no_prompt):
     try:
-        org_name, org_config = config.get_org(org_name)
+        org_name, org_config = config.get_org(org_name, no_prompt=no_prompt)
         org_config.refresh_oauth_token(config.keychain)
     except OrgNotFound as e:
         raise click.ClickException(e)
@@ -1200,7 +1210,7 @@ def task_info(config, task_name):
 def task_run(config, task_name, org, o, debug, debug_before, debug_after, no_prompt):
 
     # Get necessary configs
-    org, org_config = config.get_org(org, fail_if_missing=False)
+    org, org_config = config.get_org(org, fail_if_missing=False, no_prompt=no_prompt)
     try:
         task_config = config.project_config.get_task(task_name)
     except CumulusCIUsageError as e:
@@ -1331,7 +1341,7 @@ def flow_info(config, flow_name):
 def flow_run(config, flow_name, org, delete_org, debug, o, skip, no_prompt):
 
     # Get necessary configs
-    org, org_config = config.get_org(org)
+    org, org_config = config.get_org(org, no_prompt=no_prompt)
     if delete_org and not org_config.scratch:
         raise click.UsageError("--delete-org can only be used with a scratch org")
 

--- a/cumulusci/cli/config.py
+++ b/cumulusci/cli/config.py
@@ -18,7 +18,6 @@ from cumulusci.utils import get_cci_upgrade_command
 from cumulusci.utils import random_alphanumeric_underscore
 
 # Environment Variables
-NO_PROMPT_ENV = "CUMULUSCI_NO_PROMPT"
 KEYCHAIN_CLASS_ENV = "CUMULUSCI_KEYCHAIN_CLASS"
 CUMULUSCI_KEY_ENV = "CUMULUSCI_KEY"
 
@@ -125,10 +124,10 @@ class CliRuntime(BaseCumulusCI):
         return org_config
 
     def _should_recreate_expired_org(self, no_prompt):
-        if no_prompt or os.environ.get(NO_PROMPT_ENV, False):
-            return True
-        else:
+        if not no_prompt:
             return click.confirm("Attempt to recreate the scratch org?", default=True)
+        else:
+            return no_prompt
 
     def check_org_overwrite(self, org_name):
         try:

--- a/cumulusci/cli/options.py
+++ b/cumulusci/cli/options.py
@@ -1,40 +1,28 @@
 """Process environment variables and global configurations for some options.
 
 Returns option values in the following order of precedence:
-1. Environment variables
-2. Global configuration options
-3. Click Option
+1. Global configuration options
+2. Click Option
+3. Environment variables
+4. Click Option default value
 """
 
-import os
 
 from cumulusci.core.config import BaseGlobalConfig
 
 # CLI Environment Variables
-NO_PROMPT_ENV = "CUMULUSCI_NO_PROMPT"
-PLAIN_OUTPUT_ENV = "CUMULUSCI_PLAIN_OUTPUT"
+CCI_ENV_PREFIX = "CCI__"
+CLI_ENV_PREFIX = CCI_ENV_PREFIX + "CLI__"
+NO_PROMPT_ENV = CLI_ENV_PREFIX + "ALWAYS_RECREATE"
+PLAIN_OUTPUT_ENV = CLI_ENV_PREFIX + "PLAIN_OUTPUT"
 
 
-def no_prompt_callback(ctx, param, value):
-    """Process the "No Prompt". output global setting."""
-    print(param)
+def global_option_lookup(ctx, param, value):
+    """Process Click Option and return global config setting, if it exists."""
+    global_attr = param.envvar.replace(CCI_ENV_PREFIX, "").lower()
     global_config = BaseGlobalConfig()
-    global_value = global_config.cli__no_prompt
-    return _select_value(NO_PROMPT_ENV, global_value, value)
-
-
-def plain_output_callback(ctx, param, value):
-    """Process the Plain Table output global setting."""
-    global_config = BaseGlobalConfig()
-    global_value = global_config.cli__plain_output
-    return _select_value(PLAIN_OUTPUT_ENV, global_value, value)
-
-
-def _select_value(env_var, global_value, value):
-    """Returns the option value in the order of precedence."""
-    if env_var in os.environ:
-        return os.environ[env_var]
-    elif global_value is not None:
+    global_value = getattr(global_config, global_attr)
+    if global_value is not None:
         return global_value
     else:
         return value

--- a/cumulusci/cli/options.py
+++ b/cumulusci/cli/options.py
@@ -1,0 +1,40 @@
+"""Process environment variables and global configurations for some options.
+
+Returns option values in the following order of precedence:
+1. Environment variables
+2. Global configuration options
+3. Click Option
+"""
+
+import os
+
+from cumulusci.core.config import BaseGlobalConfig
+
+# CLI Environment Variables
+NO_PROMPT_ENV = "CUMULUSCI_NO_PROMPT"
+PLAIN_OUTPUT_ENV = "CUMULUSCI_PLAIN_OUTPUT"
+
+
+def no_prompt_callback(ctx, param, value):
+    """Process the "No Prompt". output global setting."""
+    print(param)
+    global_config = BaseGlobalConfig()
+    global_value = global_config.cli__no_prompt
+    return _select_value(NO_PROMPT_ENV, global_value, value)
+
+
+def plain_output_callback(ctx, param, value):
+    """Process the Plain Table output global setting."""
+    global_config = BaseGlobalConfig()
+    global_value = global_config.cli__plain_output
+    return _select_value(PLAIN_OUTPUT_ENV, global_value, value)
+
+
+def _select_value(env_var, global_value, value):
+    """Returns the option value in the order of precedence."""
+    if env_var in os.environ:
+        return os.environ[env_var]
+    elif global_value is not None:
+        return global_value
+    else:
+        return value

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -516,7 +516,9 @@ class TestCCI(unittest.TestCase):
         config = mock.Mock()
         config.get_org.return_value = ("test", org_config)
 
-        run_click_command(cci.org_browser, config=config, org_name="test")
+        run_click_command(
+            cci.org_browser, config=config, org_name="test", no_prompt=False
+        )
 
         org_config.refresh_oauth_token.assert_called_once()
         browser_open.assert_called_once()
@@ -691,7 +693,11 @@ class TestCCI(unittest.TestCase):
 
         with mock.patch("cumulusci.cli.cci.CliTable") as cli_tbl:
             run_click_command(
-                cci.org_info, config=config, org_name="test", print_json=False
+                cci.org_info,
+                config=config,
+                org_name="test",
+                print_json=False,
+                no_prompt=False,
             )
             cli_tbl.assert_called_with(
                 [
@@ -720,7 +726,11 @@ class TestCCI(unittest.TestCase):
         out = []
         with mock.patch("click.echo", out.append):
             run_click_command(
-                cci.org_info, config=config, org_name="test", print_json=True
+                cci.org_info,
+                config=config,
+                org_name="test",
+                print_json=True,
+                no_prompt=False,
             )
 
         org_config.refresh_oauth_token.assert_called_once()

--- a/cumulusci/cli/tests/test_config.py
+++ b/cumulusci/cli/tests/test_config.py
@@ -8,7 +8,7 @@ import click
 import pytest
 
 import cumulusci
-from cumulusci.cli.config import CUMULUSCI_KEY_ENV, NO_PROMPT_ENV, CliRuntime
+from cumulusci.cli.config import CUMULUSCI_KEY_ENV, CliRuntime
 from cumulusci.core.config import OrgConfig
 from cumulusci.core.exceptions import (
     ConfigError,
@@ -133,24 +133,6 @@ class TestCliRuntime(unittest.TestCase):
             "test",
         )
         confirm.return_value = True
-
-        config.check_org_expired("test", org_config, no_prompt=False)
-        config.keychain.create_scratch_org.assert_called_once()
-
-    @mock.patch("click.confirm")
-    @mock.patch.dict(os.environ, {NO_PROMPT_ENV: "true"})
-    def test_check_org_expired_envvar(self, confirm):
-        config = CliRuntime()
-        config.keychain = mock.Mock()
-        org_config = OrgConfig(
-            {
-                "scratch": True,
-                "date_created": date.today() - timedelta(days=2),
-                "expired": True,
-            },
-            "test",
-        )
-        confirm.return_value = False
 
         config.check_org_expired("test", org_config, no_prompt=False)
         config.keychain.create_scratch_org.assert_called_once()

--- a/cumulusci/cli/tests/test_options.py
+++ b/cumulusci/cli/tests/test_options.py
@@ -1,0 +1,57 @@
+from cumulusci.cli import options
+from cumulusci.core.config import BaseGlobalConfig
+
+
+def test_no_prompt_callback_env(monkeypatch):
+    monkeypatch.setenv(options.NO_PROMPT_ENV, "true")
+    selected_val = options.no_prompt_callback(None, None, False)
+    assert selected_val == "true"
+
+
+def test_no_prompt_callback_global(monkeypatch):
+    monkeypatch.setattr(BaseGlobalConfig, "config", {"cli": {"no_prompt": True}})
+    selected_val = options.no_prompt_callback(None, None, False)
+    assert selected_val is True
+
+
+def test_no_prompt_callback_local(monkeypatch):
+    monkeypatch.setattr(BaseGlobalConfig, "config", {"cli": {"no_prompt": None}})
+    selected_val = options.no_prompt_callback(None, None, True)
+    assert selected_val is True
+
+
+def test_plain_output_callback_env(monkeypatch):
+    monkeypatch.setenv(options.PLAIN_OUTPUT_ENV, "true")
+    selected_val = options.plain_output_callback(None, None, False)
+    assert selected_val == "true"
+
+
+def test_plain_output_callback_global(monkeypatch):
+    monkeypatch.setattr(BaseGlobalConfig, "config", {"cli": {"plain_output": True}})
+    selected_val = options.plain_output_callback(None, None, False)
+    assert selected_val is True
+
+
+def test_plain_output_callback_local(monkeypatch):
+    monkeypatch.setattr(BaseGlobalConfig, "config", {"cli": {"plain_output": None}})
+    selected_val = options.plain_output_callback(None, None, True)
+    assert selected_val is True
+
+
+def test_select_val_env(monkeypatch):
+    monkeypatch.setenv("TEST", "expected")
+    selected_val = options._select_value("TEST", None, "fail")
+    assert selected_val == "expected"
+
+
+# @mock.patch("cumulusci.core.config.BaseGlobalConfig")
+def test_select_val_global(monkeypatch):
+    monkeypatch.delenv("TEST", raising=False)
+    selected_val = options._select_value("TEST", "expected", "fail")
+    assert selected_val == "expected"
+
+
+def test_select_val_local(monkeypatch):
+    monkeypatch.delenv("TEST", raising=False)
+    selected_val = options._select_value("TEST", None, "expected")
+    assert selected_val == "expected"

--- a/cumulusci/cli/tests/test_options.py
+++ b/cumulusci/cli/tests/test_options.py
@@ -1,56 +1,39 @@
+import pytest
 from cumulusci.cli import options
 from cumulusci.core.config import BaseGlobalConfig
 
 
-def test_no_prompt_callback_env(monkeypatch):
-    monkeypatch.setenv(options.NO_PROMPT_ENV, "true")
-    selected_val = options.no_prompt_callback(None, None, False)
-    assert selected_val == "true"
+@pytest.fixture
+def param_mock():
+    class ParameterMock:
+        envvar = None
+
+    return ParameterMock()
 
 
-def test_no_prompt_callback_global(monkeypatch):
-    monkeypatch.setattr(BaseGlobalConfig, "config", {"cli": {"no_prompt": True}})
-    selected_val = options.no_prompt_callback(None, None, False)
+def test_no_prompt_callback_global(monkeypatch, param_mock):
+    monkeypatch.setattr(BaseGlobalConfig, "config", {"cli": {"always_recreate": True}})
+    param_mock.envvar = options.NO_PROMPT_ENV
+    selected_val = options.global_option_lookup(None, param_mock, False)
     assert selected_val is True
 
 
-def test_no_prompt_callback_local(monkeypatch):
-    monkeypatch.setattr(BaseGlobalConfig, "config", {"cli": {"no_prompt": None}})
-    selected_val = options.no_prompt_callback(None, None, True)
+def test_no_prompt_callback_local(monkeypatch, param_mock):
+    monkeypatch.setattr(BaseGlobalConfig, "config", {"cli": {"always_recreate": None}})
+    param_mock.envvar = options.NO_PROMPT_ENV
+    selected_val = options.global_option_lookup(None, param_mock, True)
     assert selected_val is True
 
 
-def test_plain_output_callback_env(monkeypatch):
-    monkeypatch.setenv(options.PLAIN_OUTPUT_ENV, "true")
-    selected_val = options.plain_output_callback(None, None, False)
-    assert selected_val == "true"
-
-
-def test_plain_output_callback_global(monkeypatch):
+def test_plain_output_callback_global(monkeypatch, param_mock):
     monkeypatch.setattr(BaseGlobalConfig, "config", {"cli": {"plain_output": True}})
-    selected_val = options.plain_output_callback(None, None, False)
+    param_mock.envvar = options.PLAIN_OUTPUT_ENV
+    selected_val = options.global_option_lookup(None, param_mock, False)
     assert selected_val is True
 
 
-def test_plain_output_callback_local(monkeypatch):
+def test_plain_output_callback_local(monkeypatch, param_mock):
     monkeypatch.setattr(BaseGlobalConfig, "config", {"cli": {"plain_output": None}})
-    selected_val = options.plain_output_callback(None, None, True)
+    param_mock.envvar = options.PLAIN_OUTPUT_ENV
+    selected_val = options.global_option_lookup(None, param_mock, True)
     assert selected_val is True
-
-
-def test_select_val_env(monkeypatch):
-    monkeypatch.setenv("TEST", "expected")
-    selected_val = options._select_value("TEST", None, "fail")
-    assert selected_val == "expected"
-
-
-def test_select_val_global(monkeypatch):
-    monkeypatch.delenv("TEST", raising=False)
-    selected_val = options._select_value("TEST", "expected", "fail")
-    assert selected_val == "expected"
-
-
-def test_select_val_local(monkeypatch):
-    monkeypatch.delenv("TEST", raising=False)
-    selected_val = options._select_value("TEST", None, "expected")
-    assert selected_val == "expected"

--- a/cumulusci/cli/tests/test_options.py
+++ b/cumulusci/cli/tests/test_options.py
@@ -44,7 +44,6 @@ def test_select_val_env(monkeypatch):
     assert selected_val == "expected"
 
 
-# @mock.patch("cumulusci.core.config.BaseGlobalConfig")
 def test_select_val_global(monkeypatch):
     monkeypatch.delenv("TEST", raising=False)
     selected_val = options._select_value("TEST", "expected", "fail")


### PR DESCRIPTION
## Original Issue
```console
$ ccfr dependencies --org fev
The scratch org is expired
Attempt to recreate the scratch org? [Y/n]:
```
Setting `always_recreate: True` should bypass the prompt and always recreate the scratch org.

---
This PR allows bypassing the confirmation prompt for expired org recreation by setting the `CUMULUSCI_NO_PROMPT` environment variable, or by passing the `--no-prompt` option to the following commands:

- task_run
- flow_run
- org_info
- org_browser

Also includes some refactoring of environment variables to constants in
`cumulusci.cli.config`.

- [x] Add YAML configuration option
- [ ] Add configuration docs

---
# Critical Changes

# Changes
- We've added support for bypassing confirmation prompts for expired scratch orgs via the `--no-prompt` option on some commands, or via setting the `CUMULUSCI_NO_PROMPT` environment variable globally.

# Issues Closed