### PR TITLE
bumb SeleniumLibrary version to 4.1

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -5,11 +5,7 @@ update_configs:
     update_schedule: "weekly"
     ignored_updates:
       - match:
-          # Waiting for Bryan to review newest version
-          dependency_name: "robotframework-seleniumlibrary"
-          version_requirement: "3.x"
-      - match:
-          # No published source tarbal for 0.74.3
+          # No published source tarball for 0.74.3
           dependency_name: "simple-salesforce"
           version_requirement: "0.74.2"
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ PyYAML==5.1.2
 raven==6.10.0
 requests[security]==2.22.0
 robotframework==3.1.2
-robotframework-seleniumlibrary==3.3.1  # pyup: <4
+robotframework-seleniumlibrary==4.1.0
 rst2ansi==0.1.5
 salesforce-bulk==2.1.0
 sarge==0.1.5.post0


### PR DESCRIPTION
This upgrades SeleniumLibrary to version 4.1. There are no code changes, only a change to requirements.txt.

**This introduces backwards incompatibilities** which may trip up some teams. Some keywords which have been deprecated for quite a while have finally been removed and/or replaced. Most notably, `Get matching xpath count` which is a fairly common keyword. It has been replaced with a more general-purpose `Get element count`.

Release notes for SeleniumLibrary 4.1 and 4.0 that document the backwards-incompatible changes can be found on the [Releases](https://github.com/robotframework/SeleniumLibrary/releases)  page of the SeleniumLibrary project

Note: a [post](https://salesforce.quip.com/JbX0AZxopaaZ#LOfACAaMoqt) was written to the robot blog a couple of weeks ago alerting people about the pending changes. 

# Critical Changes

# Changes

# Issues Closed
