### PR TITLE
Fix test runner for Spring '20

### DIFF
--- a/cumulusci/tasks/apex/testrunner.py
+++ b/cumulusci/tasks/apex/testrunner.py
@@ -331,7 +331,7 @@ class RunApexTests(BaseSalesforceApiTask):
             )
 
             # In Spring '20, we cannot get symbol tables for managed classes.
-            if "__" in class_name:
+            if self.options["managed"]:
                 self.logger.error(
                     f"Cannot access symbol table for managed class {class_name}. Failure will not be retried."
                 )

--- a/cumulusci/tasks/apex/testrunner.py
+++ b/cumulusci/tasks/apex/testrunner.py
@@ -330,6 +330,13 @@ class RunApexTests(BaseSalesforceApiTask):
                 f"Class {class_name} failed to run some tests with the message {error}. Applying error to unit test results."
             )
 
+            # In Spring '20, we cannot get symbol tables for managed classes.
+            if "__" in class_name:
+                self.logger.error(
+                    f"Cannot access symbol table for managed class {class_name}. Failure will not be retried."
+                )
+                continue
+
             # Get all the method names for this class
             test_methods = self._get_test_methods_for_class(class_name)
             for test_method in test_methods:

--- a/cumulusci/tasks/apex/tests/test_apex_tasks.py
+++ b/cumulusci/tasks/apex/tests/test_apex_tasks.py
@@ -6,7 +6,7 @@ import unittest
 
 import responses
 from copy import deepcopy
-from unittest.mock import MagicMock, patch
+from unittest.mock import Mock, MagicMock, patch
 from simple_salesforce import SalesforceGeneralError
 
 
@@ -67,7 +67,7 @@ class TestRunApexTests(MockLoggerMixin, unittest.TestCase):
             self.org_config.instance_url, self.api_version
         )
 
-    def _mock_apex_class_query(self):
+    def _mock_apex_class_query(self, name="TestClass_TEST"):
         url = (
             self.base_tooling_url
             + "query/?q=SELECT+Id%2C+Name+"
@@ -76,7 +76,7 @@ class TestRunApexTests(MockLoggerMixin, unittest.TestCase):
         )
         expected_response = {
             "done": True,
-            "records": [{"Id": 1, "Name": "TestClass_TEST"}],
+            "records": [{"Id": 1, "Name": name}],
             "totalSize": 1,
         }
         responses.add(
@@ -347,6 +347,21 @@ class TestRunApexTests(MockLoggerMixin, unittest.TestCase):
         task = RunApexTests(self.project_config, self.task_config, self.org_config)
         with self.assertRaises(CumulusCIException):
             task()
+
+    @responses.activate
+    def test_run_task__failed_class_level_no_symboltable__spring20_managed(self):
+        self._mock_apex_class_query(name="ns__Test_TEST")
+        self._mock_run_tests()
+        self._mock_get_failed_test_classes_failure()
+        self._mock_tests_complete()
+        self._mock_get_test_results()
+        self._mock_get_symboltable_failure()
+        task = RunApexTests(self.project_config, self.task_config, self.org_config)
+        task._get_test_methods_for_class = Mock()
+
+        task()
+
+        task._get_test_methods_for_class.assert_not_called()
 
     @responses.activate
     def test_run_task__retry_tests(self):


### PR DESCRIPTION
# Critical Changes

# Changes

- CumulusCI now will not attempt to retry class-level concurrency failures when running Apex unit tests in a managed package due to changes made to the Tooling API in Spring '20. Such failures will be logged but will not cause a build failure.

# Issues Closed
