### PR TITLE
Robot spring20 part2

### DIFF
--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -417,19 +417,24 @@ class Salesforce(object):
         self.wait_until_modal_is_open()
 
     def populate_field(self, name, value):
-        """Enters a value into a text field.
+        """Enters a value into an input or textarea field.
+
+        'name' represents the label on the page (eg: "First Name"),
+        and 'value' is the new value.
 
         Any existing value will be replaced.
         """
-        locator = lex_locators["object"]["field"].format(name)
+        locator = self._get_input_field_locator(name)
         self._populate_field(locator, value)
 
     def populate_lookup_field(self, name, value):
         """Enters a value into a lookup field.
         """
-        input_locator = lex_locators["object"]["field"].format(name)
+        input_locator = self._get_input_field_locator(name)
         menu_locator = lex_locators["object"]["field_lookup_link"].format(value)
-        self.populate_field(name, value)
+
+        self._populate_field(input_locator, value)
+
         for x in range(3):
             self.wait_for_aura()
             try:
@@ -444,7 +449,38 @@ class Salesforce(object):
         self.selenium.set_focus_to_element(menu_locator)
         self._jsclick(menu_locator)
 
+    def _get_input_field_locator(self, name):
+        """Given an input field label, return a locator for the related input field
+
+        This looks for a <label> element with the given text, or
+        a label with a span with the given text. The value of the
+        'for' attribute is then extracted from the label and used
+        to create a new locator with that id.
+
+        For example, the locator 'abc123' will be returned
+        for the following html:
+
+        <label for='abc123'>First Name</label>
+        -or-
+        <label for='abc123'><span>First Name</span>
+        """
+        try:
+            # we need to make sure that if a modal is open, we only find
+            # the input element inside the modal. Otherwise it's possible
+            # that the xpath could pick the wrong element.
+            self.selenium.get_webelement(lex_locators["modal"]["is_open"])
+            modal_prefix = "//div[contains(@class, 'modal-container')]"
+        except ElementNotFound:
+            modal_prefix = ""
+
+        locator = modal_prefix + lex_locators["object"]["field_label"].format(
+            name, name
+        )
+        input_element_id = self.selenium.get_element_attribute(locator, "for")
+        return input_element_id
+
     def _populate_field(self, locator, value):
+        self.builtin.log(f"value: {value}' locator: '{locator}'", "DEBUG")
         field = self.selenium.get_webelement(locator)
         self._focus(field)
         if field.get_attribute("value"):
@@ -506,8 +542,7 @@ class Salesforce(object):
     def populate_form(self, **kwargs):
         """Enters multiple values from a mapping into form fields."""
         for name, value in kwargs.items():
-            locator = lex_locators["object"]["field"].format(name)
-            self._populate_field(locator, value)
+            self.populate_field(name, value)
 
     def remove_session_record(self, obj_type, obj_id):
         """Remove a record from the list of records that should be automatically removed."""

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -181,14 +181,17 @@ class Salesforce(object):
     def click_related_item_link(self, heading, title):
         """Clicks a link in the related list with the specified heading.
 
-        This keyword will automatically call `Wait until loading is complete`
+         This keyword will automatically call `Wait until loading is complete`
         """
-        self.builtin.log("loading related list...", "DEBUG")
         self.load_related_list(heading)
         locator = lex_locators["record"]["related"]["link"].format(heading, title)
-        self.builtin.log("clicking...", "DEBUG")
-        self._jsclick(locator)
-        self.builtin.log("waiting...", "DEBUG")
+        try:
+            self._jsclick(locator)
+        except Exception as e:
+            self.builtin.log(f"Exception: {e}", "DEBUG")
+            raise Exception(
+                f"Unable to find related link under heading '{heading}' with the text '{title}'"
+            )
         self.wait_until_loading_is_complete()
 
     def click_related_item_popup_link(self, heading, title, link):
@@ -560,8 +563,7 @@ class Salesforce(object):
         self.wait_until_modal_is_open()
         locator = lex_locators["object"]["record_type_option"].format(label)
         self._jsclick(locator)
-        locator = lex_locators["modal"]["button"].format("Next")
-        self._jsclick(locator)
+        self.click_modal_button("Next")
 
     @capture_screenshot_on_error
     def select_app_launcher_app(self, app_name):

--- a/cumulusci/robotframework/locators_47.py
+++ b/cumulusci/robotframework/locators_47.py
@@ -8,3 +8,6 @@ lex_locators["record"]["related"][
 lex_locators["record"]["related"][
     "popup_trigger"
 ] = "//article[.//span[@title='{}'][//a[text()='{}']]]//div[contains(@class, 'forceVirtualAction')]/a"
+lex_locators["object"][
+    "field_label"
+] = "//label[@for!='' and text()='{}']|//label[@for!=''][./span[text()='{}']]"

--- a/cumulusci/robotframework/locators_48.py
+++ b/cumulusci/robotframework/locators_48.py
@@ -16,6 +16,13 @@ lex_locators["record"]["header"]["field_value_link"] = (
     "//p[contains(@class, 'fieldComponent')]//a[text()]"
 )
 
+lex_locators["record"]["related"]["link"] = (
+    "//article[contains(@class, 'forceRelatedListCardDesktop')]"
+    "[.//img]"
+    "[.//span[@title='{}']]"
+    "//*[text()='{}']"
+)
+
 lex_locators["app_launcher"]["menu"] = "//div[contains(@class, 'appLauncherMenu')]"
 lex_locators["app_launcher"]["view_all"] = (
     "//div[contains(@class, 'appLauncherMenu')]" "//button[text()='View All']"
@@ -26,3 +33,15 @@ lex_locators["app_launcher"][
 lex_locators["app_launcher"][
     "tab_link"
 ] = "//one-app-launcher-modal//one-app-launcher-tab-item//a[.='{}']"
+
+lex_locators["object"]["field_lookup_link"] = "//*[@role='option'][.//*[@title='{}']]"
+
+# NPSP tests were failing because the New Opportunity modal no longer
+# is using the class modal-footer.
+lex_locators["modal"]["button"] = (
+    "//div[contains(@class,'uiModal')]"
+    "//div[contains(@class, 'modal-footer') or contains(@class, 'inlineFooter')]"
+    # I don't like using an '*' here, but the link might be an <a> or it
+    # might be a <span>.
+    "//button[.//*[text()='{}']]"
+)

--- a/cumulusci/robotframework/tests/salesforce/ui.robot
+++ b/cumulusci/robotframework/tests/salesforce/ui.robot
@@ -1,9 +1,10 @@
-*** Settings ***
+** Settings ***
 
 Resource        cumulusci/robotframework/Salesforce.robot
 Library         cumulusci.robotframework.PageObjects
 Suite Setup     Run keywords  Create test data  AND  Open Test Browser
 Suite Teardown  Delete Records and Close Browser
+Library         Dialogs
 
 
 *** Keywords ***
@@ -74,7 +75,7 @@ Click related item link
     ...  Verify that 'Click related item link' works
 
     [Setup]  Create test data
-    set log level  DEBUG
+
     Salesforce Insert  Note
     ...  Title=This is the title of the note
     ...  Body=This is the body of the note
@@ -223,7 +224,12 @@ Populate Form
     ${account_name} =    Generate Random String
     Go To Object Home    Account
     Click Object Button  New
-    Populate Form        Account Name=${account_name}
+    Populate Form
+    ...  Ticker Symbol=CASH
+    ...  Account Name=${account_name}
     ${locator} =         Get Locator  object.field  Account Name
     ${value} =           Get Value  ${locator}
     Should Be Equal      ${value}  ${account_name}
+    ${locator}=          Get Locator  object.field  Ticker Symbol
+    ${value} =           Get Value  ${locator}
+    Should Be Equal      ${value}  CASH

--- a/cumulusci/robotframework/tests/salesforce/ui.robot
+++ b/cumulusci/robotframework/tests/salesforce/ui.robot
@@ -73,7 +73,6 @@ Click Related List Button
 Click related item link
     [Documentation]
     ...  Verify that 'Click related item link' works
-    [tags]  foo
     [Setup]  Create test data
 
     Salesforce Insert  Note

--- a/cumulusci/robotframework/tests/salesforce/ui.robot
+++ b/cumulusci/robotframework/tests/salesforce/ui.robot
@@ -73,7 +73,7 @@ Click Related List Button
 Click related item link
     [Documentation]
     ...  Verify that 'Click related item link' works
-
+    [tags]  foo
     [Setup]  Create test data
 
     Salesforce Insert  Note
@@ -87,6 +87,17 @@ Click related item link
     ...  This is the title of the note
 
     Current page should be   Detail  Note
+
+Click related item link exception
+    [Documentation]
+    ...  Verify that 'Click related item link' throws a useful error
+
+    [Setup]  Create test data
+
+    Go to page  Detail  Contact  ${CONTACT ID}
+    Run keyword and expect error
+    ...  Unable to find related link under heading 'Notes & Attachments' with the text 'Bogus'
+    ...  Click related item link  Notes & Attachments  Bogus
 
 Click related item popup link
     [Setup]  Create test data


### PR DESCRIPTION
This fixes keyword issues that have been reported for Spring '20. The biggest change is in
the populate keywords, where I rewrote the basic algorithm for finding the input elements. There are also fixes for clicking on related item links. 

Unfortunately, an input element and its label can be marked up in at least two different ways, and the ways are so different as to make it almost impossible to craft a single xpath that works in both cases. With this change, we find the label and then use the 'for' attribute on that element to get the id of
the related input element. All of our tests pass with this change, and I've also spot-checked it with several NPSP tests that were brought to my attention.

# Critical Changes

# Changes

# Issues Closed
