### PR TITLE
Avoid leaving an incomplete codebase in the cache if zipball extraction fails

### DIFF
--- a/cumulusci/core/source/github.py
+++ b/cumulusci/core/source/github.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 from cumulusci.core.exceptions import DependencyResolutionError
 from cumulusci.core.github import get_github_api_for_repo
@@ -99,7 +100,12 @@ class GitHubSource:
             zf = download_extract_github(
                 self.gh, self.repo_owner, self.repo_name, ref=self.commit
             )
-            zf.extractall(path)
+            try:
+                zf.extractall(path)
+            except Exception:
+                # make sure we don't leave an incomplete cache
+                shutil.rmtree(path)
+                raise
 
         project_config = self.project_config.construct_subproject_config(
             repo_info={


### PR DESCRIPTION

# Critical Changes

# Changes

# Issues Closed
- Fixed an issue where an error while extracting the codebase of a cross-project source could leave behind an incomplete copy of the codebase which would then be used by future commands.