### PR TITLE
Convert num_records to a number if provided as str

### DIFF
--- a/cumulusci/tasks/bulkdata/generate_from_yaml.py
+++ b/cumulusci/tasks/bulkdata/generate_from_yaml.py
@@ -67,6 +67,7 @@ class GenerateDataFromYaml(BaseGenerateDataTask):
             self.generate_mapping_file = os.path.abspath(self.generate_mapping_file)
         num_records = self.options.get("num_records")
         if num_records is not None:
+            num_records = int(num_records)
             num_records_tablename = self.options.get("num_records_tablename")
 
             if not num_records_tablename:


### PR DESCRIPTION
Previously if num_records was specified on the CLI (as opposed to in the YAML), it would cause a type error in Snowfakery.