### PR TITLE
Add support for CHROME_LOG variable in robot tests

### DIFF
--- a/cumulusci/robotframework/Salesforce.robot
+++ b/cumulusci/robotframework/Salesforce.robot
@@ -35,6 +35,7 @@ ${INITIAL_TIMEOUT}  180.0
 ${TIMEOUT}          30.0
 ${LOCATION STRATEGIES INITIALIZED}  ${False}
 ${DEFAULT BROWSER SIZE}  1280x1024
+${CHROME LOG}       ${EMPTY}
 
 *** Keywords ***
 
@@ -87,9 +88,16 @@ Open Test Browser
     Log browser capabilities
 
 Open Test Browser Chrome
-    [Arguments]     ${login_url}  ${alias}=${NONE}
-    ${options} =                Get Chrome Options
-    Create Webdriver With Retry  Chrome  options=${options}  alias=${alias}
+    [Documentation]
+    ...  Opens Chrome. Setting ${CHROME LOG} to a filename will cause
+    ...  verbose chrome logs to be written to that file instead of stdout/stderr
+    [Arguments]       ${login_url}  ${alias}=${NONE}
+    ${options} =      Get Chrome Options
+    ${service_args}=  Run keyword if  '${CHROME LOG}' == ''
+    ...  Create List
+    ...  ELSE  Create list  --verbose  --log-path=${CHROME LOG}
+
+    Create Webdriver With Retry  Chrome  options=${options}  service_args=${service_args}  alias=${alias}
     Set Selenium Implicit Wait  ${IMPLICIT_WAIT}
     Set Selenium Timeout        ${TIMEOUT}
     Go To                       ${login_url}

--- a/cumulusci/robotframework/tests/salesforce/browsers.robot
+++ b/cumulusci/robotframework/tests/salesforce/browsers.robot
@@ -120,3 +120,35 @@ Initializing selenium speed via global variable
 
     Open test browser
     Assert keyword status  PASS  SeleniumLibrary.Set Selenium Speed  \${SELENIUM_SPEED}
+
+
+CHROME LOG variable
+    [Documentation]
+    ...  Verify that setting the variable CHROME_LOG to
+    ...  a path causes the log to be saved to that path
+    [Setup]     Remove file  ${TEMPDIR}/chrome_log.txt
+    [tags]  foo
+    [Teardown]  Run keywords
+    ...  Close all browsers
+    # Note: 'Remove file' gracefully handles the case where the file doesn't exist
+    ...  AND  Remove file  ${TEMPDIR}/chrome_log.txt
+
+    File should not exist  ${TEMPDIR}/chrome_log.txt
+    Set test variable      ${BROWSER}     headlesschrome
+
+    # Verify the variable has a default value
+    Variable should exist  ${CHROME LOG}
+    ...  Expected ${CHROME LOG} to be initialized but it wasn't
+    Should be equal  ${CHROME LOG}  ${EMPTY}
+    ...  Expected \${CHROME LOG} to be initialized to NONE but it was '${CHROME LOG}'
+
+    Open test browser
+    Close browser
+    sleep  1 second        # give chrome a moment to die with dignity
+    File should not exist  ${TEMPDIR}/chrome_log.txt
+
+    Set test variable      ${CHROME LOG}  ${TEMPDIR}/chrome_log.txt
+    Open test browser
+    Close browser
+    sleep  1 second        # give chrome a moment to die with dignity
+    File should exist      ${TEMPDIR}/chrome_log.txt


### PR DESCRIPTION
Setting this variable to a filename will cause chrome logs to be
written to that file.

I'm creating this PR even though I'm having a dickens of a time getting all of the tests to pass on circleci. The new test passes, but I am seeing timeout failures on the app menu in one of the other tests. <scratches head>


# Critical Changes

# Changes

# Issues Closed
