### PR TITLE
Fix the logic for blocking beta installs in non-scratch orgs

### DIFF
--- a/cumulusci/tasks/salesforce/UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/UpdateDependencies.py
@@ -2,7 +2,6 @@ import functools
 from distutils.version import LooseVersion
 
 from cumulusci.core.utils import process_bool_arg
-from cumulusci.core.config import ScratchOrgConfig
 from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.salesforce_api.metadata import ApiDeploy
 from cumulusci.salesforce_api.metadata import ApiRetrieveInstalledPackages
@@ -97,9 +96,7 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
             self.logger.info("Project has no dependencies, doing nothing")
             return
 
-        if self.options["include_beta"] and not isinstance(
-            self.org_config, ScratchOrgConfig
-        ):
+        if self.options["include_beta"] and not self.org_config.scratch:
             raise TaskOptionsError(
                 "Target org must be a scratch org when `include_beta` is true."
             )

--- a/cumulusci/tasks/salesforce/tests/test_UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/tests/test_UpdateDependencies.py
@@ -202,7 +202,7 @@ class TestUpdateDependencies(unittest.TestCase):
         project_config.config["project"]["dependencies"] = [{"namespace": "foo"}]
         task = create_task(UpdateDependencies, project_config=project_config)
         task.options["include_beta"] = True
-        task.org_config = mock.Mock()
+        task.org_config = mock.Mock(scratch=False)
 
         with self.assertRaises(TaskOptionsError):
             task()


### PR DESCRIPTION
Check org_config.scratch instead of isinstance(org_config, ScratchOrgConfig). In Metecho, OrgConfig is used for scratch orgs too to avoid calling out to sfdx.

# Critical Changes

# Changes

# Issues Closed
- Fixed a bug in the logic to prevent installing beta packages in non-scratch orgs which affected Metecho.