### PR TITLE
Add option to ignore existing community

### DIFF
--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -494,6 +494,11 @@ Options
 
 	 Time to wait, in seconds, for the community to be created
 
+``-o skip_existing SKIPEXISTING``
+	 *Optional*
+
+	 If True, an existing community with the same name will not raise an exception.
+
 **insert_record**
 ==========================================
 


### PR DESCRIPTION
When troubleshooting/developing community automation it can be useful to ignore exceptions caused by an existing community.

# Critical Changes

# Changes
- We added a new option, `skip_existing`, to the `create_community` task. When `True`, the task will not raise an exception when a community with the same name exists in the org.
# Issues Closed
