### PR TITLE
Fix a few things related to handling scratch org dates:

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -866,6 +866,8 @@ def org_import(config, username_or_alias, org_name):
 def calculate_org_days(info):
     """Returns the difference in days between created_date (ISO 8601),
     and expiration_date (%Y-%m-%d)"""
+    if not info.get("created_date") or not info.get("expiration_date"):
+        return 1
     created_date = parse_api_datetime(info["created_date"]).date()
     expires_date = datetime.strptime(info["expiration_date"], "%Y-%m-%d").date()
     return abs((expires_date - created_date).days)

--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -71,16 +71,19 @@ class ScratchOrgConfig(OrgConfig):
             password = self.config.get("password")
 
         self._scratch_info = {
-            "created_date": org_info["result"]["createdDate"],
-            "expiration_date": org_info["result"]["expirationDate"],
             "instance_url": org_info["result"]["instanceUrl"],
             "access_token": org_info["result"]["accessToken"],
             "org_id": org_id,
             "username": org_info["result"]["username"],
             "password": password,
         }
-
         self.config.update(self._scratch_info)
+        self._scratch_info.update(
+            {
+                "created_date": org_info["result"].get("createdDate"),
+                "expiration_date": org_info["result"].get("expirationDate"),
+            }
+        )
 
         self._scratch_info_date = datetime.datetime.utcnow()
 
@@ -145,7 +148,7 @@ class ScratchOrgConfig(OrgConfig):
     @property
     def expired(self):
         """Check if an org has already expired"""
-        return bool(self.expires) and self.expires < datetime.datetime.now()
+        return bool(self.expires) and self.expires < datetime.datetime.utcnow()
 
     @property
     def expires(self):
@@ -155,7 +158,7 @@ class ScratchOrgConfig(OrgConfig):
     @property
     def days_alive(self):
         if self.date_created and not self.expired:
-            delta = datetime.datetime.now() - self.date_created
+            delta = datetime.datetime.utcnow() - self.date_created
             return delta.days + 1
 
     def create_org(self):
@@ -214,7 +217,7 @@ class ScratchOrgConfig(OrgConfig):
         for line in stderr:
             self.logger.error(line)
 
-        self.config["date_created"] = datetime.datetime.now()
+        self.config["date_created"] = datetime.datetime.utcnow()
 
         if self.config.get("set_password"):
             self.generate_password()

--- a/cumulusci/core/tests/test_config_expensive.py
+++ b/cumulusci/core/tests/test_config_expensive.py
@@ -281,7 +281,8 @@ class TestScratchOrgConfig(unittest.TestCase):
             },
         )
         self.assertIs(info, config._scratch_info)
-        self.assertTrue(set(info.items()).issubset(set(config.config.items())))
+        for key in ("access_token", "instance_url", "org_id", "password", "username"):
+            assert key in config.config
         self.assertTrue(config._scratch_info_date)
 
     def test_scratch_info_memoized(self, Command):


### PR DESCRIPTION
- Don't add unparsed created_date and expiration_date to the CCI keychain
- Don't break if these dates weren't provided by sfdx for some reason
- Be consistent about working with these as UTC dates


# Critical Changes

# Changes

# Issues Closed
