### PR TITLE
Upgrade robotframework-seleniumlibrary from 4.3.0 to 4.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ certifi==2020.4.5.1
 cffi==1.14.0
 chardet==3.0.4
 click==7.1.2
-coloredlogs==14.0   
+coloredlogs==14.0
 cryptography==2.9.2
 docutils==0.16
 github3.py==1.3.0
@@ -22,7 +22,7 @@ PyYAML==5.3.1
 raven==6.10.0
 requests==2.23.0
 robotframework==3.1.2
-robotframework-seleniumlibrary==4.3.0
+robotframework-seleniumlibrary==4.4.0
 rst2ansi==0.1.5
 salesforce-bulk==2.1.0
 sarge==0.1.5.post0


### PR DESCRIPTION
There doesn't appear to be anything surprising in SeleniumLibrary 4.4.0. I ran all of the CumulusCI tests in both the dev and prerelease orgs without a hitch.

# Critical Changes

# Changes

# Issues Closed
