### PR TITLE
Failed deletes (and loads) throw an exception

### DIFF
--- a/cumulusci/robotframework/tests/cumulusci/bulkdata.robot
+++ b/cumulusci/robotframework/tests/cumulusci/bulkdata.robot
@@ -5,25 +5,6 @@ Resource  cumulusci/robotframework/CumulusCI.robot
 
 Force Tags    bulkdata
 
-*** Keywords ***
-Assert Row Count
-    [Arguments]     ${count}        ${object_name}      &{kwargs}
-
-    ${status}     ${result} =   Run Keyword And Ignore Error
-    ...           Salesforce Query  ${object_name}  
-    ...           select=COUNT(Id)
-    ...           &{kwargs}
-
-    Run Keyword If      '${status}' != 'PASS'
-    ...           Log    
-    ...           Salesforce query failed: probably timeout. ${object_name} ${result}
-    ...           console=True
-
-    Should Be Equal    PASS    ${status}
-
-    ${matching_records} =   Set Variable    ${result}[0][expr0]
-    Should Be Equal As Numbers        ${matching_records}     ${count}
-
 *** Test Cases ***
 
 Test Run Bulk Data Deletion With Error

--- a/cumulusci/robotframework/tests/cumulusci/bulkdata.robot
+++ b/cumulusci/robotframework/tests/cumulusci/bulkdata.robot
@@ -1,0 +1,52 @@
+*** Settings ***
+
+Resource       cumulusci/robotframework/Salesforce.robot
+Resource  cumulusci/robotframework/CumulusCI.robot
+
+Force Tags    bulkdata
+
+*** Keywords ***
+Assert Row Count
+    [Arguments]     ${count}        ${object_name}      &{kwargs}
+
+    ${status}     ${result} =   Run Keyword And Ignore Error
+    ...           Salesforce Query  ${object_name}  
+    ...           select=COUNT(Id)
+    ...           &{kwargs}
+
+    Run Keyword If      '${status}' != 'PASS'
+    ...           Log    
+    ...           Salesforce query failed: probably timeout. ${object_name} ${result}
+    ...           console=True
+
+    Should Be Equal    PASS    ${status}
+
+    ${matching_records} =   Set Variable    ${result}[0][expr0]
+    Should Be Equal As Numbers        ${matching_records}     ${count}
+
+*** Test Cases ***
+
+Test Run Bulk Data Deletion With Error
+
+    ${account_name} =  Generate Random String
+    ${account_id} =  Salesforce Insert  Account
+    ...  Name=${account_name}
+    ...  BillingStreet=Baker St.
+
+    ${contract_id} =    Salesforce Insert  Contract
+    ...  AccountId=${account_id}
+
+    Salesforce Update    Contract    ${contract_id}
+    ...     status=Activated
+
+    ${opportunity} =    Salesforce Insert   Opportunity
+    ...  AccountId=${account_id}
+    ...  StageName=Prospecting
+    ...  Name=${account_name}
+    ...  CloseDate=2025-05-05
+
+    Run Keyword and Expect Error        *BulkDataException*
+    ...     Run Task Class   cumulusci.tasks.bulkdata.delete.DeleteData
+    ...         objects=Account
+    ...         where=BillingStreet='Baker St.'
+

--- a/cumulusci/robotframework/tests/cumulusci/bulkdata.robot
+++ b/cumulusci/robotframework/tests/cumulusci/bulkdata.robot
@@ -12,7 +12,7 @@ Test Run Bulk Data Deletion With Error
     ${account_name} =  Generate Random String
     ${account_id} =  Salesforce Insert  Account
     ...  Name=${account_name}
-    ...  BillingStreet=Baker St.
+    ...  BillingStreet=Granville Ave., SFDO
 
     ${contract_id} =    Salesforce Insert  Contract
     ...  AccountId=${account_id}
@@ -29,5 +29,10 @@ Test Run Bulk Data Deletion With Error
     Run Keyword and Expect Error        *BulkDataException*
     ...     Run Task Class   cumulusci.tasks.bulkdata.delete.DeleteData
     ...         objects=Account
-    ...         where=BillingStreet='Baker St.'
+    ...         where=BillingStreet='Granville Ave., SFDO'
 
+    Salesforce Delete   Contract     ${contract_id}
+
+    Run Task Class   cumulusci.tasks.bulkdata.delete.DeleteData
+    ...         objects=Account
+    ...         where=BillingStreet='Granville Ave., SFDO'

--- a/cumulusci/tasks/bulkdata/delete.py
+++ b/cumulusci/tasks/bulkdata/delete.py
@@ -44,7 +44,7 @@ class DeleteData(BaseSalesforceApiTask, BulkJobTaskMixin):
             self.logger.info(f"Deleting {self._object_description(obj)} ")
             delete_job = self._create_job(obj, self.options["where"])
             if delete_job is not None:
-                self._wait_for_job(delete_job)
+                self._wait_for_job(delete_job, error_behaviour="raise")
 
     def _create_job(self, obj, where=None):
         # Query for rows to delete

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -101,7 +101,7 @@ class LoadData(BulkJobTaskMixin, BaseSalesforceApiTask):
             self._load_record_types([mapping["sf_object"]], conn)
         mapping["oid_as_pk"] = bool(mapping.get("fields", {}).get("Id"))
         job_id, local_ids_for_batch = self._create_job(mapping)
-        result = self._wait_for_job(job_id)
+        result = self._wait_for_job(job_id, error_behaviour="return")
 
         self._process_job_results(mapping, job_id, local_ids_for_batch)
 

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -102,6 +102,8 @@ class LoadData(BulkJobTaskMixin, BaseSalesforceApiTask):
         mapping["oid_as_pk"] = bool(mapping.get("fields", {}).get("Id"))
         job_id, local_ids_for_batch = self._create_job(mapping)
         result = self._wait_for_job(job_id, error_behaviour="return")
+        if result == "Failed":
+            errors = self.error_messages  # noQA   # Todo: what to do with these errors?
 
         self._process_job_results(mapping, job_id, local_ids_for_batch)
 

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -71,10 +71,7 @@ class LoadData(BulkJobTaskMixin, BaseSalesforceApiTask):
         self.bulk_mode = (
             self.options.get("bulk_mode") and self.options.get("bulk_mode").title()
         )
-        if self.bulk_mode and self.bulk_mode not in [
-            "Serial",
-            "Parallel",
-        ]:
+        if self.bulk_mode and self.bulk_mode not in ["Serial", "Parallel"]:
             raise TaskOptionsError("bulk_mode must be either Serial or Parallel")
 
     def _run_task(self):
@@ -99,7 +96,7 @@ class LoadData(BulkJobTaskMixin, BaseSalesforceApiTask):
                 for after_name, after_step in self.after_steps[name].items():
                     self.logger.info(f"Running post-load step: {after_name}")
                     result = self._load_mapping(after_step)
-                    if not result.startswith("Completed"):
+                    if result not in ("Completed", "CompletedWithFailures"):
                         raise BulkDataException(
                             f"Job {after_name} did not complete successfully"
                         )

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -93,7 +93,7 @@ class LoadData(BulkJobTaskMixin, BaseSalesforceApiTask):
 
             self.logger.info(f"Running Job: {name}")
             result = self._load_mapping(mapping)
-            if not result.startswith("Completed"):
+            if result not in ("Completed", "CompletedWithFailures"):
                 raise BulkDataException(f"Job {name} did not complete successfully")
             if name in self.after_steps:
                 for after_name, after_step in self.after_steps[name].items():
@@ -113,8 +113,6 @@ class LoadData(BulkJobTaskMixin, BaseSalesforceApiTask):
         mapping["oid_as_pk"] = bool(mapping.get("fields", {}).get("Id"))
         job_id, local_ids_for_batch = self._create_job(mapping)
         result = self._wait_for_job(job_id, error_behaviour="return")
-        if result == "CompletedWithFailures":
-            errors = self.error_messages  # noQA   # Todo: what to do with these errors?
 
         self._process_job_results(mapping, job_id, local_ids_for_batch)
 

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -82,13 +82,13 @@ class LoadData(BulkJobTaskMixin, BaseSalesforceApiTask):
 
             self.logger.info(f"Running Job: {name}")
             result = self._load_mapping(mapping)
-            if result != "Completed":
+            if not result.startswith("Completed"):
                 raise BulkDataException(f"Job {name} did not complete successfully")
             if name in self.after_steps:
                 for after_name, after_step in self.after_steps[name].items():
                     self.logger.info(f"Running post-load step: {after_name}")
                     result = self._load_mapping(after_step)
-                    if result != "Completed":
+                    if not result.startswith("Completed"):
                         raise BulkDataException(
                             f"Job {after_name} did not complete successfully"
                         )
@@ -102,7 +102,7 @@ class LoadData(BulkJobTaskMixin, BaseSalesforceApiTask):
         mapping["oid_as_pk"] = bool(mapping.get("fields", {}).get("Id"))
         job_id, local_ids_for_batch = self._create_job(mapping)
         result = self._wait_for_job(job_id, error_behaviour="return")
-        if result == "Failed":
+        if result == "CompletedWithFailures":
             errors = self.error_messages  # noQA   # Todo: what to do with these errors?
 
         self._process_job_results(mapping, job_id, local_ids_for_batch)

--- a/cumulusci/tasks/bulkdata/tests/test_bulkdata.py
+++ b/cumulusci/tasks/bulkdata/tests/test_bulkdata.py
@@ -904,9 +904,31 @@ class TestLoadDataWithSFIds(unittest.TestCase):
         )
         task.logger = mock.Mock()
 
-        task._wait_for_job("750000000000000")
+        with self.assertRaises(BulkDataException):
+            task._wait_for_job("750000000000000")
         task.logger.error.assert_any_call("Batch failure message: Test1")
         task.logger.error.assert_any_call("Batch failure message: Test2")
+
+    def test_wait_for_job__throws_exceptions(self):
+        base_path = os.path.dirname(__file__)
+        mapping_path = os.path.join(base_path, self.mapping_file)
+        task = _make_task(
+            bulkdata.LoadData,
+            {"options": {"database_url": "sqlite://", "mapping": mapping_path}},
+        )
+
+        task.bulk = mock.Mock()
+        task.bulk.job_status.return_value = {
+            "numberBatchesCompleted": 1,
+            "numberRecordsFailed": 1,
+            "numberBatchesTotal": 2,
+        }
+        task._job_state_from_batches = mock.Mock(
+            return_value=("Failed", ["Test1", "Test2"])
+        )
+
+        with self.assertRaises(BulkDataException):
+            task._wait_for_job("750000000000000")
 
     def test_load_mapping__record_type_mapping(self):
         base_path = os.path.dirname(__file__)

--- a/cumulusci/tasks/bulkdata/tests/test_bulkdata.py
+++ b/cumulusci/tasks/bulkdata/tests/test_bulkdata.py
@@ -930,6 +930,28 @@ class TestLoadDataWithSFIds(unittest.TestCase):
         with self.assertRaises(BulkDataException):
             task._wait_for_job("750000000000000")
 
+    def test_wait_for_job__returns_error(self):
+        base_path = os.path.dirname(__file__)
+        mapping_path = os.path.join(base_path, self.mapping_file)
+        task = _make_task(
+            bulkdata.LoadData,
+            {"options": {"database_url": "sqlite://", "mapping": mapping_path}},
+        )
+
+        task.bulk = mock.Mock()
+        task.bulk.job_status.return_value = {
+            "numberBatchesCompleted": 1,
+            "numberRecordsFailed": 1,
+            "numberBatchesTotal": 2,
+        }
+        task._job_state_from_batches = mock.Mock(
+            return_value=("Failed", ["Test1", "Test2"])
+        )
+
+        task._wait_for_job("750000000000000", error_behaviour="return")
+
+        assert task.error_messages == ["Test1", "Test2"]
+
     def test_load_mapping__record_type_mapping(self):
         base_path = os.path.dirname(__file__)
         mapping_path = os.path.join(base_path, self.mapping_file)

--- a/cumulusci/tasks/bulkdata/tests/test_delete.py
+++ b/cumulusci/tasks/bulkdata/tests/test_delete.py
@@ -150,6 +150,15 @@ class TestDeleteData(unittest.TestCase):
                 "</root>"
             ),
         )
+        self.assertEqual(
+            ("Failed", ["Failures detected: 200"]),
+            task._parse_job_state(
+                '<root xmlns="http://ns">'
+                "  <batch><state>Completed</state></batch>"
+                "  <numberRecordsFailed>200</numberRecordsFailed>"
+                "</root>"
+            ),
+        )
 
     @responses.activate
     def test_upload_batches__error(self):

--- a/cumulusci/tasks/bulkdata/tests/test_delete.py
+++ b/cumulusci/tasks/bulkdata/tests/test_delete.py
@@ -151,7 +151,7 @@ class TestDeleteData(unittest.TestCase):
             ),
         )
         self.assertEqual(
-            ("Failed", ["Failures detected: 200"]),
+            ("CompletedWithFailures", ["Failures detected: 200"]),
             task._parse_job_state(
                 '<root xmlns="http://ns">'
                 "  <batch><state>Completed</state></batch>"

--- a/cumulusci/tasks/bulkdata/utils.py
+++ b/cumulusci/tasks/bulkdata/utils.py
@@ -112,7 +112,7 @@ class BulkJobTaskMixin(object):
                 break
             time.sleep(10)
         self.logger.info(f"Job {job_id} finished with result: {result}")
-        if result == "Failed":
+        if "Fail" in result:
             for state_message in messages:
                 self.logger.error(f"Batch failure message: {state_message}")
             if error_behaviour == "raise":

--- a/cumulusci/tasks/bulkdata/utils.py
+++ b/cumulusci/tasks/bulkdata/utils.py
@@ -88,7 +88,7 @@ class BulkJobTaskMixin(object):
         if failures is not None:
             num_failures = int(failures.text)
             if num_failures:
-                return "Failed", [f"Failures detected: {num_failures}"]
+                return "CompletedWithFailures", [f"Failures detected: {num_failures}"]
 
         return "Completed", None
 


### PR DESCRIPTION
If a batch job has numberRecordsFailed then _wait_for_job will throw an exception. (this part is controversial)

Unless it is caught, the task that called it will throw an exception.

This means that the keywords Run Task and Run Task Class will also error.

All of this is tested below.

As far as we know, only DeleteData and LoadData uses these functions, but we don't know for sure about customers in the market.

It is unclear whether LoadData behaviour changes significantly, because it already has some error checking and exception raising.

====

This MAY NOT be an entirely backwards compatible change. Who knows how many errors are currently being swallowed in DeleteData (and perhaps also LoadData)? It is possible that some flows which currently seem to succeed will be revealed to actually have failing subtasks.
 
Arguably, we might need "exception behaviour" as a task option on effected tasks to give a way to get the old behaviour back.

Or arguably the old behaviour might be the default (during a transition period?)