### PR TITLE
Add support for GitHub Enterprise

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ coloredlogs==14.0
 cryptography==2.8
 docutils==0.16
 github3.py==1.3.0
+giturlparse==0.9.2
 humanfriendly==7.1.1
 jinja2==2.11.1
 jwcrypto==0.7


### PR DESCRIPTION
- Use a real parser for repo url instead of a dumb split.  Convert all repo urls to https format since that's what's required for calling the GitHub API
- Changes cumulusci.core.github.get_github_api_for_repo to accept args for the project_config and the repo_url
- Use a mapping of service names to github site base url in project.git.sites in cumulusci.yml to look up service names for different repo base urls.  The custom service still has to be defined under services for the mapping to work


# Critical Changes

# Changes

# Issues Closed
