### PR TITLE
Add task to publish project files for a release to a second repository

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -196,6 +196,16 @@ tasks:
             children_only: True
             source_branch: $project_config.repo_branch
         group: GitHub
+    github_publish_release:
+        description: Publishes a release from the project repo to a target repo with filtering of files
+        class_path: cumulusci.tasks.github.public_repo.PublishRelease
+        options:
+            version: latest
+            branch: master
+            exclude:
+                - force-app
+                - push
+                - src
     github_pull_requests:
         description: Lists open pull requests in project Github repository
         class_path: cumulusci.tasks.github.PullRequests

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -197,7 +197,7 @@ tasks:
             source_branch: $project_config.repo_branch
         group: GitHub
     github_copy_subtree:
-        description: Copies a subtree from the project repo at a given ref to a target repo.
+        description: Copies one or more subtrees from the project repository for a given release to a target repository, with the option to include release notes.
         class_path: cumulusci.tasks.github.publish.PublishSubtree
         group: GitHub
         options:

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -198,7 +198,7 @@ tasks:
         group: GitHub
     github_copy_subtree:
         description: Copies a subtree from the project repo at a given ref to a target repo.
-        class_path: cumulusci.tasks.github.public_repo.PublishRelease
+        class_path: cumulusci.tasks.github.publish.PublishSubtree
         group: GitHub
         options:
             ref: latest

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -200,9 +200,6 @@ tasks:
         description: Copies one or more subtrees from the project repository for a given release to a target repository, with the option to include release notes.
         class_path: cumulusci.tasks.github.publish.PublishSubtree
         group: GitHub
-        options:
-            ref: latest
-            branch: master
     github_pull_requests:
         description: Lists open pull requests in project Github repository
         class_path: cumulusci.tasks.github.PullRequests

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -196,16 +196,18 @@ tasks:
             children_only: True
             source_branch: $project_config.repo_branch
         group: GitHub
-    github_publish_release:
-        description: Publishes a release from the project repo to a target repo with filtering of files
+    github_copy_subtree:
+        description: Copies a subtree from the project repo at a given ref to a target repo.
         class_path: cumulusci.tasks.github.public_repo.PublishRelease
+        group: GitHub
         options:
-            version: latest
+            ref: latest
             branch: master
-            exclude:
-                - force-app
-                - push
-                - src
+            include:
+                - datasets/
+                - documentation/
+                - tasks/
+                - unpackaged/
     github_pull_requests:
         description: Lists open pull requests in project Github repository
         class_path: cumulusci.tasks.github.PullRequests

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -203,11 +203,6 @@ tasks:
         options:
             ref: latest
             branch: master
-            include:
-                - datasets/
-                - documentation/
-                - tasks/
-                - unpackaged/
     github_pull_requests:
         description: Lists open pull requests in project Github repository
         class_path: cumulusci.tasks.github.PullRequests

--- a/cumulusci/tasks/github/public_repo.py
+++ b/cumulusci/tasks/github/public_repo.py
@@ -113,6 +113,7 @@ class PublishRelease(BaseGithubTask):
         # Get the release
         try:
             release = repo.release_from_tag(tag_name)
+            release_body = release.body if self.options["release_body"] else ""
         except github3.exceptions.NotFoundError:
             message = f"Release for {tag_name} not found"
             self.logger.error(message)
@@ -142,9 +143,9 @@ class PublishRelease(BaseGithubTask):
         )
 
         # Create the release
-        release.body if self.options["release_body"] else ""
         self.target_repo.create_release(
             tag_name=tag_name,
             name=self.options["version"],
             prerelease=release.prerelease,
+            body=release_body,
         )

--- a/cumulusci/tasks/github/public_repo.py
+++ b/cumulusci/tasks/github/public_repo.py
@@ -1,0 +1,148 @@
+import os
+import shutil
+from datetime import datetime
+import github3.exceptions
+
+from cumulusci.core.exceptions import GithubException
+from cumulusci.core.github import get_github_api_for_repo
+from cumulusci.core.utils import process_bool_arg
+from cumulusci.core.utils import process_list_arg
+from cumulusci.tasks.github.base import BaseGithubTask
+from cumulusci.tasks.github.util import CommitDir
+from cumulusci.utils import cd
+from cumulusci.utils import download_extract_github_from_repo
+from cumulusci.utils import temporary_dir
+
+
+class PublishRelease(BaseGithubTask):
+    task_options = {
+        "repo_url": {"description": "The url to the public repo", "required": True,},
+        "branch": {
+            "description": "The branch to update in the target repo",
+            "required": True,
+        },
+        "version": {
+            "description": "The version number to release.  Also supports latest and latest_beta to look up the latest releases.",
+            "required": True,
+        },
+        "exclude": {"description": "A list of paths from repo root to exclude",},
+        "release_body": {
+            "description": "If True, the entire release body will be published to the public repo.  Defaults to False",
+        },
+    }
+
+    def _init_options(self, kwargs):
+        super()._init_options(kwargs)
+        self.options["exclude"] = process_list_arg(self.options.get("exclude", []))
+        self.options["release_body"] = process_bool_arg(
+            self.options.get("release_body", False)
+        )
+        if self.options["version"] == "latest":
+            self.options["version"] = str(self.project_config.get_latest_version())
+        elif self.options["version"] == "latest_beta":
+            self.options["version"] = str(
+                self.project_config.get_latest_version(beta=True)
+            )
+
+    def _get_target_repo_api(self):
+        gh = self.project_config.get_github_api(
+            self._target_repo_info["owner"], self._target_repo_info["name"],
+        )
+        return gh.repository(
+            self._target_repo_info["owner"], self._target_repo_info["name"],
+        )
+
+    def _run_task(self):
+        self._target_repo_info = self.project_config._split_repo_url(
+            self.options["repo_url"]
+        )
+        self.target_repo = self._get_target_repo_api()
+
+        with temporary_dir(chdir=False) as target:
+            self._download_repo(target)
+            self._exclude_files(target)
+            commit = self._create_commit(target)
+            self._create_release(target, commit)
+
+    def _download_repo(self, path):
+        zf = download_extract_github_from_repo(
+            self.get_repo(),
+            ref="tags/{}".format(
+                self.project_config.get_tag_for_version(self.options["version"])
+            ),
+        )
+        with cd(path):
+            zf.extractall()
+
+    def _exclude_files(self, path):
+        with cd(path):
+            for path in self.options["exclude"]:
+                if os.path.isdir(path):
+                    shutil.rmtree(path)
+                elif os.path.isfile(path):
+                    os.remove(path)
+
+    def _create_commit(self, path):
+        committer = CommitDir(self.target_repo)
+        message = f"Publishing release {self.options['version']}"
+        commit = committer(path, self.options["branch"], commit_message=message)
+        return commit.sha
+
+    def _create_release(self, path, commit):
+        # Get current release info
+        tag_name = self.project_config.get_tag_for_version(self.options["version"])
+        repo = self.get_repo()
+        # Get the ref
+        try:
+            ref = repo.ref(f"tags/{tag_name}")
+        except github3.exceptions.NotFoundError:
+            message = f"Ref not found for tag {tag_name}"
+            self.logger.error(message)
+            raise GithubException(message)
+        # Get the tag
+        try:
+            tag = repo.tag(ref.object.sha)
+        except github3.exceptions.NotFoundError:
+            message = f"Tag {tag_name} not found"
+            self.logger.error(message)
+            raise GithubException(message)
+        # Get the release
+        try:
+            release = repo.release_from_tag(tag_name)
+        except github3.exceptions.NotFoundError:
+            message = f"Release for {tag_name} not found"
+            self.logger.error(message)
+            raise GithubException(message)
+
+        # Check for tag in target repo
+        target_ref = None
+        try:
+            target_ref = self.target_repo.ref(f"tags/{tag_name}")
+        except github3.exceptions.NotFoundError:
+            pass
+        if target_ref:
+            message = "Ref for tag {tag_name} already exists in target repo"
+            raise GithubException(message)
+
+        # Create the tag
+        target_tag = self.target_repo.create_tag(
+            tag=tag_name,
+            message=tag.message,
+            sha=commit,
+            obj_type="commit",
+            tagger={
+                "name": self.github_config.username,
+                "email": self.github_config.email,
+                "date": "{}Z".format(datetime.utcnow().isoformat()),
+            },
+            lightweight=False,
+        )
+
+        # Create the release
+        body = release.body if self.options["release_body"] else ""
+        target_release = self.target_repo.create_release(
+            tag_name=tag_name,
+            name=self.options["version"],
+            prerelease=release.prerelease,
+        )
+

--- a/cumulusci/tasks/github/public_repo.py
+++ b/cumulusci/tasks/github/public_repo.py
@@ -81,7 +81,7 @@ class PublishRelease(BaseGithubTask):
         return list(filtered_names)
 
     def _create_commit(self, path):
-        committer = CommitDir(self.target_repo)
+        committer = CommitDir(self.target_repo, logger=self.logger)
         message = f"Publishing release {self.options['version']}"
         commit = committer(
             path, self.options["branch"], repo_dir="", commit_message=message

--- a/cumulusci/tasks/github/public_repo.py
+++ b/cumulusci/tasks/github/public_repo.py
@@ -30,7 +30,11 @@ class PublishRelease(BaseGithubTask):
 
     def _init_options(self, kwargs):
         super()._init_options(kwargs)
-        self.options["include"] = process_list_arg(self.options.get("include", []))
+        self.options["include"] = process_list_arg(
+            self.options.get(
+                "include", ["datasets/", "documentation/", "tasks/", "unpackaged/"]
+            )
+        )
         self.options["release_body"] = process_bool_arg(
             self.options.get("release_body", False)
         )

--- a/cumulusci/tasks/github/public_repo.py
+++ b/cumulusci/tasks/github/public_repo.py
@@ -120,7 +120,7 @@ class PublishRelease(BaseGithubTask):
             target_ref = self.target_repo.ref(f"tags/{tag_name}")
         except github3.exceptions.NotFoundError:
             pass
-        if target_ref:
+        else:
             message = "Ref for tag {tag_name} already exists in target repo"
             raise GithubException(message)
 
@@ -145,4 +145,3 @@ class PublishRelease(BaseGithubTask):
             name=self.options["version"],
             prerelease=release.prerelease,
         )
-

--- a/cumulusci/tasks/github/publish.py
+++ b/cumulusci/tasks/github/publish.py
@@ -56,17 +56,13 @@ class PublishSubtree(BaseGithubTask):
         self.options["dry_run"] = process_bool_arg(self.options.get("dry_run", False))
 
     def _get_target_repo_api(self):
+        target_repo_info = self.project_config._split_repo_url(self.options["repo_url"])
         gh = self.project_config.get_github_api(
-            self._target_repo_info["owner"], self._target_repo_info["name"]
+            target_repo_info["owner"], target_repo_info["name"]
         )
-        return gh.repository(
-            self._target_repo_info["owner"], self._target_repo_info["name"]
-        )
+        return gh.repository(target_repo_info["owner"], target_repo_info["name"])
 
     def _run_task(self):
-        self._target_repo_info = self.project_config._split_repo_url(
-            self.options["repo_url"]
-        )
         self.target_repo = self._get_target_repo_api()
         self.tag_name = self.project_config.get_tag_for_version(self.options["version"])
 

--- a/cumulusci/tasks/github/publish.py
+++ b/cumulusci/tasks/github/publish.py
@@ -88,12 +88,8 @@ class PublishSubtree(BaseGithubTask):
         zf.extractall(path=path, members=included_members)
 
     def _filter_namelist(self, includes, namelist):
-        filtered_names = set()
         dirs = tuple(name for name in includes if name.endswith("/"))
-        filtered_names.update(
-            {name for name in namelist if name.startswith(dirs) or name in includes}
-        )
-        return list(filtered_names)
+        return list({name for name in namelist if name.startswith(dirs) or name in includes})
 
     def _create_commit(self, path):
         committer = CommitDir(self.target_repo, logger=self.logger)
@@ -115,14 +111,12 @@ class PublishSubtree(BaseGithubTask):
             ref = repo.ref(f"tags/{tag_name}")
         except github3.exceptions.NotFoundError:
             message = f"Ref not found for tag {tag_name}"
-            self.logger.error(message)
             raise GithubException(message)
         # Get the tag
         try:
             tag = repo.tag(ref.object.sha)
         except github3.exceptions.NotFoundError:
             message = f"Tag {tag_name} not found"
-            self.logger.error(message)
             raise GithubException(message)
         # Get the release
         try:
@@ -130,7 +124,6 @@ class PublishSubtree(BaseGithubTask):
             release_body = release.body if self.options["release_body"] else ""
         except github3.exceptions.NotFoundError:
             message = f"Release for {tag_name} not found"
-            self.logger.error(message)
             raise GithubException(message)
 
         # Check for tag in target repo

--- a/cumulusci/tasks/github/publish.py
+++ b/cumulusci/tasks/github/publish.py
@@ -2,6 +2,7 @@ import tempfile
 from datetime import datetime
 
 import github3.exceptions
+
 from cumulusci.core.exceptions import GithubException
 from cumulusci.core.utils import process_bool_arg, process_list_arg
 from cumulusci.tasks.github.base import BaseGithubTask
@@ -9,7 +10,7 @@ from cumulusci.tasks.github.util import CommitDir
 from cumulusci.utils import download_extract_github_from_repo
 
 
-class PublishRelease(BaseGithubTask):
+class PublishSubtree(BaseGithubTask):
     task_options = {
         "repo_url": {"description": "The url to the public repo", "required": True},
         "branch": {

--- a/cumulusci/tasks/github/tests/test_publish.py
+++ b/cumulusci/tasks/github/tests/test_publish.py
@@ -1,0 +1,366 @@
+import unittest
+from unittest import mock
+
+import pytest
+import responses
+
+from cumulusci.core.config import ServiceConfig, TaskConfig
+from cumulusci.core.exceptions import GithubException
+from cumulusci.tasks.github.publish import PublishSubtree
+from cumulusci.tasks.github.tests.util_github_api import GithubApiTestMixin
+from cumulusci.tests.util import create_project_config
+
+
+class TestPublishSubtree(unittest.TestCase, GithubApiTestMixin):
+    def setUp(self):
+        self.repo_owner = "TestOwner"
+        self.repo_name = "TestRepo"
+        self.repo_api_url = (
+            f"https://api.github.com/repos/{self.repo_owner}/{self.repo_name}"
+        )
+
+        self.public_owner = "TestOwner"
+        self.public_name = "TestRepo"
+        self.public_repo_url = (
+            f"https://api.github.com/repos/{self.public_owner}/{self.public_name}"
+        )
+
+        self.project_config = create_project_config(self.repo_name, self.repo_owner)
+        self.project_config.keychain.set_service(
+            "github",
+            ServiceConfig(
+                {
+                    "username": "TestUser",
+                    "password": "TestPass",
+                    "email": "testuser@testdomain.com",
+                }
+            ),
+        )
+
+    @responses.activate
+    @mock.patch("cumulusci.tasks.github.publish.download_extract_github_from_repo")
+    @mock.patch("cumulusci.tasks.github.publish.CommitDir")
+    def test_run_task(self, commit_dir, extract_github):
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url,
+            json=self._get_expected_repo(owner=self.repo_owner, name=self.repo_name),
+        )
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url,
+            json=self._get_expected_repo(
+                owner=self.public_owner, name=self.public_name
+            ),
+        )
+        responses.add(
+            responses.GET,
+            self.repo_api_url + "/releases/latest",
+            json=self._get_expected_release("release/1.0"),
+        )
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url + "/git/refs/tags/release/1.0",
+            status=201,
+            json=self._get_expected_tag_ref("release/1.0", "SHA"),
+        )
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url + "/git/tags/SHA",
+            json=self._get_expected_tag("release/1.0", "SHA"),
+            status=201,
+        )
+        responses.add(
+            responses.GET,
+            self.repo_api_url + "/releases/tags/release/1.0",
+            json=self._get_expected_release("release/1.0"),
+        )
+        responses.add(
+            responses.GET,
+            self.public_repo_url + "/releases/tags/release/1.0",
+            status=404,
+        )
+        responses.add(
+            responses.GET,
+            self.public_repo_url + "/git/refs/tags/release/1.0",
+            status=404,
+        )
+        responses.add(
+            responses.POST,
+            self.public_repo_url + "/releases",
+            json=self._get_expected_release("release"),
+        )
+        responses.add(
+            responses.POST,
+            self.repo_api_url + "/git/tags",
+            json=self._get_expected_tag("release/1.0", "SHA0"),
+            status=201,
+        )
+        responses.add(
+            responses.POST, self.repo_api_url + "/git/refs", json={}, status=201
+        )
+        task_config = TaskConfig(
+            {
+                "options": {
+                    "branch": "master",
+                    "version": "latest",
+                    "repo_url": self.public_repo_url,
+                    "includes": ["tasks/foo.py", "unpackaged/pre/foo/package.xml"],
+                }
+            }
+        )
+        extract_github.return_value.namelist.return_value = [
+            "tasks/foo.py",
+            "unpackaged/pre/foo/package.xml",
+            "force-app",
+        ]
+        task = PublishSubtree(self.project_config, task_config)
+        task()
+
+    @responses.activate
+    @mock.patch("cumulusci.core.config.project_config.BaseProjectConfig.get_latest_tag")
+    @mock.patch("cumulusci.tasks.github.publish.download_extract_github_from_repo")
+    @mock.patch("cumulusci.tasks.github.publish.CommitDir.__call__")
+    def test_run_task_latest_beta(self, commit_dir, download, get_tag):
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url,
+            json=self._get_expected_repo(owner=self.repo_owner, name=self.repo_name),
+        )
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url,
+            json=self._get_expected_repo(
+                owner=self.public_owner, name=self.public_name
+            ),
+        )
+        task_config = TaskConfig(
+            {
+                "options": {
+                    "branch": "master",
+                    "version": "latest_beta",
+                    "repo_url": self.public_repo_url,
+                    "includes": ["tasks/foo.py", "unpackaged/pre/foo/package.xml"],
+                }
+            }
+        )
+        get_tag.return_value = "beta/1.0_Beta_1"
+        commit_dir.return_value = None
+        task = PublishSubtree(self.project_config, task_config)
+        task()
+        get_tag.assert_called_once_with(True)
+
+    @responses.activate
+    @mock.patch("cumulusci.tasks.github.publish.download_extract_github_from_repo")
+    @mock.patch("cumulusci.tasks.github.publish.CommitDir")
+    def test_ref_not_found(self, commit_dir, extract_github):
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url,
+            json=self._get_expected_repo(owner=self.repo_owner, name=self.repo_name),
+        )
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url,
+            json=self._get_expected_repo(
+                owner=self.public_owner, name=self.public_name
+            ),
+        )
+        responses.add(
+            responses.GET,
+            self.repo_api_url + "/releases/latest",
+            json=self._get_expected_release("release/1.0"),
+        )
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url + "/git/refs/tags/release/1.0",
+            status=404,
+        )
+        task_config = TaskConfig(
+            {
+                "options": {
+                    "branch": "master",
+                    "version": "latest",
+                    "repo_url": self.public_repo_url,
+                    "includes": ["tasks/foo.py", "unpackaged/pre/foo/package.xml"],
+                }
+            }
+        )
+        extract_github.return_value.namelist.return_value = [
+            "tasks/foo.py",
+            "unpackaged/pre/foo/package.xml",
+            "force-app",
+        ]
+        task = PublishSubtree(self.project_config, task_config)
+        with pytest.raises(GithubException) as exc:
+            task()
+        assert "Ref not found for tag release/1.0" == str(exc.value)
+
+    @responses.activate
+    @mock.patch("cumulusci.tasks.github.publish.download_extract_github_from_repo")
+    @mock.patch("cumulusci.tasks.github.publish.CommitDir")
+    def test_tag_not_found(self, commit_dir, extract_github):
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url,
+            json=self._get_expected_repo(owner=self.repo_owner, name=self.repo_name),
+        )
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url,
+            json=self._get_expected_repo(
+                owner=self.public_owner, name=self.public_name
+            ),
+        )
+        responses.add(
+            responses.GET,
+            self.repo_api_url + "/releases/latest",
+            json=self._get_expected_release("release/1.0"),
+        )
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url + "/git/refs/tags/release/1.0",
+            status=201,
+            json=self._get_expected_tag_ref("release/1.0", "SHA"),
+        )
+        responses.add(
+            method=responses.GET, url=self.repo_api_url + "/git/tags/SHA", status=404
+        )
+        task_config = TaskConfig(
+            {
+                "options": {
+                    "branch": "master",
+                    "version": "latest",
+                    "repo_url": self.public_repo_url,
+                    "includes": ["tasks/foo.py", "unpackaged/pre/foo/package.xml"],
+                }
+            }
+        )
+        extract_github.return_value.namelist.return_value = [
+            "tasks/foo.py",
+            "unpackaged/pre/foo/package.xml",
+            "force-app",
+        ]
+        task = PublishSubtree(self.project_config, task_config)
+        with pytest.raises(GithubException) as exc:
+            task()
+        assert "Tag release/1.0 not found" == str(exc.value)
+
+    @responses.activate
+    @mock.patch("cumulusci.tasks.github.publish.download_extract_github_from_repo")
+    @mock.patch("cumulusci.tasks.github.publish.CommitDir")
+    def test_release_not_found(self, commit_dir, extract_github):
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url,
+            json=self._get_expected_repo(owner=self.repo_owner, name=self.repo_name),
+        )
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url,
+            json=self._get_expected_repo(
+                owner=self.public_owner, name=self.public_name
+            ),
+        )
+        responses.add(
+            responses.GET,
+            self.repo_api_url + "/releases/latest",
+            json=self._get_expected_release("release/1.0"),
+        )
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url + "/git/refs/tags/release/1.0",
+            status=201,
+            json=self._get_expected_tag_ref("release/1.0", "SHA"),
+        )
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url + "/git/tags/SHA",
+            json=self._get_expected_tag("release/1.0", "SHA"),
+            status=201,
+        )
+        responses.add(
+            responses.GET, self.repo_api_url + "/releases/tags/release/1.0", status=404
+        )
+        task_config = TaskConfig(
+            {
+                "options": {
+                    "branch": "master",
+                    "version": "latest",
+                    "repo_url": self.public_repo_url,
+                    "includes": ["tasks/foo.py", "unpackaged/pre/foo/package.xml"],
+                }
+            }
+        )
+        extract_github.return_value.namelist.return_value = [
+            "tasks/foo.py",
+            "unpackaged/pre/foo/package.xml",
+            "force-app",
+        ]
+        task = PublishSubtree(self.project_config, task_config)
+        with pytest.raises(GithubException) as exc:
+            task()
+        assert "Release for release/1.0 not found" == str(exc.value)
+
+    @responses.activate
+    @mock.patch("cumulusci.tasks.github.publish.download_extract_github_from_repo")
+    @mock.patch("cumulusci.tasks.github.publish.CommitDir")
+    def test_target_release_exists(self, commit_dir, extract_github):
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url,
+            json=self._get_expected_repo(owner=self.repo_owner, name=self.repo_name),
+        )
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url,
+            json=self._get_expected_repo(
+                owner=self.public_owner, name=self.public_name
+            ),
+        )
+        responses.add(
+            responses.GET,
+            self.repo_api_url + "/releases/latest",
+            json=self._get_expected_release("release/1.0"),
+        )
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url + "/git/refs/tags/release/1.0",
+            status=201,
+            json=self._get_expected_tag_ref("release/1.0", "SHA"),
+        )
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url + "/git/tags/SHA",
+            json=self._get_expected_tag("release/1.0", "SHA"),
+            status=201,
+        )
+        responses.add(
+            responses.GET,
+            self.repo_api_url + "/releases/tags/release/1.0",
+            json=self._get_expected_release("release/1.0"),
+        )
+        responses.add(
+            responses.GET,
+            self.public_repo_url + "/releases/tags/release/1.0",
+            json=self._get_expected_release("release/1.0"),
+        )
+        task_config = TaskConfig(
+            {
+                "options": {
+                    "branch": "master",
+                    "version": "latest",
+                    "repo_url": self.public_repo_url,
+                    "includes": ["tasks/foo.py", "unpackaged/pre/foo/package.xml"],
+                }
+            }
+        )
+        extract_github.return_value.namelist.return_value = [
+            "tasks/foo.py",
+            "unpackaged/pre/foo/package.xml",
+            "force-app",
+        ]
+        task = PublishSubtree(self.project_config, task_config)
+        with pytest.raises(GithubException) as exc:
+            task()
+        assert "Ref for tag release/1.0 already exists in target repo" == str(exc.value)

--- a/cumulusci/tasks/github/tests/test_util.py
+++ b/cumulusci/tasks/github/tests/test_util.py
@@ -1,9 +1,10 @@
 import hashlib
-from unittest import mock
 import unittest
+from unittest import mock
 
-from github3.repos import Repository
 from github3.git import Tree
+from github3.repos import Repository
+
 from cumulusci.core.exceptions import GithubException
 from cumulusci.tasks.github.util import CommitDir
 from cumulusci.utils import temporary_dir
@@ -32,6 +33,12 @@ class TestCommitDir(unittest.TestCase):
                             "mode": "100644",
                             "path": "file_outside_dir",
                             "sha": "bogus2",
+                        },
+                        {
+                            "type": "blob",
+                            "mode": "100644",
+                            "path": "dir/deleteme",
+                            "sha": "deletedfilesha",
                         },
                         {
                             "type": "blob",

--- a/cumulusci/tasks/github/util.py
+++ b/cumulusci/tasks/github/util.py
@@ -54,6 +54,7 @@ class CommitDir(object):
         self._set_git_data(branch)
 
         self.new_tree_list = [self._create_new_tree_item(item) for item in self.tree]
+        self.new_tree_list = [item for item in self.new_tree_list if item]
         self._add_new_files_to_tree(self.new_tree_list)
 
         tree_unchanged = self._summarize_changes(self.new_tree_list)
@@ -100,7 +101,11 @@ class CommitDir(object):
 
         local_file, content = self._read_item_content(item)
         new_item = item.copy()
-        if self._item_changed(item, content):
+        if content is None:
+            # delete blob from tree
+            self.logger.debug(f"Delete: {item['path']}")
+            return content
+        elif self._item_changed(item, content):
             self.logger.debug("Update: {}".format(local_file))
             blob_sha = self._create_blob(content, local_file)
             new_item["sha"] = blob_sha
@@ -204,16 +209,12 @@ class CommitDir(object):
         item_subpath = self._get_item_sub_path(item)
         local_file = os.path.join(self.local_dir, item_subpath)
         if not os.path.isfile(local_file):
-            # delete blob from tree
-            self.logger.debug("Delete: {}".format(item["path"]))
             return local_file, None
         with io.open(local_file, "rb") as f:
             content = f.read()
         return local_file, content
 
     def _item_changed(self, item, content):
-        if content is None:
-            return False
         header = b"blob " + str(len(content)).encode() + b"\0"
         return hashlib.sha1(header + content).hexdigest() != item["sha"]
 

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -1554,6 +1554,60 @@ Options
 
 	 Default: True
 
+**github_copy_subtree**
+==========================================
+
+**Description:** Copies a subtree from the project repo at a given ref to a target repo.
+
+**Class:** cumulusci.tasks.github.publish.PublishSubtree
+
+Command Syntax
+------------------------------------------
+
+``$ cci task run github_copy_subtree``
+
+
+Options
+------------------------------------------
+
+
+``-o repo_url REPOURL``
+	 *Required*
+
+	 The url to the public repo
+
+``-o branch BRANCH``
+	 *Required*
+
+	 The branch to update in the target repo
+
+	 Default: master
+
+``-o version VERSION``
+	 *Required*
+
+	 The version number to release.  Also supports latest and latest_beta to look up the latest releases.
+
+``-o include INCLUDE``
+	 *Optional*
+
+	 A list of paths from repo root to include. Directories must end with a trailing slash.
+
+``-o create_release CREATERELEASE``
+	 *Optional*
+
+	 If True, create a release in the public repo.  Defaults to True
+
+``-o release_body RELEASEBODY``
+	 *Optional*
+
+	 If True, the entire release body will be published to the public repo.  Defaults to False
+
+``-o dry_run DRYRUN``
+	 *Optional*
+
+	 If True, skip creating Github data.  Defaults to False
+
 **github_pull_requests**
 ==========================================
 

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -1557,7 +1557,7 @@ Options
 **github_copy_subtree**
 ==========================================
 
-**Description:** Copies a subtree from the project repo at a given ref to a target repo.
+**Description:** Copies one or more subtrees from the project repository for a given release to a target repository, with the option to include release notes.
 
 **Class:** cumulusci.tasks.github.publish.PublishSubtree
 


### PR DESCRIPTION
# Critical Changes

# Changes
- We added a new task, `github_publish_subtree`, to allow publishing a list of files or directories to another repository after a release. This allows pushing a subset of your project's code from a private repository to a public one, for example.
# Issues Closed
Closes #1414 