### PR TITLE
Don't prompt for scratch org recreation

### DIFF
--- a/cumulusci/cli/runtime.py
+++ b/cumulusci/cli/runtime.py
@@ -98,23 +98,20 @@ class CliRuntime(BaseCumulusCI):
     def check_org_expired(self, org_name, org_config):
         if org_config.scratch and org_config.date_created and org_config.expired:
             click.echo(click.style("The scratch org is expired", fg="yellow"))
-            if click.confirm("Attempt to recreate the scratch org?", default=True):
-                self.keychain.create_scratch_org(
-                    org_name,
-                    org_config.config_name,
-                    days=org_config.days,
-                    set_password=org_config.set_password,
+            self.keychain.create_scratch_org(
+                org_name,
+                org_config.config_name,
+                days=org_config.days,
+                set_password=org_config.set_password,
+            )
+            click.echo(
+                click.style(
+                    "Org config was refreshed, attempting to recreate scratch org",
+                    fg="yellow",
                 )
-                click.echo(
-                    "Org config was refreshed, attempting to recreate scratch org"
-                )
-                org_config = self.keychain.get_org(org_name)
-                org_config.create_org()
-            else:
-                raise click.ClickException(
-                    f"The target scratch org is expired.  You can use cci org remove {org_name} "
-                    "to remove the org and then recreate the config manually"
-                )
+            )
+            org_config = self.keychain.get_org(org_name)
+            org_config.create_org()
 
         return org_config
 

--- a/cumulusci/cli/tests/test_runtime.py
+++ b/cumulusci/cli/tests/test_runtime.py
@@ -102,8 +102,7 @@ class TestCliRuntime(unittest.TestCase):
         with self.assertRaises(click.UsageError):
             org_name, org_config_result = config.get_org("test", fail_if_missing=True)
 
-    @mock.patch("click.confirm")
-    def test_check_org_expired(self, confirm):
+    def test_check_org_expired(self):
         config = CliRuntime()
         config.keychain = mock.Mock()
         org_config = OrgConfig(
@@ -114,27 +113,9 @@ class TestCliRuntime(unittest.TestCase):
             },
             "test",
         )
-        confirm.return_value = True
 
         config.check_org_expired("test", org_config)
         config.keychain.create_scratch_org.assert_called_once()
-
-    @mock.patch("click.confirm")
-    def test_check_org_expired_decline(self, confirm):
-        config = CliRuntime()
-        config.keychain = mock.Mock()
-        org_config = OrgConfig(
-            {
-                "scratch": True,
-                "date_created": date.today() - timedelta(days=2),
-                "expired": True,
-            },
-            "test",
-        )
-        confirm.return_value = False
-
-        with self.assertRaises(click.ClickException):
-            config.check_org_expired("test", org_config)
 
     def test_check_org_overwrite_not_found(self):
         config = CliRuntime()


### PR DESCRIPTION
This commit suppreses the user prompt upon scratch org expiration.


----

# Critical Changes

# Changes
- We've removed the prompt users see when a scratch org expires, and now automatically recreate the scratch org.

# Issues Closed
- Fixes #1136