### PR TITLE
Feature/robot spring 20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,8 +135,8 @@ jobs:
           command: |
             echo $SFDX_HUB_KEY_BASE64 | base64 --decode > sfdx.key
             sfdx force:auth:jwt:grant --clientid $SFDX_CLIENT_ID --jwtkeyfile sfdx.key --username $SFDX_HUB_USERNAME --setdefaultdevhubusername -a hub
-            venv/bin/cci org info dev > org_info.txt
-            venv/bin/cci org default dev
+            venv/bin/cci org info prerelease > org_info.txt
+            venv/bin/cci org default prerelease
       - run:
           name: Run robot tests
           command: |
@@ -161,7 +161,7 @@ jobs:
       - run:
           name: Delete scratch org
           command: |
-            venv/bin/cci org scratch_delete dev
+            venv/bin/cci org scratch_delete prerelease
           when: always
       - run:
           name: Preserve coverage

--- a/cumulusci/core/tests/test_pageobjects.py
+++ b/cumulusci/core/tests/test_pageobjects.py
@@ -21,6 +21,7 @@ from cumulusci.robotframework.CumulusCI import CumulusCI
 from cumulusci.robotframework.pageobjects.PageObjectLibrary import _PageObjectLibrary
 from cumulusci.robotframework.pageobjects import (
     ListingPage,
+    EditModal,
     NewModal,
     HomePage,
     DetailPage,
@@ -43,6 +44,7 @@ CORE_KEYWORDS = [
 
 BASE_REGISTRY = {
     ("Detail", ""): DetailPage,
+    ("Edit", ""): EditModal,
     ("Home", ""): HomePage,
     ("Listing", ""): ListingPage,
     ("New", ""): NewModal,

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -783,6 +783,15 @@ class Salesforce(object):
             self.builtin.log("waiting for a refresh...", "DEBUG")
             self.selenium.capture_page_screenshot()
             time.sleep(interval)
+            location = self.selenium.get_location()
+            if "//test.salesforce.com" in location:
+                # did we land on https://test.salesforce.com? If so, maybe
+                # the authentication succeeded so let's try the url without
+                # the frontdoor servelet
+                login_url = self.cumulusci.org.config["instance_url"]
+                self.builtin.log(
+                    f"setting login_url temporarily to {login_url}", "DEBUG"
+                )
             self.selenium.go_to(login_url)
 
     def breakpoint(self):

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -12,7 +12,7 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.action_chains import ActionChains
 
 from simple_salesforce import SalesforceResourceNotFound
-from cumulusci.robotframework.utils import selenium_retry
+from cumulusci.robotframework.utils import selenium_retry, capture_screenshot_on_error
 from SeleniumLibrary.errors import ElementNotFound, NoOpenBrowser
 from urllib3.exceptions import ProtocolError
 
@@ -178,14 +178,19 @@ class Salesforce(object):
         self._jsclick(locator)
         self.wait_until_modal_is_open()
 
+    @capture_screenshot_on_error
     def click_related_item_link(self, heading, title):
         """Clicks a link in the related list with the specified heading.
 
         This keyword will automatically call `Wait until loading is complete`
         """
+        self.builtin.set_log_level("DEBUG")
+        self.builtin.log("loading related list...", "DEBUG")
         self.load_related_list(heading)
         locator = lex_locators["record"]["related"]["link"].format(heading, title)
+        self.builtin.log("clicking...", "DEBUG")
         self._jsclick(locator)
+        self.builtin.log("waiting...", "DEBUG")
         self.wait_until_loading_is_complete()
 
     def click_related_item_popup_link(self, heading, title, link):

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -404,7 +404,16 @@ class Salesforce(object):
 
         api_version = int(float(self.get_latest_api_version()))
         if api_version >= 48:
-            self.selenium.click_element(lex_locators["app_launcher"]["view_all"])
+            self.selenium.wait_until_element_is_visible(
+                lex_locators["app_launcher"]["menu"],
+                error="Expected to see the app launcher menu, but didn't",
+            )
+            element = self.selenium.get_webelement(
+                lex_locators["app_launcher"]["view_all"]
+            )
+            self.builtin.log("clicking 'view all' button")
+            self.selenium.capture_page_screenshot()
+            self._jsclick(element)
         self.wait_until_modal_is_open()
 
     def populate_field(self, name, value):
@@ -715,10 +724,13 @@ class Salesforce(object):
         self.builtin.log("Storing {} {} to session records".format(obj_type, obj_id))
         self._session_records.append({"type": obj_type, "id": obj_id})
 
+    @capture_screenshot_on_error
     def wait_until_modal_is_open(self):
         """ Wait for modal to open """
         self.selenium.wait_until_page_contains_element(
-            lex_locators["modal"]["is_open"], timeout=15
+            lex_locators["modal"]["is_open"],
+            timeout=15,
+            error="Expected to see a modal window, but didn't",
         )
 
     def wait_until_modal_is_closed(self):

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -806,10 +806,19 @@ class Salesforce(object):
             self.selenium.capture_page_screenshot()
             time.sleep(interval)
             location = self.selenium.get_location()
-            if "//test.salesforce.com" in location:
-                # did we land on https://test.salesforce.com? If so, maybe
-                # the authentication succeeded so let's try the url without
-                # the frontdoor servelet
+            if (
+                "//test.salesforce.com" in location
+                or "//login.salesforce.com" in location
+            ):
+                # Sometimes we get redirected to a login URL rather
+                # than being logged in, and we've yet to figure out
+                # precisely why that happens. Experimentation shows
+                # that authentication has already happened, so in
+                # this case we'll try going back to the instance url
+                # rather than the front door servlet.
+                #
+                # Admittedly, this is a bit of a hack, but it's better
+                # than never getting past this redirect.
                 login_url = self.cumulusci.org.config["instance_url"]
                 self.builtin.log(
                     f"setting login_url temporarily to {login_url}", "DEBUG"

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -520,6 +520,7 @@ class Salesforce(object):
         locator = lex_locators["modal"]["button"].format("Next")
         self._jsclick(locator)
 
+    @capture_screenshot_on_error
     def select_app_launcher_app(self, app_name):
         """Navigates to a Salesforce App via the App Launcher """
         locator = lex_locators["app_launcher"]["app_link"].format(app_name)
@@ -536,6 +537,7 @@ class Salesforce(object):
         self.builtin.log("Waiting for modal to close")
         self.wait_until_modal_is_closed()
 
+    @capture_screenshot_on_error
     def select_app_launcher_tab(self, tab_name):
         """Navigates to a tab via the App Launcher"""
         locator = lex_locators["app_launcher"]["tab_link"].format(tab_name)

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -183,7 +183,6 @@ class Salesforce(object):
 
         This keyword will automatically call `Wait until loading is complete`
         """
-        self.builtin.set_log_level("DEBUG")
         self.builtin.log("loading related list...", "DEBUG")
         self.load_related_list(heading)
         locator = lex_locators["record"]["related"]["link"].format(heading, title)

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -103,7 +103,6 @@ class Salesforce(object):
         See https://help.salesforce.com/articleView?id=000352057&language=en_US&mode=1&type=1
         """
 
-        self.builtin.log("jsclick, at your service!")
         self.selenium.wait_until_page_contains_element(locator)
         element = self.selenium.get_webelement(locator)
         # Setting the focus first seems to be required as of Spring'20

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -720,6 +720,11 @@ class Salesforce(object):
         try:
             self.selenium.wait_until_page_contains_element(locator)
             self.wait_for_aura()
+            # this knowledge article recommends waiting a second. I don't
+            # like it, but it seems to help. We should do a wait instead,
+            # but I can't figure out what to wait on.
+            # https://help.salesforce.com/articleView?id=000352057&language=en_US&mode=1&type=1
+            time.sleep(1)
 
         except Exception:
             try:

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -391,10 +391,21 @@ class Salesforce(object):
         self.builtin.log(output, level=loglevel)
 
     def open_app_launcher(self):
-        """ Opens the Saleforce App Launcher """
+        """Opens the Saleforce App Launcher Modal
+
+        Note: starting with Spring '20 the app launcher button opens a
+        menu rather than a modal. To maintain backwards compatibility,
+        this keyword will continue to open the modal rather than the
+        menu. If you need to interact with the app launcher menu, you
+        will need to create a custom keyword.
+        """
         locator = lex_locators["app_launcher"]["button"]
         self.builtin.log("Clicking App Launcher button")
         self._jsclick(locator)
+
+        api_version = int(float(self.get_latest_api_version()))
+        if api_version >= 48:
+            self.selenium.click_element(lex_locators["app_launcher"]["view_all"])
         self.wait_until_modal_is_open()
 
     def populate_field(self, name, value):
@@ -531,8 +542,8 @@ class Salesforce(object):
         self.builtin.log("Opening the App Launcher")
         self.open_app_launcher()
         self.builtin.log("Clicking App Tab")
-        self.selenium.set_focus_to_element(locator)
-        self.selenium.get_webelement(locator).click()
+        element = self.selenium.get_webelement(locator)
+        self._jsclick(element)
         self.builtin.log("Waiting for modal to close")
         self.wait_until_modal_is_closed()
 

--- a/cumulusci/robotframework/locators_47.py
+++ b/cumulusci/robotframework/locators_47.py
@@ -2,4 +2,9 @@ from cumulusci.robotframework import locators_46
 
 lex_locators = locators_46.lex_locators.copy()
 
-# At the moment, there are no changes to the locators.
+lex_locators["record"]["related"][
+    "link"
+] = "//article[.//span[@title='{}']]//a[.//span[@title='{}']]"
+lex_locators["record"]["related"][
+    "popup_trigger"
+] = "//article[.//span[@title='{}'][//a[text()='{}']]]//div[contains(@class, 'forceVirtualAction')]/a"

--- a/cumulusci/robotframework/locators_48.py
+++ b/cumulusci/robotframework/locators_48.py
@@ -16,6 +16,7 @@ lex_locators["record"]["header"]["field_value_link"] = (
     "//p[contains(@class, 'fieldComponent')]//a[text()]"
 )
 
+lex_locators["app_launcher"]["menu"] = "//div[contains(@class, 'appLauncherMenu')]"
 lex_locators["app_launcher"]["view_all"] = (
     "//div[contains(@class, 'appLauncherMenu')]" "//button[text()='View All']"
 )

--- a/cumulusci/robotframework/locators_48.py
+++ b/cumulusci/robotframework/locators_48.py
@@ -15,3 +15,13 @@ lex_locators["record"]["header"]["field_value_link"] = (
     "[.//*[contains(@class, 'slds-text-title') and text()='{}']]"
     "//p[contains(@class, 'fieldComponent')]//a[text()]"
 )
+
+lex_locators["app_launcher"]["view_all"] = (
+    "//div[contains(@class, 'appLauncherMenu')]" "//button[text()='View All']"
+)
+lex_locators["app_launcher"][
+    "app_link"
+] = "//one-app-launcher-modal//one-app-launcher-app-tile//a[.='{}']"
+lex_locators["app_launcher"][
+    "tab_link"
+] = "//one-app-launcher-modal//one-app-launcher-tab-item//a[.='{}']"

--- a/cumulusci/robotframework/locators_48.py
+++ b/cumulusci/robotframework/locators_48.py
@@ -2,4 +2,16 @@ from cumulusci.robotframework import locators_47
 
 lex_locators = locators_47.lex_locators.copy()
 
-# At the moment, there are no changes to the locators.
+lex_locators["record"]["header"]["field_value"] = (
+    "//records-lwc-highlights-panel"
+    "//force-highlights-details-item"
+    "[.//*[contains(@class, 'slds-text-title') and text()='{}']]"
+    "//p[contains(@class, 'fieldComponent')]//*[text()]"
+)
+
+lex_locators["record"]["header"]["field_value_link"] = (
+    "//records-lwc-highlights-panel"
+    "//force-highlights-details-item"
+    "[.//*[contains(@class, 'slds-text-title') and text()='{}']]"
+    "//p[contains(@class, 'fieldComponent')]//a[text()]"
+)

--- a/cumulusci/robotframework/pageobjects/BasePageObjects.py
+++ b/cumulusci/robotframework/pageobjects/BasePageObjects.py
@@ -48,25 +48,7 @@ class ListingPage(BasePage):
         )
 
 
-@pageobject("New")
-class NewModal(BasePage):
-    """A page object representing the New Object modal
-
-    Note: You should not use this page object with 'Go to page'. Instead,
-    you can use 'Wait for modal to appear' after performing an action
-    that causes the new object modal to appear (eg: clicking the
-    "New" button). Once the modal appears, the keywords for that
-    modal will be available for use in the test.
-
-    Example:
-
-    | Go to page                 Home  Contact
-    | Click object button        New
-    | Wait for modal to appear  New  Contact
-
-
-    """
-
+class ModalMixin:
     def _wait_to_appear(self, expected_heading=None):
         """Waits until the modal is visible"""
         locator = "//div[contains(@class, 'uiModal')]"
@@ -101,7 +83,7 @@ class NewModal(BasePage):
 
         self.selenium.wait_until_page_contains_element(locator)
         self.selenium.wait_until_element_is_enabled(locator)
-        self.selenium.click_element(locator)
+        self.salesforce._jsclick(locator)
 
     @capture_screenshot_on_error
     def modal_should_contain_errors(self, *messages):
@@ -163,6 +145,42 @@ class NewModal(BasePage):
         locator = "//div[contains(@class, 'uiModal')]"
 
         self.selenium.wait_until_page_does_not_contain_element(locator)
+
+
+@pageobject("New")
+class NewModal(ModalMixin, BasePage):
+    """A page object representing the New Object modal
+
+    Note: You should not use this page object with 'Go to page'. Instead,
+    you can use 'Wait for modal to appear' after performing an action
+    that causes the new object modal to appear (eg: clicking the
+    "New" button). Once the modal appears, the keywords for that
+    modal will be available for use in the test.
+
+    Example:
+
+    | Go to page                 Home  Contact
+    | Click object button        New
+    | Wait for modal to appear   New  Contact
+    """
+
+
+@pageobject("Edit")
+class EditModal(ModalMixin, BasePage):
+    """A page object representing the Edit Object modal
+
+    Note: You should not use this page object with 'Go to page'. Instead,
+    you can use 'Wait for modal to appear' after performing an action
+    that causes the new object modal to appear (eg: clicking the
+    "Edit" button). Once the modal appears, the keywords for that
+    modal will be available for use in the test.
+
+    Example:
+
+    | Click object button        Edit
+    | Wait for modal to appear   Edit  Contact
+
+    """
 
 
 @pageobject("Home")

--- a/cumulusci/robotframework/pageobjects/PageObjects.py
+++ b/cumulusci/robotframework/pageobjects/PageObjects.py
@@ -289,6 +289,12 @@ class PageObjects(object):
             expected_heading = f"{pobj._page_type} {pobj._object_name}"
         pobj._wait_to_appear(expected_heading=expected_heading)
         self._set_current_page_object(pobj)
+        # Ideally we would wait for something, but I can't figure out
+        # what that would be. A knowledge article simply suggests
+        # to wait a second.
+        # https://help.salesforce.com/articleView?id=000352057&language=en_US&mode=1&type=1
+
+        self.builtin.sleep("1 second")
         return pobj
 
     @capture_screenshot_on_error

--- a/cumulusci/robotframework/pageobjects/__init__.py
+++ b/cumulusci/robotframework/pageobjects/__init__.py
@@ -2,4 +2,10 @@ from .PageObjects import PageObjects  # noqa: F401
 from .baseobjects import BasePage  # noqa: F401
 from .PageObjectLibrary import _PageObjectLibrary  # noqa: F401
 from .PageObjects import pageobject  # noqa: F401
-from .BasePageObjects import ListingPage, HomePage, DetailPage, NewModal  # noqa: F401
+from .BasePageObjects import (  # noqa: F401
+    ListingPage,
+    HomePage,
+    DetailPage,
+    NewModal,
+    EditModal,
+)

--- a/cumulusci/robotframework/tests/salesforce/browsers.robot
+++ b/cumulusci/robotframework/tests/salesforce/browsers.robot
@@ -47,21 +47,30 @@ Open Test Browser Twice
 Browser aliases
     [Documentation]  Verify that aliases are properly handled in Open Test Browser
     [Tags]  issue:1068
-    [Setup]  Run keywords
-    ...  Open test browser  alias=browser1
-    ...  AND  Open test browser  alias=browser2
-    ...  AND  Go to  about:blank
     [Teardown]  Close all browsers
 
-    # This also doubles as a test which verifies the default
-    # landing page is the Setup home page
-    Switch browser  browser1
-    Location should contain  /lightning/setup/SetupOneHome/home
-    Capture page screenshot
+    # Open the default browser, go to a specific page and
+    # save the location
+    Open test browser  alias=browser1
+    Go to setup home
+    ${browser1 location}=  get location
 
+    # open a second browser to a different specific page
+    Open test browser  alias=browser2
+    Go to  about:blank
+
+    # Switch back to the first to verify that the location
+    # hasn't changed
+    Switch browser  browser1
+    Location should be  ${browser1 location}
+
+    # Go to a new location in the first browser,
+    Go to setup object manager
+
+    # ... and then verify the location of the second
+    # browser hasn't changed.
     Switch browser  browser2
     Location should be  about:blank
-    Capture page screenshot
 
 
 Default browser size

--- a/cumulusci/robotframework/tests/salesforce/locators.robot
+++ b/cumulusci/robotframework/tests/salesforce/locators.robot
@@ -5,10 +5,7 @@ Library         TestLibraryA.py
 Library         TestLibraryB.py
 Library         Dialogs
 
-Suite Setup     Run Keywords
-...  Open test browser
-...  AND  Set log level  DEBUG
-
+Suite Setup     Open test browser
 Suite Teardown  Close all browsers
 
 *** Test Cases ***
@@ -19,6 +16,8 @@ Locator strategy 'text'
     ...  Unfortunately, selenium doesn't provide introspection
     ...  so we'll just try a locator that should work
 
+    [Setup]  Go to setup home
+
     Wait until page contains element     text:Mobile Publisher
 
 Locator strategy 'title'
@@ -27,6 +26,8 @@ Locator strategy 'title'
 
     ...  Unfortunately, selenium doesn't provide introspection
     ...  so we'll just try a locator that should work
+
+    [Setup]  Go to setup home
 
     Wait until page contains element     title:Object Manager
 
@@ -37,6 +38,8 @@ Keyword library locators
     ...  Both of the test libraries should have registered their own
     ...  locators. This test makes sure both of them were registered
     ...  and available for use.
+
+    [Setup]  Go to setup home
 
     Wait until page contains element  A:breadcrumb: Home
     Wait until page contains element  B:appname:Setup

--- a/cumulusci/robotframework/tests/salesforce/populate.robot
+++ b/cumulusci/robotframework/tests/salesforce/populate.robot
@@ -64,7 +64,7 @@ Test Populate ability to clear a field
     [Setup]  run keywords
     ...  go to object home     Opportunity
     ...  AND  click link            ${opportunity['Name']}
-    ...  AND  click button          title:Edit
+    ...  AND  click object button   Edit
     ...  AND  wait until modal is open
 
     ${60 days from now}=  Get Current Date  increment=60 days  result_format=%Y-%m-%d

--- a/cumulusci/robotframework/tests/salesforce/ui.robot
+++ b/cumulusci/robotframework/tests/salesforce/ui.robot
@@ -74,12 +74,13 @@ Click related item link
     ...  Verify that 'Click related item link' works
 
     [Setup]  Create test data
-    Go to page  Detail  Contact  ${CONTACT ID}
+    set log level  DEBUG
     Salesforce Insert  Note
     ...  Title=This is the title of the note
     ...  Body=This is the body of the note
     ...  ParentId=${CONTACT ID}
 
+    Go to page  Detail  Contact  ${CONTACT ID}
     Click related item link
     ...  Notes & Attachments
     ...  This is the title of the note

--- a/cumulusci/robotframework/tests/salesforce/ui.robot
+++ b/cumulusci/robotframework/tests/salesforce/ui.robot
@@ -2,7 +2,7 @@
 
 Resource        cumulusci/robotframework/Salesforce.robot
 Library         cumulusci.robotframework.PageObjects
-Suite Setup     Open Test Browser
+Suite Setup     Run keywords  Create test data  AND  Open Test Browser
 Suite Teardown  Delete Records and Close Browser
 
 
@@ -28,6 +28,26 @@ Create Contact
     &{contact} =     Salesforce Get  Contact  ${contact_id}
     [return]  &{contact}
 
+Create test data
+    # This was added well after 'Create Account' and
+    # 'Create Contact'
+    ${CONTACT ID}=      Salesforce Insert  Contact
+    ...                 FirstName=Eleanor
+    ...                 LastName=Rigby
+    Set suite variable  ${CONTACT ID}
+
+    ${ACCOUNT ID}=      Salesforce Insert  Account
+    ...                 Name=Big Money Account
+    Set suite variable  ${ACCOUNT ID}
+
+    ${OPPORTUNITY ID}=  Salesforce Insert  Opportunity
+    ...                 CloseDate=2020-01-27
+    ...                 Name=Big Opportunity!
+    ...                 StageName=Prospecting
+    ...                 AccountId=${ACCOUNT ID}
+    ...                 ContactId=${CONTACT ID}
+    Set suite variable  ${OPPORTUNITY ID}
+
 *** Test Cases ***
 
 Click Modal Button
@@ -48,6 +68,35 @@ Click Related List Button
     Click Related List Button  Opportunities  New
     Wait Until Modal Is Open
     Page Should Contain        New Opportunity
+
+Click related item link
+    [Documentation]
+    ...  Verify that 'Click related item link' works
+
+    [Setup]  Create test data
+    Go to page  Detail  Contact  ${CONTACT ID}
+    Salesforce Insert  Note
+    ...  Title=This is the title of the note
+    ...  Body=This is the body of the note
+    ...  ParentId=${CONTACT ID}
+
+    Click related item link
+    ...  Notes & Attachments
+    ...  This is the title of the note
+
+    Current page should be   Detail  Note
+
+Click related item popup link
+    [Setup]  Create test data
+
+    Go to page  Detail  Contact  ${CONTACT ID}
+    Click Related item popup link
+    ...  Opportunities
+    ...  Big Opportunity!
+    ...  Edit
+
+    Wait for modal        Edit  Opportunity  expected_heading=Edit Big Opportunity!
+    Click modal button    Cancel
 
 Close Modal
     Go To Object Home        Contact


### PR DESCRIPTION
This is a collection of small fixes to address issues when running robot tests against Spring '20. The 
tests seem to mostly work for me locally, though I am still getting more `StaleElementReferenceException` failures in Spring '20 than Winter '20. I currently am thinking of a way to fix that, but that fix may be in a later changeset since QEs are blocked by some things this PR addresses.

Roughly speaking, this PR addresses the following broad issues:

1) some of the DOM has changed significantly, requiring improved locators
2) more of the DOM lives in shadow elements which are hard to click on, so some of our keywords now use javascript to click on elements
3) The app menu button now has a different behavior - it shows a menu rather than immediately opening the app modal
4) more processing seems to be happening when pages are loaded, causing our tests to jump the gun, so to speak. I've added a couple sleeps to minimize the problem, but I'll want to revisit this later to see if I can find a better solution. 
5) a couple new tests have been added, but our coverage of keywords still needs improvement.

I'm seeing more flakiness on circleci, so I've added a little extra debugging information in a few spots.

For background on the switch to using javascript for some of the clicks, see the knowledge article [Fixing Automated UI Tests in Spring '20](https://help.salesforce.com/articleView?id=000352057&language=en_US&mode=1&type=1)

There is still at least one known issue yet to be fixed, and that is with the `Populate lookup field` keyword. I've got it so that it's able to click the field and wait for the popup, but it's still not able to click an item on the menu. 
# Critical Changes

# Changes

# Issues Closed
