### PR TITLE
Refactor CliTable to support logger

### DIFF
--- a/cumulusci/cli/tests/test_ui.py
+++ b/cumulusci/cli/tests/test_ui.py
@@ -175,7 +175,7 @@ def test_table_dim_rows(sample_data):
     assert all(
         (
             cell.startswith("\x1b[2m") and cell.endswith("\x1b[0m")
-            for cell in instance.table.table_data[1]
+            for cell in instance._table.table_data[1]
         )
     )
 
@@ -184,8 +184,8 @@ def test_table_stringify_booleans(sample_data):
     data = sample_data["service_list"]
     data[1][2] = True
     instance = CliTable(data, bool_cols=["Configured"])
-    assert CHECKMARK in instance.table.table_data[1]
-    assert CliTable.PICTOGRAM_FALSE in instance.table.table_data[2]
+    assert CHECKMARK in instance._table.table_data[1]
+    assert CliTable.PICTOGRAM_FALSE in instance._table.table_data[2]
 
 
 @mock.patch("terminaltables.SingleTable.column_max_width")
@@ -195,4 +195,4 @@ def test_table_wrap_cols(max_width, sample_data):
     data = sample_data["service_list"]
     data[1][1] = data[1][1] + "a" * 256
     instance = CliTable(data, wrap_cols=["Description"])
-    assert all((len(line) for line in instance.table.table_data[1][1].split("\n")))
+    assert all((len(line) for line in instance._table.table_data[1][1].split("\n")))

--- a/cumulusci/cli/tests/test_ui.py
+++ b/cumulusci/cli/tests/test_ui.py
@@ -47,8 +47,7 @@ def pretty_output_win():
 ├───────────┼──────────────────────────────────────────────────────┼────────────┤
 │ saucelabs │ Configure connection for saucelabs tasks.            │ False      │
 │ sentry    │ Configure connection to sentry.io for error tracking │ False      │
-└───────────┴──────────────────────────────────────────────────────┴────────────┘
-""",
+└───────────┴──────────────────────────────────────────────────────┴────────────┘""",
         "org_list": u"""
 ┌─────────┬─────────┬─────────┬──────┬─────────┬─────────┬───────────────────────────────┐
 │ Org     │ Default │ Scratch │ Days │ Expired │ Config  │ Username                      │
@@ -106,7 +105,10 @@ def plain_output():
 @pytest.mark.parametrize("fixture_key", ["service_list", "org_list", "task_list_util"])
 def test_table_pretty_output(sample_data, pretty_output, fixture_key):
     instance = CliTable(sample_data[fixture_key])
-    assert pretty_output[fixture_key] == instance.table.table
+    instance.INNER_BORDER = False
+    table = instance.pretty_table()
+    expected = pretty_output[fixture_key] + "\n"
+    assert expected == table
 
 
 @pytest.mark.skipif(
@@ -122,10 +124,9 @@ def test_table_pretty_output_windows(sample_data, pretty_output_win, fixture_key
 @pytest.mark.parametrize("fixture_key", ["service_list", "org_list", "task_list_util"])
 def test_table_plain_output(sample_data, plain_output, fixture_key, capsys):
     instance = CliTable(sample_data[fixture_key])
-    instance.ascii_table()
-    captured = capsys.readouterr()
-    expected = plain_output[fixture_key] + "\n\n"
-    assert expected == captured.out
+    table = instance.ascii_table()
+    expected = plain_output[fixture_key].strip()
+    assert expected == table
 
 
 @pytest.mark.skipif(
@@ -139,7 +140,7 @@ def test_table_pretty_echo(sample_data, pretty_output, fixture_key, capsys):
     instance.echo(plain=False)
 
     captured = capsys.readouterr()
-    expected = pretty_output[fixture_key] + "\n\n\n"
+    expected = pretty_output[fixture_key] + "\n\n"
     assert expected == captured.out
 
 
@@ -148,7 +149,7 @@ def test_table_plain_echo(sample_data, plain_output, fixture_key, capsys):
     instance = CliTable(sample_data[fixture_key])
     instance.echo(plain=True)
     captured = capsys.readouterr()
-    expected = plain_output[fixture_key] + "\n\n"
+    expected = plain_output[fixture_key]
     assert expected == captured.out
 
 
@@ -161,7 +162,7 @@ def test_table_plain_fallback(sample_data, plain_output, capsys):
         instance.echo(plain=False)
         captured = capsys.readouterr()
         # append newlines because echo adds them to account for task tables
-        assert plain_output["service_list"] + "\n\n" == captured.out
+        assert plain_output["service_list"] == captured.out
 
 
 @pytest.mark.skipif(

--- a/cumulusci/cli/ui.py
+++ b/cumulusci/cli/ui.py
@@ -89,27 +89,26 @@ class CliTable:
         Automatically falls back to AsciiTable if there's an encoding error.
         """
         if plain or os.environ.get("TERM") == "dumb":
-            self.ascii_table()
-            return None
+            table = self.ascii_table()
+        else:
+            try:
+                table = self.pretty_table()
+            except UnicodeEncodeError:
+                table = self.ascii_table()
 
-        try:
-            self.pretty_table()
-        except UnicodeEncodeError:
-            self.ascii_table()
+        click.echo(table)
 
     def pretty_table(self):
         """Pretty prints a table."""
         self.table.inner_row_border = self.INNER_BORDER
-        click.echo(self.table.table)
-        click.echo("\n")
+        return self.table.table + "\n"
 
     def ascii_table(self):
         """Fallback for dumb terminals."""
         self.plain = AsciiTable(self.table.table_data, self._title)
         self.plain.inner_column_border = False
         self.plain.inner_row_border = False
-        click.echo(self.plain.table)
-        click.echo("\n")
+        return self.plain.table
 
     def _get_index_for_col_name(self, col_name):
         return self._header.index(col_name)

--- a/cumulusci/cli/ui.py
+++ b/cumulusci/cli/ui.py
@@ -91,11 +91,10 @@ class CliTable:
         if plain or os.environ.get("TERM") == "dumb":
             table = self.ascii_table()
         else:
-            table = self.table
+            table = str(self)
         click.echo(table)
 
-    @property
-    def table(self):
+    def __str__(self):
         try:
             return self.pretty_table()
         except UnicodeEncodeError:

--- a/cumulusci/cli/ui.py
+++ b/cumulusci/cli/ui.py
@@ -44,10 +44,10 @@ class CliTable:
         self._data = data
         self._header = data[0]
         self._title = title
-        self.table = SingleTable(self._data, self._title)
+        self._table = SingleTable(self._data, self._title)
 
         if wrap_cols:
-            self._table_wrapper(self.table, wrap_cols)
+            self._table_wrapper(self._table, wrap_cols)
         if bool_cols:
             for name in bool_cols:
                 self.stringify_boolean_col(col_name=name)
@@ -80,7 +80,7 @@ class CliTable:
         false_str = (
             click.style(false_str, fg="red") if false_str else self.PICTOGRAM_FALSE
         )
-        for row in self.table.table_data[1:]:
+        for row in self._table.table_data[1:]:
             row[col_index] = true_str if row[col_index] else false_str
 
     def echo(self, plain=False):
@@ -91,21 +91,24 @@ class CliTable:
         if plain or os.environ.get("TERM") == "dumb":
             table = self.ascii_table()
         else:
-            try:
-                table = self.pretty_table()
-            except UnicodeEncodeError:
-                table = self.ascii_table()
-
+            table = self.table
         click.echo(table)
+
+    @property
+    def table(self):
+        try:
+            return self.pretty_table()
+        except UnicodeEncodeError:
+            return self.ascii_table()
 
     def pretty_table(self):
         """Pretty prints a table."""
-        self.table.inner_row_border = self.INNER_BORDER
-        return self.table.table + "\n"
+        self._table.inner_row_border = self.INNER_BORDER
+        return self._table.table + "\n"
 
     def ascii_table(self):
         """Fallback for dumb terminals."""
-        self.plain = AsciiTable(self.table.table_data, self._title)
+        self.plain = AsciiTable(self._table.table_data, self._title)
         self.plain.inner_column_border = False
         self.plain.inner_row_border = False
         return self.plain.table
@@ -120,8 +123,8 @@ class CliTable:
         """
         for row_index in dim_rows:
             if row_index != 0:
-                self.table.table_data[row_index] = [
-                    self._dim_value(cell) for cell in self.table.table_data[row_index]
+                self._table.table_data[row_index] = [
+                    self._dim_value(cell) for cell in self._table.table_data[row_index]
                 ]
 
     def _dim_value(self, val):

--- a/cumulusci/tasks/salesforce/package_upload.py
+++ b/cumulusci/tasks/salesforce/package_upload.py
@@ -126,7 +126,7 @@ class PackageUpload(BaseSalesforceApiTask):
         table_title = "Failed Apex Tests"
         table_data = self._get_table_data(results)
         table = CliTable(table_data, table_title, wrap_cols=["Message", "Stacktrace"])
-        table.echo()
+        self.logger.error(table.table)
 
     def _get_table_data(self, results):
         """Returns table data compatible with CliTable class"""

--- a/cumulusci/tasks/salesforce/package_upload.py
+++ b/cumulusci/tasks/salesforce/package_upload.py
@@ -126,7 +126,7 @@ class PackageUpload(BaseSalesforceApiTask):
         table_title = "Failed Apex Tests"
         table_data = self._get_table_data(results)
         table = CliTable(table_data, table_title, wrap_cols=["Message", "Stacktrace"])
-        self.logger.error(table.table)
+        self.logger.error(str(table))
 
     def _get_table_data(self, results):
         """Returns table data compatible with CliTable class"""


### PR DESCRIPTION
This PR updates `CliTable` to support the use of loggers where needed by adding a `table` property that returns a properly formatted string.

Also, updated `PackageUpload` to use `self.logger` for reporting apex test failures.

---
# Critical Changes

# Changes

# Issues Closed
