### PR TITLE
Use current branch as default for cci project init

### DIFF
--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -237,56 +237,56 @@ jobs:
         name: robot
         path: robot/CumulusCI/results
 
-  robot_ui_prerelease:
-    name: "Robot: Summer '20"
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    - name: pip cache
-      uses: actions/cache@v1
-      with:
-        path: ~\AppData\Local\pip\Cache
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-    - name: Install Python dependencies
-      run: |
-        python -m pip install -U pip
-        pip install -r requirements_dev.txt
-    - name: Install sfdx
-      run: |
-        mkdir sfdx
-        wget -qO- https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz | tar xJ -C sfdx --strip-components 1
-        ./sfdx/install
-        echo $SFDX_HUB_KEY_BASE64 | base64 --decode > sfdx.key
-        sfdx force:auth:jwt:grant --clientid $SFDX_CLIENT_ID --jwtkeyfile sfdx.key --username $SFDX_HUB_USERNAME --setdefaultdevhubusername -a hub
-      env:
-        SFDX_HUB_KEY_BASE64: ${{ secrets.SFDX_HUB_KEY_BASE64 }}
-        SFDX_CLIENT_ID: ${{ secrets.SFDX_CLIENT_ID }}
-        SFDX_HUB_USERNAME: ${{ secrets.SFDX_HUB_USERNAME }}
-    - name: Run robot tests
-      run: |
-        coverage run --append $(which cci) task run robot \
-          --org prerelease \
-          -o suites cumulusci/robotframework/tests/salesforce \
-          -o exclude no-browser \
-          -o vars BROWSER:headlesschrome
-    - name: Delete scratch org
-      if: always()
-      run: |
-        cci org scratch_delete prerelease
-    - name: Report coverage
-      run: coveralls
-    - name: Store robot results
-      if: failure()
-      uses: actions/upload-artifact@v1
-      with:
-        name: robot
-        path: robot/CumulusCI/results
+  # robot_ui_prerelease:
+  #   name: "Robot: Summer '20"
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Set up Python 3.8
+  #     uses: actions/setup-python@v1
+  #     with:
+  #       python-version: 3.8
+  #   - name: pip cache
+  #     uses: actions/cache@v1
+  #     with:
+  #       path: ~\AppData\Local\pip\Cache
+  #       key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
+  #       restore-keys: |
+  #         ${{ runner.os }}-pip-
+  #   - name: Install Python dependencies
+  #     run: |
+  #       python -m pip install -U pip
+  #       pip install -r requirements_dev.txt
+  #   - name: Install sfdx
+  #     run: |
+  #       mkdir sfdx
+  #       wget -qO- https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz | tar xJ -C sfdx --strip-components 1
+  #       ./sfdx/install
+  #       echo $SFDX_HUB_KEY_BASE64 | base64 --decode > sfdx.key
+  #       sfdx force:auth:jwt:grant --clientid $SFDX_CLIENT_ID --jwtkeyfile sfdx.key --username $SFDX_HUB_USERNAME --setdefaultdevhubusername -a hub
+  #     env:
+  #       SFDX_HUB_KEY_BASE64: ${{ secrets.SFDX_HUB_KEY_BASE64 }}
+  #       SFDX_CLIENT_ID: ${{ secrets.SFDX_CLIENT_ID }}
+  #       SFDX_HUB_USERNAME: ${{ secrets.SFDX_HUB_USERNAME }}
+  #   - name: Run robot tests
+  #     run: |
+  #       coverage run --append $(which cci) task run robot \
+  #         --org prerelease \
+  #         -o suites cumulusci/robotframework/tests/salesforce \
+  #         -o exclude no-browser \
+  #         -o vars BROWSER:headlesschrome
+  #   - name: Delete scratch org
+  #     if: always()
+  #     run: |
+  #       cci org scratch_delete prerelease
+  #   - name: Report coverage
+  #     run: coveralls
+  #   - name: Store robot results
+  #     if: failure()
+  #     uses: actions/upload-artifact@v1
+  #     with:
+  #       name: robot
+  #       path: robot/CumulusCI/results
 
   coveralls_done:
     name: Finalize coveralls

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -7,7 +7,7 @@ on:
     - master
 
 env:
-  CUMULUSCI_ORG_scratch: '{"config_file": "orgs/prerelease.json", "scratch": true}'
+  CUMULUSCI_ORG_scratch: '{"config_file": "orgs/dev.json", "scratch": true}'
   CUMULUSCI_ORG_packaging: ${{ secrets.CUMULUSCI_ORG_packaging }}
   CUMULUSCI_SERVICE_github: ${{ secrets.CUMULUSCI_SERVICE_github }}
   SFDX_CLIENT_ID: ${{ secrets.SFDX_CLIENT_ID }}

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -49,6 +49,7 @@ from cumulusci.salesforce_api.utils import get_simple_salesforce_connection
 from cumulusci.utils import doc_task
 from cumulusci.utils import parse_api_datetime
 from cumulusci.utils import get_cci_upgrade_command
+from cumulusci.utils.git import current_branch
 from cumulusci.utils.logging import tee_stdout_stderr
 from cumulusci.oauth.salesforce import CaptureSalesforceOAuth
 
@@ -514,11 +515,12 @@ def project_init(runtime):
     click.echo()
     click.echo(click.style("# Git Configuration", bold=True, fg="blue"))
     click.echo(
-        "CumulusCI assumes your default branch is master, your feature branches are named feature/*, your beta release tags are named beta/*, and your release tags are release/*.  If you want to use a different branch/tag naming scheme, you can configure the overrides here.  Otherwise, just accept the defaults."
+        "CumulusCI assumes the current git branch is your default branch, your feature branches are named feature/*, your beta release tags are named beta/*, and your release tags are release/*.  If you want to use a different branch/tag naming scheme, you can configure the overrides here.  Otherwise, just accept the defaults."
     )
 
+    default_main_branch = current_branch(os.getcwd()) or "main"
     git_default_branch = click.prompt(
-        click.style("Default Branch", bold=True), default="master"
+        click.style("Default Branch", bold=True), default=default_main_branch
     )
     if (
         git_default_branch

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -551,6 +551,7 @@ Environment Info: Rossian / x68_46
     def test_project_init(self, click):
         with temporary_dir():
             os.mkdir(".git")
+            Path(".git", "HEAD").write_text("ref: refs/heads/main")
 
             click.prompt.side_effect = (
                 "testproj",  # project_name
@@ -560,7 +561,7 @@ Environment Info: Rossian / x68_46
                 "mdapi",  # source_format
                 "3",  # extend other URL
                 "https://github.com/SalesforceFoundation/NPSP",  # github_url
-                "default",  # git_default_branch
+                "main",  # git_default_branch
                 "work/",  # git_prefix_feature
                 "uat/",  # git_prefix_beta
                 "rel/",  # git_prefix_release
@@ -583,6 +584,7 @@ Environment Info: Rossian / x68_46
             self.assertEqual(
                 [
                     ".git/",
+                    ".git/HEAD",
                     ".github/",
                     ".github/PULL_REQUEST_TEMPLATE.md",
                     ".gitignore",
@@ -612,6 +614,7 @@ Environment Info: Rossian / x68_46
         """Verify that the generated cumulusci.yml file is readable and has the proper robot task"""
         with temporary_dir():
             os.mkdir(".git")
+            Path(".git", "HEAD").write_text("ref: refs/heads/main")
 
             click.prompt.side_effect = (
                 "testproj",  # project_name
@@ -621,7 +624,7 @@ Environment Info: Rossian / x68_46
                 "mdapi",  # source_format
                 "3",  # extend other URL
                 "https://github.com/SalesforceFoundation/NPSP",  # github_url
-                "default",  # git_default_branch
+                "main",  # git_default_branch
                 "work/",  # git_prefix_feature
                 "uat/",  # git_prefix_beta
                 "rel/",  # git_prefix_release
@@ -666,6 +669,7 @@ Environment Info: Rossian / x68_46
     def test_project_init_already_initted(self):
         with temporary_dir():
             os.mkdir(".git")
+            Path(".git", "HEAD").write_text("ref: refs/heads/main")
             with open("cumulusci.yml", "w"):
                 pass  # create empty file
 

--- a/cumulusci/core/github.py
+++ b/cumulusci/core/github.py
@@ -94,7 +94,7 @@ def get_pull_requests_by_head(repo, branch_name):
 
 def create_pull_request(repo, branch_name, base=None, title=None):
     """Creates a pull request for the given branch"""
-    base = base or "master"
+    base = base or repo.default_branch
     title = title or "Auto-Generated Pull Request"
     pull_request = repo.create_pull(title, base, branch_name)
     return pull_request

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -102,7 +102,7 @@ class DummyResponse(object):
 
 
 class DummyRepository(object):
-    default_branch = "master"
+    default_branch = "main"
     _api = "http://"
 
     def __init__(self, owner, name, contents, releases=None):
@@ -274,7 +274,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         env = {
             "CUMULUSCI_AUTO_DETECT": "1",
             "HEROKU_TEST_RUN_ID": "TEST1",
-            "HEROKU_TEST_RUN_BRANCH": "master",
+            "HEROKU_TEST_RUN_BRANCH": "main",
             "HEROKU_TEST_RUN_COMMIT_VERSION": "HEAD",
             "CUMULUSCI_REPO_BRANCH": "feature/test",
             "CUMULUSCI_REPO_COMMIT": "HEAD~1",
@@ -301,7 +301,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         env = {
             "CUMULUSCI_AUTO_DETECT": "1",
             "HEROKU_TEST_RUN_ID": "TEST1",
-            "HEROKU_TEST_RUN_BRANCH": "master",
+            "HEROKU_TEST_RUN_BRANCH": "main",
             "HEROKU_TEST_RUN_COMMIT_VERSION": "HEAD",
             "CUMULUSCI_REPO_BRANCH": "feature/test",
             "CUMULUSCI_REPO_COMMIT": "HEAD~1",
@@ -341,7 +341,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         with temporary_dir():
             self.assertIsNone(config.repo_url)
 
-    @mock.patch("cumulusci.core.config.project_config.BaseProjectConfig.git_path")
+    @mock.patch("cumulusci.core.config.project_config.git_path")
     def test_repo_url_from_git(self, git_path):
         git_config_file = "git_config"
         git_path.return_value = git_config_file
@@ -366,8 +366,8 @@ class TestBaseProjectConfig(unittest.TestCase):
 
     def test_repo_branch_from_repo_info(self):
         config = BaseProjectConfig(BaseGlobalConfig())
-        config._repo_info = {"branch": "master"}
-        self.assertEqual("master", config.repo_branch)
+        config._repo_info = {"branch": "main"}
+        self.assertEqual("main", config.repo_branch)
 
     def test_repo_branch_no_repo_root(self):
         config = BaseProjectConfig(BaseGlobalConfig())
@@ -1043,7 +1043,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         with pytest.raises(ConfigError):
             project_config._validate_package_api_format()
 
-    @mock.patch("cumulusci.core.config.project_config.BaseProjectConfig.git_path")
+    @mock.patch("cumulusci.core.config.project_config.git_path")
     def test_git_config_remote_origin_line(self, git_path):
         git_config_file = "test_git_config_file"
         git_path.return_value = git_config_file

--- a/cumulusci/core/tests/test_config_expensive.py
+++ b/cumulusci/core/tests/test_config_expensive.py
@@ -91,7 +91,7 @@ class TestBaseProjectConfig(unittest.TestCase):
 
         dirname = os.path.join(self.tempdir_project, ".git", "refs", "heads")
         os.makedirs(dirname)
-        filename = os.path.join(dirname, "master")
+        filename = os.path.join(dirname, "main")
         content = self.current_commit
         self._write_file(filename, content)
 
@@ -129,7 +129,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         self.tempdir_project = tempfile.mkdtemp()
         self.project_name = "TestRepo"
         self.current_commit = "abcdefg1234567890"
-        self.current_branch = "master"
+        self.current_branch = "main"
 
     def teardown_method(self, method):
         shutil.rmtree(self.tempdir_home)

--- a/cumulusci/core/tests/test_github.py
+++ b/cumulusci/core/tests/test_github.py
@@ -149,7 +149,7 @@ class TestGithub(GithubApiTestMixin):
         pull_requests = get_pull_requests_by_head(repo, "test_branch")
         assert pull_requests == []
 
-        pull_requests = get_pull_requests_by_head(repo, "master")
+        pull_requests = get_pull_requests_by_head(repo, "main")
         assert pull_requests is None
 
     @responses.activate
@@ -162,15 +162,15 @@ class TestGithub(GithubApiTestMixin):
     @responses.activate
     def test_get_pull_requests_with_base_branch(self, mock_util, repo):
         self.init_github()
-        mock_util.mock_pulls(base="master", head="TestOwner:some-branch")
+        mock_util.mock_pulls(base="main", head="TestOwner:some-branch")
         pull_requests = get_pull_requests_with_base_branch(
-            repo, "master", head="some-branch"
+            repo, "main", head="some-branch"
         )
         assert 0 == len(pull_requests)
 
         responses.reset()
-        mock_util.mock_pulls(pulls=self._get_expected_pull_requests(3), base="master")
-        pull_requests = get_pull_requests_with_base_branch(repo, "master")
+        mock_util.mock_pulls(pulls=self._get_expected_pull_requests(3), base="main")
+        pull_requests = get_pull_requests_with_base_branch(repo, "main")
         assert 3 == len(pull_requests)
 
     @responses.activate
@@ -262,7 +262,7 @@ class TestGithub(GithubApiTestMixin):
     def mock_gist(self, description, files):
         responses.add(
             method=responses.POST,
-            url=f"https://api.github.com/gists",
+            url="https://api.github.com/gists",
             json=self._get_expected_gist(description, files),
             status=201,
         )

--- a/cumulusci/core/tests/test_source.py
+++ b/cumulusci/core/tests/test_source.py
@@ -52,7 +52,7 @@ class TestGitHubSource(unittest.TestCase, MockUtil):
         )
         responses.add(
             "GET",
-            f"https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/release/1.0",
+            "https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/release/1.0",
             json=self._get_expected_tag_ref("release/1.0", "tag_sha"),
         )
 
@@ -78,16 +78,15 @@ class TestGitHubSource(unittest.TestCase, MockUtil):
         )
         responses.add(
             "GET",
-            f"https://api.github.com/repos/TestOwner/TestRepo/git/refs/heads/master",
-            json=self._get_expected_ref("heads/master", "abcdef"),
+            "https://api.github.com/repos/TestOwner/TestRepo/git/refs/heads/main",
+            json=self._get_expected_ref("heads/main", "abcdef"),
         )
 
         source = GitHubSource(
             self.project_config, {"github": "https://github.com/TestOwner/TestRepo.git"}
         )
         assert (
-            repr(source)
-            == "<GitHubSource GitHub: TestOwner/TestRepo @ master (abcdef)>"
+            repr(source) == "<GitHubSource GitHub: TestOwner/TestRepo @ main (abcdef)>"
         )
 
     @responses.activate
@@ -113,17 +112,16 @@ class TestGitHubSource(unittest.TestCase, MockUtil):
         )
         responses.add(
             "GET",
-            f"https://api.github.com/repos/TestOwner/TestRepo/git/refs/master",
-            json=self._get_expected_ref("master", "abcdef"),
+            "https://api.github.com/repos/TestOwner/TestRepo/git/refs/main",
+            json=self._get_expected_ref("main", "abcdef"),
         )
 
         source = GitHubSource(
             self.project_config,
-            {"github": "https://github.com/TestOwner/TestRepo.git", "ref": "master"},
+            {"github": "https://github.com/TestOwner/TestRepo.git", "ref": "main"},
         )
         assert (
-            repr(source)
-            == "<GitHubSource GitHub: TestOwner/TestRepo @ master (abcdef)>"
+            repr(source) == "<GitHubSource GitHub: TestOwner/TestRepo @ main (abcdef)>"
         )
 
     @responses.activate
@@ -135,17 +133,16 @@ class TestGitHubSource(unittest.TestCase, MockUtil):
         )
         responses.add(
             "GET",
-            f"https://api.github.com/repos/TestOwner/TestRepo/git/refs/heads/master",
-            json=self._get_expected_ref("master", "abcdef"),
+            "https://api.github.com/repos/TestOwner/TestRepo/git/refs/heads/main",
+            json=self._get_expected_ref("main", "abcdef"),
         )
 
         source = GitHubSource(
             self.project_config,
-            {"github": "https://github.com/TestOwner/TestRepo.git", "branch": "master"},
+            {"github": "https://github.com/TestOwner/TestRepo.git", "branch": "main"},
         )
         assert (
-            repr(source)
-            == "<GitHubSource GitHub: TestOwner/TestRepo @ master (abcdef)>"
+            repr(source) == "<GitHubSource GitHub: TestOwner/TestRepo @ main (abcdef)>"
         )
 
     @responses.activate
@@ -157,7 +154,7 @@ class TestGitHubSource(unittest.TestCase, MockUtil):
         )
         responses.add(
             "GET",
-            f"https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/release/1.0",
+            "https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/release/1.0",
             json=self._get_expected_tag_ref("release/1.0", "abcdef"),
         )
 
@@ -187,7 +184,7 @@ class TestGitHubSource(unittest.TestCase, MockUtil):
         )
         responses.add(
             "GET",
-            f"https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/release/1.0",
+            "https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/release/1.0",
             json=self._get_expected_tag_ref("release/1.0", "tag_sha"),
         )
 
@@ -217,7 +214,7 @@ class TestGitHubSource(unittest.TestCase, MockUtil):
         )
         responses.add(
             "GET",
-            f"https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/beta/1.0-Beta_1",
+            "https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/beta/1.0-Beta_1",
             json=self._get_expected_tag_ref("beta/1.0-Beta_1", "tag_sha"),
         )
 
@@ -251,7 +248,7 @@ class TestGitHubSource(unittest.TestCase, MockUtil):
         )
         responses.add(
             "GET",
-            f"https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/release/1.0",
+            "https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/release/1.0",
             json=self._get_expected_tag_ref("release/1.0", "tag_sha"),
         )
 
@@ -320,7 +317,7 @@ class TestGitHubSource(unittest.TestCase, MockUtil):
         )
         responses.add(
             "GET",
-            f"https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/release/1.0",
+            "https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/release/1.0",
             json=self._get_expected_tag_ref("release/1.0", "tag_sha"),
         )
         f = io.BytesIO()
@@ -370,7 +367,7 @@ class TestGitHubSource(unittest.TestCase, MockUtil):
         )
         responses.add(
             "GET",
-            f"https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/release/1.0",
+            "https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/release/1.0",
             json=self._get_expected_tag_ref("release/1.0", "tag_sha"),
         )
         # Set up a fake IOError while extracting the zipball
@@ -400,7 +397,7 @@ class TestGitHubSource(unittest.TestCase, MockUtil):
         )
         responses.add(
             "GET",
-            f"https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/release/1.0",
+            "https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/release/1.0",
             json=self._get_expected_tag_ref("release/1.0", "tag_sha"),
         )
 
@@ -425,7 +422,7 @@ class TestGitHubSource(unittest.TestCase, MockUtil):
         )
         responses.add(
             "GET",
-            f"https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/release/1.0",
+            "https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/release/1.0",
             json=self._get_expected_tag_ref("release/1.0", "tag_sha"),
         )
 

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -186,7 +186,7 @@ tasks:
         class_path: cumulusci.tasks.github.CloneTag
         group: GitHub
     github_master_to_feature:
-        description: Merges the latest commit on the master branch into all open feature branches
+        description: Merges the latest commit on the main branch into all open feature branches
         class_path: cumulusci.tasks.github.MergeBranch
         group: GitHub
     github_parent_to_children:
@@ -553,7 +553,7 @@ flows:
                 task: github_parent_to_children
 
     ci_master:
-        description: Deploy the package metadata to the packaging org and prepare for managed package version upload.  Intended for use against master branch commits.
+        description: Deploy the package metadata to the packaging org and prepare for managed package version upload.  Intended for use against main branch commits.
         steps:
             1:
                 flow: dependencies

--- a/cumulusci/files/templates/project/cumulusci.yml
+++ b/cumulusci/files/templates/project/cumulusci.yml
@@ -2,7 +2,7 @@ minimum_cumulusci_version: '{{ cci_version }}'
 project:
     name: {{ project_name }}
     package:
-        name:  {{ package_name }}
+        name: {{ package_name }}
         {% if package_namespace %}
         namespace: {{ package_namespace }}
         {% endif %}
@@ -23,24 +23,26 @@ project:
       {% endif %}
     {% endfor %}
     {% endif %}
-    {% if git %}
-    git:{% endif %}
-      {% if git.default_branch %} 
-        default_branch: '{{ git.default_branch }}'{% endif %}
-      {% if git.prefix_feature %} 
-        prefix_feature: '{{ git.prefix_feature }}'{% endif %}
-      {% if git.prefix_beta %} 
-        prefix_beta: '{{ git.prefix_beta }}'{% endif %}
-      {% if git.prefix_release %} 
+    git:
+{% if git.default_branch %}
+        default_branch: '{{ git.default_branch }}'
+{% endif %}
+{% if git.prefix_feature %}
+        prefix_feature: '{{ git.prefix_feature }}'
+{% endif %}
+{% if git.prefix_beta %}
+        prefix_beta: '{{ git.prefix_beta }}'
+{% endif %}
+{% if git.prefix_release %}
         prefix_release: '{{ git.prefix_release }}'
-      {% endif %}
-    {% if test_name_match %}
+{% endif %}
+{% if test_name_match %}
     test:
         name_match: '{{ test_name_match }}'
-    {% endif %}
-    {% if source_format != 'mdapi' %}
+{% endif %}
+{% if source_format != 'mdapi' %}
     source_format: {{ source_format }}
-    {% endif %}
+{% endif %}
 
 tasks:
     robot:

--- a/cumulusci/salesforce_api/tests/test_metadata.py
+++ b/cumulusci/salesforce_api/tests/test_metadata.py
@@ -66,7 +66,7 @@ class BaseTestMetadataApi(unittest.TestCase):
         self.repo_api_url = "https://api.github.com/repos/{}/{}".format(
             self.repo_owner, self.repo_name
         )
-        self.branch = "master"
+        self.branch = "main"
 
         # Create the project config
         self.project_config = create_project_config(self.repo_name, self.repo_owner)

--- a/cumulusci/tasks/github/tests/test_merge.py
+++ b/cumulusci/tasks/github/tests/test_merge.py
@@ -23,10 +23,11 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
         self.repo_api_url = "https://api.github.com/repos/{}/{}".format(
             self.owner, self.repo
         )
-        self.branch = "master"
+        self.branch = "main"
 
         # Create the project config
         self.project_config = create_project_config(self.repo, self.owner)
+        self.project_config.config["project"]["git"]["default_branch"] = self.branch
         self.project_config.keychain.set_service(
             "github",
             ServiceConfig(
@@ -37,13 +38,6 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
                 }
             ),
         )
-
-        # self.current_tag_sha = self._random_sha()
-        # self.current_tag_commit_sha = self._random_sha()
-        # self.current_tag_commit_date = datetime.utcnow()
-        # self.last_tag_sha = self._random_sha()
-        # self.last_tag_commit_sha = self._random_sha()
-        # self.last_tag_commit_date = datetime.utcnow() - timedelta(days=1)
 
     def _create_task(self, task_config=None):
         if not task_config:
@@ -76,8 +70,10 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
         else:
             expected_response = []
 
-        master = self._get_expected_branch("master", self.project_config.repo_commit)
-        expected_response = [master] + expected_response
+        default_branch = self._get_expected_branch(
+            "main", self.project_config.repo_commit
+        )
+        expected_response = [default_branch] + expected_response
 
         responses.add(method=responses.GET, url=api_url, json=expected_response)
         return expected_response
@@ -152,7 +148,7 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
             expected = [
                 ("INFO", "Beginning task: MergeBranch"),
                 ("INFO", ""),
-                ("DEBUG", "Skipping branch master: is source branch"),
+                ("DEBUG", "Skipping branch main: is source branch"),
                 (
                     "DEBUG",
                     "Skipping branch not-a-feature-branch: does not match prefix feature/",
@@ -181,7 +177,7 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
             expected = [
                 ("INFO", "Beginning task: MergeBranch"),
                 ("INFO", ""),
-                ("DEBUG", "Skipping branch master: is source branch"),
+                ("DEBUG", "Skipping branch main: is source branch"),
                 ("INFO", "Skipping branch feature/a-test: no file diffs found"),
             ]
             self.assertEqual(expected, log_lines)
@@ -210,7 +206,7 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
             expected = [
                 ("INFO", "Beginning task: MergeBranch"),
                 ("INFO", ""),
-                ("DEBUG", "Skipping branch master: is source branch"),
+                ("DEBUG", "Skipping branch main: is source branch"),
                 ("INFO", "Merged 1 commits into branch feature/a-test"),
             ]
             self.assertEqual(expected, log_lines)
@@ -259,7 +255,7 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
             expected = [
                 ("INFO", "Beginning task: MergeBranch"),
                 ("INFO", ""),
-                ("DEBUG", "Skipping branch master: is source branch"),
+                ("DEBUG", "Skipping branch main: is source branch"),
                 (
                     "INFO",
                     "Merge conflict on branch feature/a-test: created pull request #2",
@@ -299,7 +295,7 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
             expected = [
                 ("INFO", "Beginning task: MergeBranch"),
                 ("INFO", ""),
-                ("DEBUG", "Skipping branch master: is source branch"),
+                ("DEBUG", "Skipping branch main: is source branch"),
                 (
                     "INFO",
                     "Merge conflict on branch feature/a-test: merge PR already exists",
@@ -309,7 +305,7 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
         self.assertEqual(6, len(responses.calls))
 
     @responses.activate
-    def test_master_parent_with_child_pr(self):
+    def test_main_parent_with_child_pr(self):
         self._mock_repo()
         self._mock_branch(self.branch)
         # branches
@@ -342,7 +338,7 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
         expected = [
             ("INFO", "Beginning task: MergeBranch"),
             ("INFO", ""),
-            ("DEBUG", "Skipping branch master: is source branch"),
+            ("DEBUG", "Skipping branch main: is source branch"),
             (
                 "INFO",
                 "Merge conflict on parent branch {}: created pull request #2".format(
@@ -354,7 +350,7 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
         self.assertEqual(7, len(responses.calls))
 
     @responses.activate
-    def test_master_parent_does_not_merge_child(self):
+    def test_main_parent_does_not_merge_child(self):
         self._mock_repo()
         self._mock_branch(self.branch)
 
@@ -386,7 +382,7 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
             expected = [
                 ("INFO", "Beginning task: MergeBranch"),
                 ("INFO", ""),
-                ("DEBUG", "Skipping branch master: is source branch"),
+                ("DEBUG", "Skipping branch main: is source branch"),
                 (
                     "INFO",
                     "Merged 1 commits into parent branch {}".format(parent_branch_name),

--- a/cumulusci/tasks/github/tests/test_util.py
+++ b/cumulusci/tasks/github/tests/test_util.py
@@ -59,7 +59,7 @@ class TestCommitDir(unittest.TestCase):
                 f.write("new")
             with open(".hidden", "w") as f:
                 pass
-            commit(d, "master", "dir", dry_run=True)
+            commit(d, "main", "dir", dry_run=True)
             assert commit.new_tree_list == [
                 {
                     "sha": "bogus2",
@@ -84,7 +84,7 @@ class TestCommitDir(unittest.TestCase):
                 },
                 {"path": "dir/new", "mode": "100644", "type": "blob", "sha": None},
             ]
-            commit(d, "master", "dir", commit_message="msg")
+            commit(d, "main", "dir", commit_message="msg")
         repo.create_commit.assert_called_once()
 
     def test_call__no_changes(self):
@@ -96,7 +96,7 @@ class TestCommitDir(unittest.TestCase):
                 )
             )
             commit = CommitDir(repo)
-            commit(d, "master", commit_message="msg")
+            commit(d, "main", commit_message="msg")
         repo.create_commit.assert_not_called()
 
     def test_validate_dirs(self):
@@ -122,7 +122,7 @@ class TestCommitDir(unittest.TestCase):
                 f.write("new")
             commit = CommitDir(repo)
             with self.assertRaises(GithubException):
-                commit(d, "master", commit_message="msg")
+                commit(d, "main", commit_message="msg")
 
     def test_call__error_creating_commit(self):
         with temporary_dir() as d:
@@ -137,7 +137,7 @@ class TestCommitDir(unittest.TestCase):
                 f.write("new")
             commit = CommitDir(repo)
             with self.assertRaises(GithubException):
-                commit(d, "master", commit_message="msg")
+                commit(d, "main", commit_message="msg")
 
     def test_call__error_updating_head(self):
         with temporary_dir() as d:
@@ -154,7 +154,7 @@ class TestCommitDir(unittest.TestCase):
                 f.write("new")
             commit = CommitDir(repo)
             with self.assertRaises(GithubException):
-                commit(d, "master", commit_message="msg")
+                commit(d, "main", commit_message="msg")
 
     def test_create_blob__handles_decode_error(self):
         repo = mock.Mock(spec=Repository)

--- a/cumulusci/tasks/github/tests/util_github_api.py
+++ b/cumulusci/tasks/github/tests/util_github_api.py
@@ -18,7 +18,7 @@ class GithubApiTestMixin(object):
             "github_password": "TestPass",
             "prefix_beta": "beta/",
             "prefix_prod": "release/",
-            "master_branch": "master",
+            "default_branch": "main",
         }
 
     def _get_expected_user(self, name):
@@ -54,7 +54,7 @@ class GithubApiTestMixin(object):
             "description": "",
             "archived": False,
             "created_at": now,
-            "default_branch": "master",
+            "default_branch": "main",
             "fork": False,
             "forks_count": 1,
             "full_name": "{}/{}".format(owner, name),
@@ -311,15 +311,15 @@ class GithubApiTestMixin(object):
 
         base_repo = self._get_expected_repo("TestOwner", "TestRepo")
         if hasattr(self, "project_config"):
-            master_branch = self.project_config.project__git__default_branch
+            default_branch = self.project_config.project__git__default_branch
         else:
-            master_branch = "master"
+            default_branch = "main"
         pr = {
             "additions": [],
             "assignee": None,
             "assignees": [],
             "base": {
-                "ref": master_branch,
+                "ref": default_branch,
                 "sha": commit_sha,
                 "label": "",
                 "repo": base_repo,

--- a/cumulusci/tasks/release_notes/provider.py
+++ b/cumulusci/tasks/release_notes/provider.py
@@ -51,10 +51,7 @@ class GithubChangeNotesProvider(BaseChangeNotesProvider):
         - github_owner
         - github_username
         - github_password
-
-    Will optionally use the following if provided by release_notes_generator:
-
-        - master_branch: Name of the default branch. Defaults to 'master'
+        - default_branch
         - prefix_prod: Tag prefix for production release tags. Defaults to 'prod/'
     """
 
@@ -151,7 +148,7 @@ class GithubChangeNotesProvider(BaseChangeNotesProvider):
         """ Gets all pull requests from the repo since we can't do a filtered
         date merged search """
         for pull in self.repo.pull_requests(
-            state="closed", base=self.github_info["master_branch"], direction="asc"
+            state="closed", base=self.github_info["default_branch"], direction="asc"
         ):
             if self._include_pull_request(pull):
                 yield pull

--- a/cumulusci/tasks/release_notes/task.py
+++ b/cumulusci/tasks/release_notes/task.py
@@ -46,7 +46,7 @@ class GithubReleaseNotes(BaseGithubTask):
             "github_repo": self.project_config.repo_name,
             "github_username": self.github_config.username,
             "github_password": self.github_config.password,
-            "master_branch": self.project_config.project__git__default_branch,
+            "default_branch": self.project_config.project__git__default_branch,
             "prefix_beta": self.project_config.project__git__prefix_beta,
             "prefix_prod": self.project_config.project__git__prefix_release,
         }

--- a/cumulusci/tasks/release_notes/tests/test_generator.py
+++ b/cumulusci/tasks/release_notes/tests/test_generator.py
@@ -47,7 +47,7 @@ class DummyParser(BaseChangeNotesParser):
         pass
 
     def _render(self):
-        return "dummy parser output".format(self.title)
+        return "dummy parser output"
 
 
 class TestBaseReleaseNotesGenerator(unittest.TestCase):
@@ -215,7 +215,7 @@ class TestPublishingGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTest
             "github_repo": "TestRepo",
             "github_username": "TestUser",
             "github_password": "TestPass",
-            "master_branch": "master",
+            "default_branch": "main",
         }
         self.gh = get_github_api("TestUser", "TestPass")
         self.mock_util = MockUtil("TestOwner", "TestRepo")
@@ -475,8 +475,8 @@ class TestParentPullRequestNotesGenerator(GithubApiTestMixin):
         pr3_json["body"] = ""
 
         pr4_json = self._get_expected_pull_request(5, 5, "Should not be in body")
-        # simulate merge from master back into parent
-        pr4_json["head"]["ref"] = "master"
+        # simulate merge from main back into parent
+        pr4_json["head"]["ref"] = "main"
 
         mock_util.mock_pulls(pulls=[pr1_json, pr2_json, pr3_json, pr4_json])
 

--- a/cumulusci/tasks/release_notes/tests/test_task.py
+++ b/cumulusci/tasks/release_notes/tests/test_task.py
@@ -25,7 +25,7 @@ class TestGithubReleaseNotes:
                 }
             ),
         )
-        project_config.project__git__default_branch = "master"
+        project_config.project__git__default_branch = "main"
         return project_config
 
     @mock.patch("cumulusci.tasks.release_notes.task.GithubReleaseNotesGenerator")
@@ -88,7 +88,7 @@ class TestParentPullRequestNotes(GithubApiTestMixin):
             task_config = TaskConfig(options)
             task = ParentPullRequestNotes(project_config, task_config)
             task.repo = mock.Mock()
-            task.repo.default_branch = "master"
+            task.repo.default_branch = "main"
             task.repo.owner.login = "SFDO-Tooling"
             task.logger = mock.Mock()
             task.github = mock.Mock()
@@ -134,11 +134,11 @@ class TestParentPullRequestNotes(GithubApiTestMixin):
 
         task = task_factory(self.PARENT_BRANCH_OPTIONS)
         task._setup_self()
-        task.repo.default_branch = "master"
+        task.repo.default_branch = "main"
 
         actual_pull_request = task._get_parent_pull_request()
         get_pull_request.assert_called_once_with(
-            task.repo, "master", self.PARENT_BRANCH_NAME
+            task.repo, "main", self.PARENT_BRANCH_NAME
         )
         assert 1 == actual_pull_request.number
         assert "Body" == actual_pull_request.body

--- a/cumulusci/tasks/salesforce/UninstallPackagedIncremental.py
+++ b/cumulusci/tasks/salesforce/UninstallPackagedIncremental.py
@@ -69,27 +69,27 @@ class UninstallPackagedIncremental(UninstallPackaged):
         )
         return destructive_changes
 
-    def _package_xml_diff(self, master, compare):
-        with open(master, "rb") as f:
-            master_xml = xmltodict.parse(f)
+    def _package_xml_diff(self, baseline, compare):
+        with open(baseline, "rb") as f:
+            baseline_xml = xmltodict.parse(f)
         with open(compare, "rb") as f:
             compare_xml = xmltodict.parse(f)
 
         delete = {}
 
         ignore = self.options["ignore"]
-        master_items = {}
+        baseline_items = {}
         compare_items = {}
-        md_types = master_xml["Package"].get("types", [])
+        md_types = baseline_xml["Package"].get("types", [])
         md_types = [md_types] if not isinstance(md_types, list) else md_types
         for md_type in md_types:
-            master_items[md_type["name"]] = []
+            baseline_items[md_type["name"]] = []
             if "members" not in md_type:
                 continue
             if isinstance(md_type["members"], str):
-                master_items[md_type["name"]].append(md_type["members"])
+                baseline_items[md_type["name"]].append(md_type["members"])
             else:
-                master_items[md_type["name"]].extend(md_type["members"])
+                baseline_items[md_type["name"]].extend(md_type["members"])
 
         md_types = compare_xml["Package"].get("types", [])
         md_types = [md_types] if not isinstance(md_types, list) else md_types
@@ -105,12 +105,12 @@ class UninstallPackagedIncremental(UninstallPackaged):
                 compare_items[md_type["name"]].append(item)
 
         for md_type, members in compare_items.items():
-            if md_type not in master_items:
+            if md_type not in baseline_items:
                 delete[md_type] = members
                 continue
 
             for member in members:
-                if member not in master_items[md_type]:
+                if member not in baseline_items[md_type]:
                     if md_type not in delete:
                         delete[md_type] = []
                     delete[md_type].append(member)

--- a/cumulusci/tests/test_utils.py
+++ b/cumulusci/tests/test_utils.py
@@ -306,7 +306,7 @@ Options\n------------------------------------------\n\n
             zf.writestr("top/src/test", "test")
         f.seek(0)
         zipbytes = f.read()
-        mock_repo = mock.Mock(default_branch="master")
+        mock_repo = mock.Mock(default_branch="main")
         mock_github = mock.Mock()
         mock_github.repository.return_value = mock_repo
 

--- a/cumulusci/utils/git.py
+++ b/cumulusci/utils/git.py
@@ -1,0 +1,19 @@
+import pathlib
+
+
+def git_path(repo_root, tail=None):
+    """Returns a Path to the .git directory in repo_root
+    with tail appended (if present) or None if repo_root is not set.
+    """
+    path = None
+    if repo_root:
+        path = pathlib.Path(repo_root) / ".git"
+        if tail is not None:
+            path = path / str(tail)
+    return path
+
+
+def current_branch(repo_root):
+    branch_ref = git_path(repo_root, "HEAD").read_text().strip()
+    if branch_ref.startswith("ref: "):
+        return "/".join(branch_ref[5:].split("/")[2:])

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -290,9 +290,9 @@ Continuous Integration with CumulusCI and GitHub Actions
 
 The “CI” in CumulusCI stands for “continuous integration.” Continuous
 integration is the practice of automatically running a project’s tests
-for any change before that change is merged to the master branch. This
-helps keep the master branch in a state where it can be released at any
-time, because the repository can be configured to protect the master
+for any change before that change is merged to the main branch. This
+helps keep the main branch in a state where it can be released at any
+time, because the repository can be configured to protect the main
 branch so that changes can only be merged if the tests have passed.
 
 CumulusCI flows can be run on your own computer, or they can be run in a
@@ -464,7 +464,7 @@ results of the checks that were performed by the workflow:
    :alt: Screenshot showing a successful check on a GitHub pull request
 
 It is possible to configure
-the repository’s master branch as a *protected branch* so that changes
+the repository’s main branch as a *protected branch* so that changes
 can only be merged to it if these checks are passing.
 
 See GitHub’s documentation for instructions to `configure protected

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,3 @@
-.. cumulusci documentation master file, created by
-   sphinx-quickstart on Tue Jul  9 22:26:36 2013.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 Welcome to CumulusCI's documentation!
 ======================================
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -50,7 +50,7 @@ If you run the `cci project info` command from inside a git repository that has 
         uninstall_class: None
         api_version: 33.0
     git:
-        default_branch: master
+        default_branch: main
         prefix_feature: feature/
         prefix_beta: beta/
         prefix_release: release/


### PR DESCRIPTION
Use current branch as default in `cci project init`. Also changed uses of "master" to "main" where it could be done trivially.

# Critical Changes

# Changes

- `cci project init` now sets `default_branch` to the current git branch.

# Issues Closed

- Fixed a formatting error when running `cci project init` with a custom default_branch (fixes #1780)