### PR TITLE
Gist fixes

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -6,6 +6,7 @@ import functools
 import json
 import re
 import os
+import platform
 import pdb
 import shutil
 import sys
@@ -314,12 +315,12 @@ def gist(runtime):
 
 
 def get_context_info():
-    host_info = os.uname()
+    host_info = platform.uname()
 
     info = []
     info.append(f"CumulusCI version: {cumulusci.__version__}")
     info.append(f"Python version: {sys.version.split()[0]} ({sys.executable})")
-    info.append(f"Environment Info: {host_info.sysname} / {host_info.machine}")
+    info.append(f"Environment Info: {host_info.system} / {host_info.machine}")
     return "\n".join(info)
 
 

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -225,7 +225,9 @@ def main(args=None):
                 pdb.post_mortem()
             else:
                 click.echo(click.style(f"Error: {e}", fg="red"))
-                click.echo(click.style(SUGGEST_GIT_GIST_COMMAND, fg="yellow"))
+                # Only suggest gist command if it wasn't run
+                if not is_gist_command:
+                    click.echo(click.style(SUGGEST_GIT_GIST_COMMAND, fg="yellow"))
 
                 with open(CCI_LOGFILE_PATH, "a") as log_file:
                     traceback.print_exc(file=log_file)  # log stacktrace silently

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -219,16 +219,16 @@ class TestCCI(unittest.TestCase):
 
     @mock.patch("cumulusci.cli.cci.CCI_LOGFILE_PATH")
     @mock.patch("cumulusci.cli.cci.webbrowser")
-    @mock.patch("cumulusci.cli.cci.os")
+    @mock.patch("cumulusci.cli.cci.platform")
     @mock.patch("cumulusci.cli.cci.sys")
     @mock.patch("cumulusci.cli.cci.datetime")
     @mock.patch("cumulusci.cli.cci.create_gist")
     @mock.patch("cumulusci.cli.cci.get_github_api")
     def test_gist(
-        self, gh_api, create_gist, date, sys, cci_os, webbrowser, logfile_path
+        self, gh_api, create_gist, date, sys, platform, webbrowser, logfile_path
     ):
 
-        cci_os.uname.return_value = mock.Mock(sysname="Rossian", machine="x68_46")
+        platform.uname.return_value = mock.Mock(system="Rossian", machine="x68_46")
         sys.version = "1.0.0 (default Jul 24 2019)"
         sys.executable = "User/bob.ross/.pyenv/versions/cci-374/bin/python"
         date.utcnow.return_value = "01/01/1970"
@@ -265,20 +265,20 @@ Environment Info: Rossian / x68_46
 
     @mock.patch("cumulusci.cli.cci.CCI_LOGFILE_PATH")
     @mock.patch("cumulusci.cli.cci.click")
-    @mock.patch("cumulusci.cli.cci.os")
+    @mock.patch("cumulusci.cli.cci.platform")
     @mock.patch("cumulusci.cli.cci.sys")
     @mock.patch("cumulusci.cli.cci.datetime")
     @mock.patch("cumulusci.cli.cci.create_gist")
     @mock.patch("cumulusci.cli.cci.get_github_api")
     def test_gist__gist_creation_error(
-        self, gh_api, create_gist, date, sys, os_mock, click, logfile_path
+        self, gh_api, create_gist, date, sys, platform, click, logfile_path
     ):
 
         expected_logfile_content = "Hello there, I'm a logfile."
         logfile_path.is_file.return_value = True
         logfile_path.read_text.return_value = expected_logfile_content
 
-        os_mock.uname.return_value = mock.Mock(sysname="Rossian", machine="x68_46")
+        platform.uname.return_value = mock.Mock(sysname="Rossian", machine="x68_46")
         sys.version = "1.0.0 (default Jul 24 2019)"
         sys.executable = "User/bob.ross/.pyenv/versions/cci-374/bin/python"
         date.utcnow.return_value = "01/01/1970"


### PR DESCRIPTION
# Issues Closed
* Only suggest `cci gist` command we that command wasn't the last one run. (Fixes #1474) 
* Use `platform.uname` instead of `os.uname` (Fixes #1475)
