### PR TITLE
Bulk API should use project API version.

### DIFF
--- a/cumulusci/tasks/bulkdata/tests/test_load.py
+++ b/cumulusci/tasks/bulkdata/tests/test_load.py
@@ -97,7 +97,7 @@ class TestLoadData(unittest.TestCase):
     def test_run(self, step_mock):
         responses.add(
             method="GET",
-            url="https://example.com/services/data/vNone/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
+            url="https://example.com/services/data/v46.0/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
             body=json.dumps({"records": [{"Id": "1"}]}),
             status=200,
         )
@@ -237,7 +237,7 @@ class TestLoadData(unittest.TestCase):
     def test_run__sql(self, step_mock):
         responses.add(
             method="GET",
-            url="https://example.com/services/data/vNone/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
+            url="https://example.com/services/data/v46.0/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
             body=json.dumps({"records": [{"Id": "1"}]}),
             status=200,
         )
@@ -972,7 +972,7 @@ class TestLoadData(unittest.TestCase):
     def test_run__autopk(self, step_mock):
         responses.add(
             method="GET",
-            url="https://example.com/services/data/vNone/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
+            url="https://example.com/services/data/v46.0/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
             body=json.dumps({"records": [{"Id": "1"}]}),
             status=200,
         )

--- a/cumulusci/tasks/bulkdata/tests/utils.py
+++ b/cumulusci/tasks/bulkdata/tests/utils.py
@@ -6,7 +6,10 @@ from cumulusci.tests.util import DummyOrgConfig
 def _make_task(task_class, task_config):
     task_config = TaskConfig(task_config)
     global_config = BaseGlobalConfig()
-    project_config = BaseProjectConfig(global_config, config={"noyaml": True})
+    project_config = BaseProjectConfig(
+        global_config,
+        config={"noyaml": True, "project": {"package": {"api_version": "46.0"}}},
+    )
     keychain = BaseProjectKeychain(project_config, "")
     project_config.set_keychain(keychain)
     org_config = DummyOrgConfig(

--- a/cumulusci/tasks/salesforce/BaseSalesforceApiTask.py
+++ b/cumulusci/tasks/salesforce/BaseSalesforceApiTask.py
@@ -2,6 +2,7 @@ from salesforce_bulk import SalesforceBulk
 
 from cumulusci.tasks.salesforce import BaseSalesforceTask
 from cumulusci.salesforce_api.utils import get_simple_salesforce_connection
+from cumulusci.core.exceptions import ConfigError
 
 
 class BaseSalesforceApiTask(BaseSalesforceTask):
@@ -24,9 +25,13 @@ class BaseSalesforceApiTask(BaseSalesforceTask):
         return rv
 
     def _init_bulk(self):
+        version = self.api_version or self.project_config.project__package__api_version
+        if not version:
+            raise ConfigError("Cannot find Salesforce version")
         return SalesforceBulk(
             host=self.org_config.instance_url.replace("https://", "").rstrip("/"),
             sessionId=self.org_config.access_token,
+            API_version=version,
         )
 
     def _init_class(self):


### PR DESCRIPTION
Bulk API previously defaulted its API Version to SalesforceBulk's API version, which was 40.0. Some fields therefore could not be loaded.