### PR TITLE
Revert change to `select_record_type`

### DIFF
--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -563,7 +563,7 @@ class Salesforce(object):
         self.wait_until_modal_is_open()
         locator = lex_locators["object"]["record_type_option"].format(label)
         self._jsclick(locator)
-        self.click_modal_button("Next")
+        self.selenium.click_button("Next")
 
     @capture_screenshot_on_error
     def select_app_launcher_app(self, app_name):


### PR DESCRIPTION
The change worked in Spring '20 but not in Winter '20. We don't have any tests for this keyword, I've
been using NPSP to test it. Specifically, the test create_organization.robot

# Critical Changes

# Changes

# Issues Closed
