### PR TITLE
Fix formatting of ClickExceptions

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -231,6 +231,8 @@ def handle_exception(error, is_error_cmd):
     """
     if isinstance(error, exceptions.ConnectionError):
         connection_error_message()
+    elif isinstance(error, click.ClickException):
+        click.echo(click.style(f"Error: {error.format_message()}", fg="red"))
     else:
         click.echo(click.style(f"Error: {error}", fg="red"))
     # Only suggest gist command if it wasn't run

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -232,6 +232,16 @@ class TestCCI(unittest.TestCase):
         traceback.print_exc.assert_called_once()
 
     @mock.patch("cumulusci.cli.cci.open")
+    @mock.patch("cumulusci.cli.cci.traceback")
+    @mock.patch("cumulusci.cli.cci.click.style")
+    def test_handle_click_exception(self, style, traceback, cci_open):
+        cci_open.__enter__.return_value = mock.Mock()
+
+        cci.handle_exception(click.ClickException("oops"), False)
+
+        style.call_args_list[0][0] == f"Error: oops"
+
+    @mock.patch("cumulusci.cli.cci.open")
     @mock.patch("cumulusci.cli.cci.connection_error_message")
     def test_handle_connection_exception(self, connection_msg, cci_open):
         cci.handle_exception(ConnectionError(), False)


### PR DESCRIPTION
I noticed that commands with missing parameters (e.g. `cci flow info` with no flow specified) were breaking rather than reporting the missing parameter.

# Critical Changes

# Changes

# Issues Closed
* Fixed a regression where errors due to missing command line parameters were not reported correctly.