### PR TITLE
Add check_only and test_level parameters to deploy task

### DIFF
--- a/cumulusci/salesforce_api/metadata.py
+++ b/cumulusci/salesforce_api/metadata.py
@@ -366,17 +366,17 @@ class ApiDeploy(BaseMetadataApiCall):
         self,
         task,
         package_zip,
-        check_only=None,
         purge_on_delete=None,
-        run_tests=None,
         api_version=None,
+        check_only=False,
+        test_level=None,
     ):
         super(ApiDeploy, self).__init__(task, api_version)
         if purge_on_delete is None:
             purge_on_delete = True
         self._set_purge_on_delete(purge_on_delete)
-        self._set_check_only(check_only)
-        self._set_test_level(run_tests)
+        self.check_only = "true" if check_only else "false"
+        self.test_level = test_level
         self.package_zip = package_zip
 
     def _set_purge_on_delete(self, purge_on_delete):
@@ -391,29 +391,16 @@ class ApiDeploy(BaseMetadataApiCall):
         if org_type != "Developer Edition" and not is_sandbox:
             self.purge_on_delete = "false"
 
-    def _set_check_only(self, check_only):
-        if check_only is None:
-            self.check_only = "false"
-        elif not check_only or check_only == "false":
-            self.check_only = "false"
-        else:
-            self.check_only = "true"
-
-    def _set_test_level(self, run_tests):
-        if run_tests is None:
-            self.test_level = "NoTestRun"
-        elif not run_tests or run_tests == "false":
-            self.test_level = "NoTestRun"
-        else:
-            self.test_level = "RunLocalTests"
-
     def _build_envelope_start(self):
         if self.package_zip:
+            test_level = (
+                f"<testLevel>{self.test_level}</testLevel>" if self.test_level else ""
+            )
             return self.soap_envelope_start.format(
                 package_zip=self.package_zip,
                 check_only=self.check_only,
                 purge_on_delete=self.purge_on_delete,
-                test_level=self.test_level,
+                test_level=test_level,
                 api_version=self.api_version,
             )
 

--- a/cumulusci/salesforce_api/metadata.py
+++ b/cumulusci/salesforce_api/metadata.py
@@ -362,11 +362,21 @@ class ApiDeploy(BaseMetadataApiCall):
     soap_action_start = "deploy"
     soap_action_status = "checkDeployStatus"
 
-    def __init__(self, task, package_zip, purge_on_delete=None, api_version=None):
+    def __init__(
+        self,
+        task,
+        package_zip,
+        check_only=None,
+        purge_on_delete=None,
+        run_tests=None,
+        api_version=None,
+    ):
         super(ApiDeploy, self).__init__(task, api_version)
         if purge_on_delete is None:
             purge_on_delete = True
         self._set_purge_on_delete(purge_on_delete)
+        self._set_check_only(check_only)
+        self._set_test_level(run_tests)
         self.package_zip = package_zip
 
     def _set_purge_on_delete(self, purge_on_delete):
@@ -381,11 +391,29 @@ class ApiDeploy(BaseMetadataApiCall):
         if org_type != "Developer Edition" and not is_sandbox:
             self.purge_on_delete = "false"
 
+    def _set_check_only(self, check_only):
+        if check_only is None:
+            self.check_only = "false"
+        elif not check_only or check_only == "false":
+            self.check_only = "false"
+        else:
+            self.check_only = "true"
+
+    def _set_test_level(self, run_tests):
+        if run_tests is None:
+            self.test_level = "NoTestRun"
+        elif not run_tests or run_tests == "false":
+            self.test_level = "NoTestRun"
+        else:
+            self.test_level = "RunLocalTests"
+
     def _build_envelope_start(self):
         if self.package_zip:
             return self.soap_envelope_start.format(
                 package_zip=self.package_zip,
+                check_only=self.check_only,
                 purge_on_delete=self.purge_on_delete,
+                test_level=self.test_level,
                 api_version=self.api_version,
             )
 

--- a/cumulusci/salesforce_api/soap_envelopes.py
+++ b/cumulusci/salesforce_api/soap_envelopes.py
@@ -17,8 +17,8 @@ DEPLOY = """<?xml version="1.0" encoding="utf-8"?>
         <purgeOnDelete>{purge_on_delete}</purgeOnDelete>
         <rollbackOnError>true</rollbackOnError>
         <runAllTests>false</runAllTests>
-        <testLevel>{test_level}</testLevel>
         <singlePackage>true</singlePackage>
+        {test_level}
       </DeployOptions>
     </deploy>
   </soap:Body>

--- a/cumulusci/salesforce_api/soap_envelopes.py
+++ b/cumulusci/salesforce_api/soap_envelopes.py
@@ -11,12 +11,13 @@ DEPLOY = """<?xml version="1.0" encoding="utf-8"?>
       <DeployOptions>
         <allowMissingFiles>false</allowMissingFiles>
         <autoUpdatePackage>false</autoUpdatePackage>
-        <checkOnly>false</checkOnly>
+        <checkOnly>{check_only}</checkOnly>
         <ignoreWarnings>true</ignoreWarnings>
         <performRetrieve>false</performRetrieve>
         <purgeOnDelete>{purge_on_delete}</purgeOnDelete>
         <rollbackOnError>true</rollbackOnError>
         <runAllTests>false</runAllTests>
+        <testLevel>{test_level}</testLevel>
         <singlePackage>true</singlePackage>
       </DeployOptions>
     </deploy>

--- a/cumulusci/salesforce_api/tests/test_metadata.py
+++ b/cumulusci/salesforce_api/tests/test_metadata.py
@@ -581,7 +581,10 @@ class TestApiDeploy(BaseTestMetadataApi):
 
     def _expected_envelope_start(self):
         return self.envelope_start.format(
-            package_zip=self.package_zip, purge_on_delete="false"
+            package_zip=self.package_zip,
+            check_only="false",
+            purge_on_delete="false",
+            test_level="NoTestRun",
         )
 
     def _response_call_success_result(self, response_result):
@@ -590,18 +593,57 @@ class TestApiDeploy(BaseTestMetadataApi):
     def _expected_call_success_result(self, response_result):
         return "Success"
 
-    def _create_instance(self, task, api_version=None, purge_on_delete=None):
+    def _create_instance(
+        self,
+        task,
+        api_version=None,
+        purge_on_delete=None,
+        check_only=None,
+        run_tests=None,
+    ):
         return self.api_class(
             task,
             self.package_zip,
             api_version=api_version,
             purge_on_delete=purge_on_delete,
+            check_only=check_only,
+            run_tests=run_tests,
         )
 
     def test_init_no_purge_on_delete(self):
         task = self._create_task()
         api = self._create_instance(task, purge_on_delete=False)
         self.assertEqual(api.purge_on_delete, "false")
+
+    def test_init_default_check_only(self):
+        task = self._create_task()
+        api = self._create_instance(task)
+        self.assertEqual(api.check_only, "false")
+
+    def test_init_no_check_only(self):
+        task = self._create_task()
+        api = self._create_instance(task, check_only=False)
+        self.assertEqual(api.check_only, "false")
+
+    def test_init_check_only(self):
+        task = self._create_task()
+        api = self._create_instance(task, check_only=True)
+        self.assertEqual(api.check_only, "true")
+
+    def test_init_default_run_tests(self):
+        task = self._create_task()
+        api = self._create_instance(task)
+        self.assertEqual(api.test_level, "NoTestRun")
+
+    def test_init_no_run_tests(self):
+        task = self._create_task()
+        api = self._create_instance(task, run_tests=False)
+        self.assertEqual(api.test_level, "NoTestRun")
+
+    def test_init_run_tests(self):
+        task = self._create_task()
+        api = self._create_instance(task, run_tests=True)
+        self.assertEqual(api.test_level, "RunLocalTests")
 
     def test_process_response_metadata_failure(self):
         task = self._create_task()

--- a/cumulusci/salesforce_api/tests/test_metadata.py
+++ b/cumulusci/salesforce_api/tests/test_metadata.py
@@ -584,7 +584,7 @@ class TestApiDeploy(BaseTestMetadataApi):
             package_zip=self.package_zip,
             check_only="false",
             purge_on_delete="false",
-            test_level="NoTestRun",
+            test_level="",
         )
 
     def _response_call_success_result(self, response_result):
@@ -599,7 +599,7 @@ class TestApiDeploy(BaseTestMetadataApi):
         api_version=None,
         purge_on_delete=None,
         check_only=None,
-        run_tests=None,
+        test_level=None,
     ):
         return self.api_class(
             task,
@@ -607,7 +607,7 @@ class TestApiDeploy(BaseTestMetadataApi):
             api_version=api_version,
             purge_on_delete=purge_on_delete,
             check_only=check_only,
-            run_tests=run_tests,
+            test_level=test_level,
         )
 
     def test_init_no_purge_on_delete(self):
@@ -620,30 +620,20 @@ class TestApiDeploy(BaseTestMetadataApi):
         api = self._create_instance(task)
         self.assertEqual(api.check_only, "false")
 
-    def test_init_no_check_only(self):
-        task = self._create_task()
-        api = self._create_instance(task, check_only=False)
-        self.assertEqual(api.check_only, "false")
-
     def test_init_check_only(self):
         task = self._create_task()
         api = self._create_instance(task, check_only=True)
         self.assertEqual(api.check_only, "true")
 
-    def test_init_default_run_tests(self):
+    def test_init_default_test_level(self):
         task = self._create_task()
         api = self._create_instance(task)
-        self.assertEqual(api.test_level, "NoTestRun")
+        self.assertEqual(api.test_level, None)
 
-    def test_init_no_run_tests(self):
+    def test_init_test_level(self):
         task = self._create_task()
-        api = self._create_instance(task, run_tests=False)
+        api = self._create_instance(task, test_level="NoTestRun")
         self.assertEqual(api.test_level, "NoTestRun")
-
-    def test_init_run_tests(self):
-        task = self._create_task()
-        api = self._create_instance(task, run_tests=True)
-        self.assertEqual(api.test_level, "RunLocalTests")
 
     def test_process_response_metadata_failure(self):
         task = self._create_task()

--- a/cumulusci/tasks/salesforce/Deploy.py
+++ b/cumulusci/tasks/salesforce/Deploy.py
@@ -40,8 +40,8 @@ class Deploy(BaseSalesforceMetadataApiTask):
         "check_only": {
             "description": "If True, performs a test deployment (validation) of components without saving the components in the target org"
         },
-        "run_tests": {
-            "description": "If True, all tests from the package are run during the deploy (along with local tests in salesforce org)"
+        "test_level": {
+            "description": "Specifies which tests are run as part of a deployment."
         },
         "static_resource_path": {
             "description": "The path where decompressed static resources are stored.  Any subdirectories found will be zipped and added to the staticresources directory of the build."
@@ -63,9 +63,14 @@ class Deploy(BaseSalesforceMetadataApiTask):
         package_zip = self._get_package_zip(path)
         self.logger.info("Payload size: {} bytes".format(len(package_zip)))
         check_only = process_bool_arg(self.options.get("check_only", False))
-        run_tests = process_bool_arg(self.options.get("run_tests", False))
-        purge_on_delete = False
-        return self.api_class(self, package_zip, check_only, purge_on_delete, run_tests)
+        test_level = self.options.get("test_level")
+        return self.api_class(
+            self,
+            package_zip,
+            purge_on_delete=False,
+            check_only=check_only,
+            test_level=test_level,
+        )
 
     def _include_directory(self, root_parts):
         # include the root directory, all non-lwc directories and sub-directories, and lwc component directories

--- a/cumulusci/tasks/salesforce/Deploy.py
+++ b/cumulusci/tasks/salesforce/Deploy.py
@@ -37,6 +37,12 @@ class Deploy(BaseSalesforceMetadataApiTask):
         "namespace_tokenize": {
             "description": "If set, all namespace prefixes for the namespace specified are replaced with tokens for use with namespace_inject"
         },
+        "check_only": {
+            "description": "If True, performs a test deployment (validation) of components without saving the components in the target org"
+        },
+        "run_tests": {
+            "description": "If True, all tests from the package are run during the deploy (along with local tests in salesforce org)"
+        },
         "static_resource_path": {
             "description": "The path where decompressed static resources are stored.  Any subdirectories found will be zipped and added to the staticresources directory of the build."
         },
@@ -56,7 +62,10 @@ class Deploy(BaseSalesforceMetadataApiTask):
 
         package_zip = self._get_package_zip(path)
         self.logger.info("Payload size: {} bytes".format(len(package_zip)))
-        return self.api_class(self, package_zip, purge_on_delete=False)
+        check_only = process_bool_arg(self.options.get("check_only", False))
+        run_tests = process_bool_arg(self.options.get("run_tests", False))
+        purge_on_delete = False
+        return self.api_class(self, package_zip, check_only, purge_on_delete, run_tests)
 
     def _include_directory(self, root_parts):
         # include the root directory, all non-lwc directories and sub-directories, and lwc component directories

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -144,6 +144,8 @@ Options:
 * **namespace_inject**: If set, the namespace tokens in files and filenames are replaced with the namespace's prefix
 * **namespace_strip**: If set, all namespace prefixes for the namespace specified are stripped from files and filenames
 * **namespace_tokenize**: If set, all namespace prefixes for the namespace specified are replaced with tokens for use with namespace_inject
+* **check_only**: If True, performs a test deployment (validation) of components without saving the components in the target org
+* **run_tests**: If True, all tests from the package are run during the deploy (along with local tests in salesforce org)
 * **static_resource_path**: The path where decompressed static resources are stored.  Any subdirectories found will be zipped and added to the staticresources directory of the build.
 * **namespaced_org**: If True, the tokens %%%NAMESPACED_ORG%%% and ___NAMESPACED_ORG___ will get replaced with the namespace.  The default is false causing those tokens to get stripped and replaced with an empty string.  Set this if deploying to a namespaced scratch org or packaging org.
 * **clean_meta_xml**: Defaults to True which strips the <packageVersions/> element from all meta.xml files.  The packageVersion element gets added automatically by the target org and is set to whatever version is installed in the org.  To disable this, set this option to False

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -145,7 +145,7 @@ Options:
 * **namespace_strip**: If set, all namespace prefixes for the namespace specified are stripped from files and filenames
 * **namespace_tokenize**: If set, all namespace prefixes for the namespace specified are replaced with tokens for use with namespace_inject
 * **check_only**: If True, performs a test deployment (validation) of components without saving the components in the target org
-* **run_tests**: If True, all tests from the package are run during the deploy (along with local tests in salesforce org)
+* **test_level**: Specifies which tests are run as part of a deployment.
 * **static_resource_path**: The path where decompressed static resources are stored.  Any subdirectories found will be zipped and added to the staticresources directory of the build.
 * **namespaced_org**: If True, the tokens %%%NAMESPACED_ORG%%% and ___NAMESPACED_ORG___ will get replaced with the namespace.  The default is false causing those tokens to get stripped and replaced with an empty string.  Set this if deploying to a namespaced scratch org or packaging org.
 * **clean_meta_xml**: Defaults to True which strips the <packageVersions/> element from all meta.xml files.  The packageVersion element gets added automatically by the target org and is set to whatever version is installed in the org.  To disable this, set this option to False
@@ -165,6 +165,8 @@ Options:
 * **namespace_inject**: If set, the namespace tokens in files and filenames are replaced with the namespace's prefix
 * **namespace_strip**: If set, all namespace prefixes for the namespace specified are stripped from files and filenames
 * **namespace_tokenize**: If set, all namespace prefixes for the namespace specified are replaced with tokens for use with namespace_inject
+* **check_only**: If True, performs a test deployment (validation) of components without saving the components in the target org
+* **test_level**: Specifies which tests are run as part of a deployment.
 * **static_resource_path**: The path where decompressed static resources are stored.  Any subdirectories found will be zipped and added to the staticresources directory of the build.
 * **namespaced_org**: If True, the tokens %%%NAMESPACED_ORG%%% and ___NAMESPACED_ORG___ will get replaced with the namespace.  The default is false causing those tokens to get stripped and replaced with an empty string.  Set this if deploying to a namespaced scratch org or packaging org.
 * **clean_meta_xml**: Defaults to True which strips the <packageVersions/> element from all meta.xml files.  The packageVersion element gets added automatically by the target org and is set to whatever version is installed in the org.  To disable this, set this option to False
@@ -184,6 +186,8 @@ Options:
 * **namespace_inject**: If set, the namespace tokens in files and filenames are replaced with the namespace's prefix **Default: $project_config.project__package__namespace**
 * **namespace_strip**: If set, all namespace prefixes for the namespace specified are stripped from files and filenames
 * **namespace_tokenize**: If set, all namespace prefixes for the namespace specified are replaced with tokens for use with namespace_inject
+* **check_only**: If True, performs a test deployment (validation) of components without saving the components in the target org
+* **test_level**: Specifies which tests are run as part of a deployment.
 * **static_resource_path**: The path where decompressed static resources are stored.  Any subdirectories found will be zipped and added to the staticresources directory of the build.
 * **namespaced_org**: If True, the tokens %%%NAMESPACED_ORG%%% and ___NAMESPACED_ORG___ will get replaced with the namespace.  The default is false causing those tokens to get stripped and replaced with an empty string.  Set this if deploying to a namespaced scratch org or packaging org.
 * **clean_meta_xml**: Defaults to True which strips the <packageVersions/> element from all meta.xml files.  The packageVersion element gets added automatically by the target org and is set to whatever version is installed in the org.  To disable this, set this option to False
@@ -203,6 +207,8 @@ Options:
 * **namespace_inject**: If set, the namespace tokens in files and filenames are replaced with the namespace's prefix **Default: $project_config.project__package__namespace**
 * **namespace_strip**: If set, all namespace prefixes for the namespace specified are stripped from files and filenames
 * **namespace_tokenize**: If set, all namespace prefixes for the namespace specified are replaced with tokens for use with namespace_inject
+* **check_only**: If True, performs a test deployment (validation) of components without saving the components in the target org
+* **test_level**: Specifies which tests are run as part of a deployment.
 * **static_resource_path**: The path where decompressed static resources are stored.  Any subdirectories found will be zipped and added to the staticresources directory of the build.
 * **namespaced_org**: If True, the tokens %%%NAMESPACED_ORG%%% and ___NAMESPACED_ORG___ will get replaced with the namespace.  The default is false causing those tokens to get stripped and replaced with an empty string.  Set this if deploying to a namespaced scratch org or packaging org.
 * **clean_meta_xml**: Defaults to True which strips the <packageVersions/> element from all meta.xml files.  The packageVersion element gets added automatically by the target org and is set to whatever version is installed in the org.  To disable this, set this option to False
@@ -1017,6 +1023,8 @@ Options:
 * **namespace_inject**: If set, the namespace tokens in files and filenames are replaced with the namespace's prefix
 * **namespace_strip**: If set, all namespace prefixes for the namespace specified are stripped from files and filenames
 * **namespace_tokenize**: If set, all namespace prefixes for the namespace specified are replaced with tokens for use with namespace_inject
+* **check_only**: If True, performs a test deployment (validation) of components without saving the components in the target org
+* **test_level**: Specifies which tests are run as part of a deployment.
 * **static_resource_path**: The path where decompressed static resources are stored.  Any subdirectories found will be zipped and added to the staticresources directory of the build.
 * **namespaced_org**: If True, the tokens %%%NAMESPACED_ORG%%% and ___NAMESPACED_ORG___ will get replaced with the namespace.  The default is false causing those tokens to get stripped and replaced with an empty string.  Set this if deploying to a namespaced scratch org or packaging org.
 * **clean_meta_xml**: Defaults to True which strips the <packageVersions/> element from all meta.xml files.  The packageVersion element gets added automatically by the target org and is set to whatever version is installed in the org.  To disable this, set this option to False
@@ -1037,6 +1045,8 @@ Options:
 * **namespace_inject**: If set, the namespace tokens in files and filenames are replaced with the namespace's prefix
 * **namespace_strip**: If set, all namespace prefixes for the namespace specified are stripped from files and filenames
 * **namespace_tokenize**: If set, all namespace prefixes for the namespace specified are replaced with tokens for use with namespace_inject
+* **check_only**: If True, performs a test deployment (validation) of components without saving the components in the target org
+* **test_level**: Specifies which tests are run as part of a deployment.
 * **static_resource_path**: The path where decompressed static resources are stored.  Any subdirectories found will be zipped and added to the staticresources directory of the build.
 * **namespaced_org**: If True, the tokens %%%NAMESPACED_ORG%%% and ___NAMESPACED_ORG___ will get replaced with the namespace.  The default is false causing those tokens to get stripped and replaced with an empty string.  Set this if deploying to a namespaced scratch org or packaging org.
 * **clean_meta_xml**: Defaults to True which strips the <packageVersions/> element from all meta.xml files.  The packageVersion element gets added automatically by the target org and is set to whatever version is installed in the org.  To disable this, set this option to False
@@ -1249,6 +1259,7 @@ Options:
 * **start_step**: If specified, skip steps before this one in the mapping
 * **sql_path**: If specified, a database will be created from an SQL script at the provided path **Default: datasets/sample.sql**
 * **ignore_row_errors**: If True, allow the load to continue even if individual rows fail to load.
+* **reset_oids**: If True (the default), and the _sf_ids tables exist, reset them before continuing.
 
 load_custom_settings
 ==========================================


### PR DESCRIPTION
This is based on @mrcmac's work and replaces #1066 with a branch within the SFDO-Tooling github organization so that the builds will run.

I also made some changes:
- Avoid changing the order of parameters for ApiDeploy.__init__ in case someone is passing the named arguments positionally.
- Provide the `test_level` option as a string instead of `run_tests` as a boolean, in order to better parallel testLevel in the actual API and support passing all of its options.
- Expect that check_only must be passed to ApiDeploy as a boolean, not a string.

@mrcmac please let me know if you have concerns about any of these changes.

# Critical Changes

# Changes

# Issues Closed
- Fixes #1066 