### PR TITLE
Work around keychain issues

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,8 +2,18 @@
 History
 =======
 
-3.5.0 (2020-01--15)
--------------------
+3.5.1 (2020-01-15)
+------------------
+
+Issues closed:
+
+* Avoid errors that can happen when trying to store the CumulusCI encryption key in the system keychain using Python's keyring library, which can fail on some systems such as CI systems:
+
+  * We fixed a regression that caused CumulusCI to try to load the keychain even for commands where it's not used.
+  * We fixed a bug that caused CumulusCI to try to load the keychain key even when using an unencrypted keychain such as the EnvironmentProjectKeychain.
+
+3.5.0 (2020-01-15)
+------------------
 
 Changes:
 

--- a/cumulusci/__init__.py
+++ b/cumulusci/__init__.py
@@ -3,7 +3,7 @@ import sys
 
 __import__("pkg_resources").declare_namespace("cumulusci")
 
-__version__ = "3.5.0"
+__version__ = "3.5.1"
 
 __location__ = os.path.dirname(os.path.realpath(__file__))
 

--- a/cumulusci/core/runtime.py
+++ b/cumulusci/core/runtime.py
@@ -77,10 +77,11 @@ class BaseCumulusCI(object):
         )
 
     def _load_keychain(self):
+        keychain_key = self.keychain_key if self.keychain_cls.encrypted else None
         if self.project_config is None:
-            self.keychain = self.keychain_cls(self.global_config, self.keychain_key)
+            self.keychain = self.keychain_cls(self.global_config, keychain_key)
         else:
-            self.keychain = self.keychain_cls(self.project_config, self.keychain_key)
+            self.keychain = self.keychain_cls(self.project_config, keychain_key)
             self.project_config.keychain = self.keychain
 
     def get_flow(self, name, options=None):

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -102,7 +102,7 @@ is installed correctly by running ``cci version``:
 .. code:: console
 
    $ cci version
-    CumulusCI version: 3.5.0 (/path/to/bin/cci)
+    CumulusCI version: 3.5.1 (/path/to/bin/cci)
     Python version: 3.7.4 (/path/to/bin/python)
 
     You have the latest version of CumulusCI.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.5.0
+current_version = 3.5.1
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("requirements_dev.txt") as dev_requirements_file:
 
 setup(
     name="cumulusci",
-    version="3.5.0",
+    version="3.5.1",
     description="Build and release tools for Salesforce developers",
     long_description=readme + u"\n\n" + history,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
I think this will fix our problems (or at least make them no worse than the previous state).

It returns to only trying to load the keychain for commands that actually use it, which should resolve our problem in the `brew test` command. This could do with some sanity checks/testing to make sure I identified the correct commands.

It also will now only try to look up the keychain key if the keychain class declares itself to be an encrypted keychain. This means CI systems that set CUMULUSCI_KEYCHAIN_CLASS to cumulusci.core.keychain.EnvironmentProjectKeychain will no longer need to set CUMULUSCI_KEY if they don't have a working keyring. This is not a new bug, just something that made sense to fix while I was paying attention to it.

# Critical Changes

# Changes

# Issues Closed
