### PR TITLE
Fix a couple things related to retrieve_changes

### DIFF
--- a/cumulusci/core/sfdx.py
+++ b/cumulusci/core/sfdx.py
@@ -42,11 +42,13 @@ def sfdx(
         env=env,
     )
     p.run()
-    if capture_output:
+    if capture_output or (check_return and p.returncode):
         p.stdout_text = io.TextIOWrapper(p.stdout, encoding=sys.stdout.encoding)
         p.stderr_text = io.TextIOWrapper(p.stderr, encoding=sys.stdout.encoding)
     if check_return and p.returncode:
-        raise Exception(f"Command exited with return code {p.returncode}")
+        raise Exception(
+            f"Command exited with return code {p.returncode}:\n{p.stderr_text}"
+        )
     return p
 
 

--- a/cumulusci/core/sfdx.py
+++ b/cumulusci/core/sfdx.py
@@ -47,7 +47,7 @@ def sfdx(
         p.stderr_text = io.TextIOWrapper(p.stderr, encoding=sys.stdout.encoding)
     if check_return and p.returncode:
         raise Exception(
-            f"Command exited with return code {p.returncode}:\n{p.stderr_text}"
+            f"Command exited with return code {p.returncode}:\n{p.stderr_text.read()}"
         )
     return p
 

--- a/cumulusci/core/tests/test_sfdx.py
+++ b/cumulusci/core/tests/test_sfdx.py
@@ -1,4 +1,5 @@
 from unittest import mock
+import io
 import sys
 
 import pytest
@@ -29,6 +30,7 @@ class TestSfdx:
     @mock.patch("sarge.Command")
     def test_check_return(self, Command):
         Command.return_value.returncode = 1
+        Command.return_value.stderr = io.BytesIO(b"Egads!")
         with pytest.raises(Exception) as exc_info:
             sfdx("cmd", check_return=True)
-        assert str(exc_info.value) == "Command exited with return code 1"
+        assert str(exc_info.value) == "Command exited with return code 1:\nEgads!"

--- a/cumulusci/tasks/salesforce/sourcetracking.py
+++ b/cumulusci/tasks/salesforce/sourcetracking.py
@@ -207,6 +207,7 @@ def retrieve_components(
     to a namespace prefix to replace it with a `%%%NAMESPACE%%%` token.
     """
 
+    target = os.path.realpath(target)
     with contextlib.ExitStack() as stack:
         if md_format:
             # Create target if it doesn't exist


### PR DESCRIPTION
The retrieve_components helper now makes sure the target path is absolute before switching to a different working directory. This was not an issue when used from the retrieve_changes task (which is why I'm not putting it in the release notes) but affected MetaShare.

# Critical Changes

# Changes

# Issues Closed
- If there is an error from sfdx while using the `retrieve_changes` task, it will now be logged.