### PR TITLE
Mock urllib in addition to Requests

### DIFF
--- a/cumulusci/utils/fileutils.py
+++ b/cumulusci/utils/fileutils.py
@@ -47,7 +47,7 @@ def load_from_source(
     <!DOCTYPE
 
     >>> from urllib.request import urlopen
-    >>> with urlopen("http://www.salesforce.com") as f:
+    >>> with urlopen("https://www.salesforce.com") as f:
     ...     with load_from_source(f) as (path, file):
     ...         print(path)
     ...         print(file.read(10).strip())  #doctest: +ELLIPSIS


### PR DESCRIPTION
I notice this test fails if the Internet is down. That's because it uses urllib in a doctest example and urrlib was not mocked.
