### PR TITLE
expose InstalledPackage securityType

### DIFF
--- a/cumulusci/salesforce_api/package_zip.py
+++ b/cumulusci/salesforce_api/package_zip.py
@@ -28,6 +28,7 @@ INSTALLED_PACKAGE = u"""<?xml version="1.0" encoding="UTF-8"?>
 <InstalledPackage xmlns="http://soap.sforce.com/2006/04/metadata">
   <versionNumber>{}</versionNumber>
   <activateRSS>{}</activateRSS>
+  <securityType>{}</securityType>
   {}
 </InstalledPackage>"""
 
@@ -86,7 +87,9 @@ class CreatePackageZipBuilder(BasePackageZipBuilder):
 class InstallPackageZipBuilder(BasePackageZipBuilder):
     api_version = "43.0"
 
-    def __init__(self, namespace, version, activateRSS=False, password=None):
+    def __init__(
+        self, namespace, version, activateRSS=False, password=None, securityType="FULL"
+    ):
         if not namespace:
             raise ValueError("You must provide a namespace to install a package")
         if not version:
@@ -95,6 +98,7 @@ class InstallPackageZipBuilder(BasePackageZipBuilder):
         self.version = version
         self.activateRSS = activateRSS
         self.password = password
+        self.securityType = securityType
 
     def _populate_zip(self):
         package_xml = INSTALLED_PACKAGE_PACKAGE_XML.format(
@@ -109,7 +113,7 @@ class InstallPackageZipBuilder(BasePackageZipBuilder):
             else ""
         )
         installed_package = INSTALLED_PACKAGE.format(
-            self.version, activateRSS, password
+            self.version, activateRSS, self.securityType, password
         )
         self._write_file(
             "installedPackages/{}.installedPackage".format(self.namespace),

--- a/cumulusci/tasks/salesforce/InstallPackageVersion.py
+++ b/cumulusci/tasks/salesforce/InstallPackageVersion.py
@@ -31,6 +31,9 @@ class InstallPackageVersion(Deploy):
         "retry_interval_add": {
             "description": "Number of seconds to add before each retry (default=30),"
         },
+        "security_type": {
+            "description": "Which users to install package for (FULL = all users, NONE = admins only)"
+        },
     }
 
     def _init_options(self, kwargs):
@@ -64,6 +67,7 @@ class InstallPackageVersion(Deploy):
             version=self.options["version"],
             activateRSS=self.options["activateRSS"],
             password=self.options.get("password"),
+            securityType=self.options.get("security_type", "FULL"),
         )
         return self.api_class(self, package_zip(), purge_on_delete=False)
 

--- a/cumulusci/tasks/salesforce/InstallPackageVersion.py
+++ b/cumulusci/tasks/salesforce/InstallPackageVersion.py
@@ -1,3 +1,4 @@
+from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.core.utils import process_bool_arg
 from cumulusci.salesforce_api.exceptions import MetadataApiError
 from cumulusci.salesforce_api.package_zip import InstallPackageZipBuilder
@@ -60,6 +61,11 @@ class InstallPackageVersion(Deploy):
         elif version == "previous":
             self.options["version"] = self.project_config.get_previous_version()
         self.options["activateRSS"] = process_bool_arg(self.options.get("activateRSS"))
+        self.options["security_type"] = self.options.get("security_type", "FULL")
+        if self.options["security_type"] not in ("FULL", "NONE", "PUSH"):
+            raise TaskOptionsError(
+                f"Unsupported value for security_type: {self.options['security_type']}"
+            )
 
     def _get_api(self, path=None):
         package_zip = InstallPackageZipBuilder(

--- a/cumulusci/tasks/salesforce/UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/UpdateDependencies.py
@@ -46,6 +46,9 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
             "in order to install the requested version. Defaults to False. "
             "Warning: Enabling this may destroy data."
         },
+        "security_type": {
+            "description": "Which users to install packages for (FULL = all users, NONE = admins only)"
+        },
     }
 
     def _init_options(self, kwargs):
@@ -69,6 +72,11 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
         self.options["allow_uninstalls"] = process_bool_arg(
             self.options.get("allow_uninstalls", False)
         )
+        self.options["security_type"] = self.options.get("security_type", "FULL")
+        if self.options["security_type"] not in ("FULL", "NONE", "PUSH"):
+            raise TaskOptionsError(
+                f"Unsupported value for security_type: {self.options['security_type']}"
+            )
 
     def _run_task(self):
         if not self.options["dependencies"]:
@@ -307,7 +315,7 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
                 package_zip = InstallPackageZipBuilder(
                     dependency["namespace"],
                     dependency["version"],
-                    securityType=dependency.get("security_type", "FULL"),
+                    securityType=self.options["security_type"],
                 )()
 
         api = self.api_class(

--- a/cumulusci/tasks/salesforce/UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/UpdateDependencies.py
@@ -305,7 +305,9 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
                     )
                 )
                 package_zip = InstallPackageZipBuilder(
-                    dependency["namespace"], dependency["version"]
+                    dependency["namespace"],
+                    dependency["version"],
+                    securityType=dependency.get("security_type", "FULL"),
                 )()
 
         api = self.api_class(

--- a/cumulusci/tasks/salesforce/tests/test_UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/tests/test_UpdateDependencies.py
@@ -207,6 +207,17 @@ class TestUpdateDependencies(unittest.TestCase):
         with self.assertRaises(TaskOptionsError):
             task()
 
+    def test_run_task__bad_security_type(self):
+        project_config = create_project_config()
+        project_config.config["project"]["dependencies"] = PROJECT_DEPENDENCIES
+        with self.assertRaises(TaskOptionsError):
+            create_task(
+                UpdateDependencies,
+                {"security_type": "BOGUS"},
+                project_config,
+                mock.Mock(),
+            )
+
     def test_run_task__metadata_bundle(self):
         project_config = create_project_config()
         project_config.get_github_api = mock.Mock()
@@ -283,6 +294,7 @@ class TestUpdateDependencies(unittest.TestCase):
                             "purge_on_delete": True,
                             "allow_newer": True,
                             "allow_uninstalls": False,
+                            "security_type": "FULL",
                         },
                         "checks": [],
                     },
@@ -310,6 +322,7 @@ class TestUpdateDependencies(unittest.TestCase):
                             "purge_on_delete": True,
                             "allow_newer": True,
                             "allow_uninstalls": False,
+                            "security_type": "FULL",
                         },
                         "checks": [],
                     },

--- a/cumulusci/tasks/tests/test_metadeploy.py
+++ b/cumulusci/tasks/tests/test_metadeploy.py
@@ -203,6 +203,7 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
                             "retries": 5,
                             "retry_interval": 5,
                             "retry_interval_add": 30,
+                            "security_type": "FULL",
                             "version": "1.0",
                         },
                         "checks": [],

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -132,7 +132,7 @@ Options
 
 **Description:** Adds specified picklist entries to a custom picklist field.
 
-**Class:** cumulusci.tasks.metadata_etl.AddPicklistEntries
+**Class:** cumulusci.tasks.metadata_etl.picklists.AddPicklistEntries
 
 Command Syntax
 ------------------------------------------
@@ -1632,6 +1632,11 @@ Options
 
 	 Number of seconds to add before each retry (default=30),
 
+``-o security_type SECURITYTYPE``
+	 *Optional*
+
+	 Which users to install package for (FULL = all users, NONE = admins only)
+
 **install_managed_beta**
 ==========================================
 
@@ -1692,6 +1697,11 @@ Options
 	 *Optional*
 
 	 Number of seconds to add before each retry (default=30),
+
+``-o security_type SECURITYTYPE``
+	 *Optional*
+
+	 Which users to install package for (FULL = all users, NONE = admins only)
 
 **list_communities**
 ==========================================
@@ -3423,6 +3433,11 @@ Options
 	 *Optional*
 
 	 Allow uninstalling a beta release or newer final release in order to install the requested version. Defaults to False. Warning: Enabling this may destroy data.
+
+``-o security_type SECURITYTYPE``
+	 *Optional*
+
+	 Which users to install packages for (FULL = all users, NONE = admins only)
 
 **update_package_xml**
 ==========================================


### PR DESCRIPTION
# Critical Changes

# Changes
* The install_managed and update_dependencies tasks now accept a security_type option to specify which users the package should be installed for.

# Issues Closed
