### PR TITLE
Don't log stacktrace when running `cci error` cmds

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -210,6 +210,7 @@ def main(args=None):
         # Only create logfiles for commands
         # that are not `cci error`
         is_error_command = len(args) > 2 and args[1] == "error"
+        tempfile_path = None
         if not is_error_command:
             logger, tempfile_path = get_tempfile_logger()
             stack.enter_context(tee_stdout_stderr(args, logger, tempfile_path))
@@ -242,8 +243,11 @@ def handle_exception(error, is_error_cmd, logfile_path):
     if not is_error_cmd:
         click.echo(click.style(SUGGEST_ERROR_COMMAND, fg="yellow"))
 
-    with open(logfile_path, "a") as log_file:
-        traceback.print_exc(file=log_file)  # log stacktrace silently
+    # This is None if we're handling an exception for a
+    # `cci error` command.
+    if logfile_path:
+        with open(logfile_path, "a") as log_file:
+            traceback.print_exc(file=log_file)  # log stacktrace silently
 
 
 def connection_error_message():

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -258,6 +258,19 @@ class TestCCI(unittest.TestCase):
     @mock.patch("cumulusci.cli.cci.open")
     @mock.patch("cumulusci.cli.cci.traceback")
     @mock.patch("cumulusci.cli.cci.click.style")
+    def test_handle_exception__error_cmd(self, style, traceback, cci_open):
+        """Ensure we don't write to logfiles when running `cci error ...` commands."""
+        error = "Something bad happened."
+        logfile_path = None
+        cci.handle_exception(error, False, logfile_path)
+
+        style.call_args_list[0][0] == f"Error: {error}"
+        style.call_args_list[1][0] == cci.SUGGEST_ERROR_COMMAND
+        assert not cci_open.called
+
+    @mock.patch("cumulusci.cli.cci.open")
+    @mock.patch("cumulusci.cli.cci.traceback")
+    @mock.patch("cumulusci.cli.cci.click.style")
     def test_handle_click_exception(self, style, traceback, cci_open):
         logfile_path = "file.log"
         Path(logfile_path).touch()


### PR DESCRIPTION
# Critical Changes

# Changes
* We now set the `tempfile_log` variable to None and check for the presence of its value in the `handle_exception()` method. This fixes a bug that occurred if we encountered an exception when running any of the `cci error ...` commands.

# Issues Closed
