### PR TITLE
add note about including access token for json option to help message for cci org info command

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -932,7 +932,7 @@ def calculate_org_days(info):
 
 @org.command(name="info", help="Display information for a connected org")
 @click.argument("org_name", required=False)
-@click.option("print_json", "--json", is_flag=True, help="Print as JSON")
+@click.option("print_json", "--json", is_flag=True, help="Print as JSON.  Includes access token")
 @pass_runtime(require_project=False, require_keychain=True)
 def org_info(runtime, org_name, print_json):
     org_name, org_config = runtime.get_org(org_name)


### PR DESCRIPTION

# Critical Changes

# Changes
- added a note about including access token for json option to the help message for `cci org info command`

# Issues Closed
- #1566