### PR TITLE
Make it possible to switch a project to a non-default devhub

### DIFF
--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -236,8 +236,6 @@ class ScratchOrgConfig(OrgConfig):
                 pass
             else:
                 devhub = devhub_service.username
-        if devhub:
-            self.config["devhub"] = devhub
         return devhub
 
     def generate_password(self):

--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -10,6 +10,7 @@ from cumulusci.core.sfdx import sfdx
 from cumulusci.core.config import FAILED_TO_CREATE_SCRATCH_ORG
 from cumulusci.core.config import OrgConfig
 from cumulusci.core.exceptions import ScratchOrgException
+from cumulusci.core.exceptions import ServiceNotConfigured
 
 nl = "\n"  # fstrings can't contain backslashes
 
@@ -173,9 +174,10 @@ class ScratchOrgConfig(OrgConfig):
             org_def_data = json.load(org_def)
             org_def_has_email = "adminEmail" in org_def_data
 
+        devhub = self._choose_devhub()
         options = {
             "config_file": self.config_file,
-            "devhub": f" --targetdevhubsername {self.devhub}" if self.devhub else "",
+            "devhub": f" --targetdevhubusername {devhub}" if devhub else "",
             "namespaced": " -n" if not self.namespaced else "",
             "days": f" --durationdays {self.days}" if self.days else "",
             "alias": sarge.shell_format(' -a "{0!s}"', self.sfdx_alias)
@@ -219,6 +221,24 @@ class ScratchOrgConfig(OrgConfig):
 
         # Flag that this org has been created
         self.config["created"] = True
+
+    def _choose_devhub(self):
+        """Determine which devhub to specify when calling sfdx, if any."""
+        # If a devhub was specified via `cci org scratch`, use it.
+        # (This will return None if "devhub" isn't set in the org config,
+        # in which case sfdx will use its defaultdevhubusername.)
+        devhub = self.devhub
+        if not devhub and self.keychain is not None:
+            # Otherwise see if one is configured via the "devhub" service
+            try:
+                devhub_service = self.keychain.get_service("devhub")
+            except ServiceNotConfigured:
+                pass
+            else:
+                devhub = devhub_service.username
+        if devhub:
+            self.config["devhub"] = devhub
+        return devhub
 
     def generate_password(self):
         """Generates an org password with the sfdx utility. """

--- a/cumulusci/core/keychain/BaseProjectKeychain.py
+++ b/cumulusci/core/keychain/BaseProjectKeychain.py
@@ -185,7 +185,9 @@ class BaseProjectKeychain(BaseConfig):
         """ retrieve an org configuration by name key """
         if name not in self.orgs:
             self._raise_org_not_found(name)
-        return self._get_org(name)
+        org = self._get_org(name)
+        org.keychain = self
+        return org
 
     def _get_org(self, name):
         return self.orgs.get(name)

--- a/cumulusci/core/tests/test_config_expensive.py
+++ b/cumulusci/core/tests/test_config_expensive.py
@@ -12,9 +12,11 @@ from cumulusci.utils import temporary_dir
 from cumulusci.core.config import ScratchOrgConfig
 from cumulusci.core.config import BaseGlobalConfig
 from cumulusci.core.config import BaseProjectConfig
+from cumulusci.core.config import ServiceConfig
 from cumulusci.core.exceptions import NotInProject
 from cumulusci.core.exceptions import ProjectConfigNotFound
 from cumulusci.core.exceptions import ScratchOrgException
+from cumulusci.core.exceptions import ServiceNotConfigured
 
 __location__ = os.path.dirname(os.path.realpath(__file__))
 
@@ -668,3 +670,23 @@ class TestScratchOrgConfig(unittest.TestCase):
 
         config.force_refresh_oauth_token.assert_called_once()
         self.assertTrue(config._scratch_info)
+
+    def test_choose_devhub(self, Command):
+        mock_keychain = mock.Mock()
+        mock_keychain.get_service.return_value = ServiceConfig(
+            {"username": "fake@fake.devhub"}
+        )
+        config = ScratchOrgConfig({}, "test")
+        config.keychain = mock_keychain
+
+        assert config._choose_devhub() == "fake@fake.devhub"
+        assert config.devhub == "fake@fake.devhub"
+
+    def test_choose_devhub__service_not_configured(self, Command):
+        mock_keychain = mock.Mock()
+        mock_keychain.get_service.side_effect = ServiceNotConfigured
+        config = ScratchOrgConfig({}, "test")
+        config.keychain = mock_keychain
+
+        assert config._choose_devhub() is None
+        assert config.devhub is None

--- a/cumulusci/core/tests/test_config_expensive.py
+++ b/cumulusci/core/tests/test_config_expensive.py
@@ -680,7 +680,6 @@ class TestScratchOrgConfig(unittest.TestCase):
         config.keychain = mock_keychain
 
         assert config._choose_devhub() == "fake@fake.devhub"
-        assert config.devhub == "fake@fake.devhub"
 
     def test_choose_devhub__service_not_configured(self, Command):
         mock_keychain = mock.Mock()
@@ -689,4 +688,3 @@ class TestScratchOrgConfig(unittest.TestCase):
         config.keychain = mock_keychain
 
         assert config._choose_devhub() is None
-        assert config.devhub is None

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -817,6 +817,12 @@ services:
       client_secret:
         description: Client Secret/Consumer Secret from the Connected App
         required: True
+  devhub:
+    description: Configure which SFDX org to use as a Dev Hub for creating scratch orgs
+    attributes:
+      username:
+        description: Username or alias of the SFDX org to use as a Dev Hub
+        required: True
   github:
     description: Configure connection for github tasks, e.g. Create Release
     attributes:

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -194,6 +194,18 @@ If for some reason recreating the org doesn't work, you can resolve the issue wi
     $ cci org remove <org_name>
     $ cci org scratch <config_name> <org_name>
 
+Using a Different Dev Hub Org
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, CumulusCI will create scratch orgs using the Dev Hub org that is configured as the defaultdevhubusername in sfdx.
+You can switch to a different Dev Hub org within a particular project by configuring the ``devhub`` service:
+
+.. code-block: console
+
+    $ cci service connect devhub --project
+    Username: [type the Dev Hub username here]
+    devhub is now configured for this project.
+
 
 Managing Dependencies
 =====================


### PR DESCRIPTION
# Critical Changes

# Changes
* Added a `devhub` service. This can be used to switch a project to a non-default sfdx dev hub using `cci service connect devhub --project`

# Issues Closed
