### PR TITLE
Make UpdateAdminProfile deploy profiles only

### DIFF
--- a/cumulusci/tasks/salesforce/UpdateAdminProfile.py
+++ b/cumulusci/tasks/salesforce/UpdateAdminProfile.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import tempfile
 
 from pathlib import Path
@@ -56,11 +55,19 @@ class UpdateAdminProfile(Deploy):
         }
 
     def _run_task(self):
-        self.tempdir = tempfile.mkdtemp()
-        self._retrieve_unpackaged()
-        self._process_metadata()
-        self._deploy_metadata()
-        shutil.rmtree(self.tempdir)
+        self.retrieve_dir = None
+        self.deploy_dir = None
+        with tempfile.TemporaryDirectory() as tempdir:
+            self._create_directories(tempdir)
+            self._retrieve_unpackaged()
+            self._process_metadata()
+            self._deploy_metadata()
+
+    def _create_directories(self, tempdir):
+        self.retrieve_dir = Path(tempdir, "retrieve")
+        self.deploy_dir = Path(tempdir, "deploy")
+        self.retrieve_dir.mkdir()
+        self.deploy_dir.mkdir()
 
     def _retrieve_unpackaged(self):
         path = self.options.get("package_xml") or os.path.join(
@@ -83,11 +90,11 @@ class UpdateAdminProfile(Deploy):
             self.project_config.project__package__api_version,
         )
         unpackaged = api_retrieve()
-        unpackaged.extractall(self.tempdir)
+        unpackaged.extractall(self.retrieve_dir)
 
     def _process_metadata(self):
-        self.logger.info("Processing retrieved metadata in {}".format(self.tempdir))
-        path = os.path.join(self.tempdir, "profiles", "Admin.profile")
+        self.logger.info(f"Processing retrieved metadata in {self.retrieve_dir}")
+        path = self.retrieve_dir / "profiles" / "Admin.profile"
         self.tree = elementtree_parse_file(path)
 
         self._set_apps_visible()
@@ -176,19 +183,18 @@ class UpdateAdminProfile(Deploy):
             elem.find("sf:visibility", self.namespaces).text = "DefaultOn"
 
     def _deploy_metadata(self):
-        deploy_dir = tempfile.mkdtemp()
-        self.logger.info(f"Deploying updated Admin.profile from {deploy_dir}")
+        self.logger.info(f"Deploying updated Admin.profile from {self.deploy_dir}")
 
-        target_profile_xml = Path(deploy_dir, "package.xml")
+        target_profile_xml = Path(self.deploy_dir, "package.xml")
         target_profile_xml.write_text(
             """<?xml version="1.0" encoding="UTF-8"?><Package xmlns="http://soap.sforce.com/2006/04/metadata">
         <types><members>Admin</members><name>Profile</name></types><version>39.0</version></Package>
         """
         )
 
-        source_profile_dir = Path(self.tempdir, "profiles")
-        target_profile_dir = Path(deploy_dir, "profiles")
-        source_profile_dir.replace(target_profile_dir)
+        retreived_profile_dir = Path(self.retrieve_dir, "profiles")
+        target_profile_dir = Path(self.deploy_dir, "profiles")
+        retreived_profile_dir.replace(target_profile_dir)
 
-        api = self._get_api(path=deploy_dir)
+        api = self._get_api(path=self.deploy_dir)
         return api()

--- a/cumulusci/tasks/salesforce/UpdateAdminProfile.py
+++ b/cumulusci/tasks/salesforce/UpdateAdminProfile.py
@@ -192,9 +192,9 @@ class UpdateAdminProfile(Deploy):
         """
         )
 
-        retreived_profile_dir = Path(self.retrieve_dir, "profiles")
+        retrieved_profile_dir = Path(self.retrieve_dir, "profiles")
         target_profile_dir = Path(self.deploy_dir, "profiles")
-        retreived_profile_dir.replace(target_profile_dir)
+        retrieved_profile_dir.replace(target_profile_dir)
 
         api = self._get_api(path=self.deploy_dir)
         return api()

--- a/cumulusci/tasks/salesforce/tests/test_UpdateAdminProfile.py
+++ b/cumulusci/tasks/salesforce/tests/test_UpdateAdminProfile.py
@@ -141,9 +141,11 @@ class TestUpdateAdminProfile(unittest.TestCase):
         task._retrieve_unpackaged()
         ApiRetrieveUnpackaged.assert_called_once()
 
-    def test_deploy_metadata(self):
-        task = create_task(UpdateAdminProfile)
-        task.tempdir = "/tmp"
-        task._get_api = mock.Mock()
-        task._deploy_metadata()
-        task._get_api.assert_called_once()
+
+def test_deploy_metadata(tmpdir):
+    task = create_task(UpdateAdminProfile)
+    task.tempdir = str(tmpdir)
+    tmpdir.mkdir("profiles")
+    task._get_api = mock.Mock()
+    task._deploy_metadata()
+    task._get_api.assert_called_once()


### PR DESCRIPTION
Prerelease [build failure](https://sfdo-metaci.herokuapp.com/builds/165142) when running `update_admin_profile`:

```
MetadataParseError: Could not process MDAPI response: Update of CustomObject Contact: Error on line 7891, col 20: No more than 10 columns may be specified in lookupPhoneDialogsAdditionalFields
```

This commit changes `UpdateAdminProfile` so that it only deploys the modified Admin profile. While it is necessary to retrieve profiles along their associated metadata objects, we don't need to do that for deployments.

----

# Critical Changes

# Changes

# Issues Closed