### PR TITLE
Various adjustments to metadata ETL

### DIFF
--- a/cumulusci/tasks/salesforce/metadata_etl/__init__.py
+++ b/cumulusci/tasks/salesforce/metadata_etl/__init__.py
@@ -4,6 +4,7 @@ from cumulusci.tasks.salesforce.metadata_etl.base import (
     BaseMetadataTransformTask,
     MetadataSingleEntityTransformTask,
     get_new_tag_index,
+    MD,
 )
 from cumulusci.tasks.salesforce.metadata_etl.layouts import AddRelatedLists
 from cumulusci.tasks.salesforce.metadata_etl.permissions import AddPermissions
@@ -20,4 +21,5 @@ flake8 = (
     AddValueSetEntries,
     SetOrgWideDefaults,
     get_new_tag_index,
+    MD,
 )

--- a/cumulusci/tasks/salesforce/metadata_etl/sharing.py
+++ b/cumulusci/tasks/salesforce/metadata_etl/sharing.py
@@ -1,9 +1,12 @@
-import xml.etree.ElementTree as XML_ET
-
 from datetime import datetime
 
+from lxml import etree
+
 from cumulusci.core.exceptions import CumulusCIException, TaskOptionsError
-from cumulusci.tasks.salesforce.metadata_etl import MetadataSingleEntityTransformTask
+from cumulusci.tasks.salesforce.metadata_etl import (
+    MetadataSingleEntityTransformTask,
+    MD,
+)
 
 
 class SetOrgWideDefaults(MetadataSingleEntityTransformTask):
@@ -60,26 +63,18 @@ class SetOrgWideDefaults(MetadataSingleEntityTransformTask):
         desired_external_model = self.owds[api_name].get("external_sharing_model")
 
         if desired_external_model:
-            external_model = metadata.findall(
-                f".//sf:externalSharingModel", self.namespaces
-            )
+            external_model = metadata.findall(f".//{MD}externalSharingModel")
             if not external_model:
                 external_model = [
-                    XML_ET.SubElement(
-                        metadata.getroot(),
-                        "{%s}externalSharingModel" % (self.namespaces.get("sf")),
-                    )
+                    etree.SubElement(metadata.getroot(), f"{MD}externalSharingModel")
                 ]
             external_model[0].text = desired_external_model
 
         if desired_internal_model:
-            internal_model = metadata.findall(f".//sf:sharingModel", self.namespaces)
+            internal_model = metadata.findall(f".//{MD}sharingModel")
             if not internal_model:
                 internal_model = [
-                    XML_ET.SubElement(
-                        metadata.getroot(),
-                        "{%s}sharingModel" % (self.namespaces.get("sf")),
-                    )
+                    etree.SubElement(metadata.getroot(), f"{MD}sharingModel")
                 ]
             internal_model[0].text = desired_internal_model
 

--- a/cumulusci/tasks/salesforce/metadata_etl/tests/test_base.py
+++ b/cumulusci/tasks/salesforce/metadata_etl/tests/test_base.py
@@ -16,18 +16,21 @@ from cumulusci.tasks.salesforce.metadata_etl import (
 )
 
 
+class MetadataETLTask(BaseMetadataETLTask):
+    _get_package_xml_content = mock.Mock()
+    _transform = mock.Mock()
+
+
 class TestBaseMetadataETLTask:
     def test_init_options(self):
-        task = create_task(
-            BaseMetadataETLTask, {"unmanaged": True, "api_version": "47.0"}
-        )
+        task = create_task(MetadataETLTask, {"unmanaged": True, "api_version": "47.0"})
 
         assert task.options["unmanaged"]
         assert task.options["api_version"] == "47.0"
 
     def test_inject_namespace(self):
         task = create_task(
-            BaseMetadataETLTask,
+            MetadataETLTask,
             {"unmanaged": False, "namespace_inject": "test", "api_version": "47.0"},
         )
 
@@ -38,7 +41,7 @@ class TestBaseMetadataETLTask:
     @mock.patch("cumulusci.tasks.salesforce.metadata_etl.base.ApiRetrieveUnpackaged")
     def test_retrieve(self, api_mock):
         task = create_task(
-            BaseMetadataETLTask,
+            MetadataETLTask,
             {"unmanaged": False, "namespace_inject": "test", "api_version": "47.0"},
         )
         task.retrieve_dir = mock.Mock()
@@ -58,7 +61,7 @@ class TestBaseMetadataETLTask:
     def test_deploy(self, deploy_mock):
         with tempfile.TemporaryDirectory() as tmpdir:
             task = create_task(
-                BaseMetadataETLTask,
+                MetadataETLTask,
                 {"unmanaged": False, "namespace_inject": "test", "api_version": "47.0"},
             )
             task.deploy_dir = Path(tmpdir)
@@ -76,7 +79,7 @@ class TestBaseMetadataETLTask:
 
     def test_run_task(self):
         task = create_task(
-            BaseMetadataETLTask,
+            MetadataETLTask,
             {"unmanaged": False, "namespace_inject": "test", "api_version": "47.0"},
         )
 
@@ -91,10 +94,15 @@ class TestBaseMetadataETLTask:
         task._deploy.assert_called_once_with()
 
 
+class MetadataSynthesisTask(BaseMetadataSynthesisTask):
+    _get_package_xml_content = mock.Mock()
+    _synthesize = mock.Mock()
+
+
 class TestBaseMetadataSynthesisTask:
     def test_synthesis(self):
         task = create_task(
-            BaseMetadataSynthesisTask,
+            MetadataSynthesisTask,
             {"unmanaged": False, "namespace_inject": "test", "api_version": "47.0"},
         )
 
@@ -110,7 +118,7 @@ class TestBaseMetadataSynthesisTask:
     @mock.patch("cumulusci.tasks.salesforce.metadata_etl.base.PackageXmlGenerator")
     def test_generate_package_xml(self, package_mock):
         task = create_task(
-            BaseMetadataSynthesisTask,
+            MetadataSynthesisTask,
             {"unmanaged": False, "namespace_inject": "test", "api_version": "47.0"},
         )
         task.deploy_dir = "test"
@@ -121,10 +129,15 @@ class TestBaseMetadataSynthesisTask:
         assert result == package_mock.return_value.return_value
 
 
+class MetadataTransformTask(BaseMetadataTransformTask):
+    _get_entities = mock.Mock()
+    _transform = mock.Mock()
+
+
 class TestBaseMetadataTransformTask:
     def test_generate_package_xml(self):
         task = create_task(
-            BaseMetadataTransformTask,
+            MetadataTransformTask,
             {"unmanaged": False, "namespace_inject": "test", "api_version": "47.0"},
         )
 
@@ -154,9 +167,13 @@ class TestBaseMetadataTransformTask:
         )
 
 
+class ConcreteMetadataSingleEntityTransformTask(MetadataSingleEntityTransformTask):
+    _transform_entity = mock.Mock()
+
+
 class TestMetadataSingleEntityTransformTask:
     def test_init_options(self):
-        task = create_task(MetadataSingleEntityTransformTask, {})
+        task = create_task(ConcreteMetadataSingleEntityTransformTask, {})
         task._init_options(
             {
                 "unmanaged": False,
@@ -169,14 +186,14 @@ class TestMetadataSingleEntityTransformTask:
 
     def test_get_entities(self):
         task = create_task(
-            MetadataSingleEntityTransformTask,
+            ConcreteMetadataSingleEntityTransformTask,
             {"unmanaged": False, "api_version": "47.0", "api_names": "bar,foo"},
         )
 
         assert task._get_entities() == {None: ["bar", "foo"]}
 
         task = create_task(
-            MetadataSingleEntityTransformTask,
+            ConcreteMetadataSingleEntityTransformTask,
             {"unmanaged": False, "api_version": "47.0"},
         )
 
@@ -184,7 +201,7 @@ class TestMetadataSingleEntityTransformTask:
 
     def test_transform(self):
         task = create_task(
-            MetadataSingleEntityTransformTask,
+            ConcreteMetadataSingleEntityTransformTask,
             {"unmanaged": False, "api_version": "47.0", "api_names": "Test"},
         )
 
@@ -210,7 +227,7 @@ class TestMetadataSingleEntityTransformTask:
 
     def test_transform__bad_entity(self):
         task = create_task(
-            MetadataSingleEntityTransformTask,
+            ConcreteMetadataSingleEntityTransformTask,
             {"unmanaged": False, "api_version": "47.0", "api_names": "bar,foo"},
         )
 
@@ -221,7 +238,7 @@ class TestMetadataSingleEntityTransformTask:
 
     def test_transform__non_xml_entity(self):
         task = create_task(
-            MetadataSingleEntityTransformTask,
+            ConcreteMetadataSingleEntityTransformTask,
             {"unmanaged": False, "api_version": "47.0", "api_names": "bar,foo"},
         )
 
@@ -232,7 +249,7 @@ class TestMetadataSingleEntityTransformTask:
 
     def test_transform__missing_record(self):
         task = create_task(
-            MetadataSingleEntityTransformTask,
+            ConcreteMetadataSingleEntityTransformTask,
             {"unmanaged": False, "api_version": "47.0", "api_names": "Test"},
         )
 

--- a/cumulusci/tasks/salesforce/metadata_etl/tests/test_layouts.py
+++ b/cumulusci/tasks/salesforce/metadata_etl/tests/test_layouts.py
@@ -1,9 +1,8 @@
-import io
-import unittest
-import xml.etree.ElementTree as ET
+from lxml import etree
 
 from cumulusci.tasks.salesforce.tests.util import create_task
 from cumulusci.tasks.salesforce.metadata_etl import AddRelatedLists
+from cumulusci.tasks.salesforce.metadata_etl import MD
 
 LAYOUT_XML = """<?xml version="1.0" encoding="UTF-8"?>
 <Layout xmlns="http://soap.sforce.com/2006/04/metadata">
@@ -35,7 +34,7 @@ RELATED_LIST = """    <relatedLists>
 """
 
 
-class test_AddRelatedLists(unittest.TestCase):
+class TestAddRelatedLists:
     def test_adds_related_list(self):
         task = create_task(
             AddRelatedLists,
@@ -48,24 +47,17 @@ class test_AddRelatedLists(unittest.TestCase):
             },
         )
 
-        root = ET.ElementTree(
-            file=io.StringIO(LAYOUT_XML.format(relatedLists=RELATED_LIST))
-        )
-        namespaces = {"sf": "http://soap.sforce.com/2006/04/metadata"}
+        tree = etree.fromstring(
+            LAYOUT_XML.format(relatedLists=RELATED_LIST).encode("utf-8")
+        ).getroottree()
 
-        assert (
-            len(root.findall(f".//sf:relatedLists[sf:relatedList='TEST']", namespaces))
-            == 0
-        )
+        assert len(tree.findall(f".//{MD}relatedLists[{MD}relatedList='TEST']")) == 0
 
-        result = task._transform_entity(root, "Layout")
+        result = task._transform_entity(tree, "Layout")
 
-        assert (
-            len(result.findall(".//sf:relatedLists[sf:relatedList='TEST']", namespaces))
-            == 1
-        )
+        assert len(result.findall(f".//{MD}relatedLists[{MD}relatedList='TEST']")) == 1
         field_elements = result.findall(
-            f".//sf:relatedLists[sf:relatedList='TEST']/sf:fields", namespaces
+            f".//{MD}relatedLists[{MD}relatedList='TEST']/{MD}fields"
         )
         field_names = {elem.text for elem in field_elements}
         assert field_names == set(["foo__c", "bar__c"])
@@ -82,22 +74,17 @@ class test_AddRelatedLists(unittest.TestCase):
             },
         )
 
-        root = ET.ElementTree(file=io.StringIO(LAYOUT_XML.format(relatedLists="")))
-        namespaces = {"sf": "http://soap.sforce.com/2006/04/metadata"}
+        tree = etree.fromstring(
+            LAYOUT_XML.format(relatedLists="").encode("utf-8")
+        ).getroottree()
 
-        assert (
-            len(root.findall(f".//sf:relatedLists[sf:relatedList='TEST']", namespaces))
-            == 0
-        )
+        assert len(tree.findall(f".//{MD}relatedLists[{MD}relatedList='TEST']")) == 0
 
-        result = task._transform_entity(root, "Layout")
+        result = task._transform_entity(tree, "Layout")
 
-        assert (
-            len(result.findall(".//sf:relatedLists[sf:relatedList='TEST']", namespaces))
-            == 1
-        )
+        assert len(result.findall(f".//{MD}relatedLists[{MD}relatedList='TEST']")) == 1
         field_elements = result.findall(
-            f".//sf:relatedLists[sf:relatedList='TEST']/sf:fields", namespaces
+            f".//{MD}relatedLists[{MD}relatedList='TEST']/{MD}fields"
         )
         field_names = {elem.text for elem in field_elements}
         assert field_names == set(["foo__c", "bar__c"])
@@ -114,28 +101,25 @@ class test_AddRelatedLists(unittest.TestCase):
             },
         )
 
-        root = ET.ElementTree(
-            file=io.StringIO(LAYOUT_XML.format(relatedLists=RELATED_LIST))
-        )
-        namespaces = {"sf": "http://soap.sforce.com/2006/04/metadata"}
+        tree = etree.fromstring(
+            LAYOUT_XML.format(relatedLists=RELATED_LIST).encode("utf-8")
+        ).getroottree()
 
         assert (
             len(
-                root.findall(
-                    f".//sf:relatedLists[sf:relatedList='RelatedContactList']",
-                    namespaces,
+                tree.findall(
+                    f".//{MD}relatedLists[{MD}relatedList='RelatedContactList']"
                 )
             )
             == 1
         )
 
-        result = task._transform_entity(root, "Layout")
+        result = task._transform_entity(tree, "Layout")
 
         assert (
             len(
                 result.findall(
-                    ".//sf:relatedLists[sf:relatedList='RelatedContactList']",
-                    namespaces,
+                    f".//{MD}relatedLists[{MD}relatedList='RelatedContactList']"
                 )
             )
             == 1

--- a/cumulusci/tasks/salesforce/metadata_etl/tests/test_permissions.py
+++ b/cumulusci/tasks/salesforce/metadata_etl/tests/test_permissions.py
@@ -1,12 +1,12 @@
-import io
-import unittest
-import xml.etree.ElementTree as ET
+from lxml import etree
+import pytest
 
 from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.tasks.salesforce.tests.util import create_task
 from cumulusci.tasks.salesforce.metadata_etl import AddPermissions
+from cumulusci.tasks.salesforce.metadata_etl import MD
 
-PERMSET_XML = """<?xml version="1.0" encoding="UTF-8"?>
+PERMSET_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
 <PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
     <applicationVisibilities>
         <application>CustomApp</application>
@@ -48,7 +48,7 @@ PERMSET_XML = """<?xml version="1.0" encoding="UTF-8"?>
 """
 
 
-class test_AddPermissions(unittest.TestCase):
+class TestAddPermissions:
     def test_adds_new_field_permission(self):
         task = create_task(
             AddPermissions,
@@ -66,29 +66,27 @@ class test_AddPermissions(unittest.TestCase):
             },
         )
 
-        root = ET.ElementTree(file=io.StringIO(PERMSET_XML))
-        namespaces = {"sf": "http://soap.sforce.com/2006/04/metadata"}
+        tree = etree.fromstring(PERMSET_XML).getroottree()
 
         assert (
             len(
-                root.findall(
-                    f".//sf:fieldPermissions[sf:field='Test__c.Description__c']",
-                    namespaces,
+                tree.findall(
+                    f".//{MD}fieldPermissions[{MD}field='Test__c.Description__c']"
                 )
             )
             == 0
         )
 
-        result = task._transform_entity(root, "PermSet")
+        result = task._transform_entity(tree, "PermSet")
 
         fieldPermissions = result.findall(
-            ".//sf:fieldPermissions[sf:field='Test__c.Description__c']", namespaces
+            f".//{MD}fieldPermissions[{MD}field='Test__c.Description__c']"
         )
         assert len(fieldPermissions) == 1
-        readable = fieldPermissions[0].findall(f".//sf:readable", namespaces)
+        readable = fieldPermissions[0].findall(f".//{MD}readable")
         assert len(readable) == 1
         assert readable[0].text == "true"
-        editable = fieldPermissions[0].findall(f".//sf:editable", namespaces)
+        editable = fieldPermissions[0].findall(f".//{MD}editable")
         assert len(editable) == 1
         assert editable[0].text == "true"
 
@@ -105,28 +103,23 @@ class test_AddPermissions(unittest.TestCase):
             },
         )
 
-        root = ET.ElementTree(file=io.StringIO(PERMSET_XML))
-        namespaces = {"sf": "http://soap.sforce.com/2006/04/metadata"}
+        tree = etree.fromstring(PERMSET_XML).getroottree()
 
         assert (
-            len(
-                root.findall(
-                    f".//sf:fieldPermissions[sf:field='Test__c.Lookup__c']", namespaces
-                )
-            )
+            len(tree.findall(f".//{MD}fieldPermissions[{MD}field='Test__c.Lookup__c']"))
             == 1
         )
 
-        result = task._transform_entity(root, "PermSet")
+        result = task._transform_entity(tree, "PermSet")
 
         fieldPermissions = result.findall(
-            ".//sf:fieldPermissions[sf:field='Test__c.Lookup__c']", namespaces
+            f".//{MD}fieldPermissions[{MD}field='Test__c.Lookup__c']"
         )
         assert len(fieldPermissions) == 1
-        readable = fieldPermissions[0].findall(f".//sf:readable", namespaces)
+        readable = fieldPermissions[0].findall(f".//{MD}readable")
         assert len(readable) == 1
         assert readable[0].text == "true"
-        editable = fieldPermissions[0].findall(f".//sf:editable", namespaces)
+        editable = fieldPermissions[0].findall(f".//{MD}editable")
         assert len(editable) == 1
         assert editable[0].text == "true"
 
@@ -141,25 +134,20 @@ class test_AddPermissions(unittest.TestCase):
             },
         )
 
-        root = ET.ElementTree(file=io.StringIO(PERMSET_XML))
-        namespaces = {"sf": "http://soap.sforce.com/2006/04/metadata"}
+        tree = etree.fromstring(PERMSET_XML).getroottree()
 
         assert (
-            len(
-                root.findall(
-                    ".//sf:classAccesses[sf:apexClass='LWCController']", namespaces
-                )
-            )
+            len(tree.findall(f".//{MD}classAccesses[{MD}apexClass='LWCController']"))
             == 0
         )
 
-        result = task._transform_entity(root, "PermSet")
+        result = task._transform_entity(tree, "PermSet")
 
         classAccesses = result.findall(
-            ".//sf:classAccesses[sf:apexClass='LWCController']", namespaces
+            f".//{MD}classAccesses[{MD}apexClass='LWCController']"
         )
         assert len(classAccesses) == 1
-        enabled = classAccesses[0].findall(f".//sf:enabled", namespaces)
+        enabled = classAccesses[0].findall(f".//{MD}enabled")
         assert len(enabled) == 1
         assert enabled[0].text == "true"
 
@@ -174,25 +162,20 @@ class test_AddPermissions(unittest.TestCase):
             },
         )
 
-        root = ET.ElementTree(file=io.StringIO(PERMSET_XML))
-        namespaces = {"sf": "http://soap.sforce.com/2006/04/metadata"}
+        tree = etree.fromstring(PERMSET_XML).getroottree()
 
         assert (
-            len(
-                root.findall(
-                    ".//sf:classAccesses[sf:apexClass='ApexController']", namespaces
-                )
-            )
+            len(tree.findall(f".//{MD}classAccesses[{MD}apexClass='ApexController']"))
             == 1
         )
 
-        result = task._transform_entity(root, "PermSet")
+        result = task._transform_entity(tree, "PermSet")
 
         classAccesses = result.findall(
-            ".//sf:classAccesses[sf:apexClass='ApexController']", namespaces
+            f".//{MD}classAccesses[{MD}apexClass='ApexController']"
         )
         assert len(classAccesses) == 1
-        enabled = classAccesses[0].findall(f".//sf:enabled", namespaces)
+        enabled = classAccesses[0].findall(f".//{MD}enabled")
         assert len(enabled) == 1
         assert enabled[0].text == "true"
 
@@ -207,10 +190,10 @@ class test_AddPermissions(unittest.TestCase):
             },
         )
 
-        root = ET.ElementTree(file=io.StringIO(PERMSET_XML))
+        tree = etree.fromstring(PERMSET_XML).getroottree()
 
-        with self.assertRaises(TaskOptionsError):
-            task._transform_entity(root, "PermSet")
+        with pytest.raises(TaskOptionsError):
+            task._transform_entity(tree, "PermSet")
 
     def test_missing_field_throws_exception(self):
         task = create_task(
@@ -223,7 +206,7 @@ class test_AddPermissions(unittest.TestCase):
             },
         )
 
-        root = ET.ElementTree(file=io.StringIO(PERMSET_XML))
+        tree = etree.fromstring(PERMSET_XML).getroottree()
 
-        with self.assertRaises(TaskOptionsError):
-            task._transform_entity(root, "PermSet")
+        with pytest.raises(TaskOptionsError):
+            task._transform_entity(tree, "PermSet")

--- a/cumulusci/tasks/salesforce/metadata_etl/tests/test_value_sets.py
+++ b/cumulusci/tasks/salesforce/metadata_etl/tests/test_value_sets.py
@@ -1,12 +1,12 @@
-import io
-import unittest
-import xml.etree.ElementTree as ET
+from lxml import etree
+import pytest
 
 from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.tasks.salesforce.tests.util import create_task
 from cumulusci.tasks.salesforce.metadata_etl import AddValueSetEntries
+from cumulusci.tasks.salesforce.metadata_etl import MD
 
-VALUESET_XML = """<?xml version="1.0" encoding="UTF-8"?>
+VALUESET_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
 <StandardValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
     <sorted>false</sorted>
     <standardValue>
@@ -23,7 +23,7 @@ VALUESET_XML = """<?xml version="1.0" encoding="UTF-8"?>
 """
 
 
-class test_AddValueSetEntries(unittest.TestCase):
+class TestAddValueSetEntries:
     def test_adds_entry(self):
         task = create_task(
             AddValueSetEntries,
@@ -38,35 +38,28 @@ class test_AddValueSetEntries(unittest.TestCase):
             },
         )
 
-        root = ET.ElementTree(file=io.StringIO(VALUESET_XML))
-        namespaces = {"sf": "http://soap.sforce.com/2006/04/metadata"}
+        tree = etree.fromstring(VALUESET_XML).getroottree()
 
-        assert (
-            len(root.findall(".//sf:standardValue[sf:fullName='Test']", namespaces))
-            == 0
-        )
-        assert (
-            len(root.findall(".//sf:standardValue[sf:fullName='Test_2']", namespaces))
-            == 0
-        )
+        assert len(tree.findall(f".//{MD}standardValue[{MD}fullName='Test']")) == 0
+        assert len(tree.findall(f".//{MD}standardValue[{MD}fullName='Test_2']")) == 0
 
-        result = task._transform_entity(root, "ValueSet")
+        result = task._transform_entity(tree, "ValueSet")
 
-        entry = result.findall(".//sf:standardValue[sf:fullName='Test']", namespaces)
+        entry = result.findall(f".//{MD}standardValue[{MD}fullName='Test']")
         assert len(entry) == 1
-        label = entry[0].findall(f".//sf:label", namespaces)
+        label = entry[0].findall(f".//{MD}label")
         assert len(label) == 1
         assert label[0].text == "Label"
-        default = entry[0].findall(f".//sf:default", namespaces)
+        default = entry[0].findall(f".//{MD}default")
         assert len(default) == 1
         assert default[0].text == "false"
 
-        entry = result.findall(".//sf:standardValue[sf:fullName='Test_2']", namespaces)
+        entry = result.findall(f".//{MD}standardValue[{MD}fullName='Test_2']")
         assert len(entry) == 1
-        label = entry[0].findall(f".//sf:label", namespaces)
+        label = entry[0].findall(f".//{MD}label")
         assert len(label) == 1
         assert label[0].text == "Label 2"
-        default = entry[0].findall(f".//sf:default", namespaces)
+        default = entry[0].findall(f".//{MD}default")
         assert len(default) == 1
         assert default[0].text == "false"
 
@@ -90,38 +83,31 @@ class test_AddValueSetEntries(unittest.TestCase):
             },
         )
 
-        root = ET.ElementTree(file=io.StringIO(VALUESET_XML))
-        namespaces = {"sf": "http://soap.sforce.com/2006/04/metadata"}
+        tree = etree.fromstring(VALUESET_XML).getroottree()
 
-        assert (
-            len(root.findall(".//sf:standardValue[sf:fullName='Test']", namespaces))
-            == 0
-        )
-        assert (
-            len(root.findall(".//sf:standardValue[sf:fullName='Test_2']", namespaces))
-            == 0
-        )
+        assert len(tree.findall(f".//{MD}standardValue[{MD}fullName='Test']")) == 0
+        assert len(tree.findall(f".//{MD}standardValue[{MD}fullName='Test_2']")) == 0
 
-        result = task._transform_entity(root, "OpportunityStage")
+        result = task._transform_entity(tree, "OpportunityStage")
 
-        entry = result.findall(".//sf:standardValue[sf:fullName='Test']", namespaces)
+        entry = result.findall(f".//{MD}standardValue[{MD}fullName='Test']")
         assert len(entry) == 1
-        label = entry[0].findall(f".//sf:label", namespaces)
+        label = entry[0].findall(f".//{MD}label")
         assert len(label) == 1
         assert label[0].text == "Label"
-        default = entry[0].findall(f".//sf:default", namespaces)
+        default = entry[0].findall(f".//{MD}default")
         assert len(default) == 1
         assert default[0].text == "false"
-        closed = entry[0].findall(f".//sf:closed", namespaces)
+        closed = entry[0].findall(f".//{MD}closed")
         assert len(closed) == 1
         assert closed[0].text == "true"
-        won = entry[0].findall(f".//sf:won", namespaces)
+        won = entry[0].findall(f".//{MD}won")
         assert len(won) == 1
         assert won[0].text == "true"
-        forecastCategory = entry[0].findall(f".//sf:forecastCategory", namespaces)
+        forecastCategory = entry[0].findall(f".//{MD}forecastCategory")
         assert len(forecastCategory) == 1
         assert forecastCategory[0].text == "Omitted"
-        probability = entry[0].findall(f".//sf:probability", namespaces)
+        probability = entry[0].findall(f".//{MD}probability")
         assert len(probability) == 1
         assert probability[0].text == "100"
 
@@ -136,29 +122,22 @@ class test_AddValueSetEntries(unittest.TestCase):
             },
         )
 
-        root = ET.ElementTree(file=io.StringIO(VALUESET_XML))
-        namespaces = {"sf": "http://soap.sforce.com/2006/04/metadata"}
+        tree = etree.fromstring(VALUESET_XML).getroottree()
 
-        assert (
-            len(root.findall(".//sf:standardValue[sf:fullName='Test']", namespaces))
-            == 0
-        )
-        assert (
-            len(root.findall(".//sf:standardValue[sf:fullName='Test_2']", namespaces))
-            == 0
-        )
+        assert len(tree.findall(f".//{MD}standardValue[{MD}fullName='Test']")) == 0
+        assert len(tree.findall(f".//{MD}standardValue[{MD}fullName='Test_2']")) == 0
 
-        result = task._transform_entity(root, "CaseStatus")
+        result = task._transform_entity(tree, "CaseStatus")
 
-        entry = result.findall(".//sf:standardValue[sf:fullName='Test']", namespaces)
+        entry = result.findall(f".//{MD}standardValue[{MD}fullName='Test']")
         assert len(entry) == 1
-        label = entry[0].findall(f".//sf:label", namespaces)
+        label = entry[0].findall(f".//{MD}label")
         assert len(label) == 1
         assert label[0].text == "Label"
-        default = entry[0].findall(f".//sf:default", namespaces)
+        default = entry[0].findall(f".//{MD}default")
         assert len(default) == 1
         assert default[0].text == "false"
-        closed = entry[0].findall(f".//sf:closed", namespaces)
+        closed = entry[0].findall(f".//{MD}closed")
         assert len(closed) == 1
         assert closed[0].text == "true"
 
@@ -173,20 +152,13 @@ class test_AddValueSetEntries(unittest.TestCase):
             },
         )
 
-        root = ET.ElementTree(file=io.StringIO(VALUESET_XML))
-        namespaces = {"sf": "http://soap.sforce.com/2006/04/metadata"}
+        tree = etree.fromstring(VALUESET_XML).getroottree()
 
-        assert (
-            len(root.findall(".//sf:standardValue[sf:fullName='Value']", namespaces))
-            == 1
-        )
+        assert len(tree.findall(f".//{MD}standardValue[{MD}fullName='Value']")) == 1
 
-        result = task._transform_entity(root, "ValueSet")
+        result = task._transform_entity(tree, "ValueSet")
 
-        assert (
-            len(result.findall(".//sf:standardValue[sf:fullName='Value']", namespaces))
-            == 1
-        )
+        assert len(result.findall(f".//{MD}standardValue[{MD}fullName='Value']")) == 1
 
     def test_raises_exception_missing_values(self):
         task = create_task(
@@ -198,10 +170,10 @@ class test_AddValueSetEntries(unittest.TestCase):
                 "entries": [{"fullName": "Value"}],
             },
         )
-        root = ET.ElementTree(file=io.StringIO(VALUESET_XML))
+        tree = etree.fromstring(VALUESET_XML).getroottree()
 
-        with self.assertRaises(TaskOptionsError):
-            task._transform_entity(root, "ValueSet")
+        with pytest.raises(TaskOptionsError):
+            task._transform_entity(tree, "ValueSet")
 
         task = create_task(
             AddValueSetEntries,
@@ -213,8 +185,8 @@ class test_AddValueSetEntries(unittest.TestCase):
             },
         )
 
-        with self.assertRaises(TaskOptionsError):
-            task._transform_entity(root, "ValueSet")
+        with pytest.raises(TaskOptionsError):
+            task._transform_entity(tree, "ValueSet")
 
     def test_raises_exception_missing_values__opportunitystage(self):
         task = create_task(
@@ -226,10 +198,10 @@ class test_AddValueSetEntries(unittest.TestCase):
                 "entries": [{"fullName": "Value", "label": "Value"}],
             },
         )
-        root = ET.ElementTree(file=io.StringIO(VALUESET_XML))
+        tree = etree.fromstring(VALUESET_XML).getroottree()
 
-        with self.assertRaises(TaskOptionsError) as err:
-            task._transform_entity(root, "OpportunityStage")
+        with pytest.raises(TaskOptionsError) as err:
+            task._transform_entity(tree, "OpportunityStage")
             assert "OpportunityStage" in err
 
     def test_raises_exception_missing_values__casestatus(self):
@@ -242,8 +214,8 @@ class test_AddValueSetEntries(unittest.TestCase):
                 "entries": [{"fullName": "Value", "label": "Value"}],
             },
         )
-        root = ET.ElementTree(file=io.StringIO(VALUESET_XML))
+        tree = etree.fromstring(VALUESET_XML).getroottree()
 
-        with self.assertRaises(TaskOptionsError) as err:
-            task._transform_entity(root, "CaseStatus")
+        with pytest.raises(TaskOptionsError) as err:
+            task._transform_entity(tree, "CaseStatus")
             assert "CaseStatus" in err


### PR DESCRIPTION
- Use lxml etree for manipulating XML (turns out f-strings make it nicer than it used to be!)
- Use camel case class names for test classes, and don't extend unittest.TestCase because we don't need to
- Declare ABCMeta metaclass the correct way for Python 3
- Add a log line before the metadata retrieve and deploy to clarify what we're showing progress of
- Fix `required` parameter of task options to be a boolean

# Critical Changes

# Changes

# Issues Closed
