### PR TITLE
Feature/robot app launcher stability

### DIFF
--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -496,7 +496,7 @@ class Salesforce(object):
         will need to create a custom keyword.
 
         If the retry parameter is true, the keyword will
-        close and then re-open the app launcher it times out
+        close and then re-open the app launcher if it times out
         while waiting for the dialog to open.
         """
 

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -485,6 +485,7 @@ class Salesforce(object):
         output += pformat(self.selenium.driver.capabilities, indent=4)
         self.builtin.log(output, level=loglevel)
 
+    @capture_screenshot_on_error
     def open_app_launcher(self, retry=True):
         """Opens the Saleforce App Launcher Modal
 
@@ -678,7 +679,6 @@ class Salesforce(object):
         locator = lex_locators["app_launcher"]["app_link"].format(app_name)
         self.open_app_launcher()
         self.selenium.wait_until_page_contains_element(locator, timeout=30)
-        self.selenium.scroll_element_into_view(locator)
         self.selenium.set_focus_to_element(locator)
         elem = self.selenium.get_webelement(locator)
         link = elem.find_element_by_xpath("../../..")
@@ -692,7 +692,7 @@ class Salesforce(object):
         locator = lex_locators["app_launcher"]["tab_link"].format(tab_name)
         self.open_app_launcher()
         self.selenium.wait_until_page_contains_element(locator)
-        self.selenium.scroll_element_into_view(locator)
+        self.selenium.set_focus_to_element(locator)
         self._jsclick(locator)
         self.wait_until_modal_is_closed()
 

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -485,7 +485,7 @@ class Salesforce(object):
         output += pformat(self.selenium.driver.capabilities, indent=4)
         self.builtin.log(output, level=loglevel)
 
-    def open_app_launcher(self):
+    def open_app_launcher(self, retry=True):
         """Opens the Saleforce App Launcher Modal
 
         Note: starting with Spring '20 the app launcher button opens a
@@ -493,24 +493,38 @@ class Salesforce(object):
         this keyword will continue to open the modal rather than the
         menu. If you need to interact with the app launcher menu, you
         will need to create a custom keyword.
-        """
-        locator = lex_locators["app_launcher"]["button"]
-        self.builtin.log("Clicking App Launcher button")
-        self._jsclick(locator)
 
-        api_version = int(float(self.get_latest_api_version()))
-        if api_version >= 48:
-            self.selenium.wait_until_element_is_visible(
-                lex_locators["app_launcher"]["menu"],
-                error="Expected to see the app launcher menu, but didn't",
-            )
-            element = self.selenium.get_webelement(
-                lex_locators["app_launcher"]["view_all"]
-            )
-            self.builtin.log("clicking 'view all' button")
-            self.selenium.capture_page_screenshot()
-            self._jsclick(element)
+        If the retry parameter is true, the keyword will
+        close and then re-open the app launcher it times out
+        while waiting for the dialog to open.
+        """
+
+        self._jsclick("sf:app_launcher.button")
+        self._jsclick("sf:app_launcher.view_all")
         self.wait_until_modal_is_open()
+        try:
+            # the modal may be open, but not yet fully rendered
+            # wait until at least one link appears. We've seen that sometimes
+            # the dialog hangs prior to any links showing up
+            self.selenium.wait_until_element_is_visible(
+                "xpath://ul[contains(@class, 'al-modal-list')]//li"
+            )
+
+        except Exception as e:
+            # This should never happen, yet it does. Experience has
+            # shown that sometimes (at least in spring '20) the modal
+            # never renders. Refreshing the modal seems to fix it.
+            if retry:
+                self.builtin.log(
+                    f"caught exception {e} waiting for app launcher; retrying", "DEBUG"
+                )
+                self.selenium.press_keys("sf:modal.is_open", "ESCAPE")
+                self.wait_until_modal_is_closed()
+                self.open_app_launcher(retry=False)
+            else:
+                self.builtin.log(
+                    f"caught exception waiting for app launcher; not retrying", "DEBUG"
+                )
 
     def populate_field(self, name, value):
         """Enters a value into an input or textarea field.
@@ -662,29 +676,24 @@ class Salesforce(object):
     def select_app_launcher_app(self, app_name):
         """Navigates to a Salesforce App via the App Launcher """
         locator = lex_locators["app_launcher"]["app_link"].format(app_name)
-        self.builtin.log("Opening the App Launcher")
         self.open_app_launcher()
-        self.builtin.log("Getting the web element for the app")
+        self.selenium.wait_until_page_contains_element(locator, timeout=30)
+        self.selenium.scroll_element_into_view(locator)
         self.selenium.set_focus_to_element(locator)
         elem = self.selenium.get_webelement(locator)
-        self.builtin.log("Getting the parent link from the web element")
         link = elem.find_element_by_xpath("../../..")
         self.selenium.set_focus_to_element(link)
-        self.builtin.log("Clicking the link")
         link.click()
-        self.builtin.log("Waiting for modal to close")
         self.wait_until_modal_is_closed()
 
     @capture_screenshot_on_error
     def select_app_launcher_tab(self, tab_name):
         """Navigates to a tab via the App Launcher"""
         locator = lex_locators["app_launcher"]["tab_link"].format(tab_name)
-        self.builtin.log("Opening the App Launcher")
         self.open_app_launcher()
-        self.builtin.log("Clicking App Tab")
-        element = self.selenium.get_webelement(locator)
-        self._jsclick(element)
-        self.builtin.log("Waiting for modal to close")
+        self.selenium.wait_until_page_contains_element(locator)
+        self.selenium.scroll_element_into_view(locator)
+        self._jsclick(locator)
         self.wait_until_modal_is_closed()
 
     def salesforce_delete(self, obj_name, obj_id):

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -526,6 +526,7 @@ class Salesforce(object):
                 self.builtin.log(
                     f"caught exception waiting for app launcher; not retrying", "DEBUG"
                 )
+                raise
 
     def populate_field(self, name, value):
         """Enters a value into an input or textarea field.


### PR DESCRIPTION
This changes the app launcher keywords to work around the fact that sometimes the app launcher
hangs up while rendering. The `Open App Launcher` keyword tries to detect that, and will refresh
the modal. 

While this code still doesn't work 100% of the time, it went from failing every 7-8 test runs to once out of 256 last night. 


# Critical Changes

# Changes

# Issues Closed
