### PR TITLE
Rebuild UpdateAdminProfile as a Metadata ETL task

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -381,7 +381,7 @@ tasks:
     update_admin_profile:
         name: Update Admin Profile
         description: Retrieves, edits, and redeploys the Admin.profile with full FLS perms for all objects/fields
-        class_path: cumulusci.tasks.salesforce.UpdateProfile
+        class_path: cumulusci.tasks.salesforce.ProfileGrantAllAccess
         group: Salesforce Metadata
     update_dependencies:
         description: Installs all dependencies in project__dependencies into the target org

--- a/cumulusci/files/admin_profile.xml
+++ b/cumulusci/files/admin_profile.xml
@@ -11,7 +11,6 @@
         <name>CustomObject</name>
     </types>
     <types>
-        <members>{profile_name}</members>
         <name>Profile</name>
     </types>
     <version>39.0</version>

--- a/cumulusci/files/admin_profile.xml
+++ b/cumulusci/files/admin_profile.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <types>
         <members>*</members>

--- a/cumulusci/tasks/metadata_etl/__init__.py
+++ b/cumulusci/tasks/metadata_etl/__init__.py
@@ -5,6 +5,7 @@ from cumulusci.tasks.metadata_etl.base import (
     MetadataSingleEntityTransformTask,
     get_new_tag_index,
     MD,
+    MetadataOperation,
 )
 from cumulusci.tasks.metadata_etl.layouts import AddRelatedLists
 from cumulusci.tasks.metadata_etl.permissions import AddPermissionSetPermissions
@@ -22,4 +23,5 @@ flake8 = (
     SetOrgWideDefaults,
     get_new_tag_index,
     MD,
+    MetadataOperation,
 )

--- a/cumulusci/tasks/salesforce/__init__.py
+++ b/cumulusci/tasks/salesforce/__init__.py
@@ -44,8 +44,12 @@ from cumulusci.tasks.salesforce.DeployBundles import DeployBundles
 from cumulusci.tasks.salesforce.InstallPackageVersion import InstallPackageVersion
 from cumulusci.tasks.salesforce.UninstallPackage import UninstallPackage
 
-# Backwards-compatibility for UpdateAdminProfile
-from cumulusci.tasks.salesforce.update_profile import UpdateProfile, UpdateAdminProfile
+# Backwards-compatibility for UpdateAdminProfile/UpdateProfile
+from cumulusci.tasks.salesforce.update_profile import (
+    ProfileGrantAllAccess,
+    UpdateProfile,
+    UpdateAdminProfile,
+)
 from cumulusci.tasks.salesforce import update_profile
 
 sys.modules["cumulusci.tasks.salesforce.UpdateAdminProfile"] = update_profile
@@ -93,6 +97,7 @@ flake8Hack = (
     UninstallPackage,
     UpdateProfile,
     UpdateAdminProfile,
+    ProfileGrantAllAccess,
     UninstallLocal,
     UninstallLocalBundles,
     UninstallPackaged,

--- a/cumulusci/tasks/salesforce/tests/test_Deploy.py
+++ b/cumulusci/tasks/salesforce/tests/test_Deploy.py
@@ -5,6 +5,7 @@ import unittest
 import zipfile
 
 from cumulusci.core.exceptions import TaskOptionsError
+from cumulusci.core.flowrunner import StepSpec
 from cumulusci.tasks.salesforce import Deploy
 from cumulusci.utils import cd
 from cumulusci.utils import temporary_dir
@@ -478,3 +479,23 @@ class TestDeploy(unittest.TestCase):
             actual = task._get_package_zip(path)
 
             self.assertEqual(expected, actual)
+
+    def test_freeze_sets_kind(self):
+        task = create_task(
+            Deploy,
+            {
+                "path": "path",
+                "namespace_tokenize": "ns",
+                "namespace_inject": "ns",
+                "namespace_strip": "ns",
+            },
+        )
+        step = StepSpec(
+            step_num=1,
+            task_name="deploy",
+            task_config=task.task_config,
+            task_class=None,
+            project_config=task.project_config,
+        )
+
+        assert all(s["kind"] == "metadata" for s in task.freeze(step))

--- a/cumulusci/tasks/salesforce/tests/test_ProfileGrantAllAccess.py
+++ b/cumulusci/tasks/salesforce/tests/test_ProfileGrantAllAccess.py
@@ -356,3 +356,11 @@ def test_generate_package_xml__retrieve():
         task._generate_package_xml(MetadataOperation.RETRIEVE)
         task._expand_profile_members.assert_called_once()
         task._expand_package_xml.assert_not_called()
+
+
+def test_init_options_raises_combined_options():
+    with pytest.raises(TaskOptionsError):
+        create_task(
+            ProfileGrantAllAccess,
+            {"package_xml": "admin_profile.xml", "profile_name": "test"},
+        )

--- a/cumulusci/tasks/salesforce/tests/test_ProfileGrantAllAccess.py
+++ b/cumulusci/tasks/salesforce/tests/test_ProfileGrantAllAccess.py
@@ -7,7 +7,7 @@ import pytest
 
 from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.tasks.metadata_etl import MetadataOperation
-from cumulusci.tasks.salesforce import UpdateProfile
+from cumulusci.tasks.salesforce import ProfileGrantAllAccess
 from cumulusci.utils import CUMULUSCI_PATH
 from cumulusci.utils.xml import metadata_tree
 from cumulusci.tests.util import create_project_config
@@ -125,7 +125,7 @@ def test_run_task():
             f.write(ADMIN_PROFILE_BEFORE)
 
         task = create_task(
-            UpdateProfile,
+            ProfileGrantAllAccess,
             {
                 "record_types": [
                     {
@@ -157,7 +157,7 @@ def test_run_task():
 
 def test_transforms_profile():
     task = create_task(
-        UpdateProfile,
+        ProfileGrantAllAccess,
         {
             "record_types": [
                 {
@@ -180,7 +180,7 @@ def test_transforms_profile():
 
 def test_throws_exception_record_type_not_found():
     task = create_task(
-        UpdateProfile,
+        ProfileGrantAllAccess,
         {"record_types": [{"record_type": "DOESNT_EXIST"}], "namespaced_org": True},
     )
 
@@ -189,7 +189,7 @@ def test_throws_exception_record_type_not_found():
 
 
 def test_expand_package_xml():
-    task = create_task(UpdateProfile, {"api_names": ["Admin"]})
+    task = create_task(ProfileGrantAllAccess, {"api_names": ["Admin"]})
     task.tooling = mock.Mock()
     task.tooling.query.return_value = {
         "totalSize": 2,
@@ -208,7 +208,7 @@ def test_expand_package_xml():
 
 def test_expand_profile_members():
     task = create_task(
-        UpdateProfile,
+        ProfileGrantAllAccess,
         {
             "api_names": ["Admin", "%%%NAMESPACE%%%Continuous Integration"],
             "namespace_inject": "ns",
@@ -229,19 +229,21 @@ def test_expand_profile_members():
 def test_init_options__general():
     pc = create_project_config()
     pc.project__package__namespace = "ns"
-    task = create_task(UpdateProfile, {"managed": "true"}, project_config=pc)
+    task = create_task(ProfileGrantAllAccess, {"managed": "true"}, project_config=pc)
     assert task.options["managed"]
     assert not task.options["namespaced_org"]
     assert task.options["namespace_inject"] == "ns"
     assert task.namespace_prefixes == {"managed": "ns__", "namespaced_org": ""}
 
-    task = create_task(UpdateProfile, {"namespaced_org": "true"}, project_config=pc)
+    task = create_task(
+        ProfileGrantAllAccess, {"namespaced_org": "true"}, project_config=pc
+    )
     assert task.options["managed"]
     assert task.options["namespaced_org"]
     assert task.options["namespace_inject"] == "ns"
     assert task.namespace_prefixes == {"managed": "ns__", "namespaced_org": "ns__"}
 
-    task = create_task(UpdateProfile, {}, project_config=pc)
+    task = create_task(ProfileGrantAllAccess, {}, project_config=pc)
     assert not task.options["managed"]
     assert not task.options["namespaced_org"]
     assert task.options["namespace_inject"] == "ns"
@@ -250,7 +252,7 @@ def test_init_options__general():
 
 def test_init_options__api_names():
     task = create_task(
-        UpdateProfile,
+        ProfileGrantAllAccess,
         {
             "api_names": ["Admin", "%%%NAMESPACE%%%Continuous Integration"],
             "namespace_inject": "ns",
@@ -260,7 +262,7 @@ def test_init_options__api_names():
     assert task.api_names == {"Admin", "ns__Continuous Integration"}
 
     task = create_task(
-        UpdateProfile,
+        ProfileGrantAllAccess,
         {
             "api_names": ["Admin", "%%%NAMESPACE%%%Continuous Integration"],
             "namespace_inject": "ns",
@@ -269,13 +271,15 @@ def test_init_options__api_names():
     )
     assert task.api_names == {"Admin", "Continuous Integration"}
 
-    task = create_task(UpdateProfile, {"profile_name": "Continuous Integration"})
+    task = create_task(
+        ProfileGrantAllAccess, {"profile_name": "Continuous Integration"}
+    )
     assert task.api_names == {"Continuous Integration"}
 
-    task = create_task(UpdateProfile, {})
+    task = create_task(ProfileGrantAllAccess, {})
     assert task.api_names == {"Admin"}
 
-    task = create_task(UpdateProfile, {"package_xml": "lib/admin_profile.xml"})
+    task = create_task(ProfileGrantAllAccess, {"package_xml": "lib/admin_profile.xml"})
     assert task.api_names == {"*"}
 
 
@@ -283,23 +287,25 @@ def test_init_options__include_packaged_objects():
     pc = create_project_config()
     pc.minimum_cumulusci_version = "4.0.0"
     task = create_task(
-        UpdateProfile, {"package_xml": "lib/admin_profile.xml"}, project_config=pc
+        ProfileGrantAllAccess,
+        {"package_xml": "lib/admin_profile.xml"},
+        project_config=pc,
     )
     assert task.package_xml_path == "lib/admin_profile.xml"
     assert not task.options["include_packaged_objects"]
 
-    task = create_task(UpdateProfile, {}, project_config=pc)
+    task = create_task(ProfileGrantAllAccess, {}, project_config=pc)
     assert task.options["include_packaged_objects"]
     assert task.package_xml_path == os.path.join(
         CUMULUSCI_PATH, "cumulusci", "files", "admin_profile.xml"
     )
 
     pc.minimum_cumulusci_version = "2.0.0"
-    task = create_task(UpdateProfile, {}, project_config=pc)
+    task = create_task(ProfileGrantAllAccess, {}, project_config=pc)
     assert not task.options["include_packaged_objects"]
 
     task = create_task(
-        UpdateProfile, {"include_packaged_objects": True}, project_config=pc
+        ProfileGrantAllAccess, {"include_packaged_objects": True}, project_config=pc
     )
     assert task.options["include_packaged_objects"]
 
@@ -314,7 +320,7 @@ def test_generate_package_xml__retrieve():
             f.write(PACKAGE_XML_BEFORE)
 
         task = create_task(
-            UpdateProfile,
+            ProfileGrantAllAccess,
             {"package_xml": "admin_profile.xml", "include_packaged_objects": False},
         )
 
@@ -325,7 +331,7 @@ def test_generate_package_xml__retrieve():
         task._expand_package_xml.assert_not_called()
 
         task = create_task(
-            UpdateProfile,
+            ProfileGrantAllAccess,
             {"package_xml": "admin_profile.xml", "include_packaged_objects": True},
         )
 
@@ -335,7 +341,7 @@ def test_generate_package_xml__retrieve():
         task._expand_profile_members.assert_not_called()
         task._expand_package_xml.assert_called_once()
 
-        task = create_task(UpdateProfile, {"include_packaged_objects": True})
+        task = create_task(ProfileGrantAllAccess, {"include_packaged_objects": True})
 
         task._expand_profile_members = mock.Mock()
         task._expand_package_xml = mock.Mock()
@@ -343,7 +349,7 @@ def test_generate_package_xml__retrieve():
         task._expand_profile_members.assert_called_once()
         task._expand_package_xml.assert_called_once()
 
-        task = create_task(UpdateProfile, {"include_packaged_objects": False})
+        task = create_task(ProfileGrantAllAccess, {"include_packaged_objects": False})
 
         task._expand_profile_members = mock.Mock()
         task._expand_package_xml = mock.Mock()

--- a/cumulusci/tasks/salesforce/tests/test_ProfileGrantAllAccess.py
+++ b/cumulusci/tasks/salesforce/tests/test_ProfileGrantAllAccess.py
@@ -21,10 +21,10 @@ ADMIN_PROFILE_BEFORE = b"""<?xml version='1.0' encoding='utf-8'?>
         <default>true</default>
         <visible>false</visible>
     </applicationVisibilities>
-    <classAccess>
+    <classAccesses>
         <apexClass>TestClass</apexClass>
         <enabled>false</enabled>
-    </classAccess>
+    </classAccesses>
     <fieldPermissions>
         <field>Account.TestField__c</field>
         <editable>false</editable>
@@ -59,10 +59,10 @@ ADMIN_PROFILE_EXPECTED = b"""<?xml version="1.0" encoding="UTF-8"?>
         <default>true</default>
         <visible>true</visible>
     </applicationVisibilities>
-    <classAccess>
+    <classAccesses>
         <apexClass>TestClass</apexClass>
         <enabled>true</enabled>
-    </classAccess>
+    </classAccesses>
     <fieldPermissions>
         <field>Account.TestField__c</field>
         <editable>true</editable>

--- a/cumulusci/tasks/salesforce/tests/test_UpdateProfile.py
+++ b/cumulusci/tasks/salesforce/tests/test_UpdateProfile.py
@@ -52,7 +52,7 @@ ADMIN_PROFILE_BEFORE = b"""<?xml version='1.0' encoding='utf-8'?>
     </tabVisibilities>
 </Profile>"""
 
-ADMIN_PROFILE_EXPECTED = b"""<?xml version='1.0' encoding='utf-8'?>
+ADMIN_PROFILE_EXPECTED = b"""<?xml version="1.0" encoding="UTF-8"?>
 <Profile xmlns="http://soap.sforce.com/2006/04/metadata">
     <applicationVisibilities>
         <application>npsp__Nonprofit_CRM</application>
@@ -88,7 +88,8 @@ ADMIN_PROFILE_EXPECTED = b"""<?xml version='1.0' encoding='utf-8'?>
         <tab>NPSP_Settings</tab>
         <visibility>DefaultOn</visibility>
     </tabVisibilities>
-</Profile>"""
+</Profile>
+"""
 
 PACKAGE_XML_BEFORE = """<Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <types>
@@ -149,8 +150,9 @@ def test_run_task():
 
         dest_path = task.deploy_dir / "profiles" / "Admin.profile"
         assert dest_path.exists()
-        print(dest_path.read_bytes())
-        assert dest_path.read_bytes() == ADMIN_PROFILE_EXPECTED
+        assert dest_path.read_bytes().decode("utf-8") == ADMIN_PROFILE_EXPECTED.decode(
+            "utf-8"
+        )
 
 
 def test_transforms_profile():
@@ -168,11 +170,12 @@ def test_transforms_profile():
         },
     )
 
-    result = task._transform_entity(
-        metadata_tree.fromstring(ADMIN_PROFILE_BEFORE), "Admin"
-    ).tostring(xml_declaration=True)
+    inbound = metadata_tree.fromstring(ADMIN_PROFILE_BEFORE)
+    outbound = task._transform_entity(inbound, "Admin")
 
-    assert result == ADMIN_PROFILE_EXPECTED
+    xml_output = outbound.tostring(xml_declaration=True)
+
+    assert xml_output == ADMIN_PROFILE_EXPECTED.decode("utf-8")
 
 
 def test_throws_exception_record_type_not_found():

--- a/cumulusci/tasks/salesforce/tests/test_UpdateProfile.py
+++ b/cumulusci/tasks/salesforce/tests/test_UpdateProfile.py
@@ -1,14 +1,18 @@
-from pathlib import Path
+import os
 from unittest import mock
 
+from lxml import etree
 import pytest
+
 from cumulusci.core.exceptions import TaskOptionsError
+from cumulusci.tasks.metadata_etl import MD
 from cumulusci.tasks.salesforce import UpdateProfile
+from cumulusci.utils import CUMULUSCI_PATH
+from cumulusci.tests.util import create_project_config
 
 from .util import create_task
 
-ADMIN_PROFILE_BEFORE = """<?xml version='1.0' encoding='utf-8'?>
-<Profile xmlns="http://soap.sforce.com/2006/04/metadata">
+ADMIN_PROFILE_BEFORE = """<Profile xmlns="http://soap.sforce.com/2006/04/metadata">
     <applicationVisibilities>
         <application>npsp__Nonprofit_CRM</application>
         <default>true</default>
@@ -83,8 +87,25 @@ ADMIN_PROFILE_EXPECTED = """<?xml version='1.0' encoding='utf-8'?>
     </tabVisibilities>
 </Profile>"""
 
+PACKAGE_XML_BEFORE = """<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>*</members>
+        <members>Account</members>
+        <members>Campaign</members>
+        <members>CampaignMember</members>
+        <members>Contact</members>
+        <members>Lead</members>
+        <members>Opportunity</members>
+        <name>CustomObject</name>
+    </types>
+    <types>
+        <name>Profile</name>
+    </types>
+    <version>39.0</version>
+</Package>"""
 
-def test_run_task():
+
+def test_transforms_profile():
     task = create_task(
         UpdateProfile,
         {
@@ -99,110 +120,140 @@ def test_run_task():
         },
     )
 
-    def _retrieve_unpackaged():
-        profiles_path = Path(task.retrieve_dir, "profiles")
-        admin_profile_path = Path(profiles_path, "Admin.profile")
-        profiles_path.mkdir()
-        admin_profile_path.write_text(ADMIN_PROFILE_BEFORE)
-
-    def _check_result():
-        result_path = Path(task.retrieve_dir, "profiles", "Admin.profile")
-        result = result_path.read_text()
-        assert ADMIN_PROFILE_EXPECTED == result
-
-    task._retrieve_unpackaged = _retrieve_unpackaged
-    task._deploy_metadata = _check_result
-    task()
+    result = etree.tostring(
+        task._transform_entity(etree.fromstring(ADMIN_PROFILE_BEFORE), "Admin"),
+        encoding="utf-8",
+        xml_declaration=True,
+    ).decode("utf-8")
+    print(result)
+    assert result == ADMIN_PROFILE_EXPECTED
 
 
-def test_run_task__other_profile():
-    task = create_task(
-        UpdateProfile,
-        {
-            "record_types": [
-                {
-                    "record_type": "Account.HH_Account",
-                    "default": True,
-                    "person_account_default": True,
-                }
-            ],
-            "namespaced_org": True,
-            "profile_name": "Continuous Integration",
-        },
-    )
-
-    def _retrieve_unpackaged():
-        profiles_path = Path(task.retrieve_dir, "profiles")
-        admin_profile_path = Path(profiles_path, "Continuous Integration.profile")
-        profiles_path.mkdir()
-        admin_profile_path.write_text(ADMIN_PROFILE_BEFORE)
-
-    def _check_result():
-        result_path = Path(
-            task.retrieve_dir, "profiles", "Continuous Integration.profile"
-        )
-        result = result_path.read_text()
-        assert ADMIN_PROFILE_EXPECTED == result
-
-    task._retrieve_unpackaged = _retrieve_unpackaged
-    task._deploy_metadata = _check_result
-    task()
-
-
-def test_run_task__record_type_not_found():
+def test_throws_exception_record_type_not_found():
     task = create_task(
         UpdateProfile,
         {"record_types": [{"record_type": "DOESNT_EXIST"}], "namespaced_org": True},
     )
 
-    def _retrieve_unpackaged():
-        profiles_path = Path(task.retrieve_dir, "profiles")
-        admin_profile_path = Path(profiles_path, "Admin.profile")
-        profiles_path.mkdir()
-        admin_profile_path.write_text(ADMIN_PROFILE_BEFORE)
-
-    task._retrieve_unpackaged = _retrieve_unpackaged
     with pytest.raises(TaskOptionsError):
-        task()
+        task._transform_entity(etree.fromstring(ADMIN_PROFILE_BEFORE), "Admin")
 
 
-@mock.patch("cumulusci.salesforce_api.metadata.ApiRetrieveUnpackaged.__call__")
-def test_retrieve_unpackaged(ApiRetrieveUnpackaged):
-    task = create_task(UpdateProfile)
-    task.retrieve_dir = "/tmp"
-    task._retrieve_unpackaged()
-    ApiRetrieveUnpackaged.assert_called_once()
+def test_expand_package_xml():
+    task = create_task(UpdateProfile, {"api_names": ["Admin"]})
+    task.tooling = mock.Mock()
+    task.tooling.query.return_value = {
+        "totalSize": 2,
+        "records": [
+            {"DeveloperName": "Test", "NamespacePrefix": "ns"},
+            {"DeveloperName": "Foo_Bar", "NamespacePrefix": "fb"},
+        ],
+    }
+
+    package_xml = etree.fromstring(PACKAGE_XML_BEFORE)
+    task._expand_package_xml(package_xml)
+    types = package_xml.findall(f".//{MD}types[{MD}name='CustomObject']")[0]
+    assert "ns__Test__c" in {elem.text for elem in types.findall(f".//{MD}members")}
+    assert "fb__Foo_Bar__c" in {elem.text for elem in types.findall(f".//{MD}members")}
 
 
-def test_deploy_metadata(tmpdir):
-    task = create_task(UpdateProfile)
-    task.retrieve_dir = Path(tmpdir, "retrieve", "profiles")
-    task.deploy_dir = Path(tmpdir, "deploy")
-    task.retrieve_dir.mkdir(parents=True)
-    task.deploy_dir.mkdir(parents=True)
-    task.retrieve_dir = task.retrieve_dir.parent
-    task.deploy_dir = task.deploy_dir.parent
+def test_expand_profile_members():
+    task = create_task(
+        UpdateProfile,
+        {
+            "api_names": ["Admin", "%%%NAMESPACE%%%Continuous Integration"],
+            "namespace_inject": "ns",
+            "managed": True,
+        },
+    )
+    package_xml = etree.fromstring(PACKAGE_XML_BEFORE)
 
-    task._get_api = mock.Mock()
-    task._deploy_metadata()
-    task._get_api.assert_called_once()
+    task._expand_profile_members(package_xml)
 
-
-def test_get_deploy_package_xml_content():
-    task = create_task(UpdateProfile, {"profile_name": "Test"})
-
-    assert "Test" in task._get_deploy_package_xml_content()
-
-    task = create_task(UpdateProfile)
-
-    assert "Admin" in task._get_deploy_package_xml_content()
+    types = package_xml.findall(f".//{MD}types[{MD}name='Profile']")[0]
+    assert {elem.text for elem in types.findall(f".//{MD}members")} == {
+        "Admin",
+        "ns__Continuous Integration",
+    }
 
 
-def test_get_retrieve_package_xml_content():
-    task = create_task(UpdateProfile, {"profile_name": "Test"})
+def test_init_options__general():
+    pc = create_project_config()
+    pc.project__package__namespace = "ns"
+    task = create_task(UpdateProfile, {"managed": "true"}, project_config=pc)
+    assert task.options["managed"]
+    assert not task.options["namespaced_org"]
+    assert task.options["namespace_inject"] == "ns"
+    assert task.namespace_prefixes == {"managed": "ns__", "namespaced_org": ""}
 
-    assert "Test" in task._get_retrieve_package_xml_content()
+    task = create_task(UpdateProfile, {"namespaced_org": "true"}, project_config=pc)
+    assert task.options["managed"]
+    assert task.options["namespaced_org"]
+    assert task.options["namespace_inject"] == "ns"
+    assert task.namespace_prefixes == {"managed": "ns__", "namespaced_org": "ns__"}
 
-    task = create_task(UpdateProfile)
+    task = create_task(UpdateProfile, {}, project_config=pc)
+    assert not task.options["managed"]
+    assert not task.options["namespaced_org"]
+    assert task.options["namespace_inject"] == "ns"
+    assert task.namespace_prefixes == {"managed": "", "namespaced_org": ""}
 
-    assert "Admin" in task._get_retrieve_package_xml_content()
+
+def test_init_options__api_names():
+    task = create_task(
+        UpdateProfile,
+        {
+            "api_names": ["Admin", "%%%NAMESPACE%%%Continuous Integration"],
+            "namespace_inject": "ns",
+            "managed": True,
+        },
+    )
+    assert task.api_names == {"Admin", "ns__Continuous Integration"}
+
+    task = create_task(
+        UpdateProfile,
+        {
+            "api_names": ["Admin", "%%%NAMESPACE%%%Continuous Integration"],
+            "namespace_inject": "ns",
+            "managed": False,
+        },
+    )
+    assert task.api_names == {"Admin", "Continuous Integration"}
+
+    task = create_task(UpdateProfile, {"profile_name": "Continuous Integration"})
+    assert task.api_names == {"Continuous Integration"}
+
+    task = create_task(UpdateProfile, {})
+    assert task.api_names == {"Admin"}
+
+    task = create_task(UpdateProfile, {"package_xml": "lib/admin_profile.xml"})
+    assert task.api_names == {"*"}
+
+
+def test_init_options__include_packaged_objects():
+    pc = create_project_config()
+    pc.minimum_cumulusci_version = "4.0.0"
+    task = create_task(
+        UpdateProfile, {"package_xml": "lib/admin_profile.xml"}, project_config=pc
+    )
+    assert task.package_xml_path == "lib/admin_profile.xml"
+    assert not task.options["include_packaged_objects"]
+
+    task = create_task(UpdateProfile, {}, project_config=pc)
+    assert task.options["include_packaged_objects"]
+    assert task.package_xml_path == os.path.join(
+        CUMULUSCI_PATH, "cumulusci", "files", "admin_profile.xml"
+    )
+
+    pc.minimum_cumulusci_version = "2.0.0"
+    task = create_task(UpdateProfile, {}, project_config=pc)
+    assert not task.options["include_packaged_objects"]
+
+    task = create_task(
+        UpdateProfile, {"include_packaged_objects": True}, project_config=pc
+    )
+    assert task.options["include_packaged_objects"]
+
+
+def test_generate_package_xml():
+    raise NotImplementedError

--- a/cumulusci/tasks/salesforce/update_profile.py
+++ b/cumulusci/tasks/salesforce/update_profile.py
@@ -198,7 +198,7 @@ class ProfileGrantAllAccess(MetadataSingleEntityTransformTask):
         if any("default" in rt for rt in record_types):
             for default in ("default", "personAccountDefault"):
                 for elem in tree.findall("recordTypeVisibilities"):
-                    elem.default.text = "false"
+                    elem.find(default).text = "false"
 
         # Set recordTypeVisibilities
         for rt in record_types:

--- a/cumulusci/tasks/salesforce/update_profile.py
+++ b/cumulusci/tasks/salesforce/update_profile.py
@@ -174,7 +174,7 @@ class ProfileGrantAllAccess(MetadataSingleEntityTransformTask):
         # Custom applications
         self._set_elements_visible(tree, "applicationVisibilities", "visible")
         # Apex classes
-        self._set_elements_visible(tree, "classAccess", "enabled")
+        self._set_elements_visible(tree, "classAccesses", "enabled")
         # Fields
         self._set_elements_visible(tree, "fieldPermissions", "editable")
         self._set_elements_visible(tree, "fieldPermissions", "readable")

--- a/cumulusci/tasks/salesforce/update_profile.py
+++ b/cumulusci/tasks/salesforce/update_profile.py
@@ -207,7 +207,8 @@ class ProfileGrantAllAccess(MetadataSingleEntityTransformTask):
         if any("default" in rt for rt in record_types):
             for default in ("default", "personAccountDefault"):
                 for elem in tree.findall("recordTypeVisibilities"):
-                    elem.find(default).text = "false"
+                    if elem.find(default):
+                        elem.find(default).text = "false"
 
         # Set recordTypeVisibilities
         for rt in record_types:

--- a/cumulusci/tasks/salesforce/update_profile.py
+++ b/cumulusci/tasks/salesforce/update_profile.py
@@ -14,7 +14,7 @@ from cumulusci.utils.xml import metadata_tree
 
 
 class ProfileGrantAllAccess(MetadataSingleEntityTransformTask):
-    name = "UpdateProfile"
+    name = "ProfileGrantAllAccess"
     entity = "Profile"
 
     task_options = {
@@ -111,6 +111,15 @@ class ProfileGrantAllAccess(MetadataSingleEntityTransformTask):
             self.package_xml_path = os.path.join(
                 CUMULUSCI_PATH, "cumulusci", "files", "admin_profile.xml"
             )
+
+    def freeze(self, step):
+        # Preserve behavior from when we subclassed Deploy.
+
+        steps = super().freeze(step)
+        for step in steps:
+            if step["kind"] == "other":
+                step["kind"] = "metadata"
+        return steps
 
     def _generate_package_xml(self, operation):
         if operation is MetadataOperation.RETRIEVE:

--- a/cumulusci/tasks/salesforce/update_profile.py
+++ b/cumulusci/tasks/salesforce/update_profile.py
@@ -38,7 +38,7 @@ class ProfileGrantAllAccess(MetadataSingleEntityTransformTask):
             "default": "Admin",
         },
         "include_packaged_objects": {
-            "description": "Automatically include objects from all installed managed packages. Defaults to True in projects that require CumulusCI 3.7.1 and greater, otherwise False."
+            "description": "Automatically include objects from all installed managed packages. Defaults to True in projects that require CumulusCI 3.8.1 and greater, otherwise False."
         },
         "api_names": {"description": "List of API names of Profiles to affect"},
     }
@@ -71,13 +71,13 @@ class ProfileGrantAllAccess(MetadataSingleEntityTransformTask):
 
         # We enable new functionality to extend the package.xml to packaged objects
         # by default only if we meet specific requirements: the project has to require
-        # CumulusCI >= 3.7.1 (i.e., creation date or opt-in after release), and it must
+        # CumulusCI >= 3.8.1 (i.e., creation date or opt-in after release), and it must
         # not be using a custom `package.xml`
         min_cci_version = self.project_config.minimum_cumulusci_version
         if min_cci_version and "package_xml" not in self.options:
             parsed_version = pkg_resources.parse_version(min_cci_version)
             default_packages_arg = parsed_version >= pkg_resources.parse_version(
-                "3.7.1"
+                "3.8.1"
             )
         else:
             default_packages_arg = False

--- a/cumulusci/tasks/salesforce/update_profile.py
+++ b/cumulusci/tasks/salesforce/update_profile.py
@@ -93,7 +93,7 @@ class ProfileGrantAllAccess(MetadataSingleEntityTransformTask):
         if "package_xml" in self.options:
             if self.api_names or "profile_name" in self.options:
                 raise TaskOptionsError(
-                    "The package_xml option is not compatible with the package_name or api_names options. "
+                    "The package_xml option is not compatible with the profile_name or api_names options. "
                     "Specify desired packages in the custom package.xml"
                 )
 

--- a/cumulusci/tasks/salesforce/update_profile.py
+++ b/cumulusci/tasks/salesforce/update_profile.py
@@ -19,26 +19,35 @@ class ProfileGrantAllAccess(MetadataSingleEntityTransformTask):
 
     task_options = {
         "package_xml": {
-            "description": "Override the default package.xml file for retrieving the Admin.profile and all objects and classes that need to be included by providing a path to your custom package.xml"
+            "description": "Override the default package.xml file for retrieving the Admin.profile and all objects and classes "
+            "that need to be included by providing a path to your custom package.xml"
         },
         "record_types": {
-            "description": "A list of dictionaries containing the required key `record_type` with a value specifying the record type in format <object>.<developer_name>.  Record type names can use the token strings {managed} and {namespaced_org} for namespace prefix injection as needed.  By default, all listed record types will be set to visible and not default.  Use the additional keys `visible`, `default`, and `person_account_default` set to true/false to override.  NOTE: Setting record_types is only supported in cumulusci.yml, command line override is not supported."
+            "description": "A list of dictionaries containing the required key `record_type` with a value specifying "
+            "the record type in format <object>.<developer_name>.  Record type names can use the token strings {managed} "
+            "and {namespaced_org} for namespace prefix injection as needed.  By default, all listed record types will be set "
+            "to visible and not default.  Use the additional keys `visible`, `default`, and `person_account_default` set to "
+            "true/false to override.  NOTE: Setting record_types is only supported in cumulusci.yml, command line override is not supported."
         },
         "managed": {
-            "description": "If True, uses the namespace prefix where appropriate.  Use if running against an org with the managed package installed.  Defaults to False"
+            "description": "If True, uses the namespace prefix where appropriate.  Use if running against an org with the managed package "
+            "installed.  Defaults to False"
         },
         "namespaced_org": {
-            "description": "If True, attempts to prefix all unmanaged metadata references with the namespace prefix for deployment to the packaging org or a namespaced scratch org.  Defaults to False"
+            "description": "If True, attempts to prefix all unmanaged metadata references with the namespace prefix for deployment to the "
+            "packaging org or a namespaced scratch org.  Defaults to False"
         },
         "namespace_inject": {
-            "description": "If set, the namespace tokens in files and filenames are replaced with the namespace's prefix. Defaults to project__package__namespace"
+            "description": "If set, the namespace tokens in files and filenames are replaced with the namespace's prefix. "
+            "Defaults to project__package__namespace"
         },
         "profile_name": {
-            "description": "Name of the Profile to target for updates (legacy; use api_names to target multiple profiles).",
+            "description": "Name of the Profile to target for updates (deprecated; use api_names to target multiple profiles).",
             "default": "Admin",
         },
         "include_packaged_objects": {
-            "description": "Automatically include objects from all installed managed packages. Defaults to True in projects that require CumulusCI 3.8.1 and greater, otherwise False."
+            "description": "Automatically include objects from all installed managed packages. "
+            "Defaults to True in projects that require CumulusCI 3.8.1 and greater that don't use a custom package.xml, otherwise False."
         },
         "api_names": {"description": "List of API names of Profiles to affect"},
     }

--- a/cumulusci/tasks/salesforce/update_profile.py
+++ b/cumulusci/tasks/salesforce/update_profile.py
@@ -117,23 +117,26 @@ class ProfileGrantAllAccess(MetadataSingleEntityTransformTask):
             with open(self.package_xml_path, "r") as f:
                 package_xml_content = f.read()
 
-            package_xml_content = package_xml_content.format(
-                **self.namespace_prefixes, profile_name=self.profile_name
-            )
+            package_xml_content = package_xml_content.format(**self.namespace_prefixes)
 
             if (
                 self.options["include_packaged_objects"]
                 or "package_xml" not in self.options
             ):
-                # we need to rewrite the package.xml for one or two reasons.
-                package_xml = etree.parse(package_xml_content)
+                # We need to rewrite the package.xml for one or two reasons.
+                # Either we are using packaged-object expansion, or we're using
+                # the built-in admin_profile.xml and need to substitute in
+                # profile API names.
+                package_xml = etree.fromstring(package_xml_content)
 
                 if self.options["include_packaged_objects"]:
                     self._expand_package_xml(package_xml)
                 if "package_xml" not in self.options:
                     self._expand_profile_members(package_xml)
 
-                package_xml_content = etree.tostring(package_xml, encoding="utf-8")
+                package_xml_content = etree.tostring(
+                    package_xml, encoding="utf-8", xml_declaration=True
+                )
 
             return package_xml_content
         else:

--- a/cumulusci/tasks/tests/test_metadeploy.py
+++ b/cumulusci/tasks/tests/test_metadeploy.py
@@ -183,9 +183,14 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
                     "path": "install_prod.config_managed.update_admin_profile",
                     "source": None,
                     "step_num": "1/3/2",
-                    "task_class": "cumulusci.tasks.salesforce.UpdateProfile",
+                    "task_class": "cumulusci.tasks.salesforce.ProfileGrantAllAccess",
                     "task_config": {
-                        "options": {"managed": True, "namespaced_org": False},
+                        "options": {
+                            "managed": True,
+                            "namespaced_org": False,
+                            "namespace_inject": "ns",
+                            "include_packaged_objects": False,
+                        },
                         "checks": [],
                     },
                 },

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -3018,7 +3018,7 @@ Options
 
 **Description:** Retrieves, edits, and redeploys the Admin.profile with full FLS perms for all objects/fields
 
-**Class:** cumulusci.tasks.salesforce.UpdateProfile
+**Class:** cumulusci.tasks.salesforce.ProfileGrantAllAccess
 
 Command Syntax
 ------------------------------------------
@@ -3050,10 +3050,25 @@ Options
 
 	 If True, attempts to prefix all unmanaged metadata references with the namespace prefix for deployment to the packaging org or a namespaced scratch org.  Defaults to False
 
+``-o namespace_inject NAMESPACEINJECT``
+	 *Optional*
+
+	 If set, the namespace tokens in files and filenames are replaced with the namespace's prefix. Defaults to project__package__namespace
+
 ``-o profile_name PROFILENAME``
 	 *Optional*
 
-	 Name of the Profile to target for updates.
+	 Name of the Profile to target for updates (deprecated; use api_names to target multiple profiles).
+
+``-o include_packaged_objects INCLUDEPACKAGEDOBJECTS``
+	 *Optional*
+
+	 Automatically include objects from all installed managed packages. Defaults to True in projects that require CumulusCI 3.8.1 and greater that don't use a custom package.xml, otherwise False.
+
+``-o api_names APINAMES``
+	 *Optional*
+
+	 List of API names of Profiles to affect
 
 **update_dependencies**
 ==========================================


### PR DESCRIPTION
This PR converts UpdateAdminProfile/UpdateProfile to a Metadata ETL task called ProfileGrantAllAccess.

- [x] Unit testing
- [x] End to end testing
- [ ] MetaDeploy testing
- [x] Deal with any breaking changes in projects that subclasses UpdateAdminProfile
  - [x] NPSP
  - [x] EDA
  - [x] K12
  - [x] CaseMan
  - [x] FGM-Portal
  - [x] FC-Reviewer
- [x] Validate fix for CCI Trailhead

# Critical Changes

# Changes

- The `UpdateAdminProfile`/`UpdateProfile` task has been revised to use the new Metadata ETL framework as `ProfileGrantAllAccess`. This is a breaking change for local tasks which subclassed `UpdateAdminProfile`. The new task supports updating arbitrary Profiles in addition to System Administrator. 
- **Note**: At time of release, please update `update_profile.py` line 89 to actual version number.

# Issues Closed
