### PR TITLE
add check_only option to deploy task

### DIFF
--- a/cumulusci/salesforce_api/metadata.py
+++ b/cumulusci/salesforce_api/metadata.py
@@ -362,12 +362,20 @@ class ApiDeploy(BaseMetadataApiCall):
     soap_action_start = "deploy"
     soap_action_status = "checkDeployStatus"
 
-    def __init__(self, task, package_zip, purge_on_delete=None, api_version=None):
+    def __init__(
+        self,
+        task,
+        package_zip,
+        purge_on_delete=None,
+        api_version=None,
+        check_only=False,
+    ):
         super(ApiDeploy, self).__init__(task, api_version)
         if purge_on_delete is None:
             purge_on_delete = True
         self._set_purge_on_delete(purge_on_delete)
         self.package_zip = package_zip
+        self.check_only = check_only
 
     def _set_purge_on_delete(self, purge_on_delete):
         if not purge_on_delete or purge_on_delete == "false":
@@ -387,6 +395,7 @@ class ApiDeploy(BaseMetadataApiCall):
                 package_zip=self.package_zip,
                 purge_on_delete=self.purge_on_delete,
                 api_version=self.api_version,
+                check_only=self.check_only,
             )
 
     def _process_response(self, response):

--- a/cumulusci/salesforce_api/soap_envelopes.py
+++ b/cumulusci/salesforce_api/soap_envelopes.py
@@ -11,7 +11,7 @@ DEPLOY = """<?xml version="1.0" encoding="utf-8"?>
       <DeployOptions>
         <allowMissingFiles>false</allowMissingFiles>
         <autoUpdatePackage>false</autoUpdatePackage>
-        <checkOnly>false</checkOnly>
+        <checkOnly>{check_only}</checkOnly>
         <ignoreWarnings>true</ignoreWarnings>
         <performRetrieve>false</performRetrieve>
         <purgeOnDelete>{purge_on_delete}</purgeOnDelete>

--- a/cumulusci/salesforce_api/tests/test_metadata.py
+++ b/cumulusci/salesforce_api/tests/test_metadata.py
@@ -178,7 +178,8 @@ class BaseTestMetadataApi(unittest.TestCase):
 
     def _expected_envelope_start(self):
         return self.envelope_start.format(
-            api_version=self.project_config.project__package__api_version
+            api_version=self.project_config.project__package__api_version,
+            check_only=False,
         )
 
     def test_build_envelope_status(self):

--- a/cumulusci/salesforce_api/tests/test_metadata.py
+++ b/cumulusci/salesforce_api/tests/test_metadata.py
@@ -582,7 +582,7 @@ class TestApiDeploy(BaseTestMetadataApi):
 
     def _expected_envelope_start(self):
         return self.envelope_start.format(
-            package_zip=self.package_zip, purge_on_delete="false"
+            package_zip=self.package_zip, purge_on_delete="false", check_only=False
         )
 
     def _response_call_success_result(self, response_result):

--- a/cumulusci/tasks/salesforce/Deploy.py
+++ b/cumulusci/tasks/salesforce/Deploy.py
@@ -46,6 +46,9 @@ class Deploy(BaseSalesforceMetadataApiTask):
         "clean_meta_xml": {
             "description": "Defaults to True which strips the <packageVersions/> element from all meta.xml files.  The packageVersion element gets added automatically by the target org and is set to whatever version is installed in the org.  To disable this, set this option to False"
         },
+        "check_only": {
+            "description": "Specifies the value of the CheckOnly flag during deployment. (default=False)"
+        },
     }
 
     namespaces = {"sf": "http://soap.sforce.com/2006/04/metadata"}
@@ -56,7 +59,10 @@ class Deploy(BaseSalesforceMetadataApiTask):
 
         package_zip = self._get_package_zip(path)
         self.logger.info("Payload size: {} bytes".format(len(package_zip)))
-        return self.api_class(self, package_zip, purge_on_delete=False)
+        check_only = process_bool_arg(self.options.get("check_only", False))
+        return self.api_class(
+            self, package_zip, purge_on_delete=False, check_only=check_only
+        )
 
     def _include_directory(self, root_parts):
         # include the root directory, all non-lwc directories and sub-directories, and lwc component directories


### PR DESCRIPTION
#521 Issues Closed
* We now include a `check_only` option to the deploy task (#1066)