### PR TITLE
Allow the user to specify generate_mapping_file

### DIFF
--- a/cumulusci/tasks/bulkdata/generate_and_load_data.py
+++ b/cumulusci/tasks/bulkdata/generate_and_load_data.py
@@ -179,11 +179,11 @@ class GenerateAndLoadData(BaseSalesforceApiTask):
         # some generator tasks can generate the mapping file instead of reading it
         with TemporaryDirectory() as tempdir:
             temp_mapping = Path(tempdir) / "temp_mapping.yml"
-            with open(temp_mapping, "w+") as generated_mapping_file:
-                subtask_options["generate_mapping_file"] = generated_mapping_file.name
-                self._datagen(subtask_options)
+            mapping_file = self.options.get("generate_mapping_file", temp_mapping)
+            subtask_options["generate_mapping_file"] = mapping_file
+            self._datagen(subtask_options)
             if not subtask_options.get("mapping"):
-                subtask_options["mapping"] = generated_mapping_file.name
+                subtask_options["mapping"] = mapping_file
             self._dataload(subtask_options)
 
     def _setup_engine(self, database_url):

--- a/cumulusci/tasks/bulkdata/generate_from_yaml.py
+++ b/cumulusci/tasks/bulkdata/generate_from_yaml.py
@@ -170,4 +170,3 @@ class GenerateDataFromYaml(BaseGenerateDataTask):
                     yaml.safe_dump(
                         mapping_from_factory_templates(summary), f, sort_keys=False
                     )
-                    f.close()


### PR DESCRIPTION
Fix a bug which prevented user from specifying the generate_mapping_file option. The task info implied they could, but we overwrote it with a temp file.

Also simplify the code a bit. There was no reason to open the temp file. The code just evolved that way from previous code where it was a
TemporaryNamedFile().