### PR TITLE
Enhance EnsureRecordTypes to work properly with Case, Lead, and Solution

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -98,6 +98,13 @@ tasks:
         options:
             command: 'force:source:push'
         group: Salesforce DX
+    ensure_record_types:
+        description: Ensure that a default Record Type is extant on the given standard sObject (custom objects are not supported). If Record Types are already present, do nothing.
+        class_path: cumulusci.tasks.salesforce.EnsureRecordTypes
+        options:
+            record_type_label: Default
+            record_type_developer_name: Default
+        group: 'Salesforce Metadata'
     execute_anon:
         description: Execute anonymous apex via the tooling api.
         class_path: cumulusci.tasks.apex.anon.AnonymousApexTask

--- a/cumulusci/tasks/salesforce/EnsureRecordTypes.py
+++ b/cumulusci/tasks/salesforce/EnsureRecordTypes.py
@@ -122,7 +122,7 @@ class EnsureRecordTypes(BaseSalesforceApiTask):
                 )
                 # Lead, Case, and Solution require a default value in their Business Process
                 # Opportunity prohibits it.
-                default = self.options["sobject"] != "Opportunity":
+                default = self.options["sobject"] != "Opportunity"
 
                 business_process_metadata = BUSINESS_PROCESS_METADATA.format(
                     record_type_developer_name=self.options[

--- a/cumulusci/tasks/salesforce/EnsureRecordTypes.py
+++ b/cumulusci/tasks/salesforce/EnsureRecordTypes.py
@@ -122,10 +122,7 @@ class EnsureRecordTypes(BaseSalesforceApiTask):
                 )
                 # Lead, Case, and Solution require a default value in their Business Process
                 # Opportunity prohibits it.
-                if self.options["sobject"] == "Opportunity":
-                    default = "false"
-                else:
-                    default = "true"
+                default = self.options["sobject"] != "Opportunity":
 
                 business_process_metadata = BUSINESS_PROCESS_METADATA.format(
                     record_type_developer_name=self.options[

--- a/cumulusci/tasks/salesforce/EnsureRecordTypes.py
+++ b/cumulusci/tasks/salesforce/EnsureRecordTypes.py
@@ -122,7 +122,9 @@ class EnsureRecordTypes(BaseSalesforceApiTask):
                 )
                 # Lead, Case, and Solution require a default value in their Business Process
                 # Opportunity prohibits it.
-                default = self.options["sobject"] != "Opportunity"
+                default = (
+                    "true" if self.options["sobject"] != "Opportunity" else "false"
+                )
 
                 business_process_metadata = BUSINESS_PROCESS_METADATA.format(
                     record_type_developer_name=self.options[

--- a/cumulusci/tasks/salesforce/tests/test_EnsureRecordTypes.py
+++ b/cumulusci/tasks/salesforce/tests/test_EnsureRecordTypes.py
@@ -2,6 +2,7 @@ from unittest import mock
 import unittest
 import os
 
+from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.tasks.salesforce import EnsureRecordTypes
 from cumulusci.utils import temporary_dir
 from .util import create_task
@@ -14,6 +15,25 @@ OPPORTUNITY_METADATA = """<?xml version="1.0" encoding="utf-8"?>
         <values>
             <fullName>Test</fullName>
             <default>false</default>
+        </values>
+    </businessProcesses>
+    <recordTypes>
+        <fullName>NPSP_Default</fullName>
+        <active>true</active>
+        <businessProcess>NPSP_Default</businessProcess>
+        <label>NPSP Default</label>
+    </recordTypes>
+</CustomObject>
+"""
+
+CASE_METADATA = """<?xml version="1.0" encoding="utf-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <businessProcesses>
+        <fullName>NPSP_Default</fullName>
+        <isActive>true</isActive>
+        <values>
+            <fullName>Test</fullName>
+            <default>true</default>
         </values>
     </businessProcesses>
     <recordTypes>
@@ -52,6 +72,20 @@ OPPORTUNITY_DESCRIBE_NO_RTS = {
         {"name": "Id"},
         {
             "name": "StageName",
+            "picklistValues": [
+                {"value": "Bad", "active": False},
+                {"value": "Test", "active": True},
+            ],
+        },
+    ],
+}
+
+CASE_DESCRIBE_NO_RTS = {
+    "recordTypeInfos": [{"master": True}],
+    "fields": [
+        {"name": "Id"},
+        {
+            "name": "Status",
             "picklistValues": [
                 {"value": "Bad", "active": False},
                 {"value": "Test", "active": True},
@@ -142,6 +176,30 @@ class TestEnsureRecordTypes(unittest.TestCase):
                 pkg_contents = f.read()
                 self.assertMultiLineEqual(PACKAGE_XML, pkg_contents)
 
+    def test_generates_record_type_and_business_process__case(self):
+        task = create_task(
+            EnsureRecordTypes,
+            {
+                "record_type_developer_name": "NPSP_Default",
+                "record_type_label": "NPSP Default",
+                "sobject": "Case",
+            },
+        )
+
+        task.sf = mock.Mock()
+        task.sf.Case = mock.Mock()
+        task.sf.Case.describe = mock.Mock(return_value=CASE_DESCRIBE_NO_RTS)
+        task._infer_requirements()
+
+        with temporary_dir():
+            task._build_package()
+            with open(os.path.join("objects", "Case.object"), "r") as f:
+                opp_contents = f.read()
+                self.assertMultiLineEqual(CASE_METADATA, opp_contents)
+            with open(os.path.join("package.xml"), "r") as f:
+                pkg_contents = f.read()
+                self.assertMultiLineEqual(PACKAGE_XML, pkg_contents)
+
     def test_generates_record_type_only(self):
         task = create_task(
             EnsureRecordTypes,
@@ -226,3 +284,24 @@ class TestEnsureRecordTypes(unittest.TestCase):
         task._run_task()
 
         task._deploy.assert_not_called()
+
+    def test_init_options(self):
+        with self.assertRaises(TaskOptionsError):
+            create_task(
+                EnsureRecordTypes,
+                {
+                    "record_type_developer_name": "%#$(*%(%))",
+                    "record_type_label": "NPSP Default",
+                    "sobject": "Opportunity",
+                },
+            )
+
+        with self.assertRaises(TaskOptionsError):
+            create_task(
+                EnsureRecordTypes,
+                {
+                    "record_type_developer_name": "NPSP_Default",
+                    "record_type_label": "NPSP Default",
+                    "sobject": "Test__c",
+                },
+            )

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -269,6 +269,20 @@ Options:
 * **command** *(required)*: The full command to run with the sfdx cli. **Default: force:source:push**
 * **extra**: Append additional options to the command
 
+ensure_record_type
+==========================================
+
+**Description:** Ensure that a default Record Type is extant on the given standard sObject (custom objects are not supported). If Record Types are already present, do nothing.
+
+**Class::** cumulusci.tasks.salesforce.EnsureRecordTypes
+
+Options:
+------------------------------------------
+
+* **record_type_developer_name** *(required)*: The Developer Name of the Record Type (unique).  Must contain only alphanumeric characters and underscores. **Default: Default**
+* **record_type_label** *(required)*: The Label of the Record Type. **Default: Default**
+* **sobject** *(required)*: The sObject on which to deploy the Record Type and optional Business Process.
+
 execute_anon
 ==========================================
 


### PR DESCRIPTION
# Critical Changes

# Changes

- The `EnsureRecordTypes` class is now exposed as `ensure_record_types` and correctly supports the Case, Lead, and Solution sObjects (in addition to other standard objects).

# Issues Closed
