### PR TITLE
Add opt-in defaults, templates, type-checking

### DIFF
--- a/cumulusci/core/tasks.py
+++ b/cumulusci/core/tasks.py
@@ -93,11 +93,9 @@ class BaseTask(object):
         # Handle default values
         for name, config in list(self.task_options.items()):
             if name not in self.options and "default" in config:
-                print("XXX1", name)
                 self.options[name] = config["default"]
 
             if "do_replacement" in config:
-                print("XXX2", name)
                 self.options[name] = self.options[name].format(
                     **{"project_config": self.project_config}
                 )
@@ -118,7 +116,6 @@ class BaseTask(object):
                 missing_required.append(name)
 
             elif config.get("type") and name in self.options:
-                print("XXX3", name)
                 datatype = config.get("type")
                 try:
                     self.options[name] = datatype.convert(

--- a/cumulusci/tasks/datadictionary.py
+++ b/cumulusci/tasks/datadictionary.py
@@ -2,6 +2,9 @@ import csv
 import xml.etree.ElementTree as ET
 
 from collections import defaultdict
+
+import click
+
 from cumulusci.tasks.github.base import BaseGithubTask
 from cumulusci.utils import download_extract_github_from_repo
 from distutils.version import LooseVersion
@@ -22,29 +25,23 @@ class GenerateDataDictionary(BaseGithubTask):
 
     task_options = {
         "object_path": {
-            "description": "Path to a CSV file to contain an sObject-level data dictionary."
+            "description": "Path to a CSV file to contain an sObject-level data dictionary.",
+            "type": click.Path(exists=False, file_okay=True, dir_okay=False),
+            "default": "{project_config.project__name} sObject Data Dictionary.csv",
+            "do_replacement": True,
         },
         "field_path": {
-            "description": "Path to a CSV file to contain an field-level data dictionary."
+            "description": "Path to a CSV file to contain an field-level data dictionary.",
+            "type": click.Path(exists=False, file_okay=True, dir_okay=False),
+            "default": "{project_config.project__name} Field Data Dictionary.csv",
+            "do_replacement": True,
         },
         "release_prefix": {
             "description": "The tag prefix used for releases.",
             "required": True,
+            "type": click.STRING,
         },
     }
-
-    def _init_options(self, kwargs):
-        super()._init_options(kwargs)
-
-        if self.options.get("object_path") is None:
-            self.options[
-                "object_path"
-            ] = f"{self.project_config.project__name} sObject Data Dictionary.csv"
-
-        if self.options.get("field_path") is None:
-            self.options[
-                "field_path"
-            ] = f"{self.project_config.project__name} Field Data Dictionary.csv"
 
     def _run_task(self):
         self.logger.info("Starting data dictionary generation")

--- a/cumulusci/tasks/robotframework/lint.py
+++ b/cumulusci/tasks/robotframework/lint.py
@@ -55,23 +55,23 @@ class RobotLint(BaseTask):
     task_options = {
         "configure": {
             "description": "List of rule configuration values, in the form of rule:args.",
-            "default": None,
+            "default": [],
         },
         "ignore": {
             "description": "List of rules to ignore. Use 'all' to ignore all rules",
-            "default": None,
+            "default": [],
         },
         "error": {
             "description": "List of rules to treat as errors. Use 'all' to affect all rules.",
-            "default": None,
+            "default": [],
         },
         "warning": {
             "description": "List of rules to treat as warnings. Use 'all' to affect all rules.",
-            "default": None,
+            "default": [],
         },
         "list": {
             "description": "If option is True, print a list of known rules instead of processing files.",
-            "default": None,
+            "default": False,
         },
         "path": {
             "description": "The path to one or more files or folders. "


### PR DESCRIPTION
A prototype of a few different Task option declarative features:

1. type checking and coercion using Click's checkers.

2. value defaulting.

3. very simple templating language based on format-strings

The basic principle is that all features are opt-in, so there SHOULD be generally no change for tasks that do not opt-in. (Brian's robot linter did actually have a latent bug in it which was exposed by my code: he had specified incorrect defaults even though there was no default-handling mechanism that I am aware of. My code turned his incorrect, ignored defaults into real defaults and tests failed.)

