### PR TITLE
Update bulk data task defaults

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -391,19 +391,19 @@ tasks:
         class_path: cumulusci.tasks.bulkdata.GenerateMapping
         options:
             namespace_prefix: $project_config.project__package__namespace
-            path: 'datasets/generated_mapping.yml'
+            path: 'datasets/mapping.yml'
     extract_dataset:
         description: Extract a sample dataset using the bulk API.
         class_path: cumulusci.tasks.bulkdata.ExtractData
         options:
-            database_url: 'sqlite:///datasets/sample.db'
             mapping: 'datasets/mapping.yml'
+            sql_path: 'datasets/sample.sql'
     load_dataset:
         description: Load a sample dataset using the bulk API.
         class_path: cumulusci.tasks.bulkdata.LoadData
         options:
-            database_url: 'sqlite:///datasets/sample.db'
             mapping: 'datasets/mapping.yml'
+            sql_path: 'datasets/sample.sql'
 
 flows:
     apex_docs:
@@ -940,6 +940,9 @@ project:
 orgs:
     scratch:
         dev:
+            config_file: orgs/dev.json
+            days: 7
+        qa:
             config_file: orgs/dev.json
             days: 7
         feature:

--- a/cumulusci/tasks/bulkdata/extract.py
+++ b/cumulusci/tasks/bulkdata/extract.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 import unicodecsv
 
@@ -29,8 +28,7 @@ from salesforce_bulk.util import IteratorBytesIO
 class ExtractData(BulkJobTaskMixin, BaseSalesforceApiTask):
     task_options = {
         "database_url": {
-            "description": "A DATABASE_URL where the query output should be written",
-            "required": True,
+            "description": "A DATABASE_URL where the query output should be written"
         },
         "mapping": {
             "description": "The path to a yaml file containing mappings of the database fields to Salesforce object fields",
@@ -45,13 +43,13 @@ class ExtractData(BulkJobTaskMixin, BaseSalesforceApiTask):
     def _init_options(self, kwargs):
         super(ExtractData, self)._init_options(kwargs)
         if self.options.get("sql_path"):
-            if self.options.get("database_url"):
-                raise TaskOptionsError(
-                    "The database_url option is set dynamically with the sql_path option.  Please unset the database_url option."
-                )
             self.logger.info("Using in-memory sqlite database")
             self.options["database_url"] = "sqlite://"
             self.options["sql_path"] = os_friendly_path(self.options["sql_path"])
+        elif not self.options.get("database_url"):
+            raise TaskOptionsError(
+                "You must set either the database_url or sql_path option."
+            )
 
     def _run_task(self):
         self._init_mapping()
@@ -268,8 +266,6 @@ class ExtractData(BulkJobTaskMixin, BaseSalesforceApiTask):
 
     def _sqlite_dump(self):
         path = self.options["sql_path"]
-        if os.path.exists(path):
-            os.remove(path)
         with open(path, "w") as f:
             for line in self.session.connection().connection.iterdump():
                 f.write(line + "\n")

--- a/cumulusci/tasks/bulkdata/extract.py
+++ b/cumulusci/tasks/bulkdata/extract.py
@@ -42,11 +42,14 @@ class ExtractData(BulkJobTaskMixin, BaseSalesforceApiTask):
 
     def _init_options(self, kwargs):
         super(ExtractData, self)._init_options(kwargs)
-        if self.options.get("sql_path"):
+        if self.options.get("database_url"):
+            # prefer database_url if it's set
+            self.options["sql_path"] = None
+        elif self.options.get("sql_path"):
             self.logger.info("Using in-memory sqlite database")
             self.options["database_url"] = "sqlite://"
             self.options["sql_path"] = os_friendly_path(self.options["sql_path"])
-        elif not self.options.get("database_url"):
+        else:
             raise TaskOptionsError(
                 "You must set either the database_url or sql_path option."
             )

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -50,11 +50,14 @@ class LoadData(BulkJobTaskMixin, BaseSalesforceApiTask):
         self.options["ignore_row_errors"] = process_bool_arg(
             self.options.get("ignore_row_errors", False)
         )
-        if self.options.get("sql_path"):
+        if self.options.get("database_url"):
+            # prefer database_url if it's set
+            self.options["sql_path"] = None
+        elif self.options.get("sql_path"):
             self.options["sql_path"] = os_friendly_path(self.options["sql_path"])
             self.logger.info("Using in-memory sqlite database")
             self.options["database_url"] = "sqlite://"
-        elif not self.options.get("database_url"):
+        else:
             raise TaskOptionsError(
                 "You must set either the database_url or sql_path option."
             )

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -1,5 +1,4 @@
 import datetime
-import os
 import io
 
 from collections import defaultdict
@@ -27,8 +26,7 @@ class LoadData(BulkJobTaskMixin, BaseSalesforceApiTask):
 
     task_options = {
         "database_url": {
-            "description": "The database url to a database containing the test data to load",
-            "required": True,
+            "description": "The database url to a database containing the test data to load"
         },
         "mapping": {
             "description": "The path to a yaml file containing mappings of the database fields to Salesforce object fields",
@@ -53,17 +51,13 @@ class LoadData(BulkJobTaskMixin, BaseSalesforceApiTask):
             self.options.get("ignore_row_errors", False)
         )
         if self.options.get("sql_path"):
-            if self.options.get("database_url"):
-                raise TaskOptionsError(
-                    "The database_url option is set dynamically with the sql_path option.  Please unset the database_url option."
-                )
             self.options["sql_path"] = os_friendly_path(self.options["sql_path"])
-            if not os.path.isfile(self.options["sql_path"]):
-                raise TaskOptionsError(
-                    f"File {self.options['sql_path']} does not exist"
-                )
             self.logger.info("Using in-memory sqlite database")
             self.options["database_url"] = "sqlite://"
+        elif not self.options.get("database_url"):
+            raise TaskOptionsError(
+                "You must set either the database_url or sql_path option."
+            )
 
     def _run_task(self):
         self._init_mapping()

--- a/cumulusci/tasks/bulkdata/tests/test_bulkdata.py
+++ b/cumulusci/tasks/bulkdata/tests/test_bulkdata.py
@@ -19,6 +19,7 @@ from cumulusci.core.config import BaseGlobalConfig
 from cumulusci.core.config import BaseProjectConfig
 from cumulusci.core.config import TaskConfig
 from cumulusci.core.exceptions import BulkDataException
+from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.core.keychain import BaseProjectKeychain
 from cumulusci.tasks import bulkdata
 from cumulusci.tests.util import DummyOrgConfig
@@ -270,6 +271,80 @@ class TestLoadDataWithSFIds(unittest.TestCase):
         task._load_mapping = mock.Mock(side_effect=["Completed", "Failed"])
         with self.assertRaises(BulkDataException):
             task()
+
+    @responses.activate
+    def test_run__sql(self):
+        api = mock.Mock()
+        api.endpoint = "http://api"
+        api.headers.return_value = {}
+        api.create_insert_job.side_effect = ["1", "3"]
+        api.post_batch.side_effect = ["2", "4"]
+        api.job_status.return_value = {
+            "numberBatchesCompleted": 1,
+            "numberBatchesTotal": 1,
+        }
+        responses.add(
+            method="GET",
+            url="http://api/job/1/batch",
+            body=BULK_BATCH_RESPONSE.format("Completed"),
+            status=200,
+        )
+        responses.add(
+            method="GET",
+            url="http://api/job/3/batch",
+            body=BULK_BATCH_RESPONSE.format("Completed"),
+            status=200,
+        )
+        responses.add(
+            method="GET",
+            url="http://api/job/1/batch/2/result",
+            body=b"Id,Success,Created,Errors\n1,true,true,",
+            status=200,
+        )
+        responses.add(
+            method="GET",
+            url="https://example.com/services/data/vNone/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
+            body=json.dumps({"records": [{"Id": "1"}]}),
+            status=200,
+        )
+        responses.add(
+            method="GET",
+            url="http://api/job/3/batch/4/result",
+            body=b"Id,Success,Created,Errors\n1,true,true,\n2,true,true,Error",
+            status=200,
+        )
+
+        base_path = os.path.dirname(__file__)
+        sql_path = os.path.join(base_path, "testdata.sql")
+        mapping_path = os.path.join(base_path, self.mapping_file)
+
+        task = _make_task(
+            bulkdata.LoadData,
+            {"options": {"sql_path": sql_path, "mapping": mapping_path}},
+        )
+
+        def _init_class():
+            task.bulk = api
+
+        task._init_class = _init_class
+        task()
+        task.session.close()
+
+        households_batch_file = api.post_batch.call_args_list[0][0][1]
+        self.assertEqual(
+            b"Name,RecordTypeId\r\nTestHousehold,1\r\n", households_batch_file.read()
+        )
+        contacts_batch_file = api.post_batch.call_args_list[1][0][1]
+        self.assertEqual(
+            b"FirstName,LastName,Email,AccountId\r\n"
+            b"Test,User,test@example.com,1\r\n"
+            b"Error,User,error@example.com,1\r\n",
+            contacts_batch_file.read(),
+        )
+
+    def test_init_options__missing_input(self):
+        with self.assertRaises(TaskOptionsError):
+            _make_task(bulkdata.LoadData, {"options": {}})
 
     def test_expand_mapping_creates_after_steps(self):
         base_path = os.path.dirname(__file__)
@@ -1185,6 +1260,46 @@ class TestExtractDataWithSFIds(unittest.TestCase):
         task._create_record_type_table = mock.Mock(side_effect=create_table_mock)
         task._init_db()
         task._create_record_type_table.assert_called_once_with("Account_rt_mapping")
+
+    @responses.activate
+    def test_run__sql(self):
+        api = mock.Mock()
+        api.endpoint = "http://api"
+        api.headers.return_value = {}
+        api.create_query_job.side_effect = ["1", "2"]
+        api.query.side_effect = ["3", "4"]
+        api.get_query_batch_result_ids.side_effect = [["5"], ["6"]]
+        responses.add(
+            responses.GET,
+            "http://api/job/1/batch/3/result/5",
+            body=self.HOUSEHOLD_QUERY_RESULT,
+        )
+        responses.add(
+            responses.GET,
+            "http://api/job/2/batch/4/result/6",
+            body=self.CONTACT_QUERY_RESULT,
+        )
+
+        base_path = os.path.dirname(__file__)
+        mapping_path = os.path.join(base_path, self.mapping_file)
+
+        with temporary_dir():
+            task = _make_task(
+                bulkdata.ExtractData,
+                {"options": {"sql_path": "testdata.sql", "mapping": mapping_path}},
+            )
+
+            def _init_class():
+                task.bulk = api
+
+            task._init_class = _init_class
+            task()
+
+            assert os.path.exists("testdata.sql")
+
+    def test_init_options__missing_output(self):
+        with self.assertRaises(TaskOptionsError):
+            _make_task(bulkdata.ExtractData, {"options": {}})
 
 
 class TestExtractDataWithoutSFIds(unittest.TestCase):

--- a/cumulusci/tasks/bulkdata/tests/testdata.sql
+++ b/cumulusci/tasks/bulkdata/tests/testdata.sql
@@ -1,0 +1,18 @@
+BEGIN TRANSACTION;
+CREATE TABLE contacts (
+	sf_id VARCHAR(255) NOT NULL, 
+	first_name VARCHAR(255), 
+	last_name VARCHAR(255), 
+	email VARCHAR(255), 
+	household_id VARCHAR(255), 
+	PRIMARY KEY (sf_id)
+);
+INSERT INTO "contacts" VALUES('1','Test','User','test@example.com','1');
+INSERT INTO "contacts" VALUES('2','Error','User','error@example.com','1');
+CREATE TABLE households (
+	sf_id VARCHAR(255) NOT NULL, 
+	record_type VARCHAR(255), 
+	PRIMARY KEY (sf_id)
+);
+INSERT INTO "households" VALUES('1','HH_Account');
+COMMIT;

--- a/docs/bulk_data.rst
+++ b/docs/bulk_data.rst
@@ -314,7 +314,7 @@ target records become available.
 Options
 +++++++
 
-* ``path``: Location to write the mapping file. Default: datasets/generated_mapping.yml
+* ``path``: Location to write the mapping file. Default: datasets/mapping.yml
 * ``ignore``: Object API names, or fields in Object.Field format, to ignore
 * ``namespace_prefix``: The namespace prefix to treat as belonging to the project, if any
 


### PR DESCRIPTION
# Critical Changes
- We changed the default path for the mapping file created by the `generate_dataset_mapping` task to `datasets/mapping.yml` so that it matches the defaults for `extract_dataset` and `load_dataset`
- We changed the `extract_dataset` and `load_dataset` tasks to default to storing data in an SQL file, `datasets/sample.sql`, instead of a binary SQLite database file.

# Changes
- We added a predefined `qa` scratch org. It uses the same scratch org definition file as the `dev` org, but makes it easier to spin up a second org for QA purposes without needing to first create it using `cci org scratch`.
- The `database_url` option for the `extract_dataset` and `load_dataset` tasks is no longer required. Either `database_url` or `sql_path` must be specified. If both are specified, the `sql_path` will be ignored.

# Issues Closed
