### PR TITLE
2gp adjustments

### DIFF
--- a/cumulusci/core/exceptions.py
+++ b/cumulusci/core/exceptions.py
@@ -255,6 +255,12 @@ class DependencyLookupError(CumulusCIFailure):
     pass
 
 
+class PackageInstallError(CumulusCIFailure):
+    """ Raise for errors in installing a package version """
+
+    pass
+
+
 class PackageUploadFailure(CumulusCIFailure):
     """ Raise for errors in uploading a 2GP package version """
 

--- a/cumulusci/core/flowrunner.py
+++ b/cumulusci/core/flowrunner.py
@@ -92,6 +92,7 @@ class StepSpec(object):
         "path",  # type: str
         "skip",  # type: bool
         "when",  # type: str
+        "org",  # type: str
     )
 
     def __init__(
@@ -105,6 +106,7 @@ class StepSpec(object):
         from_flow=None,
         skip=None,
         when=None,
+        org=None,
     ):
         self.step_num = step_num
         self.task_name = task_name
@@ -114,6 +116,7 @@ class StepSpec(object):
         self.allow_failure = allow_failure
         self.skip = skip
         self.when = when
+        self.org = org
 
         # Store the dotted path to this step.
         # This is not guaranteed to be unique, because multiple steps
@@ -194,11 +197,15 @@ class TaskRunner(object):
         self.flow.resolve_return_value_options(task_config["options"])
 
         task_config["options"].update(options)
+        if self.step.org:
+            org_config = self.flow.project_config.keychain.get_org(self.step.org)
+        else:
+            org_config = self.org_config
 
         task = self.step.task_class(
             self.step.project_config,
             TaskConfig(task_config),
-            org_config=self.org_config,
+            org_config=org_config,
             name=self.step.task_name,
             stepnum=self.step.step_num,
             flow=self.flow,
@@ -525,6 +532,7 @@ class FlowCoordinator(object):
                     allow_failure=step_config.get("ignore_failure", False),
                     from_flow=from_flow,
                     when=step_config.get("when"),
+                    org=step_config.get("org"),
                 )
             )
             return visited_steps

--- a/cumulusci/core/tasks.py
+++ b/cumulusci/core/tasks.py
@@ -95,7 +95,7 @@ class BaseTask(object):
                     attr, extra = parts + [""] * (2 - len(parts))
                     self.options[option] = getattr(self.project_config, attr, None)
                     if extra and isinstance(self.options[option], str):
-                        self.options[option] += extra
+                        self.options[option] += " " + extra
             except AttributeError:
                 pass
 

--- a/cumulusci/core/tasks.py
+++ b/cumulusci/core/tasks.py
@@ -91,8 +91,11 @@ class BaseTask(object):
         for option, value in list(self.options.items()):
             try:
                 if value.startswith("$project_config."):
-                    attr = value.replace("$project_config.", "", 1)
+                    parts = value.replace("$project_config.", "", 1).split(" ", 1)
+                    attr, extra = parts + [""] * (2 - len(parts))
                     self.options[option] = getattr(self.project_config, attr, None)
+                    if extra and isinstance(self.options[option], str):
+                        self.options[option] += extra
             except AttributeError:
                 pass
 

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -556,6 +556,29 @@ flows:
             5:
                 task: github_parent_to_children
 
+    ci_feature_2gp:
+        description: Uploads and tests a namespaced unlocked package version
+        steps:
+            1:
+                task: create_package_version
+                org: devhub
+                options:
+                    package_type: Unlocked
+                    package_name: $project_config.project__package__name Unlocked Feature Test
+                    skip_validation: True
+            2:
+                flow: dependencies
+            3:
+                task: install_managed
+                options:
+                    version: ^^create_package_version.subscriber_package_version_id
+            4:
+                flow: config_managed
+            5:
+                task: run_tests
+                options:
+                    managed: True
+
     ci_master:
         description: Deploy the package metadata to the packaging org and prepare for managed package version upload.  Intended for use against master branch commits.
         steps:
@@ -987,7 +1010,7 @@ project:
         namespace:
         install_class:
         uninstall_class:
-        api_version: '48.0'
+        api_version: '49.0'
     git:
         default_branch: master
         prefix_feature: feature/

--- a/cumulusci/tasks/package_2gp.py
+++ b/cumulusci/tasks/package_2gp.py
@@ -67,6 +67,9 @@ class CreatePackageVersion(BaseSalesforceApiTask):
             "description": "If true, skip validation of the package version. Default: false. "
             "Skipping validation creates packages more quickly, but they cannot be promoted for release."
         },
+        "force_upload": {
+            "description": "If true, force reuploading a package even if a package with the same metadata already exists",
+        },
     }
 
     def _init_options(self, kwargs):
@@ -84,6 +87,9 @@ class CreatePackageVersion(BaseSalesforceApiTask):
         )
         self.options["skip_validation"] = process_bool_arg(
             self.options.get("skip_validation", False)
+        )
+        self.options["force_upload"] = process_bool_arg(
+            self.options.get("force_upload", False)
         )
 
     def _run_task(self):
@@ -197,20 +203,23 @@ class CreatePackageVersion(BaseSalesforceApiTask):
             package_hash = package_zip_builder.as_hash()
             version_info.writestr("package.zip", package_zip_builder.as_bytes())
 
-            # Check for an existing package with the same contents
-            res = self.tooling.query(
-                "SELECT Id "
-                "FROM Package2VersionCreateRequest "
-                f"WHERE Package2Id = '{package_id}' "
-                "AND Status != 'Error' "
-                f"AND Tag = 'hash:{package_hash}'"
-                # @@@ order by created
-            )
-            if res["size"] > 0:
-                self.logger.info(
-                    "Found existing request for package with the same metadata.  Using existing package."
+            if self.options["force_upload"] is False:
+                # Check for an existing package with the same contents
+                skip_validation = "true" if self.options["skip_validation"] else "false"
+                res = self.tooling.query(
+                    "SELECT Id "
+                    "FROM Package2VersionCreateRequest "
+                    f"WHERE Package2Id = '{package_id}' "
+                    "AND Status != 'Error' "
+                    f"AND SkipValidation = {skip_validation} "
+                    f"AND Tag = 'hash:{package_hash}'"
+                    # @@@ order by created
                 )
-                return res["records"][0]["Id"]
+                if res["size"] > 0:
+                    self.logger.info(
+                        "Found existing request for package with the same metadata.  Using existing package."
+                    )
+                    return res["records"][0]["Id"]
 
             # Create the package2-descriptor.json contents and write to version_info
             # @@@ we should support releasing a successor to an older version by specifying a base version

--- a/cumulusci/tasks/salesforce/InstallPackageVersion.py
+++ b/cumulusci/tasks/salesforce/InstallPackageVersion.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion
 from cumulusci.core.exceptions import PackageInstallError
 from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.core.utils import process_bool_arg
@@ -97,7 +98,11 @@ class InstallPackageVersion(BaseSalesforceApiTask, Deploy):
         self.org_config.reset_installed_packages()
 
     def _is_version_id(self, version):
-        return version and version.lower().startswith("04t")
+        return (
+            version
+            and not isinstance(version, LooseVersion)
+            and version.lower().startswith("04t")
+        )
 
     def _try(self):
         if self._is_version_id(self.options["version"]):


### PR DESCRIPTION
- Allow flow steps to specify an org
- Support text after $project_config.some__attr syntax (ex `$project_config.project__package__name Feature Test`)
- Add `ci_feature_2gp` flow for testing a feature branch as a namespaced unlocked 2gp package
- Added support for installing 04t versions in InstallPackageVersion
- Add SkipValidation to existing 2gp package lookup query
- Add `force_upload` task option to `create_package_version`


# Critical Changes

# Changes

# Issues Closed
