### PR TITLE
Global orgs had bugs relating to defaulting

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -918,7 +918,7 @@ def org_connect(runtime, org_name, sandbox, login_url, default, global_org):
 
     org_config.save()
 
-    if default:
+    if default and not global_org:
         runtime.keychain.set_default_org(org_name)
         click.echo(f"{org_name} is now the default org")
 

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -918,7 +918,7 @@ def org_connect(runtime, org_name, sandbox, login_url, default, global_org):
 
     org_config.save()
 
-    if default and not global_org:
+    if default and runtime.project_config is not None:
         runtime.keychain.set_default_org(org_name)
         click.echo(f"{org_name} is now the default org")
 
@@ -1044,8 +1044,9 @@ def org_list(runtime, plain):
         org: runtime.keychain.get_org(org) for org in runtime.keychain.list_orgs()
     }
     rows_to_dim = []
+    default_org_name, _ = runtime.keychain.get_default_org()
     for org, org_config in org_configs.items():
-        row = [org, org_config.default]
+        row = [org, org == default_org_name]
         if isinstance(org_config, ScratchOrgConfig):
             org_days = org_config.format_org_days()
             if org_config.expired:

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -1210,6 +1210,21 @@ Environment Info: Rossian / x68_46
             ),
         ]
 
+        runtime.keychain.get_default_org.return_value = (
+            "test0",
+            ScratchOrgConfig(
+                {
+                    "default": True,
+                    "scratch": True,
+                    "date_created": datetime.now() - timedelta(days=8),
+                    "days": 7,
+                    "config_name": "dev",
+                    "username": "test0@example.com",
+                },
+                "test0",
+            ),
+        )
+
         run_click_command(cci.org_list, runtime=runtime, plain=False)
 
         scratch_table_call = mock.call(

--- a/cumulusci/core/keychain/BaseProjectKeychain.py
+++ b/cumulusci/core/keychain/BaseProjectKeychain.py
@@ -142,11 +142,6 @@ class BaseProjectKeychain(BaseConfig):
         del self.orgs[name]
         self._load_orgs()
 
-    # TODO: Are these used in any context other than
-    # encrypted_file_project_keychain?
-    #
-    # If not, they can be removed after a reasonable
-    # period of backwards compatibility
     def set_org(self, org_config, global_org=False):
         if isinstance(org_config, ScratchOrgConfig):
             org_config.config["scratch"] = True
@@ -155,6 +150,11 @@ class BaseProjectKeychain(BaseConfig):
 
     def _set_org(self, org_config, global_org):
         self.orgs[org_config.name] = org_config
+
+    # This implementation of get_default_org, set_default_org, and unset_default_org
+    # is currently kept for backwards compatibility, but EncryptedFileProjectKeychain
+    # now stores the default elsewhere, and EnvironmentProjectKeychain doesn't actually
+    # persist across multiple invocations of cci, so we should consider getting rid of this.
 
     def get_default_org(self):
         """ retrieve the name and configuration of the default org """

--- a/cumulusci/core/keychain/BaseProjectKeychain.py
+++ b/cumulusci/core/keychain/BaseProjectKeychain.py
@@ -142,6 +142,11 @@ class BaseProjectKeychain(BaseConfig):
         del self.orgs[name]
         self._load_orgs()
 
+    # TODO: Are these used in any context other than
+    # encrypted_file_project_keychain?
+    #
+    # If not, they can be removed after a reasonable
+    # period of backwards compatibility
     def set_org(self, org_config, global_org=False):
         if isinstance(org_config, ScratchOrgConfig):
             org_config.config["scratch"] = True
@@ -181,7 +186,7 @@ class BaseProjectKeychain(BaseConfig):
                 org_config.save()
         sfdx("force:config:set defaultusername=")
 
-    def get_org(self, name):
+    def get_org(self, name: str):
         """ retrieve an org configuration by name key """
         if name not in self.orgs:
             self._raise_org_not_found(name)

--- a/cumulusci/core/keychain/encrypted_file_project_keychain.py
+++ b/cumulusci/core/keychain/encrypted_file_project_keychain.py
@@ -134,8 +134,7 @@ class EncryptedFileProjectKeychain(BaseEncryptedProjectKeychain):
         if default_org_path.exists():
             org_name = default_org_path.read_text().strip()
             org_config = self.get_org(org_name)
-            if org_config:
-                return org_name, org_config
+            return org_name, org_config
 
         # fallback to old way of doing it
         org_name, org_config = super().get_default_org()

--- a/cumulusci/core/keychain/encrypted_file_project_keychain.py
+++ b/cumulusci/core/keychain/encrypted_file_project_keychain.py
@@ -130,9 +130,8 @@ class EncryptedFileProjectKeychain(BaseEncryptedProjectKeychain):
     def get_default_org(self):
         """ Retrieve the name and configuration of the default org """
         # first look for a file with the default org in it
-        if os.path.exists(self.default_org_name):
-            with open(self.default_org_name, "r") as f:
-                org_name = f.read().strip()
+        if self.default_org_name.exists():
+            org_name = self.default_org_name.read_text().strip()
             org_config = self.get_org(org_name)
             if org_config:
                 return org_name, org_config
@@ -146,16 +145,12 @@ class EncryptedFileProjectKeychain(BaseEncryptedProjectKeychain):
     def set_default_org(self, name: str):
         """ Set the default org for tasks and flows by name """
         super().set_default_org(name)
-        with open(self.default_org_name, "w") as f:
-            f.write(name)
+        self.default_org_name.write_text(name)
 
     def unset_default_org(self):
         """Unset the default orgs for tasks and flows """
         super().unset_default_org()
-        try:
-            os.unlink(self.default_org_name)
-        except FileNotFoundError:
-            pass
+        self.default_org_name.unlink(missing_ok=True)
 
 
 class GlobalOrg(NamedTuple):

--- a/cumulusci/core/keychain/encrypted_file_project_keychain.py
+++ b/cumulusci/core/keychain/encrypted_file_project_keychain.py
@@ -151,7 +151,10 @@ class EncryptedFileProjectKeychain(BaseEncryptedProjectKeychain):
     def unset_default_org(self):
         """Unset the default orgs for tasks and flows """
         super().unset_default_org()
-        self._default_org_path.unlink(missing_ok=True)
+        try:
+            self._default_org_path.unlink()
+        except FileNotFoundError:
+            pass
 
 
 class GlobalOrg(NamedTuple):

--- a/cumulusci/core/keychain/encrypted_file_project_keychain.py
+++ b/cumulusci/core/keychain/encrypted_file_project_keychain.py
@@ -124,14 +124,15 @@ class EncryptedFileProjectKeychain(BaseEncryptedProjectKeychain):
         return org
 
     @property
-    def default_org_name(self):
+    def _default_org_path(self):
         return Path(self.project_local_dir) / "DEFAULT_ORG.txt"
 
     def get_default_org(self):
         """ Retrieve the name and configuration of the default org """
         # first look for a file with the default org in it
-        if self.default_org_name.exists():
-            org_name = self.default_org_name.read_text().strip()
+        default_org_path = self._default_org_path
+        if default_org_path.exists():
+            org_name = default_org_path.read_text().strip()
             org_config = self.get_org(org_name)
             if org_config:
                 return org_name, org_config
@@ -145,12 +146,12 @@ class EncryptedFileProjectKeychain(BaseEncryptedProjectKeychain):
     def set_default_org(self, name: str):
         """ Set the default org for tasks and flows by name """
         super().set_default_org(name)
-        self.default_org_name.write_text(name)
+        self._default_org_path.write_text(name)
 
     def unset_default_org(self):
         """Unset the default orgs for tasks and flows """
         super().unset_default_org()
-        self.default_org_name.unlink(missing_ok=True)
+        self._default_org_path.unlink(missing_ok=True)
 
 
 class GlobalOrg(NamedTuple):

--- a/cumulusci/core/tests/test_keychain.py
+++ b/cumulusci/core/tests/test_keychain.py
@@ -142,9 +142,10 @@ class ProjectKeychainTestMixin(unittest.TestCase):
     def test_get_default_org(self):
         keychain = self.keychain_class(self.project_config, self.key)
         org_config = self.org_config.config.copy()
-        org_config = OrgConfig(org_config, "test")
+        org_config = OrgConfig(org_config, "test", keychain=keychain)
+        org_config.save()
+        keychain.set_default_org("test")
         org_config.config["default"] = True
-        keychain.set_org(org_config)
         self.assertEqual(keychain.get_default_org()[1].config, org_config.config)
 
     def test_get_default_org_no_default(self):
@@ -511,3 +512,45 @@ class TestEncryptedFileProjectKeychain(ProjectKeychainTestMixin):
         new_keychain = self.keychain_class(self.project_config, self.key)
         org_config = new_keychain.get_org("test")
         assert org_config.global_org
+
+    def test_get_default_org__with_files(self):
+        keychain = self.keychain_class(self.project_config, self.key)
+        org_config = OrgConfig(self.org_config.config.copy(), "test", keychain=keychain)
+        org_config.save()
+        with open(self._default_org_path(), "w") as f:
+            f.write("test")
+        self.assertEqual(keychain.get_default_org()[1].config, org_config.config)
+        self._default_org_path().unlink()
+
+    @mock.patch("sarge.Command")
+    def test_set_default_org__with_files(self, Command):
+        keychain = self.keychain_class(self.project_config, self.key)
+        org_config = OrgConfig(self.org_config.config.copy(), "test")
+        keychain.set_org(org_config)
+        keychain.set_default_org("test")
+        with open(self._default_org_path()) as f:
+            assert f.read() == "test"
+        self._default_org_path().unlink()
+
+    @mock.patch("sarge.Command")
+    def test_unset_default_org__with_files(self, Command):
+        keychain = self.keychain_class(self.project_config, self.key)
+        org_config = self.org_config.config.copy()
+        org_config = OrgConfig(org_config, "test")
+        keychain.set_org(org_config)
+        keychain.set_default_org("test")
+        keychain.unset_default_org()
+        self.assertEqual(keychain.get_default_org()[1], None)
+        assert not self._default_org_path().exists()
+
+    def _default_org_path(self):
+        return Path(self.tempdir_home) / ".cumulusci/TestProject/DEFAULT_ORG.txt"
+
+    # old way of finding defaults used contents of the files themselves
+    # we should preserve backwards compatibiliity for a few months
+    def test_get_default_org__file_missing_fallback(self):
+        keychain = self.keychain_class(self.project_config, self.key)
+        org_config = OrgConfig(self.org_config.config.copy(), "test", keychain=keychain)
+        org_config.config["default"] = True
+        org_config.save()
+        self.assertEqual(keychain.get_default_org()[1].config, org_config.config)


### PR DESCRIPTION
Previously there were subtle issues where local org files were being created and shadowing global ones. So, for example, removing a global org might not remove it for all projects.

Fixing that bug exposed a logic error because "default" was stored on a boolean in the orgconfig which means that if a global org is defaulted it will be defaulted for all projects. This fixes that bug.

The default is now stored externally in its own file analogous to how Git stores its HEAD.