### PR TITLE
Feature/fix mdetl namespaced orgs

### DIFF
--- a/cumulusci/core/tasks.py
+++ b/cumulusci/core/tasks.py
@@ -8,7 +8,9 @@ import os
 import time
 import threading
 
+from cumulusci import __version__
 from cumulusci.utils import cd
+from cumulusci.core.exceptions import ServiceNotValid, ServiceNotConfigured
 from cumulusci.core.exceptions import TaskRequiresSalesforceOrg
 from cumulusci.core.exceptions import TaskOptionsError
 
@@ -223,3 +225,27 @@ class BaseTask(object):
             }
         )
         return [ui_step]
+
+
+class BaseSalesforceTask(BaseTask):
+    """Base for tasks that need a Salesforce org"""
+
+    name = "BaseSalesforceTask"
+    salesforce_task = True
+
+    def _get_client_name(self):
+        try:
+            app = self.project_config.keychain.get_service("connectedapp")
+            return app.client_id
+        except (ServiceNotValid, ServiceNotConfigured):
+            return "CumulusCI/{}".format(__version__)
+
+    def _run_task(self):
+        raise NotImplementedError("Subclasses should provide their own implementation")
+
+    def _update_credentials(self):
+        orig_config = self.org_config.config.copy()
+        self.org_config.refresh_oauth_token(self.project_config.keychain)
+        if self.org_config.config != orig_config:
+            self.logger.info("Org info updated, writing to keychain")
+            self.project_config.keychain.set_org(self.org_config)

--- a/cumulusci/tasks/metadata_etl/base.py
+++ b/cumulusci/tasks/metadata_etl/base.py
@@ -5,7 +5,7 @@ import tempfile
 from urllib.parse import quote, unquote
 
 from cumulusci.core.exceptions import CumulusCIException
-from cumulusci.tasks.salesforce import BaseSalesforceApiTask, Deploy
+from cumulusci.core.tasks import BaseSalesforceTask
 from cumulusci.salesforce_api.metadata import ApiRetrieveUnpackaged
 from cumulusci.tasks.metadata.package import PackageXmlGenerator
 from cumulusci.core.utils import process_bool_arg, process_list_arg
@@ -19,7 +19,7 @@ class MetadataOperation(enum.Enum):
     RETRIEVE = "retrieve"
 
 
-class BaseMetadataETLTask(BaseSalesforceApiTask, metaclass=ABCMeta):
+class BaseMetadataETLTask(BaseSalesforceTask, metaclass=ABCMeta):
     """Abstract base class for all Metadata ETL tasks. Concrete tasks should
     generally subclass BaseMetadataSynthesisTask, BaseMetadataTransformTask,
     or MetadataSingleEntityTransformTask."""
@@ -95,6 +95,9 @@ class BaseMetadataETLTask(BaseSalesforceApiTask, metaclass=ABCMeta):
         target_profile_xml.write_text(
             self._generate_package_xml(MetadataOperation.DEPLOY)
         )
+
+        # import is here to avoid an import cycle
+        from cumulusci.tasks.salesforce import Deploy
 
         api = Deploy(
             self.project_config,

--- a/cumulusci/tasks/metadata_etl/sharing.py
+++ b/cumulusci/tasks/metadata_etl/sharing.py
@@ -2,10 +2,11 @@ from datetime import datetime
 
 from cumulusci.core.exceptions import CumulusCIException, TaskOptionsError
 from cumulusci.tasks.metadata_etl import MetadataSingleEntityTransformTask
+from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 from cumulusci.utils.xml.metadata_tree import MetadataElement
 
 
-class SetOrgWideDefaults(MetadataSingleEntityTransformTask):
+class SetOrgWideDefaults(MetadataSingleEntityTransformTask, BaseSalesforceApiTask):
     entity = "CustomObject"
     task_options = {
         "org_wide_defaults": {

--- a/cumulusci/tasks/metadata_etl/tests/test_base.py
+++ b/cumulusci/tasks/metadata_etl/tests/test_base.py
@@ -56,7 +56,7 @@ class TestBaseMetadataETLTask:
             task.retrieve_dir
         )
 
-    @mock.patch("cumulusci.tasks.metadata_etl.base.Deploy")
+    @mock.patch("cumulusci.tasks.salesforce.Deploy")
     def test_deploy(self, deploy_mock):
         with tempfile.TemporaryDirectory() as tmpdir:
             task = create_task(

--- a/cumulusci/tasks/salesforce/BaseSalesforceTask.py
+++ b/cumulusci/tasks/salesforce/BaseSalesforceTask.py
@@ -1,25 +1,4 @@
-from cumulusci.core.tasks import BaseTask
-from cumulusci.core.exceptions import ServiceNotValid, ServiceNotConfigured
-from cumulusci import __version__
+# This moved to prevent an import cycle.
+from cumulusci.core.tasks import BaseSalesforceTask
 
-
-class BaseSalesforceTask(BaseTask):
-    name = "BaseSalesforceTask"
-    salesforce_task = True
-
-    def _get_client_name(self):
-        try:
-            app = self.project_config.keychain.get_service("connectedapp")
-            return app.client_id
-        except (ServiceNotValid, ServiceNotConfigured):
-            return "CumulusCI/{}".format(__version__)
-
-    def _run_task(self):
-        raise NotImplementedError("Subclasses should provide their own implementation")
-
-    def _update_credentials(self):
-        orig_config = self.org_config.config.copy()
-        self.org_config.refresh_oauth_token(self.project_config.keychain)
-        if self.org_config.config != orig_config:
-            self.logger.info("Org info updated, writing to keychain")
-            self.project_config.keychain.set_org(self.org_config)
+__all__ = ("BaseSalesforceTask",)


### PR DESCRIPTION
This builds on https://github.com/SFDO-Tooling/CumulusCI/pull/1622 to patch the Metadata ETL Sharing task so that it will work properly in namespaced scratch orgs.

Other Metadata ETL tasks should use `managed: False` in namespaced contexts.

- [ ] Hands-on testing
- [ ] Close review of behavior of `GrantProfileAllAccess`

# Critical Changes

# Changes

# Issues Closed
