### PR TITLE
Feature/connected orgs  davisagli

### DIFF
--- a/cumulusci/__main__.py
+++ b/cumulusci/__main__.py
@@ -1,0 +1,3 @@
+from cumulusci.cli.cci import main
+
+main()

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -811,17 +811,12 @@ def org_connect(config, org_name, sandbox, login_url, default, global_org):
     org_config = OrgConfig(oauth_dict, org_name)
     org_config.load_userinfo()
     org_config._load_orginfo()
-    # print(org_config.organization_sobject)
-    # org_config.organization_sobject and
-    if "TrialExpirationDate" in org_config.organization_sobject.keys():
-        if org_config.organization_sobject["TrialExpirationDate"] is None:
-            org_config.config["expires"] = "Persistent"
-        else:
-            org_config.config["expires"] = parse_api_datetime(
-                org_config.organization_sobject["TrialExpirationDate"]
-            ).date()
+    if org_config.organization_sobject["TrialExpirationDate"] is None:
+        org_config.config["expires"] = "Persistent"
     else:
-        org_config.config["expires"] = None
+        org_config.config["expires"] = parse_api_datetime(
+            org_config.organization_sobject["TrialExpirationDate"]
+        ).date()
 
     config.keychain.set_org(org_config, global_org)
 

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -557,6 +557,8 @@ class TestCCI(unittest.TestCase):
 
         config.check_org_overwrite.assert_called_once()
         config.keychain.set_org.assert_called_once()
+        org_config = config.keychain.set_org.call_args[0][0]
+        assert org_config.expires == "Persistent"
         config.keychain.set_default_org.assert_called_once_with("test")
 
     @mock.patch("cumulusci.cli.cci.CaptureSalesforceOAuth")
@@ -578,7 +580,7 @@ class TestCCI(unittest.TestCase):
             json={
                 "TrialExpirationDate": "1970-01-01T12:34:56.000+0000",
                 "OrganizationType": "Developer Edition",
-                "IsSandbox": False,
+                "IsSandbox": True,
             },
             status=200,
         )
@@ -587,13 +589,15 @@ class TestCCI(unittest.TestCase):
             config=config,
             org_name="test",
             sandbox=True,
-            login_url="https://login.salesforce.com",
+            login_url="https://test.salesforce.com",
             default=True,
             global_org=False,
         )
 
         config.check_org_overwrite.assert_called_once()
         config.keychain.set_org.assert_called_once()
+        org_config = config.keychain.set_org.call_args[0][0]
+        assert org_config.expires == date(1970, 1, 1)
         config.keychain.set_default_org.assert_called_once_with("test")
 
     def test_org_connect_connected_app_not_configured(self):

--- a/cumulusci/tests/test_main.py
+++ b/cumulusci/tests/test_main.py
@@ -1,0 +1,9 @@
+from unittest import mock
+
+
+def test_main():
+    with mock.patch("cumulusci.cli.cci.main") as main:
+        from cumulusci import __main__
+
+        __main__
+    assert main.called_once


### PR DESCRIPTION
@jofsky here are a few suggested changes which you can merge into your branch if you agree:
- I merged recent changes from master
- I removed the check for whether TrialExpirationDate is present in the organization_sobject -- I went to write a test for the else clause, which led me to realize that this can't happen because _load_orginfo would error out if it couldn't get the Organization sobject
- I added assertions to the end of the org_connect tests to confirm that the correct `expires` value was stored

# Critical Changes

# Changes

# Issues Closed
