### PR TITLE
CumulusCI `error` Command

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1399,7 +1399,7 @@ def flow_run(runtime, flow_name, org, delete_org, debug, o, skip, no_prompt):
 
 @error.command(name="info", help="Outputs the last part of the most recent traceback")
 @click.option("--num-lines", "-n", default=30, show_default=True, type=int)
-def info(num_lines):
+def error_info(num_lines):
     if not CCI_LOGFILE_PATH.is_file():
         click.echo(f"No logfile found at: {CCI_LOGFILE_PATH}")
     else:

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -333,13 +333,16 @@ def service():
 @cli.group("error")
 def error():
     """
-    If you'd like to dig into this error more yourself,
+    If you'd like to dig into an error more yourself,
     you can get the last few lines of context about it
     from `cci error info`.
 
-    If you'd like to submit it to a developer for converation,
+    If you'd like to submit it to a developer for conversation,
     you can use the `cci error gist` command. Just make sure
     that your GitHub access token has the 'create gist' scope.
+
+    For more information on working with errors in CumulusCI visit:
+    https://cumulusci.readthedocs.io/en/latest/features.html#working-with-errors
     """
     pass
 

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -173,7 +173,7 @@ def pass_runtime(func=None, require_project=True, require_keychain=False):
 
 
 SUGGEST_ERROR_COMMAND = (
-    """Type `cci error help` for more information about debugging errors."""
+    """Type `cci error --help` for more information about debugging errors."""
 )
 
 

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -344,7 +344,6 @@ def error():
     For more information on working with errors in CumulusCI visit:
     https://cumulusci.readthedocs.io/en/latest/features.html#working-with-errors
     """
-    pass
 
 
 # Commands for group: project
@@ -1399,17 +1398,13 @@ def flow_run(runtime, flow_name, org, delete_org, debug, o, skip, no_prompt):
 
 
 @error.command(name="info", help="Outputs the last part of the most recent traceback")
-@click.argument("num_lines", required=False)
+@click.option("--num-lines", "-n", default=30, show_default=True, type=int)
 def info(num_lines):
     if not CCI_LOGFILE_PATH.is_file():
         click.echo(f"No logfile found at: {CCI_LOGFILE_PATH}")
-        return
-
-    if not num_lines:
-        output_lines = 30
-
-    output = lines_from_traceback(CCI_LOGFILE_PATH.read_text(), output_lines)
-    click.echo(output)
+    else:
+        output = lines_from_traceback(CCI_LOGFILE_PATH.read_text(), num_lines or 30)
+        click.echo(output)
 
 
 def lines_from_traceback(log_content, num_lines):

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1411,17 +1411,16 @@ def info(num_lines):
 
 def lines_from_traceback(log_content, num_lines):
     """Returns the the last num_lines of the logfile,
-    or the whole traceback, whichever is shorter.
+    or the whole traceback, whichever is shorter. If
+    no stacktrace is found in the logfile, the user is
+    notified.
     """
-    stacktrace = ""
     stacktrace_start = "Traceback (most recent call last):"
-
     if stacktrace_start not in log_content:
         return f"\nNo stacktrace found in: {CCI_LOGFILE_PATH}\n"
 
-    log_lines = log_content.split("\n")
-
-    for line in reversed(log_lines):
+    stacktrace = ""
+    for line in reversed(log_content.split("\n")):
         stacktrace = "\n" + line + stacktrace
         if stacktrace_start in line:
             break

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1411,7 +1411,7 @@ def error_info(max_lines):
 
 
 def lines_from_traceback(log_content, num_lines):
-    """Returns the the last num_lines of the logfile,
+    """Returns the the last max_lines of the logfile,
     or the whole traceback, whichever is shorter. If
     no stacktrace is found in the logfile, the user is
     notified.

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1397,13 +1397,16 @@ def flow_run(runtime, flow_name, org, delete_org, debug, o, skip, no_prompt):
             click.echo(str(e))
 
 
-@error.command(name="info", help="Outputs the last part of the most recent traceback")
-@click.option("--num-lines", "-n", default=30, show_default=True, type=int)
-def error_info(num_lines):
+@error.command(
+    name="info",
+    help="Outputs the last part of the most recent traceback (if one exists in the most recent log)",
+)
+@click.option("--max-lines", "-m", default=30, show_default=True, type=int)
+def error_info(max_lines):
     if not CCI_LOGFILE_PATH.is_file():
         click.echo(f"No logfile found at: {CCI_LOGFILE_PATH}")
     else:
-        output = lines_from_traceback(CCI_LOGFILE_PATH.read_text(), num_lines)
+        output = lines_from_traceback(CCI_LOGFILE_PATH.read_text(), max_lines)
         click.echo(output)
 
 

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1403,7 +1403,7 @@ def info(num_lines):
     if not CCI_LOGFILE_PATH.is_file():
         click.echo(f"No logfile found at: {CCI_LOGFILE_PATH}")
     else:
-        output = lines_from_traceback(CCI_LOGFILE_PATH.read_text(), num_lines or 30)
+        output = lines_from_traceback(CCI_LOGFILE_PATH.read_text(), num_lines)
         click.echo(output)
 
 

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -172,9 +172,9 @@ def pass_runtime(func=None, require_project=True, require_keychain=False):
         return decorate(func)
 
 
-SUGGEST_GIT_GIST_COMMAND = """\nIt looks like you may have run into an error. Did you know cci has a command for sending this error to a GitHub gist?
-Just run `$ cci gist` and make sure that your GitHub access token has the 'create gist' scope.
-For more info see: https://cumulusci.readthedocs.io/en/latest/features.html#reporting-error-logs"""
+SUGGEST_ERROR_COMMAND = (
+    """Type `cci error help` for more information about debugging errors."""
+)
 
 
 #
@@ -207,7 +207,7 @@ def main(args=None):
 
         # Only create logfiles for commands
         # that are not `cci gist`
-        is_gist_command = len(args) > 1 and args[1] == "gist"
+        is_gist_command = len(args) > 2 and args[2] == "gist"
         if not is_gist_command:
             logger = get_gist_logger()
             stack.enter_context(tee_stdout_stderr(args, logger))
@@ -228,7 +228,7 @@ def main(args=None):
                 click.echo(click.style(f"Error: {e}", fg="red"))
                 # Only suggest gist command if it wasn't run
                 if not is_gist_command:
-                    click.echo(click.style(SUGGEST_GIT_GIST_COMMAND, fg="yellow"))
+                    click.echo(click.style(SUGGEST_ERROR_COMMAND, fg="yellow"))
 
                 with open(CCI_LOGFILE_PATH, "a") as log_file:
                     traceback.print_exc(file=log_file)  # log stacktrace silently
@@ -269,9 +269,7 @@ def version():
 
 @cli.command(name="shell", help="Drop into a Python shell")
 @click.option("--script", help="Path to a script to run", type=click.Path())
-@click.option(
-    "--python", help="Python code to run directly",
-)
+@click.option("--python", help="Python code to run directly")
 @pass_runtime(require_project=False, require_keychain=True)
 def shell(runtime, script=None, python=None):
     # alias for backwards-compatibility
@@ -290,42 +288,6 @@ def shell(runtime, script=None, python=None):
 CCI_LOGFILE_PATH = Path.home() / ".cumulusci" / "logs" / "cci.log"
 GIST_404_ERR_MSG = """A 404 error code was returned when trying to create your gist.
 Please ensure that your GitHub personal access token has the 'Create gists' scope."""
-
-
-@cli.command(name="gist", help="Create a GitHub gist from the latest logfile")
-@pass_runtime(require_project=False, require_keychain=True)
-def gist(runtime):
-    if CCI_LOGFILE_PATH.is_file():
-        log_content = CCI_LOGFILE_PATH.read_text()
-    else:
-        log_not_found_msg = """No logfile to open at path: {}
-        Please ensure you're running this command from the same directory you were experiencing an issue."""
-        error_msg = log_not_found_msg.format(CCI_LOGFILE_PATH)
-        click.echo(error_msg)
-        raise CumulusCIException(error_msg)
-
-    last_cmd_header = "\n\n\nLast Command Run\n================================\n"
-    filename = f"cci_output_{datetime.utcnow()}.txt"
-    files = {
-        filename: {"content": f"{get_context_info()}{last_cmd_header}{log_content}"}
-    }
-
-    try:
-        gh = RUNTIME.keychain.get_service("github")
-        gist = create_gist(
-            get_github_api(gh.config["username"], gh.config["password"]),
-            "CumulusCI Error Output",
-            files,
-        )
-    except github3.exceptions.NotFoundError:
-        raise CumulusCIException(GIST_404_ERR_MSG)
-    except Exception as e:
-        raise CumulusCIException(
-            f"An error occurred attempting to create your gist:\n{e}"
-        )
-    else:
-        click.echo(f"Gist created: {gist.html_url}")
-        webbrowser.open(gist.html_url)
 
 
 def get_context_info():
@@ -365,6 +327,20 @@ def flow():
 
 @cli.group("service", help="Commands for connecting services to the keychain")
 def service():
+    pass
+
+
+@cli.group("error")
+def error():
+    """
+    If you'd like to dig into this error more yourself,
+    you can get the last few lines of context about it
+    from `cci error info`.
+
+    If you'd like to submit it to a developer for converation,
+    you can use the `cci error gist` command. Just make sure
+    that your GitHub access token has the 'create gist' scope.
+    """
     pass
 
 
@@ -1137,9 +1113,7 @@ def org_scratch_delete(runtime, org_name):
 )
 @click.argument("org_name", required=False)
 @click.option("--script", help="Path to a script to run", type=click.Path())
-@click.option(
-    "--python", help="Python code to run directly",
-)
+@click.option("--python", help="Python code to run directly")
 @pass_runtime(require_keychain=True)
 def org_shell(runtime, org_name, script=None, python=None):
     org_name, org_config = runtime.get_org(org_name)
@@ -1419,3 +1393,76 @@ def flow_run(runtime, flow_name, org, delete_org, debug, o, skip, no_prompt):
                 "Scratch org deletion failed.  Ignoring the error below to complete the flow:"
             )
             click.echo(str(e))
+
+
+@error.command(name="info", help="Outputs the last part of the most recent traceback")
+@click.argument("num_lines", required=False)
+def info(num_lines):
+    if not CCI_LOGFILE_PATH.is_file():
+        click.echo(f"No logfile found at: {CCI_LOGFILE_PATH}")
+        return
+
+    if not num_lines:
+        output_lines = 30
+
+    output = lines_from_traceback(CCI_LOGFILE_PATH.read_text(), output_lines)
+    click.echo(output)
+
+
+def lines_from_traceback(log_content, num_lines):
+    """Returns the the last num_lines of the logfile,
+    or the whole traceback, whichever is shorter.
+    """
+    stacktrace = ""
+    stacktrace_start = "Traceback (most recent call last):"
+
+    if stacktrace_start not in log_content:
+        return f"\nNo stacktrace found in: {CCI_LOGFILE_PATH}\n"
+
+    log_lines = log_content.split("\n")
+
+    for line in reversed(log_lines):
+        stacktrace = "\n" + line + stacktrace
+        if stacktrace_start in line:
+            break
+        num_lines -= 1
+        if num_lines == -1:
+            break
+
+    return stacktrace
+
+
+@error.command(name="gist", help="Creates a GitHub gist from the latest logfile")
+@pass_runtime(require_project=False, require_keychain=True)
+def gist(runtime):
+    if CCI_LOGFILE_PATH.is_file():
+        log_content = CCI_LOGFILE_PATH.read_text()
+    else:
+        log_not_found_msg = """No logfile to open at path: {}
+        Please ensure you're running this command from the same directory you were experiencing an issue."""
+        error_msg = log_not_found_msg.format(CCI_LOGFILE_PATH)
+        click.echo(error_msg)
+        raise CumulusCIException(error_msg)
+
+    last_cmd_header = "\n\n\nLast Command Run\n================================\n"
+    filename = f"cci_output_{datetime.utcnow()}.txt"
+    files = {
+        filename: {"content": f"{get_context_info()}{last_cmd_header}{log_content}"}
+    }
+
+    try:
+        gh = RUNTIME.keychain.get_service("github")
+        gist = create_gist(
+            get_github_api(gh.config["username"], gh.config["password"]),
+            "CumulusCI Error Output",
+            files,
+        )
+    except github3.exceptions.NotFoundError:
+        raise CumulusCIException(GIST_404_ERR_MSG)
+    except Exception as e:
+        raise CumulusCIException(
+            f"An error occurred attempting to create your gist:\n{e}"
+        )
+    else:
+        click.echo(f"Gist created: {gist.html_url}")
+        webbrowser.open(gist.html_url)

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -1533,6 +1533,46 @@ Environment Info: Rossian / x68_46
             "Scratch org deletion failed.  Ignoring the error below to complete the flow:"
         )
 
+    @mock.patch("cumulusci.cli.cci.click.echo")
+    @mock.patch("cumulusci.cli.cci.CCI_LOGFILE_PATH")
+    def test_error_info_no_logfile_present(self, log_path, echo):
+        log_path.is_file.return_value = False
+        run_click_command(cci.error_info, num_lines=30)
+
+        echo.assert_called_once_with(f"No logfile found at: {cci.CCI_LOGFILE_PATH}")
+
+    @mock.patch("cumulusci.cli.cci.click.echo")
+    @mock.patch("cumulusci.cli.cci.CCI_LOGFILE_PATH")
+    def test_error_info(self, log_path, echo):
+        log_path.is_file.return_value = True
+        log_path.read_text.return_value = (
+            "This\nis\na\ntest\nTraceback (most recent call last):\n1\n2\n3\n4"
+        )
+
+        run_click_command(cci.error_info, num_lines=30)
+        echo.assert_called_once_with("\nTraceback (most recent call last):\n1\n2\n3\n4")
+
+    @mock.patch("cumulusci.cli.cci.click.echo")
+    @mock.patch("cumulusci.cli.cci.CCI_LOGFILE_PATH")
+    def test_error_info_output_less(self, log_path, echo):
+        log_path.is_file.return_value = True
+        log_path.read_text.return_value = (
+            "This\nis\na\ntest\nTraceback (most recent call last):\n1\n2\n3\n4"
+        )
+
+        run_click_command(cci.error_info, num_lines=3)
+        echo.assert_called_once_with("\n1\n2\n3\n4")
+
+    def test_lines_from_traceback_no_traceback(self):
+        output = cci.lines_from_traceback("test_content", 10)
+        assert "\nNo stacktrace found in:" in output
+
+    def test_lines_from_traceback(self):
+        traceback = "\nTraceback (most recent call last):\n1\n2\n3\n4"
+        content = "This\nis\na" + traceback
+        output = cci.lines_from_traceback(content, 10)
+        assert output == traceback
+
 
 class SetTrace(Exception):
     pass

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -1537,7 +1537,7 @@ Environment Info: Rossian / x68_46
     @mock.patch("cumulusci.cli.cci.CCI_LOGFILE_PATH")
     def test_error_info_no_logfile_present(self, log_path, echo):
         log_path.is_file.return_value = False
-        run_click_command(cci.error_info, num_lines=30)
+        run_click_command(cci.error_info, max_lines=30)
 
         echo.assert_called_once_with(f"No logfile found at: {cci.CCI_LOGFILE_PATH}")
 
@@ -1549,7 +1549,7 @@ Environment Info: Rossian / x68_46
             "This\nis\na\ntest\nTraceback (most recent call last):\n1\n2\n3\n4"
         )
 
-        run_click_command(cci.error_info, num_lines=30)
+        run_click_command(cci.error_info, max_lines=30)
         echo.assert_called_once_with("\nTraceback (most recent call last):\n1\n2\n3\n4")
 
     @mock.patch("cumulusci.cli.cci.click.echo")
@@ -1560,7 +1560,7 @@ Environment Info: Rossian / x68_46
             "This\nis\na\ntest\nTraceback (most recent call last):\n1\n2\n3\n4"
         )
 
-        run_click_command(cci.error_info, num_lines=3)
+        run_click_command(cci.error_info, max_lines=3)
         echo.assert_called_once_with("\n1\n2\n3\n4")
 
     def test_lines_from_traceback_no_traceback(self):

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -742,7 +742,7 @@ Viewing Stacktraces
 -------------------
 If you encounter an error and want more information on what went wrong, you can use ``cci error info`` to display the last *n* lines (30, by default) of the stacktrace (if present) from the last command you executed in CumulusCI.
 
-You can include the option num_lines argument if you want to customize how much of the stacktrace you see.
+You can include the option ``max_lines`` argument if you want to customize how much of the stacktrace you see.
 
 Reporting Error Logs 
 --------------------

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -734,15 +734,15 @@ Caveats:
 
 Working with Errors
 ===================
-Logfiles
+Log Files
 --------
-CumulusCI creates a logfile every time a cci command is run. The only exception to this is when the cci gist command is run. Logfiles are stored under `~/.cumulusci/logs`.
+CumulusCI creates a log file every time a cci command besides ``gist`` is run. Log files are stored under ``~/.cumulusci/logs``.
 
 Viewing Stacktraces
 -------------------
-If you encounter an error and want more information on what went wrong, you can use `cci error info` to display the last 30 lines of the stacktrace (if present) from the last command you executed in CumulusCI.
+If you encounter an error and want more information on what went wrong, you can use ``cci error info`` to display the last *n* lines (30, by default) of the stacktrace (if present) from the last command you executed in CumulusCI.
 
-You can include the option num_lines argument if you want to customize how much of the stacktrae you see.
+You can include the option num_lines argument if you want to customize how much of the stacktrace you see.
 
 Reporting Error Logs 
 --------------------

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -732,8 +732,20 @@ Caveats:
 * See `this link <https://ntotten.com/2018/05/11/convert-metadata-to-source-format-while-maintain-git-history/>`_ for some tips on preserving git history while converting your source format.
 
 
+Working with Errors
+===================
+Logfiles
+--------
+CumulusCI creates a logfile every time a cci command is run. The only exception to this is when the cci gist command is run. Logfiles are stored under `~/.cumulusci/logs`.
+
+Viewing Stacktraces
+-------------------
+If you encounter an error and want more information on what went wrong, you can use `cci error info` to display the last 30 lines of the stacktrace (if present) from the last command you executed in CumulusCI.
+
+You can include the option num_lines argument if you want to customize how much of the stacktrae you see.
+
 Reporting Error Logs 
-====================
+--------------------
 Use the ``cci gist`` command to send the log of your last ``cci`` command to a GitHub gist so you can submit it for support if needed.
 
 For this feature to work you will need to ensure that your `github service is setup with the proper scopes <https://cumulusci.readthedocs.io/en/latest/tutorial.html#github-service>`_.
@@ -748,6 +760,3 @@ The gist command creates a gist comprised of:
 
 The URL for the gist is displayed on the terminal of the user as output, and a web browser will automatically open a tab to the gist.
 
-**Logfiles**
-
-CumulusCI creates a logfile every time a cci command is run. The only exception to this is when the cci gist command is run. Logfiles are stored under `~/.cumulusci/logs`.


### PR DESCRIPTION
# Changes
* New top level `cci error` command for interacting with errors in CumulusCI
* `cci gist` moved to `cci error gist`
* `cci error info` displays lines of a stacktrace from the previous `cci` command run. 
* Prompt when encountering error's in cci now suggests `cci error help` (instead of `cci gist`)
* closes #1494 
* closes #1498 
