### PR TITLE
Fix keychain for flow and task info

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1204,6 +1204,8 @@ def task_doc(runtime):
 @click.argument("task_name")
 @pass_runtime(require_project=False)
 def task_info(runtime, task_name):
+    if runtime.project_config is not None:
+        runtime._load_keychain()
     task_config = (
         runtime.project_config.get_task(task_name)
         if runtime.project_config is not None
@@ -1324,7 +1326,7 @@ def flow_list(runtime, plain, print_json):
 
 @flow.command(name="info", help="Displays information for a flow")
 @click.argument("flow_name")
-@pass_runtime
+@pass_runtime(require_keychain=True)
 def flow_info(runtime, flow_name):
     try:
         coordinator = runtime.get_flow(flow_name)

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1202,10 +1202,8 @@ def task_doc(runtime):
 
 @task.command(name="info", help="Displays information for a task")
 @click.argument("task_name")
-@pass_runtime(require_project=False)
+@pass_runtime(require_project=False, require_keychain=True)
 def task_info(runtime, task_name):
-    if runtime.project_config is not None:
-        runtime._load_keychain()
     task_config = (
         runtime.project_config.get_task(task_name)
         if runtime.project_config is not None


### PR DESCRIPTION
This fixes a regression where the keychain was not loaded for the `flow info` and `task info` commands (it's needed to get the github service when using cross-project flows)

# Critical Changes

# Changes

# Issues Closed
Fixes #1529 