### PR TITLE
Add new error string to package install retries

### DIFF
--- a/cumulusci/tasks/salesforce/InstallPackageVersion.py
+++ b/cumulusci/tasks/salesforce/InstallPackageVersion.py
@@ -92,6 +92,7 @@ class InstallPackageVersion(Deploy):
         if isinstance(e, MetadataApiError) and (
             "This package is not yet available" in str(e)
             or "InstalledPackage version number" in str(e)
+            or "The requested package doesn't yet exist or has been deleted" in str(e)
         ):
             return True
 


### PR DESCRIPTION
# Critical Changes

# Changes

- The `install_managed` task now recognizes an additional error message that may be issued by the Metadata API when a package version has not yet finished propagating and performs retries appropriately. 

# Issues Closed
