### PR TITLE
Deploy org settings using the org's API version, not the package's

### DIFF
--- a/cumulusci/tasks/salesforce/org_settings.py
+++ b/cumulusci/tasks/salesforce/org_settings.py
@@ -67,8 +67,7 @@ class DeployOrgSettings(Deploy):
             with open(settings_file, "w") as f:
                 f.write(SETTINGS_XML.format(settingsName=settings_name, values=values))
         api_version = (
-            self.options.get("api_version")
-            or self.project_config.project__package__api_version
+            self.options.get("api_version") or self.org_config.latest_api_version
         )
         with open("package.xml", "w") as f:
             f.write(PACKAGE_XML.format(api_version=api_version))

--- a/cumulusci/tasks/salesforce/tests/test_org_settings.py
+++ b/cumulusci/tasks/salesforce/tests/test_org_settings.py
@@ -24,7 +24,7 @@ class TestDeployOrgSettings:
                     f,
                 )
             path = os.path.join(d, "dev.json")
-            task_options = {"definition_file": path}
+            task_options = {"definition_file": path, "api_version": "48.0"}
             task = create_task(DeployOrgSettings, task_options)
             task.api_class = Mock()
             task()


### PR DESCRIPTION
This is an attempt to fix an issue where Metecho can't deploy org settings for EDA because EDA's package version is 45.0 but it has org definition files using settings that are only available in more recent API versions. sfdx also uses the latest API version when it deploys these settings.

# Critical Changes

# Changes

# Issues Closed
