### PR TITLE
Make python -m cumulusci work

### DIFF
--- a/cumulusci/__main__.py
+++ b/cumulusci/__main__.py
@@ -1,0 +1,3 @@
+from cumulusci.cli.cci import main
+
+main()

--- a/cumulusci/tests/test_main.py
+++ b/cumulusci/tests/test_main.py
@@ -1,0 +1,9 @@
+from unittest import mock
+
+
+def test_main():
+    with mock.patch("cumulusci.cli.cci.main") as main:
+        from cumulusci import __main__
+
+        __main__
+    assert main.called_once


### PR DESCRIPTION
# Changes

Developers can now directly execute the local CumulusCI copy from the Python command line like

`python -m cumulusci` or `python cumulusci/__main__.py`
