### PR TITLE
Fix freezing LoadData options for metadeploy

### DIFF
--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -55,8 +55,7 @@ class LoadData(BulkJobTaskMixin, BaseSalesforceApiTask):
             self.options["sql_path"] = None
         elif self.options.get("sql_path"):
             self.options["sql_path"] = os_friendly_path(self.options["sql_path"])
-            self.logger.info("Using in-memory sqlite database")
-            self.options["database_url"] = "sqlite://"
+            self.options["database_url"] = None
         else:
             raise TaskOptionsError(
                 "You must set either the database_url or sql_path option."
@@ -392,7 +391,10 @@ class LoadData(BulkJobTaskMixin, BaseSalesforceApiTask):
 
     def _init_db(self):
         # initialize the DB engine
-        self.engine = create_engine(self.options["database_url"])
+        database_url = self.options["database_url"] or "sqlite://"
+        if database_url == "sqlite://":
+            self.logger.info("Using in-memory SQLite database")
+        self.engine = create_engine(database_url)
 
         # initialize the DB session
         self.session = Session(self.engine)


### PR DESCRIPTION
Prior to this fix, a load_data step using sql_path rather than database_url would freeze its options for metadeploy with database_url set to "sqlite://", which would then take precedence when running in MetaDeploy and not work. This avoids the problem for plans published in the future by leaving the database_url set to None at the time when the step is frozen, and moving the default "sqlite://" to get supplied while the task is running.

Fixes W-037718

# Critical Changes

# Changes

# Issues Closed
* Fixed a bug with freezing the load_data task for MetaDeploy where it would use an invalid option for database_url.