### PR TITLE
Installed package access in OrgConfig + Apex test code coverage enforcement

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -563,6 +563,15 @@ def project_init(runtime):
         test_name_match = None
     context["test_name_match"] = test_name_match
 
+    context["code_coverage"] = None
+    if click.confirm(
+        click.style("Do you want to enforce Apex code coverage?", bold=True),
+        default=True,
+    ):
+        context["code_coverage"] = click.prompt(
+            click.style("Minimum code coverage percentage", bold=True), default=75
+        )
+
     # Render templates
     for name in (".gitignore", "README.md", "cumulusci.yml"):
         template = env.get_template(name)

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -565,7 +565,9 @@ def project_init(runtime):
 
     context["code_coverage"] = None
     if click.confirm(
-        click.style("Do you want to enforce Apex code coverage?", bold=True),
+        click.style(
+            "Do you want to check Apex code coverage when tests are run?", bold=True
+        ),
         default=True,
     ):
         context["code_coverage"] = click.prompt(

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -519,8 +519,13 @@ Environment Info: Rossian / x68_46
                 "uat/",  # git_prefix_beta
                 "rel/",  # git_prefix_release
                 "%_TEST%",  # test_name_match
+                "90",  # code_coverage
             )
-            click.confirm.side_effect = (True, True)  # is managed?  # extending?
+            click.confirm.side_effect = (
+                True,
+                True,
+                True,
+            )  # is managed? extending? enforce Apex coverage?
 
             runtime = CliRuntime(
                 config={"project": {"test": {"name_match": "%_TEST%"}}},
@@ -575,8 +580,13 @@ Environment Info: Rossian / x68_46
                 "uat/",  # git_prefix_beta
                 "rel/",  # git_prefix_release
                 "%_TEST%",  # test_name_match
+                "90",  # code_coverage
             )
-            click.confirm.side_effect = (True, True)  # is managed?  # extending?
+            click.confirm.side_effect = (
+                True,
+                True,
+                True,
+            )  # is managed? extending? enforce code coverage?
 
             run_click_command(cci.project_init)
 
@@ -598,6 +608,7 @@ Environment Info: Rossian / x68_46
                         "output": "robot/testproj/doc/testproj_tests.html",
                     }
                 },
+                "run_tests": {"options": {"required_org_code_coverage_percent": 90}},
             }
             self.assertDictEqual(config["tasks"], expected_tasks)
 

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -812,7 +812,11 @@ Environment Info: Rossian / x68_46
     @responses.activate
     def test_org_connect(self, oauth):
         oauth.return_value = mock.Mock(
-            return_value={"instance_url": "https://instance", "access_token": "BOGUS"}
+            return_value={
+                "instance_url": "https://instance",
+                "access_token": "BOGUS",
+                "id": "OODxxxxxxxxxxxx/user",
+            }
         )
         runtime = mock.Mock()
         responses.add(
@@ -823,7 +827,7 @@ Environment Info: Rossian / x68_46
         )
         responses.add(
             method="GET",
-            url="https://instance/services/data/v45.0/sobjects/Organization/None",
+            url="https://instance/services/data/v45.0/sobjects/Organization/OODxxxxxxxxxxxx",
             json={
                 "TrialExpirationDate": None,
                 "OrganizationType": "Developer Edition",
@@ -831,6 +835,7 @@ Environment Info: Rossian / x68_46
             },
             status=200,
         )
+        responses.add("GET", "https://instance/services/data", json=[{"version": 45.0}])
         run_click_command(
             cci.org_connect,
             runtime=runtime,
@@ -851,7 +856,11 @@ Environment Info: Rossian / x68_46
     @responses.activate
     def test_org_connect_expires(self, oauth):
         oauth.return_value = mock.Mock(
-            return_value={"instance_url": "https://instance", "access_token": "BOGUS"}
+            return_value={
+                "instance_url": "https://instance",
+                "access_token": "BOGUS",
+                "id": "OODxxxxxxxxxxxx/user",
+            }
         )
         runtime = mock.Mock()
         responses.add(
@@ -862,7 +871,7 @@ Environment Info: Rossian / x68_46
         )
         responses.add(
             method="GET",
-            url="https://instance/services/data/v45.0/sobjects/Organization/None",
+            url="https://instance/services/data/v45.0/sobjects/Organization/OODxxxxxxxxxxxx",
             json={
                 "TrialExpirationDate": "1970-01-01T12:34:56.000+0000",
                 "OrganizationType": "Developer Edition",
@@ -870,6 +879,8 @@ Environment Info: Rossian / x68_46
             },
             status=200,
         )
+        responses.add("GET", "https://instance/services/data", json=[{"version": 45.0}])
+
         run_click_command(
             cci.org_connect,
             runtime=runtime,

--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -188,13 +188,13 @@ class OrgConfig(BaseConfig):
         Use a package Id to handle this circumstance."""
         installed_version = self.installed_packages.get(package_identifier)
 
-        if len(installed_version) > 1:
+        if not installed_version:
+            return False
+        elif len(installed_version) > 1:
             raise CumulusCIException(
                 f"Cannot check installed version of {package_identifier}, because multiple "
                 f"packages are installed that match this identifier."
             )
-        elif not installed_version:
-            return False
 
         return installed_version[0] >= version_identifier
 
@@ -210,7 +210,7 @@ class OrgConfig(BaseConfig):
         Beta version of a package are represented as "1.2.3b5", where 5 is the build number."""
         if not self._installed_packages:
             response = self.salesforce_client.restful(
-                "tooling/query/?q=SELECT SubscriberPackage.NamespacePrefix, SubscriSubscriberPackageVersion.MajorVersion, "
+                "tooling/query/?q=SELECT SubscriberPackage.Id, SubscriberPackage.NamespacePrefix, SubscriberPackageVersion.MajorVersion, "
                 "SubscriberPackageVersion.MinorVersion, SubscriberPackageVersion.PatchVersion,  "
                 "SubscriberPackageVersion.BuildNumber, SubscriberPackageVersion.IsBeta "
                 "FROM InstalledSubscriberPackage"

--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -216,7 +216,7 @@ class OrgConfig(BaseConfig):
                 "FROM InstalledSubscriberPackage"
             )
 
-            self._installed_packages = defaultdict(lambda: [])
+            self._installed_packages = defaultdict(list)
             for package in response["records"]:
                 sp = package["SubscriberPackage"]
                 spv = package["SubscriberPackageVersion"]

--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -186,16 +186,18 @@ class OrgConfig(BaseConfig):
         if not self._installed_packages:
             response = self.salesforce_client.restful(
                 "tooling/query/?q=SELECT SubscriberPackage.NamespacePrefix, SubscriberPackageVersion.MajorVersion, "
-                "SubscriberPackageVersion.MinorVersion, SubscriberPackageVersion.PatchVersion, "
+                "SubscriberPackageVersion.MinorVersion, SubscriberPackageVersion.PatchVersion "
                 "FROM InstalledSubscriberPackage"
             )
 
             self._installed_packages = {}
             for package in response["records"]:
                 sp = package["SubscriberPackage"]
-                version = f"{sp['MajorVersion']}.{sp['MinorVersion']}"
-                if sp["PatchVersion"]:
-                    version += f".{sp['PatchVersion']}"
+                spv = package["SubscriberPackageVersion"]
+                # PatchVersion is a 0 on a non-patch version.
+                version = (
+                    f"{spv['MajorVersion']}.{spv['MinorVersion']}.{spv['PatchVersion']}"
+                )
                 self._installed_packages[sp["NamespacePrefix"]] = StrictVersion(version)
 
         return self._installed_packages

--- a/cumulusci/core/flowrunner.py
+++ b/cumulusci/core/flowrunner.py
@@ -62,7 +62,7 @@ import copy
 import logging
 from collections import defaultdict
 from collections import namedtuple
-from distutils.version import StrictVersion, LooseVersion
+from distutils.version import LooseVersion
 from operator import attrgetter
 
 from jinja2.sandbox import ImmutableSandboxedEnvironment
@@ -359,7 +359,6 @@ class FlowCoordinator(object):
                     jinja2_context = {
                         "project_config": step.project_config,
                         "org_config": self.org_config,
-                        "StrictVersion": StrictVersion,
                     }
                     expr = jinja2_env.compile_expression(step.when)
                     value = expr(**jinja2_context)

--- a/cumulusci/core/flowrunner.py
+++ b/cumulusci/core/flowrunner.py
@@ -62,7 +62,7 @@ import copy
 import logging
 from collections import defaultdict
 from collections import namedtuple
-from distutils.version import LooseVersion
+from distutils.version import StrictVersion, LooseVersion
 from operator import attrgetter
 
 from jinja2.sandbox import ImmutableSandboxedEnvironment
@@ -359,6 +359,7 @@ class FlowCoordinator(object):
                     jinja2_context = {
                         "project_config": step.project_config,
                         "org_config": self.org_config,
+                        "StrictVersion": StrictVersion,
                     }
                     expr = jinja2_env.compile_expression(step.when)
                     value = expr(**jinja2_context)

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -1309,7 +1309,7 @@ class TestOrgConfig(unittest.TestCase):
             "03350000000DEz7AAG": [StrictVersion("1.10b5")],
         }
         config._client.restful.assert_called_once_with(
-            "tooling/query/?q=SELECT SubscriberPackage.NamespacePrefix, SubscriSubscriberPackageVersion.MajorVersion, "
+            "tooling/query/?q=SELECT SubscriberPackage.Id, SubscriberPackage.NamespacePrefix, SubscriberPackageVersion.MajorVersion, "
             "SubscriberPackageVersion.MinorVersion, SubscriberPackageVersion.PatchVersion,  "
             "SubscriberPackageVersion.BuildNumber, SubscriberPackageVersion.IsBeta "
             "FROM InstalledSubscriberPackage"
@@ -1335,6 +1335,7 @@ class TestOrgConfig(unittest.TestCase):
         assert config.has_minimum_package_version("TESTY", "1.10b5")
         assert not config.has_minimum_package_version("TESTY", "1.10b6")
         assert not config.has_minimum_package_version("TESTY", "1.10")
+        assert not config.has_minimum_package_version("npsp", "1.0")
 
         assert config.has_minimum_package_version("03350000000DEz4AAG", "3.119")
 

--- a/cumulusci/files/templates/project/cumulusci.yml
+++ b/cumulusci/files/templates/project/cumulusci.yml
@@ -53,3 +53,9 @@ tasks:
         options:
             path: robot/{{project_name}}/tests
             output: robot/{{project_name}}/doc/{{project_name}}_tests.html
+
+    {% if code_coverage %}
+    run_tests:
+        options:
+            required_org_code_coverage_percent: {{code_coverage}}
+    {% endif %}

--- a/cumulusci/tasks/apex/testrunner.py
+++ b/cumulusci/tasks/apex/testrunner.py
@@ -528,7 +528,10 @@ class RunApexTests(BaseSalesforceApiTask):
             )
 
         if self.code_coverage_level:
-            self._check_code_coverage()
+            if self.options["namespace"] not in self.org_config.installed_packages:
+                self._check_code_coverage()
+            else:
+                self.logger.info("This is a managed org; not checking code coverage.")
         else:
             self.logger.info(
                 "No code coverage level specified; not checking code coverage."

--- a/cumulusci/tasks/apex/testrunner.py
+++ b/cumulusci/tasks/apex/testrunner.py
@@ -528,7 +528,7 @@ class RunApexTests(BaseSalesforceApiTask):
             )
 
         if self.code_coverage_level:
-            if self.options["namespace"] not in self.org_config.installed_packages:
+            if self.options.get("namespace") not in self.org_config.installed_packages:
                 self._check_code_coverage()
             else:
                 self.logger.info("This is a managed org; not checking code coverage.")

--- a/cumulusci/tasks/apex/testrunner.py
+++ b/cumulusci/tasks/apex/testrunner.py
@@ -216,7 +216,7 @@ class RunApexTests(BaseSalesforceApiTask):
         if "required_org_code_coverage_percent" in self.options:
             try:
                 self.code_coverage_level = int(
-                    self.options["required_org_code_coverage_percent"]
+                    self.options["required_org_code_coverage_percent"].rstrip("%")
                 )
             except ValueError:
                 raise TaskOptionsError(
@@ -531,7 +531,9 @@ class RunApexTests(BaseSalesforceApiTask):
             if self.options.get("namespace") not in self.org_config.installed_packages:
                 self._check_code_coverage()
             else:
-                self.logger.info("This is a managed org; not checking code coverage.")
+                self.logger.info(
+                    "This org contains a managed installation; not checking code coverage."
+                )
         else:
             self.logger.info(
                 "No code coverage level specified; not checking code coverage."

--- a/cumulusci/tasks/apex/testrunner.py
+++ b/cumulusci/tasks/apex/testrunner.py
@@ -160,6 +160,9 @@ class RunApexTests(BaseSalesforceApiTask):
             "description": "By default, all failures must match retry_failures to perform "
             "a retry. Set retry_always to True to retry all failed tests if any failure matches."
         },
+        "required_org_code_coverage_percent": {
+            "description": "Require at least X percent code coverage across the org following the test run."
+        },
     }
 
     def _init_options(self, kwargs):
@@ -209,6 +212,18 @@ class RunApexTests(BaseSalesforceApiTask):
         )
 
         self.counts = {}
+
+        if "required_org_code_coverage_percent" in self.options:
+            try:
+                self.code_coverage_level = int(
+                    self.options["required_org_code_coverage_percent"]
+                )
+            except ValueError:
+                raise TaskOptionsError(
+                    f"Invalid code coverage level {self.options['required_org_code_coverage_percent']}"
+                )
+        else:
+            self.code_coverage_level = None
 
     # pylint: disable=W0201
     def _init_class(self):
@@ -511,6 +526,25 @@ class RunApexTests(BaseSalesforceApiTask):
                     self.counts.get("Fail"), self.counts.get("CompileFail")
                 )
             )
+
+        if self.code_coverage_level:
+            self._check_code_coverage()
+        else:
+            self.logger.info(
+                "No code coverage level specified; not checking code coverage."
+            )
+
+    def _check_code_coverage(self):
+        result = self.tooling.query("SELECT PercentCovered FROM ApexOrgWideCoverage")
+        coverage = result["records"][0]["PercentCovered"]
+        if coverage < self.code_coverage_level:
+            raise ApexTestException(
+                f"Organization-wide code coverage of {coverage}% is below required level of {self.code_coverage_level}"
+            )
+
+        self.logger.info(
+            f"Organization-wide code coverage of {coverage}% meets expectations."
+        )
 
     def _attempt_retries(self):
         total_method_retries = sum(

--- a/cumulusci/tasks/apex/tests/test_apex_tasks.py
+++ b/cumulusci/tasks/apex/tests/test_apex_tasks.py
@@ -515,6 +515,18 @@ class TestRunApexTests(MockLoggerMixin, unittest.TestCase):
         task()
         task._check_code_coverage.assert_called_once()
 
+    def test_exception_bad_code_coverage(self):
+        task_config = TaskConfig()
+        task_config.config["options"] = {
+            "junit_output": "results_junit.xml",
+            "poll_interval": 1,
+            "test_name_match": "%_TEST",
+            "required_org_code_coverage_percent": "foo",
+        }
+
+        with self.assertRaises(TaskOptionsError):
+            RunApexTests(self.project_config, task_config, self.org_config)
+
     @responses.activate
     def test_run_task__code_coverage_managed(self):
         self._mock_apex_class_query()

--- a/cumulusci/tasks/apex/tests/test_apex_tasks.py
+++ b/cumulusci/tasks/apex/tests/test_apex_tasks.py
@@ -1,3 +1,4 @@
+from distutils.version import StrictVersion
 import http.client
 import os
 import shutil
@@ -466,6 +467,109 @@ class TestRunApexTests(MockLoggerMixin, unittest.TestCase):
         task()
         log = self._task_log_handler.messages
         assert "Completed: 0  Processing: 1 (TestClass_TEST)  Queued: 0" in log["info"]
+
+    @responses.activate
+    def test_run_task__no_code_coverage(self):
+        self._mock_apex_class_query()
+        self._mock_run_tests()
+        self._mock_get_failed_test_classes()
+        self._mock_tests_complete()
+        self._mock_get_test_results()
+        task_config = TaskConfig()
+        task_config.config["options"] = {
+            "junit_output": "results_junit.xml",
+            "poll_interval": 1,
+            "test_name_match": "%_TEST",
+        }
+        task = RunApexTests(self.project_config, task_config, self.org_config)
+        task._check_code_coverage = Mock()
+        task()
+        task._check_code_coverage.assert_not_called()
+
+    @responses.activate
+    def test_run_task__checks_code_coverage(self):
+        self._mock_apex_class_query()
+        self._mock_run_tests()
+        self._mock_get_failed_test_classes()
+        self._mock_tests_complete()
+        self._mock_get_test_results()
+        task_config = TaskConfig()
+        task_config.config["options"] = {
+            "junit_output": "results_junit.xml",
+            "poll_interval": 1,
+            "test_name_match": "%_TEST",
+            "required_org_code_coverage_percent": "90",
+        }
+
+        org_config = OrgConfig(
+            {
+                "id": "foo/1",
+                "instance_url": "https://example.com",
+                "access_token": "abc123",
+            },
+            "test",
+        )
+        org_config._installed_packages = {"TEST": StrictVersion("1.2.3")}
+        task = RunApexTests(self.project_config, task_config, org_config)
+        task._check_code_coverage = Mock()
+        task()
+        task._check_code_coverage.assert_called_once()
+
+    @responses.activate
+    def test_run_task__code_coverage_managed(self):
+        self._mock_apex_class_query()
+        self._mock_run_tests()
+        self._mock_get_failed_test_classes()
+        self._mock_tests_complete()
+        self._mock_get_test_results()
+        task_config = TaskConfig()
+        task_config.config["options"] = {
+            "junit_output": "results_junit.xml",
+            "poll_interval": 1,
+            "test_name_match": "%_TEST",
+            "namespace": "TEST",
+            "required_org_code_coverage_percent": "90",
+        }
+        org_config = OrgConfig(
+            {
+                "id": "foo/1",
+                "instance_url": "https://example.com",
+                "access_token": "abc123",
+            },
+            "test",
+        )
+        org_config._installed_packages = {"TEST": StrictVersion("1.2.3")}
+
+        task = RunApexTests(self.project_config, task_config, org_config)
+        task._check_code_coverage = Mock()
+        task()
+        task._check_code_coverage.assert_not_called()
+
+    def test_check_code_coverage(self):
+        task = RunApexTests(self.project_config, self.task_config, self.org_config)
+        task.code_coverage_level = 90
+        task.tooling = Mock()
+        task.tooling.query.return_value = {
+            "records": [{"PercentCovered": 90}],
+            "totalSize": 1,
+        }
+
+        task._check_code_coverage()
+        task.tooling.query.assert_called_once_with(
+            "SELECT PercentCovered FROM ApexOrgWideCoverage"
+        )
+
+    def test_check_code_coverage__fail(self):
+        task = RunApexTests(self.project_config, self.task_config, self.org_config)
+        task.code_coverage_level = 90
+        task.tooling = Mock()
+        task.tooling.query.return_value = {
+            "records": [{"PercentCovered": 89}],
+            "totalSize": 1,
+        }
+
+        with self.assertRaises(ApexTestException):
+            task._check_code_coverage()
 
     def test_is_retriable_failure(self):
         task_config = TaskConfig()

--- a/cumulusci/tasks/salesforce/BaseSalesforceMetadataApiTask.py
+++ b/cumulusci/tasks/salesforce/BaseSalesforceMetadataApiTask.py
@@ -13,5 +13,6 @@ class BaseSalesforceMetadataApiTask(BaseSalesforceTask):
         result = None
         if api:
             result = api()
+            self.org_config.reset_installed_packages()
             self.return_values = result
         return result

--- a/cumulusci/tasks/salesforce/InstallPackageVersion.py
+++ b/cumulusci/tasks/salesforce/InstallPackageVersion.py
@@ -72,6 +72,7 @@ class InstallPackageVersion(Deploy):
             f"Installing {self.options['name']} release: {self.options['version']}"
         )
         self._retry()
+        self.org_config.reset_installed_packages()
 
     def _try(self):
         api = self._get_api()

--- a/cumulusci/tasks/salesforce/UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/UpdateDependencies.py
@@ -102,6 +102,7 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
 
         self._uninstall_dependencies()
         self._install_dependencies()
+        self.org_config.reset_installed_packages()
 
     def _process_dependencies(self, dependencies):
         for dependency in dependencies:

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -2814,6 +2814,11 @@ Options
 
 	 By default, all failures must match retry_failures to perform a retry. Set retry_always to True to retry all failed tests if any failure matches.
 
+``-o required_org_code_coverage_percent REQUIREDORGCODECOVERAGEPERCENT``
+	 *Optional*
+
+	 Require at least X percent code coverage across the org following the test run.
+
 **set_duplicate_rule_status**
 ==========================================
 


### PR DESCRIPTION
# Critical Changes

# Changes

- The `OrgConfig` object exposes an `installed_packages` property, containing a `dict` mapping package namespaces to `StrictVersion` objects with the installed version number. This property is accessible in `when` clauses and is updated automatically when CumulusCI performs a Metadata API deployment.
- `when` clauses may create `StrictVersion` objects, which can be compared with installed package versions.
- The `run_tests` task supports a new option, `required_org_code_coverage_percent`. If set, the task will fail if aggregate code coverage in the org is less than the configured value. Code coverage verification is available only in unmanaged builds.

# Issues Closed
