### PR TITLE
Improve error messaging around record types

### DIFF
--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -214,7 +214,11 @@ class LoadData(BaseSalesforceApiTask, SqlAlchemyMixin):
                 f"SELECT Id FROM RecordType WHERE SObjectType='{mapping.get('sf_object')}'"
                 f"AND DeveloperName = '{mapping['record_type']}' LIMIT 1"
             )
-            record_type_id = self.sf.query(query)["records"][0]["Id"]
+            records = self.sf.query(query)["records"]
+            if records:
+                record_type_id = records[0]["Id"]
+            else:
+                raise BulkDataException(f"Cannot find RecordType with query `{query}`")
             statics.append(record_type_id)
 
         return statics

--- a/cumulusci/tasks/bulkdata/tests/test_load.py
+++ b/cumulusci/tasks/bulkdata/tests/test_load.py
@@ -500,6 +500,24 @@ class TestLoadData(unittest.TestCase):
             ),
         )
 
+    def test_get_statics_record_type_not_matched(self):
+        task = _make_task(
+            LoadData, {"options": {"database_url": "sqlite://", "mapping": "test.yml"}}
+        )
+        task.sf = mock.Mock()
+        task.sf.query.return_value = {"records": []}
+        with self.assertRaises(BulkDataException) as e:
+            task._get_statics(
+                {
+                    "sf_object": "Account",
+                    "action": "insert",
+                    "fields": {"Id": "sf_id", "Name": "Name"},
+                    "static": {"Industry": "Technology"},
+                    "record_type": "Organization",
+                }
+            ),
+        assert "RecordType" in str(e.exception)
+
     @mock.patch("cumulusci.tasks.bulkdata.load.aliased")
     def test_query_db__joins_self_lookups(self, aliased):
         task = _make_task(


### PR DESCRIPTION
If you mistype a record type name, you would previously get an IndexError. Now you get a clearer message.