### PR TITLE
Don't comment on issues when no tag present

### DIFF
--- a/cumulusci/tasks/release_notes/generator.py
+++ b/cumulusci/tasks/release_notes/generator.py
@@ -111,6 +111,12 @@ class ParentPullRequestNotesGenerator(BaseReleaseNotesGenerator):
 
         self.repo = repo
         self.github = github
+        self.github_info = {
+            "github_owner": project_config.repo_owner,
+            "github_repo": project_config.repo_name,
+            "prefix_beta": project_config.project__git__prefix_beta,
+            "prefix_prod": project_config.project__git__prefix_release,
+        }
         self.link_pr = True  # create links to pr on parsed change notes
         self.has_issues = True  # need for parsers
         self.do_publish = True  # need for parsers

--- a/cumulusci/tasks/release_notes/parser.py
+++ b/cumulusci/tasks/release_notes/parser.py
@@ -253,7 +253,11 @@ class GithubIssuesParser(IssuesParser):
         # Ensure all issues have a comment on which release they were fixed
         prefix_beta = self.release_notes_generator.github_info["prefix_beta"]
         prefix_prod = self.release_notes_generator.github_info["prefix_prod"]
-        if self.release_notes_generator.current_tag.startswith(prefix_beta):
+
+        # ParentPullRequestNotesGenerator doesn't utilize a current_tag
+        if not hasattr(self.release_notes_generator, "current_tag"):
+            return
+        elif self.release_notes_generator.current_tag.startswith(prefix_beta):
             is_beta = True
         elif self.release_notes_generator.current_tag.startswith(prefix_prod):
             is_beta = False


### PR DESCRIPTION
# Issues Closed
* Fixed a bug where the `github_parent_pr_notes` was attempting to post comments on issues related to child pull request change notes. We want these comments to occur only when running task `github_release_notes` (the comment on the issue notes the tag in which it was fixed). Fixes #1482 