### PR TITLE
Make sure SetOrgWideDefaults treats api_names as a set

### DIFF
--- a/cumulusci/tasks/metadata_etl/sharing.py
+++ b/cumulusci/tasks/metadata_etl/sharing.py
@@ -27,10 +27,10 @@ class SetOrgWideDefaults(MetadataSingleEntityTransformTask):
     def _init_options(self, kwargs):
         self.task_config.options["api_names"] = "dummy"
         super()._init_options(kwargs)
-        self.api_names = [
+        self.api_names = {
             self._inject_namespace(elem["api_name"])
             for elem in self.options["org_wide_defaults"]
-        ]
+        }
         self.options["timeout"] = int(self.options.get("timeout", 600))
 
         self.owds = {}

--- a/cumulusci/tasks/metadata_etl/tests/test_sharing.py
+++ b/cumulusci/tasks/metadata_etl/tests/test_sharing.py
@@ -59,7 +59,7 @@ class TestSetOrgWideDefaults:
             },
         )
 
-        assert task.api_names == ["Account", "Test__c"]
+        assert task.api_names == set(["Account", "Test__c"])
 
         tree = etree.fromstring(CUSTOMOBJECT_XML).getroottree()
 
@@ -95,7 +95,7 @@ class TestSetOrgWideDefaults:
             },
         )
 
-        assert task.api_names == ["Account", "Test__c"]
+        assert task.api_names == set(["Account", "Test__c"])
 
         tree = etree.fromstring(CUSTOMOBJECT_XML_MISSING_TAGS).getroottree()
 


### PR DESCRIPTION
Fixes a conflict between base Metadata ETL classes and SetOrgWideDefaults.

# Critical Changes

# Changes

# Issues Closed
