### PR TITLE
1. bulk_mode. 2. _execute_step. 3. Type checking.

### DIFF
--- a/cumulusci/tasks/bulkdata/mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/mapping_parser.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from pydantic import Field, validator, ValidationError
 
 from cumulusci.utils.yaml.model_parser import CCIDictModel
+from typing_extensions import Literal
 
 LOGGER_NAME = "MAPPING_LOADER"
 logger = getLogger(LOGGER_NAME)
@@ -31,6 +32,7 @@ class MappingStep(CCIDictModel):
     action: str = "insert"
     oid_as_pk: bool = False  # this one should be discussed and probably deprecated
     record_type: str = None  # should be discussed and probably deprecated
+    bulk_mode: Literal["Serial", "Parallel"] = "Parallel"
 
     @validator("record_type")
     def record_type_is_deprecated(cls, v):

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ simple-salesforce==0.75.3
 six==1.14.0
 SQLAlchemy==1.3.15
 terminaltables==3.1.0
+typing-extensions==3.7.4.1
 unicodecsv==0.14.1
 uritemplate==3.0.1
 urllib3==1.25.8


### PR DESCRIPTION
1. I forgot bulk_mode in the schema because there were no example mapping files with it. Fixed now.

2. Renamed _load_mapping to _execute_step because _load_mapping always implied to me that it was loading the mapping file. This is subjective so tell me if you disagree.

3. I added stronger type checking which is how I found problem 1. Integration tests don't use bulk_mode but unit tests do

4. I deleted the test that checks what happens if a bulk_mode is set to a wrong value in mapping because the mapping parser should handle that now and it is hard to trigger with both pytest and typeguard working at the same time. In any case, the Salesforce API would give you an error pretty quickly if you found a way around all of this type checking...