### PR TITLE
Get rid of snake_cased mapping files entirely.

### DIFF
--- a/cumulusci/tasks/bulkdata/tests/test_extract.py
+++ b/cumulusci/tasks/bulkdata/tests/test_extract.py
@@ -179,7 +179,7 @@ class TestExtractData(unittest.TestCase):
         task._sql_bulk_insert_from_records.assert_called_once_with(
             connection=task.session.connection.return_value,
             table="Opportunity",
-            columns=["sf_id", "Name", "account_id"],
+            columns=["sf_id", "Name", "AccountId"],
             record_iterable=log_mock.return_value,
         )
 
@@ -214,7 +214,7 @@ class TestExtractData(unittest.TestCase):
                 mock.call(
                     connection=task.session.connection.return_value,
                     table="Opportunity",
-                    columns=["Name", "account_id"],
+                    columns=["Name", "AccountId"],
                     record_iterable=csv_mock.return_value,
                 ),
                 mock.call(
@@ -310,7 +310,7 @@ class TestExtractData(unittest.TestCase):
         )
 
         task.session.query.return_value.filter.return_value.update.assert_called_once_with(
-            {task.models["Opportunity"].account_id: task.models["Account_sf_ids"].id},
+            {task.models["Opportunity"].AccountId: task.models["Account_sf_ids"].id},
             synchronize_session=False,
         )
         task.session.commit.assert_called_once_with()
@@ -353,7 +353,7 @@ class TestExtractData(unittest.TestCase):
         )
 
         task.session.bulk_update_mappings.assert_called_once_with(
-            task.models["Opportunity"], [{"id": item.id, "account_id": "1"}]
+            task.models["Opportunity"], [{"id": item.id, "AccountId": "1"}]
         )
         task.session.commit.assert_called_once_with()
 

--- a/cumulusci/tasks/bulkdata/utils.py
+++ b/cumulusci/tasks/bulkdata/utils.py
@@ -9,11 +9,10 @@ from sqlalchemy import Unicode
 from sqlalchemy.orm import mapper
 
 from cumulusci.core.exceptions import BulkDataException
-from cumulusci.utils import convert_to_snake_case
 
 
 def get_lookup_key_field(lookup, sf_field):
-    return lookup.get("key_field") or convert_to_snake_case(sf_field)
+    return lookup.get("key_field") or sf_field
 
 
 # Create a custom sqlalchemy field type for sqlite datetime fields which are stored as integer of epoch time

--- a/cumulusci/tests/test_utils.py
+++ b/cumulusci/tests/test_utils.py
@@ -523,11 +523,6 @@ Options\n------------------------------------------\n\n
         upgrade_cmd = utils.get_cci_upgrade_command()
         assert utils.PIPX_UPDATE_CMD == upgrade_cmd
 
-    def test_convert_to_snake_case(self):
-        assert "one_two" == utils.convert_to_snake_case("OneTwo")
-        assert "one_two" == utils.convert_to_snake_case("ONETwo")
-        assert "one_two" == utils.convert_to_snake_case("One_Two")
-
     def test_os_friendly_path(self):
         with mock.patch("os.sep", "\\"):
             assert "\\" == utils.os_friendly_path("/")

--- a/cumulusci/utils/__init__.py
+++ b/cumulusci/utils/__init__.py
@@ -627,11 +627,6 @@ def get_cci_upgrade_command():
     return PIP_UPDATE_CMD
 
 
-def convert_to_snake_case(content):
-    s1 = re.sub("([^_])([A-Z][a-z]+)", r"\1_\2", content)
-    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
-
-
 def os_friendly_path(path):
     if os.sep != "/":
         path = path.replace("/", os.sep)


### PR DESCRIPTION
A few code paths were still ending up with snake-cased column names.