### PR TITLE
Add another missing newline

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -212,6 +212,9 @@ def main(args=None):
         # Hand CLI processing over to click, but handle exceptions
         try:
             cli(standalone_mode=False)
+        except click.Abort:  # Keyboard interrupt
+            click.echo("\nAborted!")
+            sys.exit(1)
         except Exception as e:
             # Display the error
             if debug:

--- a/cumulusci/tests/test_utils.py
+++ b/cumulusci/tests/test_utils.py
@@ -495,13 +495,13 @@ Options:
     def test_tee_stdout_stderr(self):
         args = ["cci", "test"]
         logger = mock.Mock()
-        expected_stdout_text = "This is expected stdout."
-        expected_stderr_text = "This is expected stderr."
+        expected_stdout_text = "This is expected stdout.\n"
+        expected_stderr_text = "This is expected stderr.\n"
         with utils.tee_stdout_stderr(args, logger):
             sys.stdout.write(expected_stdout_text)
             sys.stderr.write(expected_stderr_text)
 
         assert logger.debug.call_count == 3
-        assert logger.debug.call_args_list[0][0][0] == "cci test"
+        assert logger.debug.call_args_list[0][0][0] == "cci test\n"
         assert logger.debug.call_args_list[1][0][0] == expected_stdout_text
         assert logger.debug.call_args_list[2][0][0] == expected_stderr_text

--- a/cumulusci/utils.py
+++ b/cumulusci/utils.py
@@ -564,7 +564,7 @@ def tee_stdout_stderr(args, logger):
     real_stderr_write = sys.stderr.write
 
     # Add current command args as first line in logfile
-    logger.debug(" ".join(args))
+    logger.debug(" ".join(args) + "\n")
 
     def stdout_write(s):
         output = strip_ansi_sequences(s)


### PR DESCRIPTION
Fix missing newline between command args and output.

Also added special handling of click.Abort so that we don't print the gist message when the user exits using Ctrl+C.

# Critical Changes

# Changes

# Issues Closed
