### PR TITLE
Use step_num as key for preflight results

### DIFF
--- a/cumulusci/__init__.py
+++ b/cumulusci/__init__.py
@@ -3,7 +3,7 @@ import sys
 
 __import__("pkg_resources").declare_namespace("cumulusci")
 
-__version__ = "3.7.0"
+__version__ = "3.7.0.dev0"
 
 __location__ = os.path.dirname(os.path.realpath(__file__))
 

--- a/cumulusci/core/flowrunner.py
+++ b/cumulusci/core/flowrunner.py
@@ -654,7 +654,7 @@ class PreflightFlowCoordinator(FlowCoordinator):
                 for check in step.task_config.get("checks", []):
                     result = self.evaluate_check(check, jinja2_context)
                     if result:
-                        self.preflight_results[step.path].append(result)
+                        self.preflight_results[str(step.step_num)].append(result)
         finally:
             self.callbacks.post_flow(self)
 

--- a/cumulusci/core/tests/test_flowrunner.py
+++ b/cumulusci/core/tests/test_flowrunner.py
@@ -520,7 +520,7 @@ class PreflightFlowCoordinatorTest(AbstractFlowCoordinatorTest, unittest.TestCas
         self.assertDictEqual(
             {
                 None: [{"status": "error", "message": "Failed plan check"}],
-                "log": [{"status": "error", "message": "Failed step check 2"}],
+                "1": [{"status": "error", "message": "Failed step check 2"}],
             },
             flow.preflight_results,
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.7.0
+current_version = 3.7.1.dev0
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("requirements_dev.txt") as dev_requirements_file:
 
 setup(
     name="cumulusci",
-    version="3.7.0",
+    version="3.7.0.dev0",
     description="Build and release tools for Salesforce developers",
     long_description=readme + u"\n\n" + history,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
# Critical Changes

# Changes

- Corrected an issue in storing preflight check results where multiple tasks had the same path. 

# Issues Closed
