### PR TITLE
Feature/robot pabot

### DIFF
--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -7,7 +7,7 @@ on:
     - master
 
 env:
-  CUMULUSCI_ORG_scratch: '{"config_file": "orgs/prerelease.json", "scratch": true}'
+  CUMULUSCI_ORG_scratch: '{"config_file": "orgs/dev.json", "scratch": true}'
   CUMULUSCI_ORG_packaging: ${{ secrets.CUMULUSCI_ORG_packaging }}
   CUMULUSCI_SERVICE_github: ${{ secrets.CUMULUSCI_SERVICE_github }}
   SFDX_CLIENT_ID: ${{ secrets.SFDX_CLIENT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ tags
 .cache/
 .coverage
 .python-version
-selenium-screenshot-*
+*selenium-screenshot-*
 log.html
 report.html
 output.xml
@@ -36,3 +36,5 @@ pip-wheel-metadata
 .cci
 results_junit.xml
 test_results.json
+pabot_results/
+.pabotsuitenames

--- a/cumulusci/tasks/robotframework/robotframework.py
+++ b/cumulusci/tasks/robotframework/robotframework.py
@@ -40,7 +40,6 @@ class Robot(BaseSalesforceTask):
         },
         "processes": {
             "description": "*experimental* Number of processes to use for running tests in parallel. If this value is set to a number larger than 1 the tests will run using the open source tool pabot rather than robotframework. For example, -o parallel 2 will run half of the tests in one process and half in another. If not provided, all tests will run in a single process using the standard robot test runner.",
-            "type": "integer",
             "default": "1",
         },
     }

--- a/cumulusci/tasks/robotframework/robotframework.py
+++ b/cumulusci/tasks/robotframework/robotframework.py
@@ -59,15 +59,10 @@ class Robot(BaseSalesforceTask):
             self.options["options"] = {}
 
         # processes needs to be an integer.
-        if "processes" in self.options:
-            try:
-                self.options["processes"] = int(self.options["processes"])
-            except ValueError:
-                raise TaskOptionsError(
-                    f"'processes' value '{self.options['processes']}' is not an integer"
-                )
-        else:
-            self.options["processes"] = 1
+        try:
+            self.options["processes"] = int(self.options.get("processes", 1))
+        except (TypeError, ValueError):
+            raise TaskOptionsError("Please specify an integer for the `processes` option.")
 
         # There are potentially many robot options that are or could
         # be lists, but the only one we currently care about is the

--- a/cumulusci/tasks/robotframework/robotframework.py
+++ b/cumulusci/tasks/robotframework/robotframework.py
@@ -39,7 +39,7 @@ class Robot(BaseSalesforceTask):
             "description": "If true, enable the `breakpoint` keyword to enable the robot debugger"
         },
         "processes": {
-            "description": "*zexperimental* Number of parallel processes to use for running tests in parallel. If this value is set to a number larger than 1 the tests will run using the open source tool pabot rather than robot. For example, -o parallel 2 will run half of the tests in one process and half in another. If not provided, all tests will run in a single process using the standard robot test runner.",
+            "description": "*experimental* Number of processes to use for running tests in parallel. If this value is set to a number larger than 1 the tests will run using the open source tool pabot rather than robotframework. For example, -o parallel 2 will run half of the tests in one process and half in another. If not provided, all tests will run in a single process using the standard robot test runner.",
             "type": "integer",
             "default": "1",
         },

--- a/cumulusci/tasks/robotframework/robotframework.py
+++ b/cumulusci/tasks/robotframework/robotframework.py
@@ -61,7 +61,9 @@ class Robot(BaseSalesforceTask):
         try:
             self.options["processes"] = int(self.options.get("processes", 1))
         except (TypeError, ValueError):
-            raise TaskOptionsError("Please specify an integer for the `processes` option.")
+            raise TaskOptionsError(
+                "Please specify an integer for the `processes` option."
+            )
 
         # There are potentially many robot options that are or could
         # be lists, but the only one we currently care about is the

--- a/cumulusci/tasks/robotframework/robotframework.py
+++ b/cumulusci/tasks/robotframework/robotframework.py
@@ -1,10 +1,11 @@
 import os
 import sys
+import subprocess
 
 from robot import run as robot_run
 from robot.testdoc import testdoc
 
-from cumulusci.core.exceptions import RobotTestFailure
+from cumulusci.core.exceptions import RobotTestFailure, TaskOptionsError
 from cumulusci.core.tasks import BaseTask
 from cumulusci.core.utils import process_bool_arg
 from cumulusci.core.utils import process_list_arg
@@ -37,6 +38,11 @@ class Robot(BaseSalesforceTask):
         "debug": {
             "description": "If true, enable the `breakpoint` keyword to enable the robot debugger"
         },
+        "processes": {
+            "description": "*zexperimental* Number of parallel processes to use for running tests in parallel. If this value is set to a number larger than 1 the tests will run using the open source tool pabot rather than robot. For example, -o parallel 2 will run half of the tests in one process and half in another. If not provided, all tests will run in a single process using the standard robot test runner.",
+            "type": "integer",
+            "default": "1",
+        },
     }
 
     def _init_options(self, kwargs):
@@ -51,6 +57,17 @@ class Robot(BaseSalesforceTask):
         # Initialize options as a dict
         if "options" not in self.options:
             self.options["options"] = {}
+
+        # processes needs to be an integer.
+        if "processes" in self.options:
+            try:
+                self.options["processes"] = int(self.options["processes"])
+            except ValueError:
+                raise TaskOptionsError(
+                    f"'processes' value '{self.options['processes']}' is not an integer"
+                )
+        else:
+            self.options["processes"] = 1
 
         # There are potentially many robot options that are or could
         # be lists, but the only one we currently care about is the
@@ -83,7 +100,29 @@ class Robot(BaseSalesforceTask):
             os.path.join(self.working_path, options.get("outputdir", ".")), os.getcwd()
         )
 
-        num_failed = robot_run(self.options["suites"], **options)
+        if self.options["processes"] > 1:
+            cmd = [
+                sys.executable,
+                "-m",
+                "pabot.pabot",
+                "--pabotlib",
+                "--processes",
+                str(self.options["processes"]),
+            ]
+            # We need to convert options to their commandline equivalent
+            for option, value in options.items():
+                if isinstance(value, list):
+                    for item in value:
+                        cmd.extend([f"--{option}", str(item)])
+                else:
+                    cmd.extend([f"--{option}", str(value)])
+
+            cmd.append(self.options["suites"])
+            result = subprocess.run(cmd)
+            num_failed = result.returncode
+
+        else:
+            num_failed = robot_run(self.options["suites"], **options)
 
         # These numbers are from the robot framework user guide:
         # http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#return-codes

--- a/cumulusci/tasks/robotframework/tests/test_robotframework.py
+++ b/cumulusci/tasks/robotframework/tests/test_robotframework.py
@@ -87,7 +87,7 @@ class TestRobot(unittest.TestCase):
     def test_process_arg_requires_int(self):
         """Verify we throw a useful error for non-int "processes" option"""
 
-        expected = "'processes' value 'bogus' is not an integer"
+        expected = "Please specify an integer for the `processes` option."
         with pytest.raises(TaskOptionsError, match=expected):
             create_task(Robot, {"suites": "tests", "processes": "bogus"})
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ PyYAML==5.3.1
 raven==6.10.0
 requests==2.24.0
 robotframework==3.2.1
+robotframework-pabot==1.8.1
 robotframework-seleniumlibrary==4.4.0
 rst2ansi==0.1.5
 salesforce-bulk==2.1.0


### PR DESCRIPTION
This PR adds a `processes` option to the robot task. If the value is > 1, the task will use pabot to run test suites in parallel using the given number of processes.

At last weeks robot checkin there was a discussion about how to solve the problem that tests are taking a very long time to complete, which is starting to hinder some teams. One of several items discussed was the possibility to run our robot tests in parallel. Just about the only tool available off the shelf today is [pabot](https://github.com/mkorpela/pabot).

QE can't just download and use pabot themselves since they use a cci task rather than the robot command directly. It was decided at the meeting that we could try adding an option to the robot task to use pabot to run the tests. This PR is the result. I've tested it with the CumulusCI robot tests but haven't tested it with the tests of other teams.

There are a couple of pabot options that aren't supported, and I haven't mentioned this new task option in the readthedocs documentation. It may not be worth a lot of engineering time to implement additional features until we can determine if these changes add a measurable improvement, or if it just gives us a different set of problems due to concurrency issues. 

Approval for including pabot: [GUS Third Party Software approval](https://gus.lightning.force.com/lightning/r/ADM_Third_Party_Software__c/a0qB0000000ZJvFIAW/view)

# Critical Changes

# Changes

# Issues Closed
