### PR TITLE
Move null terminator to file logger

### DIFF
--- a/cumulusci/cli/logger.py
+++ b/cumulusci/cli/logger.py
@@ -27,7 +27,6 @@ def init_logger(log_requests=False):
 
     formatter = coloredlogs.ColoredFormatter(fmt="%(asctime)s: %(message)s")
     handler = logging.StreamHandler(stream=sys.stdout)
-    handler.terminator = ""  # click.echo already adds a newline
     handler.setLevel(logging.DEBUG)
     handler.setFormatter(formatter)
     logger.addHandler(handler)
@@ -55,6 +54,7 @@ def get_rot_file_logger(name, path):
 
     handler = RotatingFileHandler(path, backupCount=5)
     handler.doRollover()  # rollover existing log files
+    handler.terminator = ""  # click.echo already adds a newline
     logger.addHandler(handler)
     logger.setLevel(logging.DEBUG)
     return logger


### PR DESCRIPTION
### Before
File:
```
2020-01-15 17:10:25: Getting scratch org info from Salesforce DX
2020-01-15 17:10:27: Beginning task: SalUserGenerator
2020-01-15 17:10:27:        As user: test-zll48jmhtr6h@example.com
2020-01-15 17:10:27:         In org: 00D540000006gBv
```

stdout
```
2020-01-15 17:10:25: Getting scratch org info from Salesforce DX2020-01-15 17:10:27: Beginning task: SalUserGenerator2020-01-15 17:10:27:        As user: test-zll48jmhtr6h@example.com2020-01-15 17:10:27:         In org: 00D540000006gBv
```

### After
File:
```
2020-01-15 17:12:41: Getting scratch org info from Salesforce DX
2020-01-15 17:12:45: Beginning task: SalUserGenerator
2020-01-15 17:12:45:        As user: test-zll48jmhtr6h@example.com
2020-01-15 17:12:45:         In org: 00D540000006gBv
```

stdout:
```
2020-01-15 17:12:41: Getting scratch org info from Salesforce DX
2020-01-15 17:12:45: Beginning task: SalUserGenerator
2020-01-15 17:12:45:        As user: test-zll48jmhtr6h@example.com
2020-01-15 17:12:45:         In org: 00D540000006gBv
```

----

# Critical Changes

# Changes

# Issues Closed