### PR TITLE
Add metadata map for Navigation Menu

### DIFF
--- a/cumulusci/tasks/metadata/metadata_map.yml
+++ b/cumulusci/tasks/metadata/metadata_map.yml
@@ -266,6 +266,10 @@ MobileApplicationDetails:
     - type: MobileApplicationDetail
       class: MetadataFilenameParser
       extension: MobileApplicationDetail
+navigationMenus:
+    - type: NavigationMenu
+      class: MetadataFilenameParser
+      extension: navigationMenu
 namedCredentials:
     - type: NamedCredential
       class: MetadataFilenameParser


### PR DESCRIPTION
# Critical Changes

# Changes

- The `NavigationMenu` metadata type is now supported.

# Issues Closed
