### PR TITLE
Feature/generate and load data cleanups

### DIFF
--- a/cumulusci/tasks/bulkdata/base_generate_data_task.py
+++ b/cumulusci/tasks/bulkdata/base_generate_data_task.py
@@ -82,8 +82,9 @@ class BaseGenerateDataTask(BaseTask, metaclass=ABCMeta):
         metadata = MetaData()
         metadata.bind = engine
         if mappings:
-            for mapping in mappings.values():
-                create_table(mapping, metadata)
+            for name, mapping in mappings.items():
+                if "table" in mapping and mapping["table"] not in metadata.tables:
+                    create_table(mapping, metadata)
         metadata.create_all()
         base = automap_base(bind=engine, metadata=metadata)
         base.prepare(engine, reflect=True)

--- a/cumulusci/tasks/bulkdata/generate_and_load_data.py
+++ b/cumulusci/tasks/bulkdata/generate_and_load_data.py
@@ -178,12 +178,13 @@ class GenerateAndLoadData(BaseSalesforceApiTask):
 
         # some generator tasks can generate the mapping file instead of reading it
         with TemporaryDirectory() as tempdir:
-            temp_mapping = Path(tempdir) / "temp_mapping.yml"
-            with open(temp_mapping, "w+") as generated_mapping_file:
-                subtask_options["generate_mapping_file"] = generated_mapping_file.name
-                self._datagen(subtask_options)
             if not subtask_options.get("mapping"):
-                subtask_options["mapping"] = generated_mapping_file.name
+                temp_mapping = Path(tempdir) / "temp_mapping.yml"
+                mapping_file = self.options.get("generate_mapping_file", temp_mapping)
+                subtask_options["generate_mapping_file"] = mapping_file
+            self._datagen(subtask_options)
+            if not subtask_options.get("mapping"):
+                subtask_options["mapping"] = mapping_file
             self._dataload(subtask_options)
 
     def _setup_engine(self, database_url):

--- a/cumulusci/tasks/bulkdata/generate_from_yaml.py
+++ b/cumulusci/tasks/bulkdata/generate_from_yaml.py
@@ -87,11 +87,8 @@ class GenerateDataFromYaml(BaseGenerateDataTask):
                 self.mappings = yaml.safe_load(f)
         else:
             self.mappings = {}
-        session, engine, base = self.init_db(db_url, self.mappings)
         self.logger.info(f"Generating batch {current_batch_num} with {num_records}")
-        self.generate_data(session, engine, base, num_records, current_batch_num)
-        session.commit()
-        session.close()
+        self.generate_data(db_url, num_records, current_batch_num)
 
     def default_continuation_file_path(self):
         return Path(self.working_directory) / "continuation.yml"
@@ -137,37 +134,38 @@ class GenerateDataFromYaml(BaseGenerateDataTask):
             new_continuation_file = None
         return new_continuation_file
 
-    def generate_data(self, session, engine, base, num_records, current_batch_num):
-        output_stream = SqlOutputStream(engine, self.mappings)
+    def generate_data(self, db_url, num_records, current_batch_num):
+        output_stream = SqlOutputStream.from_url(db_url, self.mappings)
         old_continuation_file = self.get_old_continuation_file()
         if old_continuation_file:
             # reopen to ensure file pointer is at starting point
             old_continuation_file = open(old_continuation_file, "r")
         new_continuation_file = self.open_new_continuation_file()
 
-        with open(self.yaml_file) as open_yaml_file:
-            summary = generate(
-                open_yaml_file=open_yaml_file,
-                user_options=self.vars,
-                output_stream=output_stream,
-                stopping_criteria=self.stopping_criteria,
-                continuation_file=old_continuation_file,
-                generate_continuation_file=new_continuation_file,
-            )
+        try:
+            with open(self.yaml_file) as open_yaml_file:
+                summary = generate(
+                    open_yaml_file=open_yaml_file,
+                    user_options=self.vars,
+                    output_stream=output_stream,
+                    stopping_criteria=self.stopping_criteria,
+                    continuation_file=old_continuation_file,
+                    generate_continuation_file=new_continuation_file,
+                )
+        finally:
             output_stream.close()
 
-            if (
-                new_continuation_file
-                and Path(new_continuation_file.name).exists()
-                and self.working_directory
-            ):
-                shutil.copyfile(
-                    new_continuation_file.name, self.default_continuation_file_path()
-                )
+        if (
+            new_continuation_file
+            and Path(new_continuation_file.name).exists()
+            and self.working_directory
+        ):
+            shutil.copyfile(
+                new_continuation_file.name, self.default_continuation_file_path()
+            )
 
-            if self.generate_mapping_file:
-                with open(self.generate_mapping_file, "w+") as f:
-                    yaml.safe_dump(
-                        mapping_from_factory_templates(summary), f, sort_keys=False
-                    )
-                    f.close()
+        if self.generate_mapping_file:
+            with open(self.generate_mapping_file, "w+") as f:
+                yaml.safe_dump(
+                    mapping_from_factory_templates(summary), f, sort_keys=False
+                )

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -191,6 +191,8 @@ class LoadData(BaseSalesforceApiTask, SqlAlchemyMixin):
         # If we're using Record Type mapping, `RecordTypeId` goes at the end.
         if "RecordTypeId" in columns:
             columns.remove("RecordTypeId")
+        if "RecordType" in columns:
+            columns.remove("RecordType")
 
         if mapping["action"] == "insert" and "Id" in columns:
             columns.remove("Id")
@@ -237,7 +239,7 @@ class LoadData(BaseSalesforceApiTask, SqlAlchemyMixin):
         columns = [getattr(model, id_column)]
 
         for name, f in fields.items():
-            if name != "RecordTypeId":
+            if name not in ("RecordTypeId", "RecordType"):
                 columns.append(model.__table__.columns[f])
 
         lookups = {


### PR DESCRIPTION
Allow the user to specify rather than generate a mapping file (different than last week's PR)
    
Fix init_db so it is more similar to the (unfortunately not line-for-line identical) version in load.py when it comes to tables that appear in multiple mappings.
    
Change generate_from_yaml to reuse Snowfakery's database handling code instead of duplicating it.
    
Add a try:finally to close the outputstream "just in case".
    
Re-indent a bunch of code.
    
Never save a column named RecordType to Salesforce. It's presumably just there to represent the...actual record type. This prevents me from having to use one mapping file to generate the database tables and a different one to do the actual load.
