### PR TITLE
Use query_all for push failure reports

### DIFF
--- a/cumulusci/tasks/push/pushfails.py
+++ b/cumulusci/tasks/push/pushfails.py
@@ -4,8 +4,9 @@ this doesn't use the nearby push_api module, and was just a quick ccistyle
 get the job done kinda moment.
 """
 
+import csv
 import re
-import unicodecsv
+
 from cumulusci.core.utils import process_list_arg
 from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 
@@ -57,7 +58,7 @@ class ReportPushFailures(BaseSalesforceApiTask):
         # Get errors
         formatted_query = self.job_query.format(**self.options)
         self.logger.debug("Running query for job errors: " + formatted_query)
-        result = self.sf.query(formatted_query)
+        result = self.sf.query_all(formatted_query)
         job_records = result["records"]
         self.logger.debug(
             "Query is complete: {done}. Found {n} results.".format(
@@ -94,7 +95,7 @@ class ReportPushFailures(BaseSalesforceApiTask):
             formatted_query = self.subscriber_query.format(
                 org_ids=",".join("'{}'".format(org_id) for org_id in org_ids)
             )
-            result = self.sf.query(formatted_query)
+            result = self.sf.query_all(formatted_query)
             org_map.update({org["OrgKey"]: org for org in result["records"]})
         self.logger.debug(
             "Query is complete: {done}. Found {n} results.".format(
@@ -104,8 +105,8 @@ class ReportPushFailures(BaseSalesforceApiTask):
 
         ignore_errors = self.options["ignore_errors"]
         file_name = self.options["result_file"]
-        with open(file_name, "wb") as f:
-            w = unicodecsv.writer(f, encoding="utf-8")
+        with open(file_name, "w", encoding="utf-8") as f:
+            w = csv.writer(f)
             w.writerow(self.headers)
             for result in job_records:
                 error = result["Error"]

--- a/cumulusci/tasks/tests/test_pushfails.py
+++ b/cumulusci/tasks/tests/test_pushfails.py
@@ -40,7 +40,7 @@ class TestPushFailureTask(unittest.TestCase):
 
         def _init_class():
             task.sf = mock.Mock()
-            task.sf.query.side_effect = [
+            task.sf.query_all.side_effect = [
                 {
                     "done": True,
                     "totalSize": 2,
@@ -71,7 +71,7 @@ class TestPushFailureTask(unittest.TestCase):
         task._init_class = _init_class
         with temporary_dir():
             task()
-            self.assertEqual(2, task.sf.query.call_count)
+            self.assertEqual(2, task.sf.query_all.call_count)
             self.assertTrue(
                 os.path.isfile(task.result), "the result file does not exist"
             )
@@ -86,7 +86,11 @@ class TestPushFailureTask(unittest.TestCase):
 
         def _init_class():
             task.sf = mock.Mock()
-            task.sf.query.return_value = {"totalSize": 0, "records": [], "done": True}
+            task.sf.query_all.return_value = {
+                "totalSize": 0,
+                "records": [],
+                "done": True,
+            }
 
         task._init_class = _init_class
         task()

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,6 @@ snowfakery==1.0.1
 SQLAlchemy==1.3.18
 terminaltables==3.1.0
 typing-extensions==3.7.4.2
-unicodecsv==0.14.1
 uritemplate==3.0.1
 urllib3==1.25.10
 xmltodict==0.12.0


### PR DESCRIPTION
Also finish removing unicodecsv while we're in here.

# Critical Changes

# Changes

# Issues Closed
- Fixed a bug where the push_failure_report task could be missing some failed orgs if there were more than 200 errors.