### PR TITLE
Truncate warnings

### DIFF
--- a/cumulusci/tasks/bulkdata/delete.py
+++ b/cumulusci/tasks/bulkdata/delete.py
@@ -29,7 +29,6 @@ class DeleteData(BaseSalesforceApiTask):
             "description": "If True, allow the operation to continue even if individual rows fail to delete."
         },
     }
-    error_count = 0
     row_warning_limit = 10
 
     def _init_options(self, kwargs):
@@ -102,18 +101,6 @@ class DeleteData(BaseSalesforceApiTask):
                     self.options["ignore_row_errors"],
                     self.row_warning_limit,
                 )
-
-    def _check_for_row_error(self, result, row_id):
-        if not result.success:
-            msg = f"Error on record with id {row_id}: {result.error}"
-            if self.options["ignore_row_errors"]:
-                if self.error_count < self.row_warning_limit:
-                    self.logger.warning(msg)
-                elif self.error_count == self.row_warning_limit:
-                    self.logger.warning("Further warnings suppressed")
-                self.error_count += 1
-            else:
-                raise BulkDataException(msg)
 
     def _object_description(self, obj):
         """Return a readable description of the object set to delete."""

--- a/cumulusci/tasks/bulkdata/delete.py
+++ b/cumulusci/tasks/bulkdata/delete.py
@@ -7,7 +7,7 @@ from cumulusci.tasks.bulkdata.step import (
 )
 from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 from cumulusci.core.exceptions import TaskOptionsError, BulkDataException
-from cumulusci.tasks.bulkdata.utils import check_for_row_error
+from cumulusci.tasks.bulkdata.utils import RowErrorChecker
 
 
 class DeleteData(BaseSalesforceApiTask):
@@ -93,13 +93,12 @@ class DeleteData(BaseSalesforceApiTask):
                     f"Unable to delete records for {obj}: {','.join(qs.job_result.job_errors)}"
                 )
 
+            error_checker = RowErrorChecker(
+                self.logger, self.options["ignore_row_errors"], self.row_warning_limit
+            )
             for result in ds.get_results():
-                check_for_row_error(
-                    self,
-                    result,
-                    result.id,
-                    self.options["ignore_row_errors"],
-                    self.row_warning_limit,
+                error_checker.check_for_row_error(
+                    result, result.id,
                 )
 
     def _object_description(self, obj):

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -51,7 +51,6 @@ class LoadData(BaseSalesforceApiTask, SqlAlchemyMixin):
             "description": "Set to Serial to force serial mode on all jobs. Parallel is the default."
         },
     }
-    error_count = 0
     row_warning_limit = 10
 
     def _init_options(self, kwargs):

--- a/cumulusci/tasks/bulkdata/tests/test_load.py
+++ b/cumulusci/tasks/bulkdata/tests/test_load.py
@@ -732,6 +732,20 @@ class TestLoadData(unittest.TestCase):
 
         step = mock.Mock()
         step.get_results.return_value = iter(
+            [DataOperationResult(None, False, None)] * 15
+        )
+
+        with mock.patch.object(task.logger, "warning") as warning:
+            generator = task._generate_results_id_map(
+                step, ["001000000000009", "001000000000010", "001000000000011"] * 15
+            )
+            _ = list(generator)  # clear the errors out
+
+        assert len(warning.mock_calls) == task.row_warning_limit + 1 == 11
+        assert "warnings suppressed" in str(warning.mock_calls[-1])
+
+        step = mock.Mock()
+        step.get_results.return_value = iter(
             [
                 DataOperationResult("001000000000000", True, None),
                 DataOperationResult(None, False, None),

--- a/cumulusci/tasks/bulkdata/tests/test_load.py
+++ b/cumulusci/tasks/bulkdata/tests/test_load.py
@@ -739,7 +739,7 @@ class TestLoadData(unittest.TestCase):
             generator = task._generate_results_id_map(
                 step, ["001000000000009", "001000000000010", "001000000000011"] * 15
             )
-            _ = list(generator)  # clear the errors out
+            _ = list(generator)  # generate the errors
 
         assert len(warning.mock_calls) == task.row_warning_limit + 1 == 11
         assert "warnings suppressed" in str(warning.mock_calls[-1])

--- a/cumulusci/tasks/bulkdata/utils.py
+++ b/cumulusci/tasks/bulkdata/utils.py
@@ -163,3 +163,18 @@ def generate_batches(num_records, batch_size):
             batch_size = num_records - (batch_size * i)  # leftovers
         if batch_size > 0:
             yield batch_size, i
+
+
+def check_for_row_error(task, result, row_id, ignore_row_errors, row_warning_limit):
+    if not hasattr(task, "_check_for_row_error_error_count"):
+        task._check_for_row_error_error_count = 0
+    if not result.success:
+        msg = f"Error on record with id {row_id}: {result.error}"
+        if ignore_row_errors:
+            if task._check_for_row_error_error_count < row_warning_limit:
+                task.logger.warning(msg)
+            elif task._check_for_row_error_error_count == row_warning_limit:
+                task.logger.warning("Further warnings suppressed")
+            task._check_for_row_error_error_count += 1
+        else:
+            raise BulkDataException(msg)

--- a/cumulusci/tasks/bulkdata/utils.py
+++ b/cumulusci/tasks/bulkdata/utils.py
@@ -165,16 +165,22 @@ def generate_batches(num_records, batch_size):
             yield batch_size, i
 
 
-def check_for_row_error(task, result, row_id, ignore_row_errors, row_warning_limit):
-    if not hasattr(task, "_check_for_row_error_error_count"):
-        task._check_for_row_error_error_count = 0
-    if not result.success:
-        msg = f"Error on record with id {row_id}: {result.error}"
-        if ignore_row_errors:
-            if task._check_for_row_error_error_count < row_warning_limit:
-                task.logger.warning(msg)
-            elif task._check_for_row_error_error_count == row_warning_limit:
-                task.logger.warning("Further warnings suppressed")
-            task._check_for_row_error_error_count += 1
-        else:
-            raise BulkDataException(msg)
+class RowErrorChecker:
+    def __init__(self, logger, ignore_row_errors, row_warning_limit):
+        self.logger = logger
+        self.ignore_row_errors = ignore_row_errors
+        self.row_warning_limit = row_warning_limit
+        self.row_error_count = 0
+
+    def check_for_row_error(self, result, row_id):
+        if not result.success:
+            msg = f"Error on record with id {row_id}: {result.error}"
+            if self.ignore_row_errors:
+                if self.row_error_count < self.row_warning_limit:
+                    self.logger.warning(msg)
+                elif self.row_error_count == self.row_warning_limit:
+                    self.logger.warning("Further warnings suppressed")
+                self.row_error_count += 1
+                return self.row_error_count
+            else:
+                raise BulkDataException(msg)


### PR DESCRIPTION
I have had problems in LDV orgs when the logs got gargantuan due to per-row errors. This avoids that.