### PR TITLE
Specify excluded and custom buttons to new Related Lists

### DIFF
--- a/cumulusci/tasks/metadata_etl/layouts.py
+++ b/cumulusci/tasks/metadata_etl/layouts.py
@@ -19,6 +19,12 @@ class AddRelatedLists(MetadataSingleEntityTransformTask):
             "description": "Array of field API names to include in the related list",
             "required": False,
         },
+        "exclude_buttons": {
+            "description": "Array of button names to suppress from the related list"
+        },
+        "custom_buttons": {
+            "description": "Array of button names to add to the related list"
+        },
         **MetadataSingleEntityTransformTask.task_options,
     }
 
@@ -45,6 +51,14 @@ class AddRelatedLists(MetadataSingleEntityTransformTask):
             self._inject_namespace(f)
             for f in process_list_arg(self.options.get("fields", []))
         ]
+        exclude_buttons = [
+            self._inject_namespace(f)
+            for f in process_list_arg(self.options.get("exclude_buttons", []))
+        ]
+        custom_buttons = [
+            self._inject_namespace(f)
+            for f in process_list_arg(self.options.get("custom_buttons", []))
+        ]
 
         elem = etree.Element(f"{MD}relatedLists")
         metadata.getroot().insert(index, elem)
@@ -52,6 +66,14 @@ class AddRelatedLists(MetadataSingleEntityTransformTask):
         for f in fields:
             elem_field = etree.SubElement(elem, f"{MD}fields")
             elem_field.text = f
+
+        for button in exclude_buttons:
+            elem_button = etree.SubElement(elem, f"{MD}excludeButtons")
+            elem_button.text = button
+
+        for button in custom_buttons:
+            elem_button = etree.SubElement(elem, f"{MD}customButtons")
+            elem_button.text = button
 
         elem_related_list = etree.SubElement(elem, f"{MD}relatedList")
         elem_related_list.text = related_list

--- a/cumulusci/tasks/metadata_etl/tests/test_layouts.py
+++ b/cumulusci/tasks/metadata_etl/tests/test_layouts.py
@@ -62,6 +62,62 @@ class TestAddRelatedLists:
         field_names = {elem.text for elem in field_elements}
         assert field_names == set(["foo__c", "bar__c"])
 
+    def test_excludes_buttons(self):
+        task = create_task(
+            AddRelatedLists,
+            {
+                "managed": True,
+                "api_version": "47.0",
+                "api_names": "bar,foo",
+                "related_list": "TEST",
+                "fields": "foo__c,bar__c",
+                "exclude_buttons": "New,Edit",
+            },
+        )
+
+        tree = etree.fromstring(
+            LAYOUT_XML.format(relatedLists=RELATED_LIST).encode("utf-8")
+        ).getroottree()
+
+        assert len(tree.findall(f".//{MD}relatedLists[{MD}relatedList='TEST']")) == 0
+
+        result = task._transform_entity(tree, "Layout")
+
+        assert len(result.findall(f".//{MD}relatedLists[{MD}relatedList='TEST']")) == 1
+        button_elements = result.findall(
+            f".//{MD}relatedLists[{MD}relatedList='TEST']/{MD}excludeButtons"
+        )
+        excluded_buttons = {elem.text for elem in button_elements}
+        assert excluded_buttons == set(["New", "Edit"])
+
+    def test_includes_buttons(self):
+        task = create_task(
+            AddRelatedLists,
+            {
+                "managed": True,
+                "api_version": "47.0",
+                "api_names": "bar,foo",
+                "related_list": "TEST",
+                "fields": "foo__c,bar__c",
+                "custom_buttons": "MyCustomNewAction,MyCustomEditAction",
+            },
+        )
+
+        tree = etree.fromstring(
+            LAYOUT_XML.format(relatedLists=RELATED_LIST).encode("utf-8")
+        ).getroottree()
+
+        assert len(tree.findall(f".//{MD}relatedLists[{MD}relatedList='TEST']")) == 0
+
+        result = task._transform_entity(tree, "Layout")
+
+        assert len(result.findall(f".//{MD}relatedLists[{MD}relatedList='TEST']")) == 1
+        button_elements = result.findall(
+            f".//{MD}relatedLists[{MD}relatedList='TEST']/{MD}customButtons"
+        )
+        custom_buttons = {elem.text for elem in button_elements}
+        assert custom_buttons == set(["MyCustomNewAction", "MyCustomEditAction"])
+
     def test_adds_related_list_no_existing(self):
         task = create_task(
             AddRelatedLists,

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -51,6 +51,16 @@ Options
 
 	 Array of field API names to include in the related list
 
+``-o exclude_buttons EXCLUDEBUTTONS``
+	 *Optional*
+
+	 Array of button names to suppress from the related list
+
+``-o custom_buttons CUSTOMBUTTONS``
+	 *Optional*
+
+	 Array of button names to add to the related list
+
 ``-o api_names APINAMES``
 	 *Optional*
 


### PR DESCRIPTION

# Critical Changes

# Changes

- `add_page_layout_related_lists` now supports suppressing standard buttons and adding custom buttons on related lists.

# Issues Closed
