### PR TITLE
Feature/smart get lookup key field

### DIFF
--- a/cumulusci/tasks/bulkdata/base_generate_data_task.py
+++ b/cumulusci/tasks/bulkdata/base_generate_data_task.py
@@ -5,10 +5,10 @@ from sqlalchemy import create_engine
 from sqlalchemy import MetaData
 from sqlalchemy.orm import create_session
 from sqlalchemy.ext.automap import automap_base
-import yaml
 
 from cumulusci.core.tasks import BaseTask
 from cumulusci.core.exceptions import TaskOptionsError
+from cumulusci.tasks.bulkdata.mapping_parser import parse_from_yaml
 
 from .utils import create_table
 
@@ -73,8 +73,7 @@ class BaseGenerateDataTask(BaseTask, metaclass=ABCMeta):
         if not mapping_file_path:
             raise TaskOptionsError("Mapping file path required")
 
-        with open(mapping_file_path, "r") as f:
-            return yaml.safe_load(f)
+        return parse_from_yaml(mapping_file_path)
 
     @staticmethod
     def init_db(db_url, mappings):

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -10,7 +10,6 @@ from sqlalchemy.ext.automap import automap_base
 from cumulusci.core.exceptions import BulkDataException, TaskOptionsError
 from cumulusci.core.utils import process_bool_arg
 from cumulusci.tasks.bulkdata.utils import (
-    get_lookup_key_field,
     SqlAlchemyMixin,
     RowErrorChecker,
 )
@@ -292,7 +291,7 @@ class LoadData(BaseSalesforceApiTask, SqlAlchemyMixin):
         for sf_field, lookup in lookups.items():
             # Outer join with lookup ids table:
             # returns main obj even if lookup is null
-            key_field = get_lookup_key_field(lookup, sf_field, model)
+            key_field = lookup.get_lookup_key_field(model)
             value_column = getattr(model, key_field)
             query = query.outerjoin(
                 lookup["aliased_table"],
@@ -431,9 +430,11 @@ class LoadData(BaseSalesforceApiTask, SqlAlchemyMixin):
 
     def _init_mapping(self):
         """Load a YAML mapping file."""
-        with open(self.options["mapping"], "r") as f:
-            # yaml.safe_load should also work here for now.
-            self.mapping = parse_from_yaml(f)
+        mapping_file_path = self.options["mapping"]
+        if not mapping_file_path:
+            raise TaskOptionsError("Mapping file path required")
+
+        self.mapping = parse_from_yaml(mapping_file_path)
 
     def _expand_mapping(self):
         """Walk the mapping and generate any required 'after' steps

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -292,7 +292,7 @@ class LoadData(BaseSalesforceApiTask, SqlAlchemyMixin):
         for sf_field, lookup in lookups.items():
             # Outer join with lookup ids table:
             # returns main obj even if lookup is null
-            key_field = get_lookup_key_field(lookup, sf_field)
+            key_field = get_lookup_key_field(lookup, sf_field, model)
             value_column = getattr(model, key_field)
             query = query.outerjoin(
                 lookup["aliased_table"],

--- a/cumulusci/tasks/bulkdata/mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/mapping_parser.py
@@ -2,9 +2,11 @@ from typing import Dict, List, Union, IO, Optional
 from logging import getLogger
 from pathlib import Path
 
-from pydantic import Field, validator, ValidationError
+from pydantic import Field, validator, root_validator, ValidationError
 
 from cumulusci.utils.yaml.model_parser import CCIDictModel
+from cumulusci.utils import convert_to_snake_case
+
 from typing_extensions import Literal
 
 LOGGER_NAME = "MAPPING_LOADER"
@@ -19,6 +21,28 @@ class MappingLookup(CCIDictModel):
     join_field: Optional[str] = None
     after: Optional[str] = None
     aliased_table: Optional[str] = None
+    name: Optional[str] = None  # populated by parent
+
+    def get_lookup_key_field(self, model=None):
+        guesses = []
+        if self.get("key_field"):
+            guesses.append(self.get("key_field"))
+
+        guesses.append(self.name)
+
+        if not model:
+            return guesses[0]
+
+        # CCI used snake_case until mid-2020.
+        # At some point this code could probably be simplified.
+        snake_cased_guesses = list(map(convert_to_snake_case, guesses))
+        for guess in guesses + snake_cased_guesses:
+            if hasattr(model, guess):
+                return guess
+        raise KeyError(
+            f"Could not find a key field for {self.name}.\n"
+            + f"Tried {', '.join(snake_cased_guesses)}"
+        )
 
 
 class MappingStep(CCIDictModel):
@@ -35,6 +59,7 @@ class MappingStep(CCIDictModel):
     bulk_mode: Optional[
         Literal["Serial", "Parallel"]
     ] = None  # default should come from task options
+    sf_id_table: Optional[str] = None  # populated at runtime in extract.py
 
     @validator("record_type")
     def record_type_is_deprecated(cls, v):
@@ -48,6 +73,12 @@ class MappingStep(CCIDictModel):
         logger.warning(
             "oid_as_pk is deprecated. Just supply an Id column declaration and it will be inferred."
         )
+        return v
+
+    @root_validator  # not really a validator, more like a post-processor
+    def fixup_lookup_names(cls, v):
+        for name, lookup in v["lookups"].items():
+            lookup.name = name
         return v
 
 

--- a/cumulusci/tasks/bulkdata/mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/mapping_parser.py
@@ -24,6 +24,7 @@ class MappingLookup(CCIDictModel):
     name: Optional[str] = None  # populated by parent
 
     def get_lookup_key_field(self, model=None):
+        "Find the field name for this lookup."
         guesses = []
         if self.get("key_field"):
             guesses.append(self.get("key_field"))
@@ -36,12 +37,13 @@ class MappingLookup(CCIDictModel):
         # CCI used snake_case until mid-2020.
         # At some point this code could probably be simplified.
         snake_cased_guesses = list(map(convert_to_snake_case, guesses))
-        for guess in guesses + snake_cased_guesses:
+        guesses = guesses + snake_cased_guesses
+        for guess in guesses:
             if hasattr(model, guess):
                 return guess
         raise KeyError(
             f"Could not find a key field for {self.name}.\n"
-            + f"Tried {', '.join(snake_cased_guesses)}"
+            + f"Tried {', '.join(guesses)}"
         )
 
 
@@ -77,6 +79,7 @@ class MappingStep(CCIDictModel):
 
     @root_validator  # not really a validator, more like a post-processor
     def fixup_lookup_names(cls, v):
+        "Allow lookup objects to know the key they were attached to in the mapping file."
         for name, lookup in v["lookups"].items():
             lookup.name = name
         return v

--- a/cumulusci/tasks/bulkdata/tests/test_extract.py
+++ b/cumulusci/tasks/bulkdata/tests/test_extract.py
@@ -179,7 +179,7 @@ class TestExtractData(unittest.TestCase):
         task._sql_bulk_insert_from_records.assert_called_once_with(
             connection=task.session.connection.return_value,
             table="Opportunity",
-            columns=["sf_id", "Name", "account_id"],
+            columns=["sf_id", "Name", "AccountId"],
             record_iterable=log_mock.return_value,
         )
 
@@ -214,7 +214,7 @@ class TestExtractData(unittest.TestCase):
                 mock.call(
                     connection=task.session.connection.return_value,
                     table="Opportunity",
-                    columns=["Name", "account_id"],
+                    columns=["Name", "AccountId"],
                     record_iterable=csv_mock.return_value,
                 ),
                 mock.call(
@@ -310,7 +310,7 @@ class TestExtractData(unittest.TestCase):
         )
 
         task.session.query.return_value.filter.return_value.update.assert_called_once_with(
-            {task.models["Opportunity"].account_id: task.models["Account_sf_ids"].id},
+            {task.models["Opportunity"].AccountId: task.models["Account_sf_ids"].id},
             synchronize_session=False,
         )
         task.session.commit.assert_called_once_with()
@@ -353,7 +353,7 @@ class TestExtractData(unittest.TestCase):
         )
 
         task.session.bulk_update_mappings.assert_called_once_with(
-            task.models["Opportunity"], [{"id": item.id, "account_id": "1"}]
+            task.models["Opportunity"], [{"id": item.id, "AccountId": "1"}]
         )
         task.session.commit.assert_called_once_with()
 

--- a/cumulusci/tasks/bulkdata/tests/test_mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/tests/test_mapping_parser.py
@@ -1,10 +1,12 @@
 from pathlib import Path
-import logging
 from io import StringIO
+from unittest import mock
+import logging
 import pytest
 
 from yaml import safe_load, dump, YAMLError
 
+from cumulusci.tasks.bulkdata.mapping_parser import MappingLookup
 from cumulusci.tasks.bulkdata.mapping_parser import parse_from_yaml, ValidationError
 
 
@@ -21,7 +23,9 @@ class TestMappingParser:
         lookups = step["lookups"]
         assert lookups
         assert "after" in lookups["ParentId"]
-        after_list = {l["after"] for l in lookups.values() if "after" in l}
+        after_list = {
+            lookup["after"] for lookup in lookups.values() if "after" in lookup
+        }
         assert after_list
 
     def test_deprecation(self, caplog):
@@ -56,3 +60,42 @@ class TestMappingParser:
         base_path = Path(__file__).parent / "mapping_v2.yml"
         with open(base_path, "rb") as f:
             assert parse_from_yaml(f)
+
+
+class TestMappingLookup:
+    def test_get_lookup_key_field__no_model(self):
+        lookup = MappingLookup(table="contact", name="AccountId")
+        assert lookup.get_lookup_key_field() == "AccountId"
+
+    def test_get_lookup_key_field__snake_case_model(self):
+        class FakeModel:
+            account_id = mock.MagicMock()
+
+        lookup = MappingLookup(table="contact", name="AccountId")
+        assert lookup.get_lookup_key_field(FakeModel()) == "account_id"
+
+    def test_get_lookup_key_field__by_key_field(self):
+        class FakeModel:
+            foo = mock.MagicMock()
+
+        lookup = MappingLookup(table="contact", key_field="foo", name="AccountId")
+        assert lookup.get_lookup_key_field(FakeModel()) == "foo"
+
+    def test_get_lookup_key_field__by_key_field_wrong_case(self):
+        class FakeModel:
+            account_id = mock.MagicMock()
+
+        # we can correct mismatched mapping files if the mistake is just
+        # old-fashioned SQL with new Mapping File
+        lookup = MappingLookup(table="contact", key_field="AccountId", name="AccountId")
+        assert lookup.get_lookup_key_field(FakeModel()) == "account_id"
+
+    def test_get_lookup_key_field__mismatched_name(self):
+        class FakeModel:
+            account_id = mock.MagicMock()
+
+        # some mistakes can't be fixed.
+        lookup = MappingLookup(table="contact", key_field="Foo", name="Foo")
+
+        with pytest.raises(KeyError):
+            lookup.get_lookup_key_field(FakeModel())

--- a/cumulusci/tasks/bulkdata/tests/test_utils.py
+++ b/cumulusci/tasks/bulkdata/tests/test_utils.py
@@ -2,7 +2,8 @@ from datetime import datetime
 import os
 import unittest
 from unittest import mock
-import yaml
+
+import pytest
 
 import responses
 from sqlalchemy import create_engine, MetaData, Integer, types, Unicode, Column, Table
@@ -10,7 +11,12 @@ from sqlalchemy.orm import create_session, mapper
 
 from cumulusci.tasks import bulkdata
 from cumulusci.utils import temporary_dir
-from cumulusci.tasks.bulkdata.utils import create_table, generate_batches
+from cumulusci.tasks.bulkdata.utils import (
+    create_table,
+    generate_batches,
+    get_lookup_key_field,
+)
+from cumulusci.tasks.bulkdata.mapping_parser import MappingLookup, parse_from_yaml
 
 
 def create_db_file(filename):
@@ -121,9 +127,9 @@ class TestSqlAlchemyMixin(unittest.TestCase):
 class TestCreateTable(unittest.TestCase):
     def test_create_table_legacy_oid_mapping(self):
         mapping_file = os.path.join(os.path.dirname(__file__), "mapping_v1.yml")
-        with open(mapping_file, "r") as fh:
-            content = yaml.safe_load(fh)
-            account_mapping = content["Insert Contacts"]
+
+        content = parse_from_yaml(mapping_file)
+        account_mapping = content["Insert Contacts"]
 
         with temporary_dir() as d:
             tmp_db_path = os.path.join(d, "temp.db")
@@ -138,9 +144,8 @@ class TestCreateTable(unittest.TestCase):
 
     def test_create_table_modern_id_mapping(self):
         mapping_file = os.path.join(os.path.dirname(__file__), "mapping_v2.yml")
-        with open(mapping_file, "r") as fh:
-            content = yaml.safe_load(fh)
-            account_mapping = content["Insert Contacts"]
+        content = parse_from_yaml(mapping_file)
+        account_mapping = content["Insert Contacts"]
 
         with temporary_dir() as d:
             tmp_db_path = os.path.join(d, "temp.db")
@@ -171,3 +176,42 @@ class TestBatching(unittest.TestCase):
     def test_batching_with_remainder(self):
         batches = list(generate_batches(num_records=20, batch_size=7))
         assert batches == [(7, 0), (7, 1), (6, 2)]
+
+
+class TestGetLookupKeyField:
+    def test_lookup_no_model(self):
+        lookup = MappingLookup(table="contact", name="AccountId")
+        assert get_lookup_key_field(lookup) == "AccountId"
+
+    def test_lookup_snake_case_model(self):
+        class FakeModel:
+            account_id = mock.MagicMock()
+
+        lookup = MappingLookup(table="contact", name="AccountId")
+        assert get_lookup_key_field(lookup, FakeModel()) == "account_id"
+
+    def test_lookup_by_key_field(self):
+        class FakeModel:
+            foo = mock.MagicMock()
+
+        lookup = MappingLookup(table="contact", key_field="foo", name="AccountId")
+        assert get_lookup_key_field(lookup, FakeModel()) == "foo"
+
+    def test_lookup_by_key_field_wrong_case(self):
+        class FakeModel:
+            account_id = mock.MagicMock()
+
+        # we can correct mismatched mapping files if the mistake is just
+        # old-fashioned SQL with new Mapping File
+        lookup = MappingLookup(table="contact", key_field="AccountId", name="AccountId")
+        assert get_lookup_key_field(lookup, FakeModel()) == "account_id"
+
+    def test_lookup_by_key_field_mismatched_name(self):
+        class FakeModel:
+            account_id = mock.MagicMock()
+
+        # some mistakes can't be fixed.
+        lookup = MappingLookup(table="contact", key_field="Foo", name="Foo")
+
+        with pytest.raises(KeyError):
+            get_lookup_key_field(lookup, FakeModel())

--- a/cumulusci/tasks/bulkdata/utils.py
+++ b/cumulusci/tasks/bulkdata/utils.py
@@ -1,5 +1,4 @@
 import datetime
-import warnings
 
 from sqlalchemy import types
 from sqlalchemy import event
@@ -10,16 +9,6 @@ from sqlalchemy import Unicode
 from sqlalchemy.orm import mapper
 
 from cumulusci.core.exceptions import BulkDataException
-
-
-def get_lookup_key_field(lookup, model=None):
-    # This should be removed in late 2020.
-    # It just provides some temporary backwards-compatibility
-    # for Snowfakery
-    warnings.warn(
-        "get_lookup_key_field is a method, not a function", DeprecationWarning
-    )
-    return lookup.get_lookup_key_field(model=model)
 
 
 # Create a custom sqlalchemy field type for sqlite datetime fields which are stored as integer of epoch time

--- a/cumulusci/tasks/bulkdata/utils.py
+++ b/cumulusci/tasks/bulkdata/utils.py
@@ -12,8 +12,20 @@ from cumulusci.core.exceptions import BulkDataException
 from cumulusci.utils import convert_to_snake_case
 
 
-def get_lookup_key_field(lookup, sf_field):
-    return lookup.get("key_field") or convert_to_snake_case(sf_field)
+def get_lookup_key_field(lookup, sf_field, model=None):
+    guesses = []
+    if lookup.get("key_field"):
+        guesses.append(lookup.get("key_field"))
+
+    guesses.append(sf_field)
+
+    if not model:
+        return guesses[0]
+
+    snake_cased_guesses = list(map(convert_to_snake_case, guesses))
+    for guess in guesses + snake_cased_guesses:
+        if getattr(model, guess, None):
+            return guess
 
 
 # Create a custom sqlalchemy field type for sqlite datetime fields which are stored as integer of epoch time


### PR DESCRIPTION
Behaviour change:

 * lookups do not anymore default to using snake_case, although they will look for snake_case in a dataset.

 * a few code paths which previously did not use our official mapping parser, now do. Which means that they will give error messages for misplaced, misnamed or missing keys

Internal renamings/refactorings:

 * some classes used "self.mappings" and others "self.mapping". Now they all use "self.mapping".

 * get_lookup_key_field is now a method which takes 0 arguments, not a function which takes 2. The old function remains temporarily for backwards compatibility. (primarily with snowfakery)
