### PR TITLE
Feature/robot dropdown keyword

### DIFF
--- a/cumulusci/core/tests/test_pageobjects.py
+++ b/cumulusci/core/tests/test_pageobjects.py
@@ -20,12 +20,14 @@ from cumulusci.robotframework import PageObjects
 from cumulusci.robotframework.CumulusCI import CumulusCI
 from cumulusci.robotframework.pageobjects.PageObjectLibrary import _PageObjectLibrary
 from cumulusci.robotframework.pageobjects import (
+    BasePage,
     ListingPage,
     EditModal,
     NewModal,
     HomePage,
     DetailPage,
 )
+from robot.libraries.BuiltIn import BuiltIn
 import robot.utils
 
 
@@ -49,7 +51,6 @@ BASE_REGISTRY = {
     ("Listing", ""): ListingPage,
     ("New", ""): NewModal,
 }
-
 
 # this is the importer used by the page objects, which makes it easy
 # peasy to import by file path
@@ -131,3 +132,52 @@ class TestPageObjects(unittest.TestCase):
 
             pobj = po.get_page_object("Test", "Foo__c")
             self.assertEqual(pobj.object_name, "Foo__c")
+
+
+@mock.patch(
+    "robot.libraries.BuiltIn.BuiltIn.get_library_instance",
+    side_effect=MockGetLibraryInstance(),
+)
+class TestBasePage(unittest.TestCase):
+    """Some low-level tests of page object classes"""
+
+    def test_no_implicit_wait(self, mock_get_library_instance):
+        """Verify the "implicit wait" context manager restores the value"""
+
+        selib = BuiltIn().get_library_instance("SeleniumLibrary")
+        selib.set_selenium_implicit_wait.return_value = 7
+        selib.set_selenium_implicit_wait.reset_mock()
+
+        page = BasePage()
+        with page.no_implicit_wait():
+            pass
+
+        # The first call should pass in zero to turn off the
+        # implicit wait.  We've configured the mocked function to
+        # return '7'. The second call should pass the return value
+        # of the first call
+        selib.set_selenium_implicit_wait.assert_has_calls(
+            (mock.call(0), mock.call(7)), any_order=False
+        )
+
+    def test_no_implicit_wait_with_exception(self, mock_get_library_instance):
+        """Verify the "implicit wait" context manager restores the value even if exception occurs"""
+
+        selib = BuiltIn().get_library_instance("SeleniumLibrary")
+        selib.set_selenium_implicit_wait.return_value = 42
+        selib.set_selenium_implicit_wait.reset_mock()
+
+        page = BasePage()
+        try:
+            with page.no_implicit_wait():
+                raise Exception("Danger Will Robinson!")
+        except Exception:
+            pass
+
+        # The first call should pass in zero to turn off the
+        # implicit wait.  We've configured the mocked function to
+        # return '42'. The second call should pass the return value
+        # of the first call
+        selib.set_selenium_implicit_wait.assert_has_calls(
+            (mock.call(0), mock.call(42)), any_order=False
+        )

--- a/cumulusci/core/tests/test_pageobjects.py
+++ b/cumulusci/core/tests/test_pageobjects.py
@@ -149,7 +149,7 @@ class TestBasePage(unittest.TestCase):
         selib.set_selenium_implicit_wait.reset_mock()
 
         page = BasePage()
-        with page.no_implicit_wait():
+        with page._no_implicit_wait():
             pass
 
         # The first call should pass in zero to turn off the
@@ -169,7 +169,7 @@ class TestBasePage(unittest.TestCase):
 
         page = BasePage()
         try:
-            with page.no_implicit_wait():
+            with page._no_implicit_wait():
                 raise Exception("Danger Will Robinson!")
         except Exception:
             pass

--- a/cumulusci/robotframework/pageobjects/BasePageObjects.py
+++ b/cumulusci/robotframework/pageobjects/BasePageObjects.py
@@ -10,6 +10,8 @@ file.
 """
 
 import re
+from selenium.webdriver.common.action_chains import ActionChains
+from SeleniumLibrary.errors import ElementNotFound
 from cumulusci.robotframework.pageobjects import pageobject
 from cumulusci.robotframework.pageobjects import BasePage
 from cumulusci.robotframework.utils import capture_screenshot_on_error
@@ -137,6 +139,37 @@ class ModalMixin:
         self.salesforce.populate_form(*args, **kwargs)
 
     @capture_screenshot_on_error
+    def select_dropdown_value(self, label, value):
+        """Sets the value of a dropdown form field from one of the values in the dropdown
+
+        ``label`` represents the label on the form field (eg: Lead Source)
+
+        If a modal is present, the modal will be searched for the dropdown. Otherwise
+        the first matching dropdown on the entire web page will be used.
+        """
+        input_element = self._get_form_element_for_label(label)
+        if input_element is None:
+            raise Exception(f"No form element found with the label '{label}'")
+
+        self.selenium.scroll_element_into_view(input_element)
+        trigger = input_element.find_element_by_class_name("uiPopupTrigger")
+        ac = ActionChains(self.selenium.driver)
+        ac.move_to_element(trigger).click().perform()
+        popup_locator = (
+            "//div[contains(@class, 'uiPopupTarget')][contains(@class, 'visible')]"
+        )
+        try:
+            popup = self.selenium.get_webelement(popup_locator)
+        except ElementNotFound:
+            raise ElementNotFound("Timed out waiting for the popup menu")
+        try:
+            value_element = popup.find_element_by_link_text(value)
+            ac = ActionChains(self.selenium.driver)
+            ac.move_to_element(value_element).click().perform()
+        except Exception:
+            raise Exception(f"Dropdown value '{value}' not found")
+
+    @capture_screenshot_on_error
     def wait_until_modal_is_closed(self, timeout=None):
         """Waits until the modal is no longer visible
 
@@ -145,6 +178,40 @@ class ModalMixin:
         locator = "//div[contains(@class, 'uiModal')]"
 
         self.selenium.wait_until_page_does_not_contain_element(locator)
+
+    def _get_form_element_for_label(self, label):
+        """Returns an element of class 'slds-form-element' which contains the given label.
+
+        If you use this to find an item on a modal, you're responsible for waiting for the
+        modal to appear before calling this function.
+        """
+        # search from the root of the document, unless a modal
+        # is open
+        root = self.selenium.driver.find_element_by_tag_name("body")
+        with self._no_implicit_wait():
+            # We don't want to wait, we just want to know if the
+            # modal is alredy there or not. The caller should have
+            # already waited for the modal.
+
+            # also, we use find_elements (plural) here because it will
+            # return an empty list rather than throwing an error
+            modals = root.find_elements_by_xpath("//div[contains(@class, 'uiModal')]")
+            # There should only ever be zero or one, but the Salesforce
+            # UI never ceases to surprise me.
+            modals = [m for m in modals if m.is_displayed()]
+            if modals:
+                root = modals[0]
+        try:
+            # gnarly, but effective.
+            # this finds an element with the class slds-form-element which
+            # has a child element with the class 'form-element__label' and
+            # text that matches the given label.
+            locator = f".//*[contains(@class, 'slds-form-element') and .//*[contains(@class, 'form-element__label')]/descendant-or-self::text()='{label}']"
+            element = root.find_element_by_xpath(locator)
+            return element
+
+        except ElementNotFound:
+            raise ElementNotFound(f"Form element with label '{label}' was not found")
 
 
 @pageobject("New")

--- a/cumulusci/robotframework/pageobjects/BasePageObjects.py
+++ b/cumulusci/robotframework/pageobjects/BasePageObjects.py
@@ -215,7 +215,7 @@ class ModalMixin:
             element = root.find_element_by_xpath(locator)
             return element
 
-        except ElementNotFound:
+        except NoSuchElementException:
             raise ElementNotFound(f"Form element with label '{label}' was not found")
 
 

--- a/cumulusci/robotframework/pageobjects/PageObjects.py
+++ b/cumulusci/robotframework/pageobjects/PageObjects.py
@@ -271,22 +271,16 @@ class PageObjects(object):
     def wait_for_modal(self, page_type, object_name, expected_heading=None, **kwargs):
         """Wait for the given page object modal to appear.
 
-        This will both wait for the modal, and verify that the modal
-        has an expected heading. By default the expected heading will
-        be the page object type (eg "New") and object name (eg:
-        "Contact") separated by a space (eg: "New Contact").
-
-        You can override the expected heading with the expected_heading
-        parameter.
+        This will wait for modal to appear. If an expected heading
+        is provided, it will also validate that the modal has the
+        expected heading.
 
         Example:
 
-        | Wait for modal to appear    New    Contact
+        | Wait for modal to appear    New    Contact   expected_heading=New Contact
 
         """
         pobj = self.get_page_object(page_type, object_name)
-        if not expected_heading:
-            expected_heading = f"{pobj._page_type} {pobj._object_name}"
         pobj._wait_to_appear(expected_heading=expected_heading)
         self._set_current_page_object(pobj)
         # Ideally we would wait for something, but I can't figure out

--- a/cumulusci/robotframework/pageobjects/baseobjects.py
+++ b/cumulusci/robotframework/pageobjects/baseobjects.py
@@ -1,4 +1,5 @@
 from robot.libraries.BuiltIn import BuiltIn
+from contextlib import contextmanager
 
 
 class BasePage:
@@ -7,6 +8,15 @@ class BasePage:
     def __init__(self, object_name=None):
         if object_name:
             self._object_name = object_name
+
+    @contextmanager
+    def no_implicit_wait(self):
+        """Context manager for running selenium commands without an implicit wait"""
+        current_wait = self.selenium.set_selenium_implicit_wait(0)
+        try:
+            yield
+        finally:
+            self.selenium.set_selenium_implicit_wait(current_wait)
 
     def _wait_to_appear(self, timeout=None):
         """This function is called by the keyword 'wait for page object to appear'.

--- a/cumulusci/robotframework/pageobjects/baseobjects.py
+++ b/cumulusci/robotframework/pageobjects/baseobjects.py
@@ -10,7 +10,7 @@ class BasePage:
             self._object_name = object_name
 
     @contextmanager
-    def no_implicit_wait(self):
+    def _no_implicit_wait(self):
         """Context manager for running selenium commands without an implicit wait"""
         current_wait = self.selenium.set_selenium_implicit_wait(0)
         try:

--- a/cumulusci/robotframework/tests/salesforce/ui.robot
+++ b/cumulusci/robotframework/tests/salesforce/ui.robot
@@ -264,6 +264,7 @@ Populate Form
     Should Be Equal      ${value}  CASH
 
 Select Dropdown Value
+    [Documentation]  Select Dropdown Value happy path tests
     [Setup]   Run keywords
     ...  Go to page  Home  Contact
     ...  AND  Click object button   New
@@ -275,6 +276,7 @@ Select Dropdown Value
     # these two fields look and act identical, but they are
     # implemented differently in the DOM *sigh*
     Select dropdown value  Salutation   Mr.
+
     Select dropdown value  Lead Source  Purchased List
 
     Click Modal Button           Save
@@ -290,3 +292,20 @@ Select Dropdown Value
     ...    Object field should be  Contact  ${contact id}  LeadSource  Purchased List
     Wait until keyword succeeds  5 seconds  2 seconds
     ...    Object field should be  Contact  ${contact id}  Salutation  Mr.
+
+Select Dropdown Value exceptions
+    [Documentation]  Verify that the keyword throws appropriate errors
+    [Setup]   Run keywords
+    ...  Go to page  Home  Contact
+    ...  AND  Click object button   New
+    ...  AND  Wait for modal        New   Contact
+
+    # Bad input field name
+    Run keyword and continue on failure
+    ...  Run keyword and expect error  Form element with label 'Bogus' was not found
+    ...    Select dropdown value  Bogus   Mr.
+
+    # Bad value
+    Run keyword and continue on failure
+    ...  Run keyword and expect error  Dropdown value 'Bogus' not found
+    ...    Select dropdown value  Lead Source  Bogus

--- a/cumulusci/robotframework/tests/salesforce/ui.robot
+++ b/cumulusci/robotframework/tests/salesforce/ui.robot
@@ -49,6 +49,25 @@ Create test data
     ...                 ContactId=${CONTACT ID}
     Set suite variable  ${OPPORTUNITY ID}
 
+Object field should be
+    [Arguments]       ${obj name}  ${obj id}  ${field}  ${expected_value}
+    [Documentation]
+    ...  Fetches the object using the API, and verifies that the
+    ...  given field has the expected value
+
+    # it may take salesforce a second or two for the data
+    # to be saved and visible to the API, so we'll try this
+    # in a short loop
+    FOR  ${i}  IN RANGE  3
+        &{obj} =          Salesforce Get  ${obj name}  ${obj id}
+        ${actual_value}=  Set variable  ${obj}[${field}]
+
+        Return from keyword if  $expected_value == $actual_value
+        log  Retrying API call...  WARN
+        Sleep  1 second
+    END
+    Fail  Expected ${obj name} field ${field} to be '${expected_value}' but it was '${actual_value}'
+
 *** Test Cases ***
 
 Click Modal Button
@@ -243,3 +262,31 @@ Populate Form
     ${locator}=          Get Locator  object.field  Ticker Symbol
     ${value} =           Get Value  ${locator}
     Should Be Equal      ${value}  CASH
+
+Select Dropdown Value
+    [Setup]   Run keywords
+    ...  Go to page  Home  Contact
+    ...  AND  Click object button   New
+    ...  AND  Wait for modal        New   Contact
+
+    # required field
+    populate field  Last Name   ${faker.last_name()}
+
+    # these two fields look and act identical, but they are
+    # implemented differently in the DOM *sigh*
+    Select dropdown value  Salutation   Mr.
+    Select dropdown value  Lead Source  Purchased List
+
+    Click Modal Button           Save
+    Wait Until Modal Is Closed
+
+    ${contact id} =       Get Current Record Id
+    Store Session Record  Contact  ${contact id}
+
+    # Without waiting, this will sometimes fail. I guess there can be
+    # a bit of a delay for the data to be saved such that the API
+    # can retrieve it.
+    Wait until keyword succeeds  5 seconds  2 seconds
+    ...    Object field should be  Contact  ${contact id}  LeadSource  Purchased List
+    Wait until keyword succeeds  5 seconds  2 seconds
+    ...    Object field should be  Contact  ${contact id}  Salutation  Mr.

--- a/docs/robot/Keywords.html
+++ b/docs/robot/Keywords.html
@@ -476,11 +476,10 @@ class CustomDetailPage(BasePage):
                   
                 </td>
                 <td class="kwdoc"><p>Wait for the given page object modal to appear.</p>
-<p>This will both wait for the modal, and verify that the modal has an expected heading. By default the expected heading will be the page object type (eg "New") and object name (eg: "Contact") separated by a space (eg: "New Contact").</p>
-<p>You can override the expected heading with the expected_heading parameter.</p>
+<p>This will wait for modal to appear. If an expected heading is provided, it will also validate that the modal has the expected heading.</p>
 <p>Example:</p>
 <pre>
-Wait for modal to appear    New    Contact
+Wait for modal to appear    New    Contact   expected_heading=New Contact
 </pre></td>
               </tr>
               
@@ -554,7 +553,9 @@ Wait for modal to appear    New    Contact
                 </td>
                 <td class="kwargs">
                   
-                  <i>title</i>
+                  <i>*args</i>, 
+                  
+                  <i>**kwargs</i>
                   
                 </td>
                 <td class="kwdoc"><p>Clicks a button in a Lightning modal.</p></td>
@@ -566,7 +567,9 @@ Wait for modal to appear    New    Contact
                 </td>
                 <td class="kwargs">
                   
-                  <i>title</i>
+                  <i>*args</i>, 
+                  
+                  <i>**kwargs</i>
                   
                 </td>
                 <td class="kwdoc"><p>Clicks a button in an object's actions.</p></td>
@@ -751,7 +754,7 @@ Wait for modal to appear    New    Contact
 <p>This uses the <a href="https://faker.readthedocs.io/en/master/">Faker</a> library to provide fake data in a variety of formats (names, addresses, credit card numbers, dates, phone numbers, etc) and locales (en_US, fr_FR, etc).</p>
 <p>The <i>fake</i> argument is the name of a faker property such as <code>first_name</code>, <code>address</code>, <code>lorem</code>, etc. Additional arguments depend on type of data requested. For a comprehensive list of the types of fake data that can be generated see <a href="https://faker.readthedocs.io/en/master/providers.html">Faker providers</a> in the Faker documentation.</p>
 <p>The return value is typically a string, though in some cases some other type of object will be returned. For example, the <code>date_between</code> fake returns a <a href="https://docs.python.org/3/library/datetime.html#date-objects">datetime.date object</a>. Each time a piece of fake data is requested it will be regenerated, so that multiple calls will usually return different data.</p>
-<p>This keyword can also be called using robot's extend variable syntax using the variable <code>${faker}</code>. In such a case, the data being asked for is a method call and arguments must be enclosed in parenthesis and be quoted. Arguments should not be quoted when using the keyword.</p>
+<p>This keyword can also be called using robot's extended variable syntax using the variable <code>${faker}</code>. In such a case, the data being asked for is a method call and arguments must be enclosed in parentheses and be quoted. Arguments should not be quoted when using the keyword.</p>
 <p>To generate fake data for a locale other than en_US, use the keyword <code>Set Faker Locale</code> prior to calling this keyword.</p>
 <p>Examples</p>
 <pre>
@@ -1007,9 +1010,14 @@ Input text  //input  ${faker.date(pattern='%Y-%m-%d')}
                 </td>
                 <td class="kwargs">
                   
+                  <i>*args</i>, 
+                  
+                  <i>**kwargs</i>
+                  
                 </td>
                 <td class="kwdoc"><p>Opens the Saleforce App Launcher Modal</p>
-<p>Note: starting with Spring '20 the app launcher button opens a menu rather than a modal. To maintain backwards compatibility, this keyword will continue to open the modal rather than the menu. If you need to interact with the app launcher menu, you will need to create a custom keyword.</p></td>
+<p>Note: starting with Spring '20 the app launcher button opens a menu rather than a modal. To maintain backwards compatibility, this keyword will continue to open the modal rather than the menu. If you need to interact with the app launcher menu, you will need to create a custom keyword.</p>
+<p>If the retry parameter is true, the keyword will close and then re-open the app launcher if it times out while waiting for the dialog to open.</p></td>
               </tr>
               
               <tr class="kwrow" id="Salesforce.Populate Field">
@@ -1395,11 +1403,9 @@ Should be equal  ${contact['Name']}  Eleanor Rigby
                 </td>
                 <td class="kwargs">
                   
-                  <i>locator=None</i>, 
+                  <i>*args</i>, 
                   
-                  <i>timeout=None</i>, 
-                  
-                  <i>interval=5</i>
+                  <i>**kwargs</i>
                   
                 </td>
                 <td class="kwdoc"><p>Waits until we are able to render the initial salesforce landing page</p>
@@ -1525,13 +1531,15 @@ Should be equal  ${contact['Name']}  Eleanor Rigby
                   
                   <i>size=${DEFAULT BROWSER SIZE}</i>, 
                   
-                  <i>alias=${NONE}</i>
+                  <i>alias=${NONE}</i>, 
+                  
+                  <i>wait=True</i>
                   
                 </td>
                 <td class="kwdoc"><p>Opens a test browser to the org.</p>
 <p>The variable ${BROWSER} determines which browser should open. The following four browsers are explicitly supported: chrome, firefox, headlesschrome, and headlessfirefox. Any other value will be passed directly to the SeleniumLibrary 'Open Browser' keyword.</p>
 <p>Once the browser has been opened, it will be set to the given size (default=${DEFAULT BROWSER SIZE})</p>
-<p>The keyword `Log Browser Capabilities` will automatically be called.</p></td>
+<p>The keyword `Log Browser Capabilities` will automatically be called. The keyword will also call `Wait Until Salesforce is Ready` unless the `wait` parameter is set to False.</p></td>
               </tr>
               
               <tr class="kwrow" id="Salesforce.robot.Open Test Browser Chrome">
@@ -1772,6 +1780,22 @@ Populate form
 </pre></td>
               </tr>
               
+              <tr class="kwrow" id="BasePageObjects.py.Select Dropdown Value">
+                <td class="kwname">
+                  Select Dropdown Value
+                </td>
+                <td class="kwargs">
+                  
+                  <i>*args</i>, 
+                  
+                  <i>**kwargs</i>
+                  
+                </td>
+                <td class="kwdoc"><p>Sets the value of a dropdown form field from one of the values in the dropdown</p>
+<p><code>label</code> represents the label on the form field (eg: Lead Source)</p>
+<p>If a modal is present, the modal will be searched for the dropdown. Otherwise the first matching dropdown on the entire web page will be used.</p></td>
+              </tr>
+              
               <tr class="kwrow" id="BasePageObjects.py.Wait Until Modal Is Closed">
                 <td class="kwname">
                   Wait Until Modal Is Closed
@@ -2009,6 +2033,22 @@ Populate form
 </pre></td>
               </tr>
               
+              <tr class="kwrow" id="BasePageObjects.py.Select Dropdown Value">
+                <td class="kwname">
+                  Select Dropdown Value
+                </td>
+                <td class="kwargs">
+                  
+                  <i>*args</i>, 
+                  
+                  <i>**kwargs</i>
+                  
+                </td>
+                <td class="kwdoc"><p>Sets the value of a dropdown form field from one of the values in the dropdown</p>
+<p><code>label</code> represents the label on the form field (eg: Lead Source)</p>
+<p>If a modal is present, the modal will be searched for the dropdown. Otherwise the first matching dropdown on the entire web page will be used.</p></td>
+              </tr>
+              
               <tr class="kwrow" id="BasePageObjects.py.Wait Until Modal Is Closed">
                 <td class="kwname">
                   Wait Until Modal Is Closed
@@ -2032,7 +2072,7 @@ Populate form
       
     </div>
     <div class="footer">
-      Generated on Wednesday April 08, 06:48 PM - cumulusci v3.10.0
+      Generated on Friday May 29, 12:23 AM - cumulusci v3.12.2
     </div>
   </body>
 </html>


### PR DESCRIPTION
New modal page object keyword 'Select Dropdown Value'. Tested again dev and prerelease orgs, and
I also modified NPSP to use this keyword instead of its own and ran against the current release. All tests
passed with both chrome and firefox.

# Critical Changes
* added a new keyword in the modal page objects, 'Select dropdown value'. This keyword will
be available whenever you use the 'Wait for modal' keyword to pull in a modal page object.
# Changes

# Issues Closed
