### PR TITLE
Include LoadData options by default. Especially bulk_mode.

### DIFF
--- a/cumulusci/tasks/bulkdata/generate_and_load_data.py
+++ b/cumulusci/tasks/bulkdata/generate_and_load_data.py
@@ -61,17 +61,12 @@ class GenerateAndLoadData(BaseSalesforceApiTask):
             "description": "How many records to create and load at a time.",
             "required": False,
         },
-        "mapping": {"description": "A mapping YAML file to use", "required": False},
         "data_generation_task": {
             "description": "Fully qualified class path of a task to generate the data. Look at cumulusci.tasks.bulkdata.tests.dummy_data_factory to learn how to write them.",
             "required": True,
         },
         "data_generation_options": {
             "description": "Options to pass to the data generator.",
-            "required": False,
-        },
-        "database_url": {
-            "description": "A URL to store the database (defaults to a transient SQLite file)",
             "required": False,
         },
         "vars": {
@@ -83,7 +78,9 @@ class GenerateAndLoadData(BaseSalesforceApiTask):
         "debug_dir": {
             "description": "Store temporary DB files in debug_dir for easier debugging."
         },
+        **LoadData.task_options,
     }
+    task_options["mapping"]["required"] = False
 
     def _init_options(self, kwargs):
         super()._init_options(kwargs)

--- a/cumulusci/tasks/bulkdata/tests/test_generate_and_load.py
+++ b/cumulusci/tasks/bulkdata/tests/test_generate_and_load.py
@@ -166,6 +166,7 @@ class TestGenerateAndLoadData(unittest.TestCase):
                 options = kwargs["task_config"].options
                 assert options["num_records"] == 12
                 assert options["database_url"].startswith("sqlite")
+                assert options["bulk_mode"] == "Serial"
                 assert "mapping_vanilla_sf" in options["mapping"]
 
             def __call__(self):
@@ -183,6 +184,7 @@ class TestGenerateAndLoadData(unittest.TestCase):
                         "num_records": 12,
                         "data_generation_task": "cumulusci.tasks.bulkdata.tests.dummy_data_factory.GenerateDummyData",
                         "mapping": mapping_file,
+                        "bulk_mode": "Serial",
                     }
                 },
             )


### PR DESCRIPTION
This class orchestrates generating and loading data. "Inheriting" options from LoadData directly helps keep its options in sync and in particular gives it access to the bulk_mode property.