### PR TITLE
Add support for the %%%NAMESPACE_DOT%%% token, to reference Apex classes and managed Record Types

### DIFF
--- a/cumulusci/tests/test_utils.py
+++ b/cumulusci/tests/test_utils.py
@@ -365,31 +365,31 @@ Options\n------------------------------------------\n\n
     def test_inject_namespace__managed(self):
         logger = mock.Mock()
         name = "___NAMESPACE___test"
-        content = "%%%NAMESPACE%%%|%%%NAMESPACED_ORG%%%|%%%NAMESPACE_OR_C%%%|%%%NAMESPACED_ORG_OR_C%%%"
+        content = "%%%NAMESPACE%%%|%%%NAMESPACE_DOT%%%|%%%NAMESPACED_ORG%%%|%%%NAMESPACE_OR_C%%%|%%%NAMESPACED_ORG_OR_C%%%"
 
         name, content = utils.inject_namespace(
             name, content, namespace="ns", managed=True, logger=logger
         )
         assert name == "ns__test"
-        assert content == "ns__||ns|c"
+        assert content == "ns__|ns.||ns|c"
 
     def test_inject_namespace__unmanaged(self):
         name = "___NAMESPACE___test"
-        content = "%%%NAMESPACE%%%|%%%NAMESPACED_ORG%%%|%%%NAMESPACE_OR_C%%%|%%%NAMESPACED_ORG_OR_C%%%"
+        content = "%%%NAMESPACE%%%|%%%NAMESPACE_DOT%%%|%%%NAMESPACED_ORG%%%|%%%NAMESPACE_OR_C%%%|%%%NAMESPACED_ORG_OR_C%%%"
 
         name, content = utils.inject_namespace(name, content, namespace="ns")
         assert name == "test"
-        assert content == "||c|c"
+        assert content == "|||c|c"
 
     def test_inject_namespace__namespaced_org(self):
         name = "___NAMESPACE___test"
-        content = "%%%NAMESPACE%%%|%%%NAMESPACED_ORG%%%|%%%NAMESPACE_OR_C%%%|%%%NAMESPACED_ORG_OR_C%%%"
+        content = "%%%NAMESPACE%%%|%%%NAMESPACE_DOT%%%|%%%NAMESPACED_ORG%%%|%%%NAMESPACE_OR_C%%%|%%%NAMESPACED_ORG_OR_C%%%"
 
         name, content = utils.inject_namespace(
             name, content, namespace="ns", managed=True, namespaced_org=True
         )
         assert name == "ns__test"
-        assert content == "ns__|ns__|ns|ns"
+        assert content == "ns__|ns.|ns__|ns|ns"
 
     def test_strip_namespace(self):
         logger = mock.Mock()

--- a/cumulusci/utils/__init__.py
+++ b/cumulusci/utils/__init__.py
@@ -285,8 +285,12 @@ def inject_namespace(
         namespace_token = "%%%NAMESPACE%%%"
     if managed is True and namespace:
         namespace_prefix = namespace + "__"
+        namespace_dot_prefix = namespace + "."
     else:
         namespace_prefix = ""
+        namespace_dot_prefix = ""
+
+    namespace_dot_token = "%%%NAMESPACE_DOT%%%"
 
     # Handle tokens %%%NAMESPACED_ORG%%% and ___NAMESPACED_ORG___
     namespaced_org_token = "%%%NAMESPACED_ORG%%%"
@@ -306,6 +310,13 @@ def inject_namespace(
     content = content.replace(namespace_token, namespace_prefix)
     if logger and content != prev_content:
         logger.info(f'  {name}: Replaced {namespace_token} with "{namespace_prefix}"')
+
+    prev_content = content
+    content = content.replace(namespace_dot_token, namespace_dot_prefix)
+    if logger and content != prev_content:
+        logger.info(
+            f'  {name}: Replaced {namespace_dot_token} with "{namespace_dot_prefix}"'
+        )
 
     prev_content = content
     content = content.replace(namespace_or_c_token, namespace_or_c)
@@ -492,9 +503,9 @@ def create_task_options_doc(task_options):
             doc.append(f"\n``{usage_str}``")
 
         if option.get("required"):
-            doc.append(f"\t *Required*")
+            doc.append("\t *Required*")
         else:
-            doc.append(f"\t *Optional*")
+            doc.append("\t *Optional*")
 
         description = option.get("description")
         if description:


### PR DESCRIPTION

# Critical Changes

# Changes

- `deploy` now supports the `%%%NAMESPACE_DOT%%%` injection token, which can be used to support references to packaged Apex classes and Record Types. The token is replaced with `ns.` rather than `ns__`, for namespace `ns`.

# Issues Closed
