### PR TITLE
change suggest error cmd text

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -175,7 +175,7 @@ def pass_runtime(func=None, require_project=True, require_keychain=False):
 
 
 SUGGEST_ERROR_COMMAND = (
-    """Type `cci error --help` for more information about debugging errors."""
+    """Run this command for more information about debugging errors: cci error --help"""
 )
 
 


### PR DESCRIPTION
# Critical Changes

# Changes
* change the text which is displayed to users on error to not use backticks.

# Issues Closed
