### PR TITLE
Add wait of 120 minutes to org creation

### DIFF
--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -183,6 +183,7 @@ class ScratchOrgConfig(OrgConfig):
             "devhub": f" --targetdevhubusername {devhub}" if devhub else "",
             "namespaced": " -n" if not self.namespaced else "",
             "days": f" --durationdays {self.days}" if self.days else "",
+            "wait": " -w 120",
             "alias": sarge.shell_format(' -a "{0!s}"', self.sfdx_alias)
             if self.sfdx_alias
             else "",
@@ -195,7 +196,7 @@ class ScratchOrgConfig(OrgConfig):
 
         # This feels a little dirty, but the use cases for extra args would mostly
         # work best with env vars
-        command = "force:org:create -f {config_file}{devhub}{namespaced}{days}{alias}{default} {email} {extraargs}".format(
+        command = "force:org:create -f {config_file}{devhub}{namespaced}{days}{alias}{default}{wait} {email} {extraargs}".format(
             **options
         )
         p = sfdx(command, username=None, log_note="Creating scratch org")


### PR DESCRIPTION
# Critical Changes

# Changes
* Scratch org creation will now wait up to 120 minutes for the org to be created to avoid timeouts with more complex org shapes

# Issues Closed
