### PR TITLE
Changes to make coverage checking less strict.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,8 @@
 omit = */tests/*
     cumulusci/files/*
 source=cumulusci
+[report]
+exclude_lines =
+    pragma: no cover
+    @abstract
+    def __repr__

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,4 +6,3 @@ source=cumulusci
 exclude_lines =
     pragma: no cover
     @abstract
-    def __repr__

--- a/cumulusci/__init__.py
+++ b/cumulusci/__init__.py
@@ -7,5 +7,5 @@ __version__ = "3.1.2"
 
 __location__ = os.path.dirname(os.path.realpath(__file__))
 
-if sys.version_info < (3, 6):  # pragma: nocover
+if sys.version_info < (3, 6):  # pragma: no cover
     raise Exception("CumulusCI requires Python 3.6+.")

--- a/cumulusci/cli/logger.py
+++ b/cumulusci/cli/logger.py
@@ -18,10 +18,10 @@ def init_logger(log_requests=False):
     """ Initialize the logger """
 
     logger = logging.getLogger(__name__.split(".")[0])
-    for handler in logger.handlers:  # pragma: nocover
+    for handler in logger.handlers:  # pragma: no cover
         logger.removeHandler(handler)
 
-    if os.name == "nt" and "colorama" in sys.modules:  # pragma: nocover
+    if os.name == "nt" and "colorama" in sys.modules:  # pragma: no cover
         colorama.init()
 
     formatter = coloredlogs.ColoredFormatter(fmt="%(asctime)s: %(message)s")

--- a/cumulusci/tasks/github/merge.py
+++ b/cumulusci/tasks/github/merge.py
@@ -90,7 +90,7 @@ class MergeBranch(BaseGithubTask):
                 # The following line isn't included in coverage
                 # due to behavior of the CPython peephole optimizer,
                 # see https://bitbucket.org/ned/coveragepy/issues/198/continue-marked-as-not-covered
-                continue  # pragma: nocover
+                continue  # pragma: no cover
             branches.append(branch)
             branches_dict[branch.name] = branch
 

--- a/cumulusci/tasks/push/pushfails.py
+++ b/cumulusci/tasks/push/pushfails.py
@@ -113,7 +113,7 @@ class ReportPushFailures(BaseSalesforceApiTask):
                     error.get("ErrorTitle") in ignore_errors
                     or error.get("ErrorType") in ignore_errors
                 ):
-                    continue  # pragma: nocover (skipped by compiler's optimizer)
+                    continue  # pragma: no cover (skipped by compiler's optimizer)
                 org = org_map.get(result["SubscriberOrganizationKey"]) or {}
                 w.writerow(
                     [


### PR DESCRIPTION
Don't include abstract methods (running them is an error in itself)
