### PR TITLE
Feature/brandon/handle empty pr body

### DIFF
--- a/cumulusci/tasks/release_notes/parser.py
+++ b/cumulusci/tasks/release_notes/parser.py
@@ -37,6 +37,10 @@ class ChangeNotesLinesParser(BaseChangeNotesParser):
 
         line_added = False
         change_note = self._process_change_note(change_note)
+
+        if not change_note:
+            return False
+
         for line in change_note.splitlines():
             line = self._process_line(line)
 

--- a/cumulusci/tasks/release_notes/tests/test_parser.py
+++ b/cumulusci/tasks/release_notes/tests/test_parser.py
@@ -160,6 +160,13 @@ class TestGithubLinesParser(unittest.TestCase):
         self.assertEqual("http://pr", parser.pr_url)
         self.assertEqual(["foo [[PR1](http://pr)]"], parser.content)
 
+    def test_parse_empty_pull_request_body(self):
+        generator = mock.Mock(link_pr=True)
+        parser = GithubLinesParser(generator, self.title)
+        pr = mock.Mock(number=1, html_url="http://pr", body=None)
+        line_added = parser.parse(pr)
+        assert not line_added
+
 
 class TestIssuesParser(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
# Issues Closed
* #1444 `ChangeNotesLinesParser.parse` method now handles the scenario where `_process_change_note()` returns `None`.
