### PR TITLE
Add custom settings uploader

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -409,6 +409,9 @@ tasks:
         options:
             mapping: 'datasets/mapping.yml'
             sql_path: 'datasets/sample.sql'
+    upload_custom_settings:
+        description: Upload Custom Settings specified in a YAML file to the target org
+        class_path: cumulusci.tasks.salesforce.UploadCustomSettings
 
 flows:
     apex_docs:

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -413,7 +413,7 @@ tasks:
             sql_path: 'datasets/sample.sql'
         group: 'Data Operations'
     load_custom_settings:
-        description: Upload Custom Settings specified in a YAML file to the target org
+        description: Load Custom Settings specified in a YAML file to the target org
         class_path: cumulusci.tasks.salesforce.LoadCustomSettings
         group: 'Data Operations'
 

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -397,21 +397,25 @@ tasks:
         options:
             namespace_prefix: $project_config.project__package__namespace
             path: 'datasets/mapping.yml'
+        group: 'Data Operations'
     extract_dataset:
         description: Extract a sample dataset using the bulk API.
         class_path: cumulusci.tasks.bulkdata.ExtractData
         options:
             mapping: 'datasets/mapping.yml'
             sql_path: 'datasets/sample.sql'
+        group: 'Data Operations'
     load_dataset:
         description: Load a sample dataset using the bulk API.
         class_path: cumulusci.tasks.bulkdata.LoadData
         options:
             mapping: 'datasets/mapping.yml'
             sql_path: 'datasets/sample.sql'
-    upload_custom_settings:
+        group: 'Data Operations'
+    load_custom_settings:
         description: Upload Custom Settings specified in a YAML file to the target org
-        class_path: cumulusci.tasks.salesforce.UploadCustomSettings
+        class_path: cumulusci.tasks.salesforce.LoadCustomSettings
+        group: 'Data Operations'
 
 flows:
     apex_docs:

--- a/cumulusci/tasks/salesforce/__init__.py
+++ b/cumulusci/tasks/salesforce/__init__.py
@@ -16,6 +16,7 @@ from cumulusci.tasks.salesforce.CreateCommunity import CreateCommunity
 from cumulusci.tasks.salesforce.ListCommunities import ListCommunities
 from cumulusci.tasks.salesforce.ListCommunityTemplates import ListCommunityTemplates
 from cumulusci.tasks.salesforce.PublishCommunity import PublishCommunity
+from cumulusci.tasks.salesforce.custom_settings import UploadCustomSettings
 
 # inherit from BaseSalesforceMetadataApiTask
 from cumulusci.tasks.salesforce.BaseRetrieveMetadata import BaseRetrieveMetadata
@@ -88,4 +89,5 @@ flake8Hack = (
     UninstallPackaged,
     UninstallLocalNamespacedBundles,
     UninstallPackagedIncremental,
+    UploadCustomSettings,
 )

--- a/cumulusci/tasks/salesforce/__init__.py
+++ b/cumulusci/tasks/salesforce/__init__.py
@@ -16,7 +16,7 @@ from cumulusci.tasks.salesforce.CreateCommunity import CreateCommunity
 from cumulusci.tasks.salesforce.ListCommunities import ListCommunities
 from cumulusci.tasks.salesforce.ListCommunityTemplates import ListCommunityTemplates
 from cumulusci.tasks.salesforce.PublishCommunity import PublishCommunity
-from cumulusci.tasks.salesforce.custom_settings import UploadCustomSettings
+from cumulusci.tasks.salesforce.custom_settings import LoadCustomSettings
 
 # inherit from BaseSalesforceMetadataApiTask
 from cumulusci.tasks.salesforce.BaseRetrieveMetadata import BaseRetrieveMetadata
@@ -89,5 +89,5 @@ flake8Hack = (
     UninstallPackaged,
     UninstallLocalNamespacedBundles,
     UninstallPackagedIncremental,
-    UploadCustomSettings,
+    LoadCustomSettings,
 )

--- a/cumulusci/tasks/salesforce/custom_settings.py
+++ b/cumulusci/tasks/salesforce/custom_settings.py
@@ -6,8 +6,8 @@ from cumulusci.utils import os_friendly_path
 from cumulusci.core.exceptions import TaskOptionsError, CumulusCIException
 
 
-class UploadCustomSettings(BaseSalesforceApiTask):
-    """Upload Custom Settings (both List and Hierarchy) into an org
+class LoadCustomSettings(BaseSalesforceApiTask):
+    """Load Custom Settings (both List and Hierarchy) into an org
     from a YAML-format settings file.
 
     Each top-level YAML key should be the API name of a Custom Setting.

--- a/cumulusci/tasks/salesforce/custom_settings.py
+++ b/cumulusci/tasks/salesforce/custom_settings.py
@@ -71,7 +71,7 @@ class LoadCustomSettings(BaseSalesforceApiTask):
             # If it's a list, we have a Hierarchy Custom Setting.
             if isinstance(settings_data, dict):
                 for setting_instance, instance_data in settings_data.items():
-                    self.logger.debug(
+                    self.logger.info(
                         f"Loading List Custom Setting {custom_setting}.{setting_instance}"
                     )
                     proxy_obj.upsert("Name/{}".format(setting_instance), instance_data)
@@ -121,12 +121,12 @@ class LoadCustomSettings(BaseSalesforceApiTask):
 
                     setting_instance["data"].update({"SetupOwnerId": setup_owner_id})
                     if existing_records["totalSize"] == 0:
-                        self.logger.debug(
+                        self.logger.info(
                             f"Loading Hierarchy Custom Setting {custom_setting} with owner id {setup_owner_id}"
                         )
                         proxy_obj.create(setting_instance["data"])
                     else:
-                        self.logger.debug(
+                        self.logger.info(
                             f"Updating Hierarchy Custom Setting {custom_setting} with owner id {setup_owner_id}"
                         )
                         proxy_obj.update(

--- a/cumulusci/tasks/salesforce/custom_settings.py
+++ b/cumulusci/tasks/salesforce/custom_settings.py
@@ -1,0 +1,124 @@
+import os
+import yaml
+
+from cumulusci.tasks.salesforce import BaseSalesforceApiTask
+from cumulusci.utils import os_friendly_path
+from cumulusci.core.exceptions import TaskOptionsError, CumulusCIException
+
+
+class UploadCustomSettings(BaseSalesforceApiTask):
+    """Upload Custom Settings (both List and Hierarchy) into an org
+    from a YAML-format settings file.
+
+    Each top-level YAML key should be the API name of a Custom Setting.
+    List Custom Settings should contain a nested map of names to values.
+    Hierarchy Custom settings should contain a list, each of which contains
+    a `data` key and a `location` key. The `location` key may contain either
+    `profile: <profile name>`, `user: name: <username>`, `user: email: <email>`,
+    or `org`. Example:
+
+    List__c:
+        Test:
+            MyField__c: 1
+        Test 2:
+            MyField__c: 2
+    Hierarchy__c:
+        -
+            location: org
+            data:
+                MyField__c: 1
+        -
+            location:
+                user:
+                    name: test@example.com
+            data:
+                MyField__c: 2"""
+
+    task_options = {
+        "settings_path": {
+            "description": "The path to a YAML settings store",
+            "required": True,
+        }
+    }
+
+    def _init_options(self, kwargs):
+        super()._init_options(kwargs)
+        self.options["settings_path"] = os_friendly_path(
+            self.options.get("settings_path")
+        )
+        if self.options["settings_path"] is None or not os.path.isfile(
+            self.options["settings_path"]
+        ):
+            raise TaskOptionsError(
+                f"File {self.options['settings_path']} does not exist"
+            )
+
+    def _run_task(self):
+        with open(self.options["settings_path"], "r") as f:
+            self.settings = yaml.safe_load(f)
+
+        self._load_settings()
+
+    def _load_settings(self):
+        # For each top-level heading in our YAML doc, create one or more
+        # custom settings.
+
+        for custom_setting, settings_data in self.settings.items():
+            proxy_obj = getattr(self.sf, custom_setting)
+            # If this level is a dict, we're working with a List Custom Setting
+            # If it's a list, we have a Hierarchy Custom Setting.
+            if isinstance(settings_data, dict):
+                for setting_instance, instance_data in settings_data.items():
+                    proxy_obj.upsert("Name/{}".format(setting_instance), instance_data)
+            elif isinstance(settings_data, list):
+                for setting_instance in settings_data:
+                    query = None
+
+                    if "location" in setting_instance:
+                        if "profile" in setting_instance["location"]:
+                            # Query for a matching Profile to assign the Setup Owner Id.
+                            profile_name = setting_instance["location"]["profile"]
+                            query = (
+                                f"SELECT Id FROM Profile WHERE Name = '{profile_name}'"
+                            )
+                        elif "user" in setting_instance["location"]:
+                            if "name" in setting_instance["location"]["user"]:
+                                # Query for a matching User to assign the Setup Owner Id.
+                                user_name = setting_instance["location"]["user"]["name"]
+                                query = f"SELECT Id FROM User WHERE Username = '{user_name}'"
+                            elif "email" in setting_instance["location"]["user"]:
+                                # Query for a matching User to assign the Setup Owner Id.
+                                email_address = setting_instance["location"]["user"][
+                                    "email"
+                                ]
+                                query = f"SELECT Id FROM User WHERE Email = '{email_address}'"
+                        elif "org" == setting_instance["location"]:
+                            # Assign the Setup Owner Id to the organization.
+                            query = "SELECT Id FROM Organization"
+
+                    if query is None:
+                        raise CumulusCIException(
+                            f"No valid Setup Owner assignment found for Custom Setting {custom_setting}"
+                        )
+
+                    matches = self.sf.query(query)
+                    if matches["totalSize"] != 1:
+                        raise CumulusCIException(
+                            f"{matches['totalSize']} records matched the settings location query {query}. Exactly one result is required."
+                        )
+
+                    setup_owner_id = matches["records"][0]["Id"]
+
+                    # We can't upsert on SetupOwnerId. Query for any existing records.
+                    existing_records = self.sf.query(
+                        f"SELECT Id FROM {custom_setting} WHERE SetupOwnerId = '{setup_owner_id}'"
+                    )
+
+                    setting_instance["data"].update({"SetupOwnerId": setup_owner_id})
+                    if existing_records["totalSize"] == 0:
+                        proxy_obj.create(setting_instance["data"])
+                    else:
+                        proxy_obj.update(
+                            existing_records["records"][0]["Id"],
+                            setting_instance["data"],
+                        )

--- a/cumulusci/tasks/salesforce/custom_settings.py
+++ b/cumulusci/tasks/salesforce/custom_settings.py
@@ -133,3 +133,7 @@ class LoadCustomSettings(BaseSalesforceApiTask):
                             existing_records["records"][0]["Id"],
                             setting_instance["data"],
                         )
+            else:
+                raise CumulusCIException(
+                    "Each Custom Settings entry must be a list or a map structure."
+                )

--- a/cumulusci/tasks/salesforce/tests/test_custom_settings.py
+++ b/cumulusci/tasks/salesforce/tests/test_custom_settings.py
@@ -15,6 +15,17 @@ class TestLoadCustomSettings(unittest.TestCase):
             create_task(LoadCustomSettings, {"settings_path": "test.yml"})
 
     @patch("os.path.isfile")
+    def test_load_settings_bad_yaml(self, isfile):
+        isfile.return_value = True
+        task = create_task(LoadCustomSettings, {"settings_path": "test.yml"})
+
+        task.sf = Mock()
+
+        task.settings = {"Test__c": "Test"}
+        with self.assertRaises(CumulusCIException):
+            task._load_settings()
+
+    @patch("os.path.isfile")
     def test_load_settings_list_setting(self, isfile):
         isfile.return_value = True
         task = create_task(LoadCustomSettings, {"settings_path": "test.yml"})

--- a/cumulusci/tasks/salesforce/tests/test_custom_settings.py
+++ b/cumulusci/tasks/salesforce/tests/test_custom_settings.py
@@ -2,22 +2,22 @@ import unittest
 import yaml
 from unittest.mock import Mock, patch, call, mock_open
 
-from cumulusci.tasks.salesforce import UploadCustomSettings
+from cumulusci.tasks.salesforce import LoadCustomSettings
 from cumulusci.tasks.salesforce.tests.util import create_task
 from cumulusci.core.exceptions import TaskOptionsError, CumulusCIException
 
 
-class TestUploadCustomSettings(unittest.TestCase):
+class TestLoadCustomSettings(unittest.TestCase):
     @patch("os.path.isfile")
     def test_init_options__exception(self, isfile):
         isfile.return_value = False
         with self.assertRaises(TaskOptionsError):
-            create_task(UploadCustomSettings, {"settings_path": "test.yml"})
+            create_task(LoadCustomSettings, {"settings_path": "test.yml"})
 
     @patch("os.path.isfile")
     def test_load_settings_list_setting(self, isfile):
         isfile.return_value = True
-        task = create_task(UploadCustomSettings, {"settings_path": "test.yml"})
+        task = create_task(LoadCustomSettings, {"settings_path": "test.yml"})
 
         task.sf = Mock()
 
@@ -31,7 +31,7 @@ class TestUploadCustomSettings(unittest.TestCase):
     @patch("os.path.isfile")
     def test_load_settings_hierarchy_setting_profile(self, isfile):
         isfile.return_value = True
-        task = create_task(UploadCustomSettings, {"settings_path": "test.yml"})
+        task = create_task(LoadCustomSettings, {"settings_path": "test.yml"})
 
         task.sf = Mock()
         task.sf.query.side_effect = [
@@ -56,7 +56,7 @@ class TestUploadCustomSettings(unittest.TestCase):
     @patch("os.path.isfile")
     def test_load_settings_hierarchy_setting_profile__error(self, isfile):
         isfile.return_value = True
-        task = create_task(UploadCustomSettings, {"settings_path": "test.yml"})
+        task = create_task(LoadCustomSettings, {"settings_path": "test.yml"})
 
         task.sf = Mock()
         task.sf.query.side_effect = [
@@ -80,7 +80,7 @@ class TestUploadCustomSettings(unittest.TestCase):
     @patch("os.path.isfile")
     def test_load_settings_hierarchy_setting_user(self, isfile):
         isfile.return_value = True
-        task = create_task(UploadCustomSettings, {"settings_path": "test.yml"})
+        task = create_task(LoadCustomSettings, {"settings_path": "test.yml"})
 
         task.sf = Mock()
         task.sf.query.side_effect = [
@@ -111,7 +111,7 @@ class TestUploadCustomSettings(unittest.TestCase):
     @patch("os.path.isfile")
     def test_load_settings_hierarchy_setting_user_email(self, isfile):
         isfile.return_value = True
-        task = create_task(UploadCustomSettings, {"settings_path": "test.yml"})
+        task = create_task(LoadCustomSettings, {"settings_path": "test.yml"})
 
         task.sf = Mock()
         task.sf.query.side_effect = [
@@ -142,7 +142,7 @@ class TestUploadCustomSettings(unittest.TestCase):
     @patch("os.path.isfile")
     def test_load_settings_hierarchy_org(self, isfile):
         isfile.return_value = True
-        task = create_task(UploadCustomSettings, {"settings_path": "test.yml"})
+        task = create_task(LoadCustomSettings, {"settings_path": "test.yml"})
 
         task.sf = Mock()
         task.sf.query.side_effect = [
@@ -166,7 +166,7 @@ class TestUploadCustomSettings(unittest.TestCase):
     @patch("os.path.isfile")
     def test_load_settings_hierarchy_no_location(self, isfile):
         isfile.return_value = True
-        task = create_task(UploadCustomSettings, {"settings_path": "test.yml"})
+        task = create_task(LoadCustomSettings, {"settings_path": "test.yml"})
 
         task.sf = Mock()
         task.sf.query.side_effect = [
@@ -182,7 +182,7 @@ class TestUploadCustomSettings(unittest.TestCase):
     @patch("os.path.isfile")
     def test_load_settings_hierarchy_update(self, isfile):
         isfile.return_value = True
-        task = create_task(UploadCustomSettings, {"settings_path": "test.yml"})
+        task = create_task(LoadCustomSettings, {"settings_path": "test.yml"})
 
         task.sf = Mock()
         task.sf.query.side_effect = [
@@ -212,7 +212,7 @@ class TestUploadCustomSettings(unittest.TestCase):
                 {"Test__c": [{"location": "org", "data": {"Field__c": "Test"}}]}
             )
         )
-        task = create_task(UploadCustomSettings, {"settings_path": "test.yml"})
+        task = create_task(LoadCustomSettings, {"settings_path": "test.yml"})
 
         sf.return_value.query.side_effect = [
             {"totalSize": 1, "records": [{"Id": "001000000000000"}]},

--- a/cumulusci/tasks/salesforce/tests/test_custom_settings.py
+++ b/cumulusci/tasks/salesforce/tests/test_custom_settings.py
@@ -1,0 +1,209 @@
+import unittest
+import yaml
+from unittest.mock import Mock, patch, call, mock_open
+
+from cumulusci.tasks.salesforce import UploadCustomSettings
+from cumulusci.tasks.salesforce.tests.util import create_task
+from cumulusci.core.exceptions import TaskOptionsError, CumulusCIException
+
+
+class TestUploadCustomSettings(unittest.TestCase):
+    @patch("os.path.isfile")
+    def test_init_options__exception(self, isfile):
+        isfile.return_value = False
+        with self.assertRaises(TaskOptionsError):
+            create_task(UploadCustomSettings, {"settings_path": "test.yml"})
+
+    @patch("os.path.isfile")
+    def test_load_settings_list_setting(self, isfile):
+        isfile.return_value = True
+        task = create_task(UploadCustomSettings, {"settings_path": "test.yml"})
+
+        task.sf = Mock()
+
+        task.settings = {"Test__c": {"Name": {"Field__c": "Test"}}}
+        task._load_settings()
+
+        task.sf.Test__c.upsert.assert_called_once_with(
+            "Name/Name", {"Field__c": "Test"}
+        )
+
+    @patch("os.path.isfile")
+    def test_load_settings_hierarchy_setting_profile(self, isfile):
+        isfile.return_value = True
+        task = create_task(UploadCustomSettings, {"settings_path": "test.yml"})
+
+        task.sf = Mock()
+        task.sf.query.side_effect = [
+            {"totalSize": 1, "records": [{"Id": "001000000000000"}]},
+            {"totalSize": 0},
+        ]
+        task.settings = {
+            "Test__c": [{"location": {"profile": "Test"}, "data": {"Field__c": "Test"}}]
+        }
+        task._load_settings()
+
+        task.sf.Test__c.create.assert_called_once_with(
+            {"Field__c": "Test", "SetupOwnerId": "001000000000000"}
+        )
+        task.sf.query.assert_has_calls(
+            [
+                call("SELECT Id FROM Profile WHERE Name = 'Test'"),
+                call("SELECT Id FROM Test__c WHERE SetupOwnerId = '001000000000000'"),
+            ]
+        )
+
+    @patch("os.path.isfile")
+    def test_load_settings_hierarchy_setting_user(self, isfile):
+        isfile.return_value = True
+        task = create_task(UploadCustomSettings, {"settings_path": "test.yml"})
+
+        task.sf = Mock()
+        task.sf.query.side_effect = [
+            {"totalSize": 1, "records": [{"Id": "001000000000000"}]},
+            {"totalSize": 0},
+        ]
+        task.settings = {
+            "Test__c": [
+                {
+                    "location": {"user": {"name": "test@example.com"}},
+                    "data": {"Field__c": "Test"},
+                }
+            ]
+        }
+        task._load_settings()
+
+        task.sf.Test__c.create.assert_called_once_with(
+            {"Field__c": "Test", "SetupOwnerId": "001000000000000"}
+        )
+
+        task.sf.query.assert_has_calls(
+            [
+                call("SELECT Id FROM User WHERE Username = 'test@example.com'"),
+                call("SELECT Id FROM Test__c WHERE SetupOwnerId = '001000000000000'"),
+            ]
+        )
+
+    @patch("os.path.isfile")
+    def test_load_settings_hierarchy_setting_user_email(self, isfile):
+        isfile.return_value = True
+        task = create_task(UploadCustomSettings, {"settings_path": "test.yml"})
+
+        task.sf = Mock()
+        task.sf.query.side_effect = [
+            {"totalSize": 1, "records": [{"Id": "001000000000000"}]},
+            {"totalSize": 0},
+        ]
+        task.settings = {
+            "Test__c": [
+                {
+                    "location": {"user": {"email": "test-user@example.com"}},
+                    "data": {"Field__c": "Test"},
+                }
+            ]
+        }
+        task._load_settings()
+
+        task.sf.Test__c.create.assert_called_once_with(
+            {"Field__c": "Test", "SetupOwnerId": "001000000000000"}
+        )
+
+        task.sf.query.assert_has_calls(
+            [
+                call("SELECT Id FROM User WHERE Email = 'test-user@example.com'"),
+                call("SELECT Id FROM Test__c WHERE SetupOwnerId = '001000000000000'"),
+            ]
+        )
+
+    @patch("os.path.isfile")
+    def test_load_settings_hierarchy_org(self, isfile):
+        isfile.return_value = True
+        task = create_task(UploadCustomSettings, {"settings_path": "test.yml"})
+
+        task.sf = Mock()
+        task.sf.query.side_effect = [
+            {"totalSize": 1, "records": [{"Id": "001000000000000"}]},
+            {"totalSize": 0},
+        ]
+        task.settings = {"Test__c": [{"location": "org", "data": {"Field__c": "Test"}}]}
+        task._load_settings()
+
+        task.sf.Test__c.create.assert_called_once_with(
+            {"Field__c": "Test", "SetupOwnerId": "001000000000000"}
+        )
+
+        task.sf.query.assert_has_calls(
+            [
+                call("SELECT Id FROM Organization"),
+                call("SELECT Id FROM Test__c WHERE SetupOwnerId = '001000000000000'"),
+            ]
+        )
+
+    @patch("os.path.isfile")
+    def test_load_settings_hierarchy_no_location(self, isfile):
+        isfile.return_value = True
+        task = create_task(UploadCustomSettings, {"settings_path": "test.yml"})
+
+        task.sf = Mock()
+        task.sf.query.side_effect = [
+            {"totalSize": 1, "records": [{"Id": "001000000000000"}]},
+            {"totalSize": 0},
+        ]
+        task.settings = {"Test__c": [{"data": {"Field__c": "Test"}}]}
+        with self.assertRaises(CumulusCIException):
+            task._load_settings()
+
+        task.sf.Test__c.create.assert_not_called()
+
+    @patch("os.path.isfile")
+    def test_load_settings_hierarchy_update(self, isfile):
+        isfile.return_value = True
+        task = create_task(UploadCustomSettings, {"settings_path": "test.yml"})
+
+        task.sf = Mock()
+        task.sf.query.side_effect = [
+            {"totalSize": 1, "records": [{"Id": "001000000000000"}]},
+            {"totalSize": 1, "records": [{"Id": "001000000000001"}]},
+        ]
+        task.settings = {"Test__c": [{"location": "org", "data": {"Field__c": "Test"}}]}
+        task._load_settings()
+
+        task.sf.Test__c.update.assert_called_once_with(
+            "001000000000001", {"Field__c": "Test", "SetupOwnerId": "001000000000000"}
+        )
+
+        task.sf.query.assert_has_calls(
+            [
+                call("SELECT Id FROM Organization"),
+                call("SELECT Id FROM Test__c WHERE SetupOwnerId = '001000000000000'"),
+            ]
+        )
+
+    @patch("os.path.isfile")
+    @patch("simple_salesforce.Salesforce")
+    def test_run_task(self, sf, isfile):
+        isfile.return_value = True
+        m = mock_open(
+            read_data=yaml.dump(
+                {"Test__c": [{"location": "org", "data": {"Field__c": "Test"}}]}
+            )
+        )
+        task = create_task(UploadCustomSettings, {"settings_path": "test.yml"})
+
+        sf.return_value.query.side_effect = [
+            {"totalSize": 1, "records": [{"Id": "001000000000000"}]},
+            {"totalSize": 1, "records": [{"Id": "001000000000001"}]},
+        ]
+        with patch("builtins.open", m):
+            task()
+
+        task.sf.Test__c.update.assert_called_once_with(
+            "001000000000001", {"Field__c": "Test", "SetupOwnerId": "001000000000000"}
+        )
+
+        task.sf.query.assert_has_calls(
+            [
+                call("SELECT Id FROM Organization"),
+                call("SELECT Id FROM Test__c WHERE SetupOwnerId = '001000000000000'"),
+            ]
+        )

--- a/docs/bulk_data.rst
+++ b/docs/bulk_data.rst
@@ -216,7 +216,7 @@ Custom Settings
 ===============
 
 Datasets don't support Custom Settings. However, a separate task is supplied to deploy Custom 
-Settings (both list and hierarchy) into an org: ``upload_custom_settings``. The data for this
+Settings (both list and hierarchy) into an org: ``load_custom_settings``. The data for this
 task is defined in a YAML text file
 
 Each top-level YAML key should be the API name of a Custom Setting.
@@ -358,10 +358,10 @@ Example: ::
 
     cci task run generate_dataset_mapping --org qa -o namespace_prefix my_ns
 
-``upload_custom_settings``
+``load_custom_settings``
 --------------------------
 
-Upload custom settings stored in YAML into an org.
+Load custom settings stored in YAML into an org.
 
 Options
 +++++++

--- a/docs/bulk_data.rst
+++ b/docs/bulk_data.rst
@@ -212,6 +212,42 @@ simply the version of the field name in the original definition file.
 Adapting an originally-namespaced definition to load into a non-namespaced org follows the same
 pattern, but in reverse.
 
+Custom Settings
+===============
+
+Datasets don't support Custom Settings. However, a separate task is supplied to deploy Custom 
+Settings (both list and hierarchy) into an org: ``upload_custom_settings``. The data for this
+task is defined in a YAML text file
+
+Each top-level YAML key should be the API name of a Custom Setting.
+List Custom Settings should contain a nested map of names to values.
+Hierarchy Custom settings should contain a list, each of which contains
+a `data` key and a `location` key. The `location` key may contain either
+`profile: <profile name>`, `user: name: <username>`, `user: email: <email>`,
+or `org`. 
+
+Example: ::
+
+    List__c:
+        Test:
+            MyField__c: 1
+        Test 2:
+            MyField__c: 2
+    Hierarchy__c:
+        -
+            location: org
+            data:
+                MyField__c: 1
+        -
+            location:
+                user:
+                    name: test@example.com
+            data:
+                MyField__c: 2"""
+
+CumulusCI will automatically resolve the ``location`` specified for Hierarchy Custom Settings
+to a ``SetupOwnerId``. Any Custom Settings existing in the target org with the specified
+name (List) or setup owner (Hierarchy) will be updated with the given data.
 
 Dataset Tasks
 =============
@@ -321,3 +357,13 @@ Options
 Example: ::
 
     cci task run generate_dataset_mapping --org qa -o namespace_prefix my_ns
+
+``upload_custom_settings``
+--------------------------
+
+Upload custom settings stored in YAML into an org.
+
+Options
++++++++
+
+* ``settings_path``: Location of the YAML settings file.

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -1279,15 +1279,15 @@ Options:
 * **sql_path**: If specified, a database will be created from an SQL script at the provided path **Default: datasets/sample.sql**
 * **ignore_row_errors**: If True, allow the load to continue even if individual rows fail to load.
 
-upload_custom_settings
+load_custom_settings
 ==========================================
 
-**Description:** Upload Custom Settings specified in a YAML file to the target org
+**Description:** Load Custom Settings specified in a YAML file to the target org
 
-**Class::** cumulusci.tasks.salesforce.UploadCustomSettings
+**Class::** cumulusci.tasks.salesforce.LoadCustomSettings
 
 Options:
 ------------------------------------------
 
-* **settings_path** *(required)*: The path to a YAML settings store
+* **settings_path** *(required)*: The path to a YAML settings file
 

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -312,6 +312,8 @@ One, in `object_path`, includes the Object Name, Object Label, and Version Intro
 with one row per packaged object.
 The other, in `field_path`, includes Object Name, Field Name, Field Label, Field Type,
 Picklist Values (if any), Version Introduced.
+Both MDAPI and SFDX format releases are supported. However, only force-app/main/default
+is processed for SFDX projects.
 
 
 Options:
@@ -319,6 +321,7 @@ Options:
 
 * **object_path**: Path to a CSV file to contain an sObject-level data dictionary.
 * **field_path**: Path to a CSV file to contain an field-level data dictionary.
+* **release_prefix** *(required)*: The tag prefix used for releases. **Default: $project_config.project__git__prefix_release**
 
 get_installed_packages
 ==========================================
@@ -593,6 +596,7 @@ Options:
 ------------------------------------------
 
 * **definition_file**: sfdx scratch org definition file
+* **api_version**: API version used to deploy the settings
 
 publish_community
 ==========================================
@@ -1241,7 +1245,7 @@ the `User` object.
 Options:
 ------------------------------------------
 
-* **path** *(required)*: Location to write the mapping file **Default: datasets/generated_mapping.yml**
+* **path** *(required)*: Location to write the mapping file **Default: datasets/mapping.yml**
 * **namespace_prefix**: The namespace prefix to use **Default: $project_config.project__package__namespace**
 * **ignore**: Object API names, or fields in Object.Field format, to ignore
 
@@ -1255,9 +1259,9 @@ extract_dataset
 Options:
 ------------------------------------------
 
-* **database_url** *(required)*: A DATABASE_URL where the query output should be written **Default: sqlite:///datasets/sample.db**
+* **database_url**: A DATABASE_URL where the query output should be written
 * **mapping** *(required)*: The path to a yaml file containing mappings of the database fields to Salesforce object fields **Default: datasets/mapping.yml**
-* **sql_path**: If set, an SQL script will be generated at the path provided This is useful for keeping data in the repository and allowing diffs.
+* **sql_path**: If set, an SQL script will be generated at the path provided This is useful for keeping data in the repository and allowing diffs. **Default: datasets/sample.sql**
 
 load_dataset
 ==========================================
@@ -1269,9 +1273,21 @@ load_dataset
 Options:
 ------------------------------------------
 
-* **database_url** *(required)*: The database url to a database containing the test data to load **Default: sqlite:///datasets/sample.db**
+* **database_url**: The database url to a database containing the test data to load
 * **mapping** *(required)*: The path to a yaml file containing mappings of the database fields to Salesforce object fields **Default: datasets/mapping.yml**
 * **start_step**: If specified, skip steps before this one in the mapping
-* **sql_path**: If specified, a database will be created from an SQL script at the provided path
+* **sql_path**: If specified, a database will be created from an SQL script at the provided path **Default: datasets/sample.sql**
 * **ignore_row_errors**: If True, allow the load to continue even if individual rows fail to load.
+
+upload_custom_settings
+==========================================
+
+**Description:** Upload Custom Settings specified in a YAML file to the target org
+
+**Class::** cumulusci.tasks.salesforce.UploadCustomSettings
+
+Options:
+------------------------------------------
+
+* **settings_path** *(required)*: The path to a YAML settings store
 


### PR DESCRIPTION
# Critical Changes

# Changes

- CumulusCI now includes a task, `load_custom_settings`, to upload YAML-defined Custom Settings into a target org.

# Issues Closed
