### PR TITLE
Feature/fix sf client cache

### DIFF
--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -22,7 +22,6 @@ class ScratchOrgConfig(OrgConfig):
     def scratch_info(self):
         if hasattr(self, "_scratch_info"):
             return self._scratch_info
-        self._client = None
 
         # Create the org if it hasn't already been created
         if not self.created:
@@ -322,6 +321,7 @@ class ScratchOrgConfig(OrgConfig):
 
     def refresh_oauth_token(self, keychain):
         """ Use sfdx force:org:describe to refresh token instead of built in OAuth handling """
+        self._client = None
         if hasattr(self, "_scratch_info"):
             # Cache the scratch_info for 1 hour to avoid unnecessary calls out
             # to sfdx CLI

--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -22,6 +22,7 @@ class ScratchOrgConfig(OrgConfig):
     def scratch_info(self):
         if hasattr(self, "_scratch_info"):
             return self._scratch_info
+        self._client = None
 
         # Create the org if it hasn't already been created
         if not self.created:


### PR DESCRIPTION
Invalidate cached SF client in ScratchOrgInfo.refresh_oauth_token

# Critical Changes

# Changes

# Issues Closed
- Fixed a regression introduced in CumulusCI 3.13.0 where connections to a scratch org could fail with a ReadTimeout or other connection error if more than 10 minutes elapsed since a prior task that interacted with the org.