### PR TITLE
CreateRelease task option validation

### DIFF
--- a/cumulusci/tasks/github/tests/test_release.py
+++ b/cumulusci/tasks/github/tests/test_release.py
@@ -20,6 +20,7 @@ class TestCreateRelease(unittest.TestCase, GithubApiTestMixin):
             self.repo_owner, self.repo_name
         )
         self.project_config = create_project_config(self.repo_name, self.repo_owner)
+        self.project_config._repo_commit = "21e04cfe480f5293e2f7103eee8a5cbdb94f7982"
         self.project_config.keychain.set_service(
             "github",
             ServiceConfig(
@@ -51,7 +52,9 @@ class TestCreateRelease(unittest.TestCase, GithubApiTestMixin):
         responses.add(
             method=responses.POST,
             url=self.repo_api_url + "/git/tags",
-            json=self._get_expected_tag("release/1.0", "SHA"),
+            json=self._get_expected_tag(
+                "release/1.0", "21e04cfe480f5293e2f7103eee8a5cbdb94f7982"
+            ),
             status=201,
         )
         responses.add(
@@ -119,10 +122,10 @@ class TestCreateRelease(unittest.TestCase, GithubApiTestMixin):
             url=self.repo_api_url + "/releases/tags/release/1.0",
             status=404,
         )
+        del self.project_config._repo_commit
 
-        task = CreateRelease(
-            self.project_config,
-            TaskConfig({"options": {"version": "1.0", "commit": None}}),
-        )
         with self.assertRaises(GithubException):
-            task()
+            CreateRelease(
+                self.project_config,
+                TaskConfig({"options": {"version": "1.0", "commit": None}}),
+            )


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed
- Fixed the github_release task to make sure it was run with a valid 40-character commit hash.
