### PR TITLE
Fix docs

### DIFF
--- a/cumulusci/tasks/apex/testrunner.py
+++ b/cumulusci/tasks/apex/testrunner.py
@@ -90,20 +90,20 @@ class RunApexTests(BaseSalesforceApiTask):
     may automatically be retried. Note that retries are supported whether or not
     the org has parallel Apex testing enabled.
 
-    The `retry_always` option modifies this behavior: if a test run fails and
+    The ``retry_always`` option modifies this behavior: if a test run fails and
     any (not all) of the failures match the specified regular expressions,
     all of the failed tests will be retried in serial. This is helpful when
     underlying row locking errors are masked by custom exceptions.
 
-    A useful base configuration for projects wishing to use retries is
+    A useful base configuration for projects wishing to use retries is:
 
-    ```yaml
-            retry_failures:
-                - "unable to obtain exclusive access to this record"
-                - "UNABLE_TO_LOCK_ROW"
-                - "connection was cancelled here"
-            retry_always: True
-    ```
+    .. code-block:: yaml
+
+        retry_failures:
+            - "unable to obtain exclusive access to this record"
+            - "UNABLE_TO_LOCK_ROW"
+            - "connection was cancelled here"
+        retry_always: True
 
     Some projects' unit tests produce so many concurrency errors that
     it's faster to execute the entire run in serial mode than to use retries.

--- a/cumulusci/tasks/apex/testrunner.py
+++ b/cumulusci/tasks/apex/testrunner.py
@@ -330,6 +330,13 @@ class RunApexTests(BaseSalesforceApiTask):
                 f"Class {class_name} failed to run some tests with the message {error}. Applying error to unit test results."
             )
 
+            # In Spring '20, we cannot get symbol tables for managed classes.
+            if self.options["managed"]:
+                self.logger.error(
+                    f"Cannot access symbol table for managed class {class_name}. Failure will not be retried."
+                )
+                continue
+
             # Get all the method names for this class
             test_methods = self._get_test_methods_for_class(class_name)
             for test_method in test_methods:

--- a/cumulusci/tasks/command.py
+++ b/cumulusci/tasks/command.py
@@ -20,14 +20,18 @@ class Command(BaseTask):
     """ Execute a shell command in a subprocess """
 
     task_docs = """
-        **Example Command-line Usage::** cci task run command -o command "echo 'Hello command task!'"
+        **Example Command-line Usage:**
+        ``cci task run command -o command "echo 'Hello command task!'"``
 
-        **Example Task to Run Command::**
-        hello_world:
-            description: Says hello world
-            class_path: cumulusci.tasks.command.Command
-            options:
-            command: echo 'Hello World!'
+        **Example Task to Run Command:**
+
+        ..code-block:: yaml
+
+            hello_world:
+                description: Says hello world
+                class_path: cumulusci.tasks.command.Command
+                options:
+                command: echo 'Hello World!'
     """
 
     task_options = {

--- a/cumulusci/tasks/robotframework/libdoc.py
+++ b/cumulusci/tasks/robotframework/libdoc.py
@@ -25,7 +25,7 @@ class RobotLibDoc(BaseTask):
                 "The path can be single a python file, a .robot file, a python "
                 "module (eg: cumulusci.robotframework.Salesforce) or a comma "
                 "separated list of any of those. Glob patterns are supported "
-                "for filenames (eg: robot/SAL/doc/*PageObject.py). The order "
+                "for filenames (eg: ``robot/SAL/doc/*PageObject.py``). The order "
                 "of the files will be preserved in the generated documentation. "
                 "The result of pattern expansion will be sorted"
             ),

--- a/cumulusci/tasks/salesforce/custom_settings.py
+++ b/cumulusci/tasks/salesforce/custom_settings.py
@@ -13,26 +13,29 @@ class LoadCustomSettings(BaseSalesforceApiTask):
     Each top-level YAML key should be the API name of a Custom Setting.
     List Custom Settings should contain a nested map of names to values.
     Hierarchy Custom settings should contain a list, each of which contains
-    a `data` key and a `location` key. The `location` key may contain either
-    `profile: <profile name>`, `user: name: <username>`, `user: email: <email>`,
-    or `org`. Example:
+    a ``data`` key and a ``location`` key. The ``location`` key may contain either
+    ``profile: <profile name>``, ``user: name: <username>``, ``user: email: <email>``,
+    or ``org``. Example:
 
-    List__c:
-        Test:
-            MyField__c: 1
-        Test 2:
-            MyField__c: 2
-    Hierarchy__c:
-        -
-            location: org
-            data:
+   .. code-block:: yaml
+
+        List__c:
+            Test:
                 MyField__c: 1
-        -
-            location:
-                user:
-                    name: test@example.com
-            data:
-                MyField__c: 2"""
+            Test 2:
+                MyField__c: 2
+        Hierarchy__c:
+            -
+                location: org
+                data:
+                    MyField__c: 1
+            -
+                location:
+                    user:
+                        name: test@example.com
+                data:
+                    MyField__c: 2
+    """
 
     task_options = {
         "settings_path": {

--- a/cumulusci/utils/__init__.py
+++ b/cumulusci/utils/__init__.py
@@ -472,6 +472,7 @@ def get_task_option_info(task_config, task_class):
 def get_option_usage_string(name, option):
     """Returns a usage string if one exists
     else creates a usage string in the form of:
+
         -o option_name OPTIONNAME
     """
     usage_str = option.get("usage")

--- a/cumulusci/utils/xml/metadata_tree.py
+++ b/cumulusci/utils/xml/metadata_tree.py
@@ -1,8 +1,26 @@
+"""Salesforce uses a very specialized subset of XML for metadata.
+This module has a parser and tree model for dealing with it in
+a very Pythonic way.
+
+For example:
+
+>>> from cumulusci.utils.xml.metadata_tree import parse
+>>> Recipe = parse("recipe.xml")
+>>> print(Recipe.ingredients[0].quantity)
+
+Or to give a more Salesforce-y example:
+
+>>> Package = parse("./cumulusci/files/admin_profile.xml")
+>>> print(Package.types[0].members[1].text)
+Account
+"""
+
 from typing import Union, Generator
 
 from lxml import etree
 
 from .salesforce_encoding import serialize_xml_for_salesforce
+
 
 METADATA_NAMESPACE = "http://soap.sforce.com/2006/04/metadata"
 
@@ -17,7 +35,6 @@ def parse(source):
         * a filename string or pathlib Path
         * an HTTP or FTP URL string
 
-    Note that passing a filename or URL is usually faster than passing an open file or file-like object. However, the HTTP/FTP client in libxml2 is rather simple, so things like HTTP authentication require a dedicated URL request library, e.g. urllib2 or requests. These libraries usually provide a file-like object for the result that you can parse from while the response is streaming in.
     """
     if hasattr(source, "open"):  # for pathlib.Path objects
         with source.open() as stream:
@@ -113,7 +130,7 @@ class MetadataElement:
 
         The "sibling element" part may seem non-intuitive but it works like this:
 
-        >>> Recipe = fromstring("recipe.xml")
+        >>> Recipe = parse("recipe.xml")
         >>> Recipe.ingredients[2]
 
         First it will evaluate `Recipe.ingredients` and generate an Element for the

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -5,6 +5,7 @@ API Reference
 Information on specific functions, classes, and methods.
 
 .. toctree::
+   :maxdepth: 3
    :glob:
 
    api/*

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"CumulusCI"
-copyright = u"2017, Salesforce.org"
+copyright = u"2020, Salesforce.org"
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout
@@ -112,24 +112,7 @@ pygments_style = "sphinx"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-
-# Allowing for building docs locally with the RTD theme as documented here:
-# https://github.com/snide/sphinx_rtd_theme#using-this-theme-locally-then-building-on-read-the-docs
-# on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
-
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    try:
-        import sphinx_rtd_theme
-
-        html_theme = "sphinx_rtd_theme"
-        html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-    except ImportError:
-        print("sphinx_rtd_theme not found, using default")
-        html_theme = "default"
-
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
-# html_theme = 'default'
+html_theme = "alabaster"
 
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.  For a list of options available for each theme, see the
@@ -172,6 +155,15 @@ html_static_path = []
 
 # Custom sidebar templates, maps document names to template names.
 # html_sidebars = {}
+html_sidebars = {
+    "**": [
+        "about.html",
+        "navigation.html",
+        "relations.html",
+        "searchbox.html",
+        "donate.html",
+    ]
+}
 
 # Additional templates that should be rendered to pages, maps page names
 # to template names.
@@ -297,7 +289,17 @@ def run_apidoc(_):
     sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
     cur_dir = os.path.abspath(os.path.dirname(__file__))
     module = os.path.join(cur_dir, "..", "cumulusci")
-    main(["-E", "-P", "-o", os.path.join(cur_dir, "api"), module, "--force"])
+    main(
+        [
+            "-T",
+            "-M",
+            "-o",
+            os.path.join(cur_dir, "api"),
+            module,
+            os.path.join(cur_dir, "..", "**", "tests", "*"),
+            "--force",
+        ]
+    )
 
 
 def setup(app):

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -668,7 +668,7 @@ If you will be retrieving changes into a directory repeatedly,
 consider creating a custom task with the correct options
 so that you don't need to specify them on the command line each time.
 
-To do this, add YAML like this to your project's ``cumulusci.yml``::
+To do this, add YAML like this to your project's ``cumulusci.yml``:
 
 .. code-block:: yaml
 
@@ -734,8 +734,9 @@ Caveats:
 
 Working with Errors
 ===================
+
 Log Files
---------
+---------
 CumulusCI creates a log file every time a cci command besides ``gist`` is run. Log files are stored under ``~/.cumulusci/logs``.
 
 Viewing Stacktraces

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,8 +21,12 @@ Contents:
    bulk_data
    cookbook
    cumulusci_flow
-   tasks
    usage
+
+.. toctree::
+   :maxdepth: 1
+
+   tasks
    history
    authors
    contributing

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -210,14 +210,18 @@ Options
 
 **Class:** cumulusci.tasks.command.Command
 
-**Example Command-line Usage::** cci task run command -o command "echo 'Hello command task!'"
+**Example Command-line Usage:**
+``cci task run command -o command "echo 'Hello command task!'"``
 
-**Example Task to Run Command::**
-hello_world:
-    description: Says hello world
-    class_path: cumulusci.tasks.command.Command
-    options:
-    command: echo 'Hello World!'
+**Example Task to Run Command:**
+
+..code-block:: yaml
+
+    hello_world:
+        description: Says hello world
+        class_path: cumulusci.tasks.command.Command
+        options:
+        command: echo 'Hello World!'
 
 Command Syntax
 ------------------------------------------
@@ -2409,7 +2413,7 @@ Options
 ``-o path PATH``
 	 *Required*
 
-	 The path to one or more keyword libraries to be documented. The path can be single a python file, a .robot file, a python module (eg: cumulusci.robotframework.Salesforce) or a comma separated list of any of those. Glob patterns are supported for filenames (eg: robot/SAL/doc/*PageObject.py). The order of the files will be preserved in the generated documentation. The result of pattern expansion will be sorted
+	 The path to one or more keyword libraries to be documented. The path can be single a python file, a .robot file, a python module (eg: cumulusci.robotframework.Salesforce) or a comma separated list of any of those. Glob patterns are supported for filenames (eg: ``robot/SAL/doc/*PageObject.py``). The order of the files will be preserved in the generated documentation. The result of pattern expansion will be sorted
 
 ``-o output OUTPUT``
 	 *Required*


### PR DESCRIPTION
Okay, I got a bit carried away but with this, you can run `make docs` and then look at docs/_build/html/api/cumulusci.utils.xml.html#module-cumulusci.utils.xml.metadata_tree for the generated metadata_tree docs. I would suggest adding a module docstring to provide an introduction.

The other things in the PR are:
- fixing some reST errors that were showing warnings while building the docs
- switched to the "alabaster" sphinx theme which is the current default and which I find nicer
- fixed the main table of contents to avoid listing all tasks and release versions
- tweaked sphinx-apidoc arguments for better output and to exclude test modules

# Critical Changes

# Changes

# Issues Closed
