### PR TITLE
Fix env var for passing persistent org access token to sfdx

### DIFF
--- a/cumulusci/tasks/sfdx.py
+++ b/cumulusci/tasks/sfdx.py
@@ -68,7 +68,7 @@ class SFDXOrgTask(SFDXBaseTask):
         if not isinstance(self.org_config, ScratchOrgConfig):
             # For non-scratch keychain orgs, pass the access token via env var
             env["SFDX_INSTANCE_URL"] = self.org_config.instance_url
-            env["SFDX_USERNAME"] = self.org_config.access_token
+            env["SFDX_DEFAULTUSERNAME"] = self.org_config.access_token
         return env
 
 

--- a/cumulusci/tasks/tests/test_sfdx.py
+++ b/cumulusci/tasks/tests/test_sfdx.py
@@ -76,8 +76,8 @@ class TestSFDXBaseTask(MockLoggerMixin, unittest.TestCase):
             pass
 
         self.assertIn("SFDX_INSTANCE_URL", task._get_env())
-        self.assertIn("SFDX_USERNAME", task._get_env())
-        self.assertIn(access_token, task._get_env()["SFDX_USERNAME"])
+        self.assertIn("SFDX_DEFAULTUSERNAME", task._get_env())
+        self.assertIn(access_token, task._get_env()["SFDX_DEFAULTUSERNAME"])
 
     def test_scratch_org_username(self):
         """ Scratch Org credentials are passed by -u flag """


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed
* Fixed a bug where using SFDXOrgTask to run an sfdx command on a non-scratch org would break with "Must pass a username and/or OAuth options when creating an AuthInfo instance."