### PR TITLE
Feature/3.5.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,25 @@
 History
 =======
 
+3.5.0 (2020-01--15)
+-------------------
+
+Changes:
+
+* Bulk data mappings now allow bulk_mode: Serial to select serial mode.
+
+* CumulusCI now stores the logs from the last five executions under ``~/.cumulusci/logs``
+
+* CumulusCI has a new top-level command: ``cci gist``. This command creates a secret GitHub gist which includes: The user's current CumulusCI version, current Python version, path to python binary, sysname (e.g. Darwin), machine (e.g. x86_64), and the most recent CumulusCI logfile (``~/.cumulusci/logs/cci.log``). The command outputs a link to the created gist and opens a browser tab with the new GitHub gist. This can be helpful for sharing information regarding errors and issues encountered when working with cci. This feature uses a users GitHub access token for creation of gists. If your access token does not have the 'gist (Create gists)' scope this command will result in a 404 error. For more info see: https://cumulusci.readthedocs.io/en/latest/features.html#reporting-error-logs
+
+*  Changed ``UpdateAdminProfile`` so that it only deploys the modified Admin profile. While it is necessary to retrieve profiles along their associated metadata objects, we don't need to do that for deployments.
+
+* Added ``RunSpecifiedTests`` support to the ``deploy`` task.
+
+# Issues Closed
+
+* Added ``check_only`` and ``test_level`` parameters to the ``deploy`` task.
+
 3.4.0 (2020-01-09)
 ------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,7 @@ History
 
 Changes:
 
-* Bulk data mappings now allow bulk_mode: Serial to select serial mode.
+* The ``load_dataset`` task now accepts a ``bulk_mode`` option which can be set to ``Serial`` to load batches serially instead of in parallel.
 
 * CumulusCI now stores the logs from the last five executions under ``~/.cumulusci/logs``
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,11 +15,7 @@ Changes:
 
 *  Changed ``UpdateAdminProfile`` so that it only deploys the modified Admin profile. While it is necessary to retrieve profiles along their associated metadata objects, we don't need to do that for deployments.
 
-* Added ``RunSpecifiedTests`` support to the ``deploy`` task.
-
-# Issues Closed
-
-* Added ``check_only`` and ``test_level`` parameters to the ``deploy`` task.
+* Added options to the `deploy` task: ``check_only``, ``test_level``, and ``specified_tests``. Run ``cci task info deploy`` for details. (#1066)
 
 3.4.0 (2020-01-09)
 ------------------

--- a/cumulusci/__init__.py
+++ b/cumulusci/__init__.py
@@ -3,7 +3,7 @@ import sys
 
 __import__("pkg_resources").declare_namespace("cumulusci")
 
-__version__ = "3.4.0"
+__version__ = "3.5.0"
 
 __location__ = os.path.dirname(os.path.realpath(__file__))
 

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -169,7 +169,8 @@ def pass_runtime(func=None, require_project=True):
 
 
 SUGGEST_GIT_GIST_COMMAND = """\nIt looks like you may have run into an error. Did you know cci has a command for sending this error to a GitHub gist?
-Just run `$ cci gist` and make sure that your GitHub access token has the 'create gist' scope.\n"""
+Just run `$ cci gist` and make sure that your GitHub access token has the 'create gist' scope.
+For more info see: https://cumulusci.readthedocs.io/en/latest/features.html#reporting-error-logs"""
 
 
 #

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -102,7 +102,10 @@ is installed correctly by running ``cci version``:
 .. code:: console
 
    $ cci version
-   CumulusCI version: 3.1.2
+    CumulusCI version: 3.5.0 (/path/to/bin/cci)
+    Python version: 3.7.4 (/path/to/bin/python)
+
+    You have the latest version of CumulusCI.
 
 You can also use this command in the future to check whether your CumulusCI installation is up to date.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.4.0
+current_version = 3.5.0
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("requirements_dev.txt") as dev_requirements_file:
 
 setup(
     name="cumulusci",
-    version="3.4.0",
+    version="3.5.0",
     description="Build and release tools for Salesforce developers",
     long_description=readme + u"\n\n" + history,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
# Changes
* Bulk data mappings now allow bulk_mode: Serial to select serial mode.
* CumulusCI now stores the logs from the last five executions under ~/.cumulusci/logs
* CumulusCI has a new top-level command: `cci gist`. This command creates a secret GitHub gist which includes: The user's current CumulusCI version, current Python version, path to python binary, sysname (e.g. Darwin), machine (e.g. x86_64), and the most recent CumulusCI logfile (`~/.cumulusci/logs/cci.log`). The command outputs a link to the created gist and opens a browser tab with the new GitHub gist. This can be helpful for sharing information regarding errors and issues encountered when working with cci. This feature uses a users GitHub access token for creation of gists. If your access token does not have the 'gist (Create gists)' scope this command will result in a 404 error. For more info see: https://cumulusci.readthedocs.io/en/latest/features.html#reporting-error-logs
*  Changed `UpdateAdminProfile` so that it only deploys the modified Admin profile. While it is necessary to retrieve profiles along their associated metadata objects, we don't need to do that for deployments.
* Added `RunSpecifiedTests` support to the `deploy` task.

# Issues Closed
* Added `check_only` and `test_level` parameters to the `deploy` task.