### PR TITLE
Update the default API version for new projects

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -987,7 +987,7 @@ project:
         namespace:
         install_class:
         uninstall_class:
-        api_version: '48.0'
+        api_version: '49.0'
     git:
         default_branch: master
         prefix_feature: feature/

--- a/cumulusci/tasks/salesforce/tests/test_insert_record.py
+++ b/cumulusci/tasks/salesforce/tests/test_insert_record.py
@@ -66,7 +66,7 @@ class TestCreateRecord:
         )
         responses.add(
             responses.POST,
-            re.compile(r"https://test.salesforce.com/services/data/v48.0/.*"),
+            re.compile(r"https://test.salesforce.com/services/data/v49.0/.*"),
             content_type="application/json",
             status=404,
             json={

--- a/cumulusci/tests/cassettes/TestIntegrationInfrastructure.test_integration_tests.yaml
+++ b/cumulusci/tests/cassettes/TestIntegrationInfrastructure.test_integration_tests.yaml
@@ -5,11 +5,11 @@ interactions:
       Request-Headers:
       - Elided
     method: GET
-    uri: https://orgname.salesforce.com/services/data/v48.0/sobjects/Organization/ORGID
+    uri: https://orgname.salesforce.com/services/data/v49.0/sobjects/Organization/ORGID
   response:
     body:
       string: "{\n  \"attributes\" : {\n    \"type\" : \"Organization\",\n    \"url\"
-        : \"/services/data/v48.0/sobjects/Organization/00D0R000000FIDcUAO\"\n  },\n
+        : \"/services/data/v49.0/sobjects/Organization/00D0R000000FIDcUAO\"\n  },\n
         \ \"Id\" : \"00D0R000000FIDcUAO\",\n  \"Name\" : \"CumulusCI - Dev Workspace\",\n
         \ \"Division\" : null,\n  \"Street\" : null,\n  \"City\" : null,\n  \"State\"
         : null,\n  \"PostalCode\" : null,\n  \"Country\" : \"US\",\n  \"Latitude\"
@@ -50,15 +50,15 @@ interactions:
       \ <soap:Header>\n    <SessionHeader xmlns=\"http://soap.sforce.com/2006/04/metadata\">\n
       \     <sessionId>**Elided**</sessionId>\n    </SessionHeader>\n  </soap:Header>\n
       \ <soap:Body>\n    <retrieve xmlns=\"http://soap.sforce.com/2006/04/metadata\">\n
-      \     <retrieveRequest>\n        <apiVersion>48.0</apiVersion>\n        <unpackaged>\n
+      \     <retrieveRequest>\n        <apiVersion>49.0</apiVersion>\n        <unpackaged>\n
       \         <types>\n            <members>*</members>\n            <name>InstalledPackage</name>\n
-      \         </types>\n          <version>48.0</version>\n        </unpackaged>\n
+      \         </types>\n          <version>49.0</version>\n        </unpackaged>\n
       \     </retrieveRequest>\n    </retrieve>\n  </soap:Body>\n</soap:Envelope>"
     headers:
       Request-Headers:
       - Elided
     method: POST
-    uri: https://orgname.salesforce.com/services/Soap/m/48.0/ORGID
+    uri: https://orgname.salesforce.com/services/Soap/m/49.0/ORGID
   response:
     body:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
@@ -80,7 +80,7 @@ interactions:
       Request-Headers:
       - Elided
     method: POST
-    uri: https://orgname.salesforce.com/services/Soap/m/48.0/ORGID
+    uri: https://orgname.salesforce.com/services/Soap/m/49.0/ORGID
   response:
     body:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
@@ -102,7 +102,7 @@ interactions:
       Request-Headers:
       - Elided
     method: POST
-    uri: https://orgname.salesforce.com/services/Soap/m/48.0/ORGID
+    uri: https://orgname.salesforce.com/services/Soap/m/49.0/ORGID
   response:
     body:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"


### PR DESCRIPTION
# Critical Changes

# Changes
- New projects now default to using API version 49.0

# Issues Closed
