### PR TITLE
Robot task now prints correct message based off of error code

### DIFF
--- a/cumulusci/tasks/robotframework/robotframework.py
+++ b/cumulusci/tasks/robotframework/robotframework.py
@@ -89,7 +89,7 @@ class Robot(BaseSalesforceTask):
         # http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#return-codes
         if 0 < num_failed < 250:
             raise RobotTestFailure(
-                "{} test{} failed.".format(num_failed, "" if num_failed == 1 else "s")
+                f"{num_failed} test{'' if num_failed == 1 else 's'} failed."
             )
         elif num_failed == 250:
             raise RobotTestFailure("250 or more tests failed.")

--- a/cumulusci/tasks/robotframework/robotframework.py
+++ b/cumulusci/tasks/robotframework/robotframework.py
@@ -84,8 +84,23 @@ class Robot(BaseSalesforceTask):
         )
 
         num_failed = robot_run(self.options["suites"], **options)
-        if num_failed:
-            raise RobotTestFailure("{} tests failed".format(num_failed))
+
+        # These numbers are from the robot framework user guide:
+        # http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#return-codes
+        if 0 < num_failed < 250:
+            raise RobotTestFailure(
+                "{} test{} failed.".format(num_failed, "" if num_failed == 1 else "s")
+            )
+        elif num_failed == 250:
+            raise RobotTestFailure("250 or more tests failed.")
+        elif num_failed == 251:
+            raise RobotTestFailure("Help or version information printed.")
+        elif num_failed == 252:
+            raise RobotTestFailure("Invalid test data or command line options.")
+        elif num_failed == 253:
+            raise RobotTestFailure("Test execution stopped by user.")
+        elif num_failed >= 255:
+            raise RobotTestFailure("Unexpected internal error")
 
 
 class RobotTestDoc(BaseTask):


### PR DESCRIPTION
Previously, the robot task assumed the error code represented the number of failed tests. That is only correct up to the value 250. After that, different values mean different things.

For more information see [return codes](http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#return-codes
) in the robot user guide 

# Critical Changes

# Changes

# Issues Closed
