### PR TITLE
Feature/org prune

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1064,13 +1064,16 @@ def org_list(runtime, plain):
     persistent_table.echo(plain)
 
 
-@org.command(name="prune", help="Removes all expired scratch orgs from the current project")
+@org.command(
+    name="prune", help="Removes all expired scratch orgs from the current project"
+)
 @click.option(
-    "--include-active", is_flag=True, help="Remove all scratch orgs, regardless of expiry."
+    "--include-active",
+    is_flag=True,
+    help="Remove all scratch orgs, regardless of expiry.",
 )
 @pass_runtime(require_project=True, require_keychain=True)
-def org_prune(runtime, include_active):
-    include_active = include_active or False
+def org_prune(runtime, include_active=False):
 
     predefined_scratch_configs = getattr(runtime.project_config, "orgs__scratch", {})
 

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1053,37 +1053,59 @@ def org_list(runtime, plain):
     persistent_table.echo(plain)
 
 
-@org.command(name="prune", help="Removes all expired orgs from the current project")
-@pass_runtime(require_project=False, require_keychain=True)
-def org_prune(runtime):
-    org_configs = {
-        org: runtime.keychain.get_org(org) for org in runtime.keychain.list_orgs()
-    }
-    scratch_configs = getattr(runtime.project_config, "orgs__scratch", {})
+@org.command(name="prune", help="Removes all expired scratch orgs from the current project")
+@click.option(
+    "--include-active", is_flag=True, help="Remove all scratch orgs, regardless of expiry."
+)
+@pass_runtime(require_project=True, require_keychain=True)
+def org_prune(runtime, include_active):
+    include_active = include_active or False
+
+    predefined_scratch_configs = getattr(runtime.project_config, "orgs__scratch", {})
 
     expired_orgs_removed = []
+    active_orgs_removed = []
     org_shapes_skipped = []
     active_orgs_skipped = []
-    for org, org_config in org_configs.items():
-        if scratch_configs.get(org):
-            org_shapes_skipped.append(org)
+    for org_name in runtime.keychain.list_orgs():
+
+        org_config = runtime.keychain.get_org(org_name)
+
+        if org_name in predefined_scratch_configs:
+            if org_config.active and include_active:
+                runtime.keychain.remove_org(org_name)
+                active_orgs_removed.append(org_name)
+            else:
+                org_shapes_skipped.append(org_name)
+
         elif org_config.active:
-            active_orgs_skipped.append(org)
-        elif isinstance(org_config, ScratchOrgConfig) and not org_config.active:
-            try:
-                runtime.keychain.remove_org(org)
-                expired_orgs_removed.append(org)
-            except Exception as e:
-                click.echo(e)
-    # see test_org_remove_delete_error for how to mock click.echo and assert the messages
+            if include_active:
+                runtime.keychain.remove_org(org_name)
+                active_orgs_removed.append(org_name)
+            else:
+                active_orgs_skipped.append(org_name)
+
+        elif isinstance(org_config, ScratchOrgConfig):
+            runtime.keychain.remove_org(org_name)
+            expired_orgs_removed.append(org_name)
+
     if expired_orgs_removed:
         click.echo(
             f"Successfully removed {len(expired_orgs_removed)} expired scratch orgs: {', '.join(expired_orgs_removed)}"
         )
     else:
         click.echo("No expired scratch orgs to delete. ✨")
+
+    if active_orgs_removed:
+        click.echo(
+            f"Successfully removed {len(active_orgs_removed)} active scratch orgs: {', '.join(active_orgs_removed)}"
+        )
+    elif include_active:
+        click.echo("No active scratch orgs to delete. ✨")
+
     if org_shapes_skipped:
         click.echo(f"Skipped org shapes: {', '.join(org_shapes_skipped)}")
+
     if active_orgs_skipped:
         click.echo(f"Skipped active orgs: {', '.join(active_orgs_skipped)}")
 

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -1271,7 +1271,7 @@ Environment Info: Rossian / x68_46
             "shape2",
             "active1",
             "active2",
-            "persistent"
+            "persistent",
         ]
         runtime.project_config.orgs__scratch = {
             "shape1": True,
@@ -1340,10 +1340,7 @@ Environment Info: Rossian / x68_46
         run_click_command(cci.org_prune, runtime=runtime)
         runtime.keychain.remove_org.assert_not_called()
 
-        echo.assert_any_call(
-            "No expired scratch orgs to delete. ✨"
-        )
-
+        echo.assert_any_call("No expired scratch orgs to delete. ✨")
 
     def test_org_remove(self):
         org_config = mock.Mock()

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -1471,7 +1471,12 @@ Environment Info: Rossian / x68_46
         echo.assert_any_call("Skipped org shapes: shape1, shape2")
 
         runtime.keychain.remove_org.assert_has_calls(
-            [mock.call("remove1"), mock.call("remove2"), mock.call("active1"), mock.call("active2")]
+            [
+                mock.call("remove1"),
+                mock.call("remove2"),
+                mock.call("active1"),
+                mock.call("active2"),
+            ]
         )
         assert runtime.keychain.remove_org.call_count == 4
 

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -1250,7 +1250,7 @@ Environment Info: Rossian / x68_46
             ),
         ]
 
-        run_click_command(cci.org_prune, runtime=runtime)
+        run_click_command(cci.org_prune, runtime=runtime, include_active=False)
 
         echo.assert_any_call(
             "Successfully removed 2 expired scratch orgs: remove1, remove2"
@@ -1337,10 +1337,121 @@ Environment Info: Rossian / x68_46
             ),
         ]
 
-        run_click_command(cci.org_prune, runtime=runtime)
+        run_click_command(cci.org_prune, runtime=runtime, include_active=False)
         runtime.keychain.remove_org.assert_not_called()
 
         echo.assert_any_call("No expired scratch orgs to delete. ✨")
+
+    @mock.patch("click.echo")
+    def test_org_prune_include_active(self, echo):
+        runtime = mock.Mock()
+        runtime.keychain.list_orgs.return_value = [
+            "shape1",
+            "shape2",
+            "remove1",
+            "remove2",
+            "active1",
+            "active2",
+            "persistent",
+        ]
+        runtime.project_config.orgs__scratch = {
+            "shape1": True,
+            "shape2": True,
+        }
+
+        runtime.keychain.get_org.side_effect = [
+            ScratchOrgConfig(
+                {
+                    "default": True,
+                    "scratch": True,
+                    "days": 7,
+                    "config_name": "dev",
+                    "username": "test0@example.com",
+                },
+                "shape1",
+            ),
+            ScratchOrgConfig(
+                {
+                    "default": False,
+                    "scratch": True,
+                    "days": 7,
+                    "config_name": "dev",
+                    "username": "test1@example.com",
+                },
+                "shape2",
+            ),
+            ScratchOrgConfig(
+                {
+                    "default": False,
+                    "scratch": True,
+                    "date_created": datetime(1999, 11, 1),
+                    "days": 7,
+                    "config_name": "dev",
+                    "username": "remove1@example.com",
+                },
+                "remove1",
+            ),
+            ScratchOrgConfig(
+                {
+                    "default": False,
+                    "scratch": True,
+                    "date_created": datetime(1999, 11, 1),
+                    "days": 7,
+                    "config_name": "dev",
+                    "username": "remove2@example.com",
+                },
+                "remove2",
+            ),
+            ScratchOrgConfig(
+                {
+                    "default": False,
+                    "scratch": True,
+                    "date_created": datetime.now() - timedelta(days=1),
+                    "days": 7,
+                    "config_name": "dev",
+                    "username": "active1@example.com",
+                },
+                "active1",
+            ),
+            ScratchOrgConfig(
+                {
+                    "default": False,
+                    "scratch": True,
+                    "date_created": datetime.now() - timedelta(days=1),
+                    "days": 7,
+                    "config_name": "dev",
+                    "username": "active2@example.com",
+                },
+                "active2",
+            ),
+            OrgConfig(
+                {
+                    "default": False,
+                    "scratch": False,
+                    "expires": "Persistent",
+                    "expired": False,
+                    "config_name": "dev",
+                    "username": "persistent@example.com",
+                    "instance_url": "https://dude-chillin-2330-dev-ed.cs22.my.salesforce.com",
+                },
+                "persistent",
+            ),
+        ]
+
+        run_click_command(cci.org_prune, runtime=runtime, include_active=True)
+
+        echo.assert_any_call(
+            "Successfully removed 2 expired scratch orgs: remove1, remove2"
+        )
+        echo.assert_any_call(
+            "Successfully removed 2 active scratch orgs: active1, active2"
+        )
+        echo.assert_any_call("Skipped org shapes: shape1, shape2")
+
+        runtime.keychain.remove_org.assert_has_calls(
+            [mock.call("remove1"), mock.call("remove2"), mock.call("active1"), mock.call("active2")]
+        )
+        assert runtime.keychain.remove_org.call_count == 4
 
     def test_org_remove(self):
         org_config = mock.Mock()


### PR DESCRIPTION
# Critical Changes

# Changes
- Adds `cci org prune` to automatically remove all expired scratch orgs from the keychain (`cci org list`)

# Issues Closed
