### PR TITLE
Add license-related preflight checks

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -144,6 +144,14 @@ tasks:
         description: Retrieves a list of the currently installed managed package namespaces and their versions
         class_path: cumulusci.tasks.salesforce.GetInstalledPackages
         group: Salesforce Metadata
+    get_available_licenses:
+        description: Retrieves a list of the currently available license definition keys
+        class_path: cumulusci.tasks.salesforce.license_preflights.GetAvailableLicenses
+        group: Salesforce Metadata
+    get_available_permission_set_licenses:
+        description: Retrieves a list of the currently available Permission Set License definition keys
+        class_path: cumulusci.tasks.salesforce.license_preflights.GetAvailablePermissionSetLicenses
+        group: Salesforce Metadata
     github_parent_pr_notes:
         description: Merges the description of a child pull request to the respective parent's pull request (if one exists).
         class_path: cumulusci.tasks.release_notes.task.ParentPullRequestNotes

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -143,15 +143,15 @@ tasks:
     get_installed_packages:
         description: Retrieves a list of the currently installed managed package namespaces and their versions
         class_path: cumulusci.tasks.salesforce.GetInstalledPackages
-        group: Salesforce Metadata
+        group: Salesforce Preflight Checks
     get_available_licenses:
         description: Retrieves a list of the currently available license definition keys
         class_path: cumulusci.tasks.salesforce.license_preflights.GetAvailableLicenses
-        group: Salesforce Metadata
+        group: Salesforce Preflight Checks
     get_available_permission_set_licenses:
         description: Retrieves a list of the currently available Permission Set License definition keys
         class_path: cumulusci.tasks.salesforce.license_preflights.GetAvailablePermissionSetLicenses
-        group: Salesforce Metadata
+        group: Salesforce Preflight Checks
     github_parent_pr_notes:
         description: Merges the description of a child pull request to the respective parent's pull request (if one exists).
         class_path: cumulusci.tasks.release_notes.task.ParentPullRequestNotes

--- a/cumulusci/tasks/salesforce/license_preflights.py
+++ b/cumulusci/tasks/salesforce/license_preflights.py
@@ -1,0 +1,25 @@
+from cumulusci.tasks.salesforce import BaseSalesforceApiTask
+
+
+class GetAvailableLicenses(BaseSalesforceApiTask):
+    def _run_task(self):
+        self.return_values = [
+            result["LicenseDefinitionKey"]
+            for result in self.sf.query("SELECT LicenseDefinitionKey FROM UserLicense")[
+                "records"
+            ]
+        ]
+        licenses = "\n".join(self.return_values)
+        self.logger.debug(f"Found licenses:\n{licenses}")
+
+
+class GetAvailablePermissionSetLicenses(BaseSalesforceApiTask):
+    def _run_task(self):
+        self.return_values = [
+            result["PermissionSetLicenseKey"]
+            for result in self.sf.query(
+                "SELECT PermissionSetLicenseKey FROM PermissionSetLicense"
+            )["records"]
+        ]
+        licenses = "\n".join(self.return_values)
+        self.logger.debug(f"Found permission set licenses:\n{licenses}")

--- a/cumulusci/tasks/salesforce/license_preflights.py
+++ b/cumulusci/tasks/salesforce/license_preflights.py
@@ -10,7 +10,7 @@ class GetAvailableLicenses(BaseSalesforceApiTask):
             ]
         ]
         licenses = "\n".join(self.return_values)
-        self.logger.debug(f"Found licenses:\n{licenses}")
+        self.logger.info(f"Found licenses:\n{licenses}")
 
 
 class GetAvailablePermissionSetLicenses(BaseSalesforceApiTask):
@@ -22,4 +22,4 @@ class GetAvailablePermissionSetLicenses(BaseSalesforceApiTask):
             )["records"]
         ]
         licenses = "\n".join(self.return_values)
-        self.logger.debug(f"Found permission set licenses:\n{licenses}")
+        self.logger.info(f"Found permission set licenses:\n{licenses}")

--- a/cumulusci/tasks/salesforce/tests/test_license_preflights.py
+++ b/cumulusci/tasks/salesforce/tests/test_license_preflights.py
@@ -1,0 +1,45 @@
+from unittest.mock import Mock
+import unittest
+
+from cumulusci.tasks.salesforce.license_preflights import (
+    GetAvailableLicenses,
+    GetAvailablePermissionSetLicenses,
+)
+from .util import create_task
+
+
+class TestLicensePreflights(unittest.TestCase):
+    def test_license_preflight(self):
+        task = create_task(GetAvailableLicenses, {})
+        task._init_api = Mock()
+        task._init_api.return_value.query.return_value = {
+            "totalSize": 2,
+            "records": [
+                {"LicenseDefinitionKey": "TEST1"},
+                {"LicenseDefinitionKey": "TEST2"},
+            ],
+        }
+        task()
+
+        task._init_api.return_value.query.assert_called_once_with(
+            "SELECT LicenseDefinitionKey FROM UserLicense"
+        )
+        assert task.return_values == ["TEST1", "TEST2"]
+
+    def test_psl_preflight(self):
+        task = create_task(GetAvailablePermissionSetLicenses, {})
+        task._init_api = Mock()
+
+        task._init_api.return_value.query.return_value = {
+            "totalSize": 2,
+            "records": [
+                {"PermissionSetLicenseKey": "TEST1"},
+                {"PermissionSetLicenseKey": "TEST2"},
+            ],
+        }
+        task()
+
+        task._init_api.return_value.query.assert_called_once_with(
+            "SELECT PermissionSetLicenseKey FROM PermissionSetLicense"
+        )
+        assert task.return_values == ["TEST1", "TEST2"]

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -1081,6 +1081,34 @@ Command Syntax
 
 
 
+**get_available_licenses**
+==========================================
+
+**Description:** Retrieves a list of the currently available license definition keys
+
+**Class:** cumulusci.tasks.salesforce.license_preflights.GetAvailableLicenses
+
+Command Syntax
+------------------------------------------
+
+``$ cci task run get_available_licenses``
+
+
+
+**get_available_permission_set_licenses**
+==========================================
+
+**Description:** Retrieves a list of the currently available Permission Set License definition keys
+
+**Class:** cumulusci.tasks.salesforce.license_preflights.GetAvailablePermissionSetLicenses
+
+Command Syntax
+------------------------------------------
+
+``$ cci task run get_available_permission_set_licenses``
+
+
+
 **github_parent_pr_notes**
 ==========================================
 
@@ -1632,10 +1660,10 @@ Options
 
 	 If True, set is_listed to True on the version. Default: False
 
-``-o labels LABELS``
+``-o labels_path LABELSPATH``
 	 *Optional*
 
-	 Path to a file that will be updated with strings to be translated.
+	 Path to a folder containing translations.
 
 **org_settings**
 ==========================================


### PR DESCRIPTION
# Critical Changes

# Changes

- Two new preflight check tasks are available for use in MetaDeploy: `get_available_licenses()` and `get_available_permission_set_licenses()`. These tasks make available lists of the License Definition Keys for the org's licenses or PSLs.

# Issues Closed
