### PR TITLE
Use working directory if provided

### DIFF
--- a/cumulusci/tasks/bulkdata/generate_and_load_data.py
+++ b/cumulusci/tasks/bulkdata/generate_and_load_data.py
@@ -75,8 +75,8 @@ class GenerateAndLoadData(BaseSalesforceApiTask):
         "replace_database": {
             "description": "Confirmation that it is okay to delete the data in database_url",
         },
-        "debug_dir": {
-            "description": "Store temporary DB files in debug_dir for easier debugging."
+        "working_directory": {
+            "description": "Store temporary files in working_directory for easier debugging."
         },
         **LoadData.task_options,
     }
@@ -108,7 +108,7 @@ class GenerateAndLoadData(BaseSalesforceApiTask):
         else:
             raise TaskOptionsError("No data generation task specified")
 
-        self.debug_dir = self.options.get("debug_dir", None)
+        self.working_directory = self.options.get("working_directory", None)
         self.database_url = self.options.get("database_url")
 
         if self.database_url:
@@ -137,7 +137,7 @@ class GenerateAndLoadData(BaseSalesforceApiTask):
                 )
                 self._generate_batch(
                     self.database_url,
-                    self.debug_dir or tempdir,
+                    self.working_directory or tempdir,
                     self.mapping_file,
                     current_batch_size,
                     index,

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -634,7 +634,7 @@ Options
 ``-o path PATH``
 	 *Required*
 
-	 The path to the parent directory containing the metadata bundles directories
+	 The path to the metadata source to be deployed
 
 	 Default: src
 
@@ -1251,10 +1251,10 @@ Options
 
 	 Confirmation that it is okay to delete the data in database_url
 
-``-o debug_dir DEBUGDIR``
+``-o working_directory WORKINGDIRECTORY``
 	 *Optional*
 
-	 Store temporary DB files in debug_dir for easier debugging.
+	 Default path for temporary / working files
 
 ``-o database_url DATABASEURL``
 	 *Optional*
@@ -1305,11 +1305,6 @@ Options
 	 *Optional*
 
 	 Path for Snowfakery to put its next continuation file
-
-``-o working_directory WORKINGDIRECTORY``
-	 *Optional*
-
-	 Default path for temporary / working files
 
 **get_installed_packages**
 ==========================================
@@ -2807,9 +2802,9 @@ Example Output::
     W: 2, 0: No suite documentation (RequireSuiteDocumentation)
     E: 30, 0: No testcase documentation (RequireTestDocumentation)
 
-To see a list of all configured options, set the 'list' option to True:
+To see a list of all configured rules, set the 'list' option to True:
 
-    cci task run robot_list -o list True
+    cci task run robot_lint -o list True
 
 
 Command Syntax


### PR DESCRIPTION
# Changes

generate_and_load and generate_and_load_from_yaml tasks now respect the working_directory option and store their tempfiles in the working directory. This is primarily helpful for debugging.

debug_dir was another name for working_directory and has been removed.