### PR TITLE
Fix Robot Framework issues

### DIFF
--- a/cumulusci/core/tests/test_salesforce_locators.py
+++ b/cumulusci/core/tests/test_salesforce_locators.py
@@ -35,7 +35,7 @@ class TestLocators(unittest.TestCase):
         # we expect the library to still be instantiated, but with the latest
         # version of the locators.
         sf = Salesforce()
-        expected = "cumulusci.robotframework.locators_47"
+        expected = "cumulusci.robotframework.locators_48"
         actual = sf.locators_module.__name__
         message = "expected to load '{}', actually loaded '{}'".format(expected, actual)
         self.assertEqual(expected, actual, message)

--- a/cumulusci/robotframework/CumulusCI.py
+++ b/cumulusci/robotframework/CumulusCI.py
@@ -2,7 +2,6 @@ import logging
 
 from robot.api import logger
 from robot.libraries.BuiltIn import BuiltIn
-from simple_salesforce import Salesforce
 
 from cumulusci.cli.config import CliRuntime
 from cumulusci.core.config import TaskConfig
@@ -10,6 +9,7 @@ from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.core.tasks import CURRENT_TASK
 from cumulusci.core.utils import import_global
 from cumulusci.robotframework.utils import set_pdb_trace
+from cumulusci.salesforce_api.utils import get_simple_salesforce_connection
 from cumulusci.tasks.robotframework.robotframework import Robot
 
 
@@ -40,8 +40,6 @@ class CumulusCI(object):
         self.org_name = org_name
         self._project_config = None
         self._org = None
-        self._sf = None
-        self._tooling = None
 
         # Turn off info logging of all http requests
         logging.getLogger("requests.packages.urllib3.connectionpool").setLevel(
@@ -79,15 +77,11 @@ class CumulusCI(object):
 
     @property
     def sf(self):
-        if self._sf is None:
-            self._sf = self._init_api()
-        return self._sf
+        return self._init_api()
 
     @property
     def tooling(self):
-        if self._tooling is None:
-            self._tooling = self._init_api("tooling/")
-        return self._tooling
+        return self._init_api("tooling/")
 
     def set_login_url(self):
         """ Sets the LOGIN_URL variable in the suite scope which will
@@ -198,16 +192,10 @@ class CumulusCI(object):
         return self._run_task(task_class, task_config)
 
     def _init_api(self, base_url=None):
-
-        api_version = self.project_config.project__package__api_version
-        rv = Salesforce(
-            instance=self.org.instance_url.replace("https://", ""),
-            session_id=self.org.access_token,
-            version=api_version,
-        )
+        client = get_simple_salesforce_connection(self.project_config, self.org)
         if base_url is not None:
-            rv.base_url += base_url
-        return rv
+            client.base_url += base_url
+        return client
 
     def _init_task(self, class_path, options, task_config):
         task_class = import_global(class_path)

--- a/cumulusci/robotframework/locators_48.py
+++ b/cumulusci/robotframework/locators_48.py
@@ -1,0 +1,5 @@
+from cumulusci.robotframework import locators_47
+
+lex_locators = locators_47.lex_locators.copy()
+
+# At the moment, there are no changes to the locators.

--- a/cumulusci/tasks/robotframework/robotframework.py
+++ b/cumulusci/tasks/robotframework/robotframework.py
@@ -107,7 +107,7 @@ class RobotTestDoc(BaseTask):
 class KeywordLogger(object):
     ROBOT_LISTENER_API_VERSION = 2
 
-    def start_keyword(name, attrs):
+    def start_keyword(self, name, attrs):
         sys.stdout.write("  {}  {}\n".format(attrs["kwname"], "  ".join(attrs["args"])))
         sys.stdout.flush()
 


### PR DESCRIPTION
This includes several fixes for Robot Framework issues:
- Make the CumulusCI library use our central get_simple_salesforce_connection util so that a retry policy is used.
- Create a new simple-salesforce client each time it's used instead of caching a reference on the CumulusCI library instance, since that can lead to trying to reuse a closed connection.
- Fixes using the Salesforce library with orgs on API version 48 (Spring '20) by adding a locator file for API 48.
- Added missing `self` to KeywordLogger.start_keyword; this was showing warnings when running the robot task with `-o debug True`

I've been testing these changes by running the NPSP robot tests locally.

# Critical Changes

# Changes
* Updated Robot Framework Salesforce library to support the Spring '20 release.
* When the CumulusCI Robot Framework library calls Salesforce APIs, it will now automatically retry when it is safe to do so. It will also avoid reusing old connections that might have been closed.

# Issues Closed
* Fixed the `-o debug True` option for the `robot` task.