### PR TITLE
Handle nbsp in dependency cumulusci.yml

### DIFF
--- a/cumulusci/core/config/project_config.py
+++ b/cumulusci/core/config/project_config.py
@@ -1,4 +1,5 @@
 from distutils.version import LooseVersion
+import io
 import os
 import re
 
@@ -579,7 +580,7 @@ class BaseProjectConfig(BaseTaskFlowConfig):
 
         # Get the cumulusci.yml file
         contents = repo.file_contents("cumulusci.yml", ref=ref)
-        cumulusci_yml = yaml.safe_load(contents.decoded)
+        cumulusci_yml = cci_safe_load(io.StringIO(contents.decoded.decode("utf-8")))
 
         # Get the namespace from the cumulusci.yml if set
         package_config = cumulusci_yml.get("project", {}).get("package", {})


### PR DESCRIPTION
Since we handle non-breaking spaces when loading cumulusci.yml from a local directory, we should also handle them when loading cumulusci.yml from a dependency. Otherwise it's possible to have a config that works until it's loaded as a dependency. (e.g. https://success.salesforce.com/_ui/core/chatter/groups/GroupProfilePage?g=0F9300000009M9Z&fId=0D53A00004rLMTz&s1oid=00D300000000iTz&s1nid=0DB30000000072L&emkind=chatterCommentNotification&s1uid=0053A00000CB68z&emtm=1585875372517&fromEmail=1&s1ext=0)

# Critical Changes

# Changes

# Issues Closed
- Don't error when loading a dependency whose cumulusci.yml contains non-breaking spaces.