### PR TITLE
Case agnostic bulkdata

### DIFF
--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Run pre-commit on changed files
       run: |
         git fetch --depth=1 origin master
-        pre-commit run --files $(git diff --diff-filter=d --name-only origin/master)
+        pre-commit run --files $(git diff --diff-filter=d --name-only origin/master...HEAD)
 
   unit_tests:
     name: "Unit tests: Python ${{ matrix.python-version }}"

--- a/cumulusci/tasks/bulkdata/mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/mapping_parser.py
@@ -18,17 +18,15 @@ logger = getLogger(__name__)
 
 class CaseInsensitiveDict(RequestsCaseInsensitiveDict):
     def __init__(self, *args, **kwargs):
+        self._canonical_keys = {}
         super().__init__(*args, **kwargs)
-        # there's a more efficient way to do this by poking around the
-        # base class internals but this way may be less fragile
-        self._canonical_keys = {key.lower(): key for key in self.keys()}
 
     def canonical_key(self, name):
         return self._canonical_keys[name.lower()]
 
-    def __setitem__(self, name, value):
-        # self._canonical_keys doesn't get updated if this dict gets mutated
-        raise NotImplementedError()
+    def __setitem__(self, key, value):
+        super().__setitem__(key, value)
+        self._canonical_keys[key.lower()] = key
 
 
 class MappingLookup(CCIDictModel):

--- a/cumulusci/tasks/bulkdata/mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/mapping_parser.py
@@ -13,7 +13,6 @@ from cumulusci.utils import convert_to_snake_case
 
 from typing_extensions import Literal
 
-LOGGER_NAME = "MAPPING_LOADER"
 logger = getLogger(__name__)
 
 

--- a/cumulusci/tasks/bulkdata/mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/mapping_parser.py
@@ -181,13 +181,14 @@ class MappingStep(CCIDictModel):
             # Canonicalize the key's case
             try:
                 new_name = describe.canonical_key(f)
-                del field_dict[f]
-                field_dict[new_name] = entry
-                f = new_name
             except KeyError:
                 logger.warning(
                     f"Field {self.sf_object}.{f} does not exist or is not visible to the current user."
                 )
+            else:
+                del field_dict[f]
+                field_dict[new_name] = entry
+                f = new_name
 
             # Do we have the right permissions for this field, or do we need to drop it?
             is_after_lookup = hasattr(field_dict[f], "after")

--- a/cumulusci/tasks/bulkdata/mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/mapping_parser.py
@@ -182,10 +182,9 @@ class MappingStep(CCIDictModel):
             # Canonicalize the key's case
             try:
                 new_name = describe.canonical_key(f)
-                if new_name != f:
-                    del field_dict[f]
-                    field_dict[new_name] = entry
-                    f = new_name
+                del field_dict[f]
+                field_dict[new_name] = entry
+                f = new_name
             except KeyError:
                 logger.warning(
                     f"Field {self.sf_object}.{f} does not exist or is not visible to the current user."

--- a/cumulusci/tasks/bulkdata/mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/mapping_parser.py
@@ -26,6 +26,10 @@ class CaseInsensitiveDict(RequestsCaseInsensitiveDict):
     def canonical_key(self, name):
         return self._canonical_keys[name.lower()]
 
+    def __setitem__(self, name, value):
+        # self._canonical_keys doesn't get updated if this dict gets mutated
+        raise NotImplementedError()
+
 
 class MappingLookup(CCIDictModel):
     "Lookup relationship between two tables."

--- a/cumulusci/tasks/bulkdata/mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/mapping_parser.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Union, IO, Optional, Any, Callable, Mapping
 from logging import getLogger
 from pathlib import Path
-from requests.structures import CaseInsensitiveDict
+from requests.structures import CaseInsensitiveDict as RequestsCaseInsensitiveDict
 
 from pydantic import Field, validator, root_validator, ValidationError
 
@@ -14,7 +14,18 @@ from cumulusci.utils import convert_to_snake_case
 from typing_extensions import Literal
 
 LOGGER_NAME = "MAPPING_LOADER"
-logger = getLogger(LOGGER_NAME)
+logger = getLogger(__name__)
+
+
+class CaseInsensitiveDict(RequestsCaseInsensitiveDict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # there's a more efficient way to do this by poking around the
+        # base class internals but this way may be less fragile
+        self._canonical_keys = {key.lower(): key for key in self.keys()}
+
+    def canonical_key(self, name):
+        return self._canonical_keys[name.lower()]
 
 
 class MappingLookup(CCIDictModel):
@@ -126,8 +137,9 @@ class MappingStep(CCIDictModel):
     def _check_object_permission(
         self, global_describe: Mapping, sobject: str, operation: DataOperationType
     ):
+        assert sobject in global_describe
         perm = self._get_permission_type(operation)
-        return sobject in global_describe and global_describe[sobject][perm]
+        return global_describe[sobject][perm]
 
     def _check_field_permission(
         self, describe: Mapping, field: str, operation: DataOperationType
@@ -140,7 +152,7 @@ class MappingStep(CCIDictModel):
 
     def _validate_field_dict(
         self,
-        describe: Mapping,
+        describe: CaseInsensitiveDict,
         field_dict: Dict[str, Any],
         inject: Optional[Callable[[str], str]],
         drop_missing: bool,
@@ -151,7 +163,9 @@ class MappingStep(CCIDictModel):
         orig_fields = field_dict.copy()
         for f, entry in orig_fields.items():
             # Do we need to inject this field?
-            if f == "Id":
+            if f.lower() == "id":
+                del field_dict[f]
+                field_dict["Id"] = entry
                 continue
 
             if inject and self._is_injectable(f) and inject(f) not in orig_fields:
@@ -164,6 +178,18 @@ class MappingStep(CCIDictModel):
                     field_dict[inject(f)] = entry
                     del field_dict[f]
                     f = inject(f)
+
+            # Canonicalize the key's case
+            try:
+                new_name = describe.canonical_key(f)
+                if new_name != f:
+                    del field_dict[f]
+                    field_dict[new_name] = entry
+                    f = new_name
+            except KeyError:
+                logger.warning(
+                    f"Field {self.sf_object}.{f} does not exist or is not visible to the current user."
+                )
 
             # Do we have the right permissions for this field, or do we need to drop it?
             is_after_lookup = hasattr(field_dict[f], "after")
@@ -186,7 +212,7 @@ class MappingStep(CCIDictModel):
 
     def _validate_sobject(
         self,
-        global_describe: Mapping,
+        global_describe: CaseInsensitiveDict,
         inject: Optional[Callable[[str], str]],
         data_operation_type: DataOperationType,
     ) -> bool:
@@ -206,12 +232,20 @@ class MappingStep(CCIDictModel):
             ):
                 self.sf_object = inject(self.sf_object)
 
+        try:
+            self.sf_object = global_describe.canonical_key(self.sf_object)
+        except KeyError:
+            logger.warning(
+                f"sObject {self.sf_object} does not exist or is not visible to the current user."
+            )
+            return False
+
         # Validate our access to this sObject.
         if not self._check_object_permission(
             global_describe, self.sf_object, data_operation_type
         ):
             logger.warning(
-                f"sObject {self.sf_object} is not present or does not have the correct permissions."
+                f"sObject {self.sf_object} does not have the correct permissions for {data_operation_type}."
             )
             return False
 

--- a/cumulusci/tasks/bulkdata/tests/test_mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/tests/test_mapping_parser.py
@@ -14,6 +14,7 @@ from cumulusci.tasks.bulkdata.mapping_parser import (
     parse_from_yaml,
     validate_and_inject_mapping,
     ValidationError,
+    CaseInsensitiveDict,
 )
 from cumulusci.tasks.bulkdata.step import DataOperationType
 from cumulusci.tasks.bulkdata.tests.test_utils import mock_describe_calls
@@ -153,7 +154,9 @@ class TestMappingParser:
         )
 
         assert ms._validate_field_dict(
-            {"Name": {"createable": True}, "Website": {"createable": True}},
+            CaseInsensitiveDict(
+                {"Name": {"createable": True}, "Website": {"createable": True}}
+            ),
             ms.fields_,
             None,
             False,
@@ -161,7 +164,9 @@ class TestMappingParser:
         )
 
         assert not ms._validate_field_dict(
-            {"Name": {"createable": True}, "Website": {"createable": False}},
+            CaseInsensitiveDict(
+                {"Name": {"createable": True}, "Website": {"createable": False}}
+            ),
             ms.fields_,
             None,
             False,
@@ -174,7 +179,9 @@ class TestMappingParser:
         )
 
         assert ms._validate_field_dict(
-            {"Name": {"createable": True}, "npsp__Test__c": {"createable": True}},
+            CaseInsensitiveDict(
+                {"Name": {"createable": True}, "npsp__Test__c": {"createable": True}}
+            ),
             ms.fields_,
             lambda field: f"npsp__{field}",
             False,
@@ -189,11 +196,13 @@ class TestMappingParser:
         )
 
         assert ms._validate_field_dict(
-            {
-                "Name": {"createable": True},
-                "npsp__Test__c": {"createable": True},
-                "Test__c": {"createable": True},
-            },
+            CaseInsensitiveDict(
+                {
+                    "Name": {"createable": True},
+                    "npsp__Test__c": {"createable": True},
+                    "Test__c": {"createable": True},
+                }
+            ),
             ms.fields_,
             lambda field: f"npsp__{field}",
             False,
@@ -208,7 +217,9 @@ class TestMappingParser:
         )
 
         assert ms._validate_field_dict(
-            {"Name": {"createable": True}, "Website": {"createable": False}},
+            CaseInsensitiveDict(
+                {"Name": {"createable": True}, "Website": {"createable": False}}
+            ),
             ms.fields_,
             None,
             True,
@@ -221,24 +232,30 @@ class TestMappingParser:
         ms = MappingStep(sf_object="Account", fields=["Name"], action="insert")
 
         assert ms._validate_sobject(
-            {"Account": {"createable": True}}, None, DataOperationType.INSERT
+            CaseInsensitiveDict({"Account": {"createable": True}}),
+            None,
+            DataOperationType.INSERT,
         )
 
         assert ms._validate_sobject(
-            {"Account": {"queryable": True}}, None, DataOperationType.QUERY
+            CaseInsensitiveDict({"Account": {"queryable": True}}),
+            None,
+            DataOperationType.QUERY,
         )
 
         ms = MappingStep(sf_object="Account", fields=["Name"], action="update")
 
         assert not ms._validate_sobject(
-            {"Account": {"updateable": False}}, None, DataOperationType.INSERT
+            CaseInsensitiveDict({"Account": {"updateable": False}}),
+            None,
+            DataOperationType.INSERT,
         )
 
     def test_validate_sobject__injection(self):
         ms = MappingStep(sf_object="Test__c", fields=["Name"], action="insert")
 
         assert ms._validate_sobject(
-            {"npsp__Test__c": {"createable": True}},
+            CaseInsensitiveDict({"npsp__Test__c": {"createable": True}}),
             lambda obj: f"npsp__{obj}",
             DataOperationType.INSERT,
         )
@@ -248,7 +265,9 @@ class TestMappingParser:
         ms = MappingStep(sf_object="Test__c", fields=["Name"], action="insert")
 
         assert ms._validate_sobject(
-            {"npsp__Test__c": {"createable": True}, "Test__c": {"createable": True}},
+            CaseInsensitiveDict(
+                {"npsp__Test__c": {"createable": True}, "Test__c": {"createable": True}}
+            ),
             lambda obj: f"npsp__{obj}",
             DataOperationType.INSERT,
         )
@@ -288,7 +307,7 @@ class TestMappingParser:
         )
 
         ms._validate_sobject.assert_called_once_with(
-            {"Account": {"name": "Account", "createable": True}},
+            CaseInsensitiveDict({"Account": {"name": "Account", "createable": True}}),
             mock.ANY,  # This is a function def
             DataOperationType.INSERT,
         )
@@ -296,7 +315,9 @@ class TestMappingParser:
         ms._validate_field_dict.assert_has_calls(
             [
                 mock.call(
-                    {"ns__Test__c": {"name": "ns__Test__c", "createable": True}},
+                    CaseInsensitiveDict(
+                        {"ns__Test__c": {"name": "ns__Test__c", "createable": True}}
+                    ),
                     ms.fields,
                     mock.ANY,  # local function def
                     False,
@@ -352,7 +373,7 @@ class TestMappingParser:
         )
 
         ms._validate_sobject.assert_called_once_with(
-            {"Account": {"name": "Account", "createable": True}},
+            CaseInsensitiveDict({"Account": {"name": "Account", "createable": True}}),
             mock.ANY,  # local function def
             DataOperationType.INSERT,
         )
@@ -413,7 +434,7 @@ class TestMappingParser:
         )
 
         ms._validate_sobject.assert_called_once_with(
-            {"Test__c": {"name": "Test__c", "createable": True}},
+            CaseInsensitiveDict({"Test__c": {"name": "Test__c", "createable": True}}),
             None,
             DataOperationType.INSERT,
         )
@@ -847,6 +868,11 @@ class TestMappingLookup:
             {"instance_url": "https://example.com", "access_token": "abc123"}, "test"
         )
 
+        assert mapping["Insert Accounts"].sf_object != "Account"
+        assert mapping["Insert Accounts"].sf_object == "account"
+        assert "name" in mapping["Insert Accounts"].fields
+        assert "Name" not in mapping["Insert Accounts"].fields
+
         validate_and_inject_mapping(
             mapping=mapping,
             org_config=org_config,
@@ -855,3 +881,7 @@ class TestMappingLookup:
             inject_namespaces=False,
             drop_missing=False,
         )
+        assert mapping["Insert Accounts"].sf_object == "Account"
+        assert mapping["Insert Accounts"].sf_object != "account"
+        assert "Name" in mapping["Insert Accounts"].fields
+        assert "name" not in mapping["Insert Accounts"].fields

--- a/cumulusci/tasks/bulkdata/tests/test_mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/tests/test_mapping_parser.py
@@ -831,3 +831,27 @@ class TestMappingLookup:
 
         with pytest.raises(KeyError):
             lookup.get_lookup_key_field(FakeModel())
+
+    @responses.activate
+    def test_validate_and_inject_mapping_works_case_insensitively(self):
+        mock_describe_calls()
+        mapping = parse_from_yaml(
+            StringIO(
+                (
+                    "Insert Accounts:\n  sf_object: account\n  table: account\n  fields:\n    - name\n"
+                    "Insert Contacts:\n  sf_object: contact\n  table: contact\n  fields:\n    - fIRSTnAME\n  lookups:\n    accountid:\n      table: account"
+                )
+            )
+        )
+        org_config = DummyOrgConfig(
+            {"instance_url": "https://example.com", "access_token": "abc123"}, "test"
+        )
+
+        validate_and_inject_mapping(
+            mapping=mapping,
+            org_config=org_config,
+            namespace=None,
+            data_operation=DataOperationType.INSERT,
+            inject_namespaces=False,
+            drop_missing=False,
+        )

--- a/cumulusci/tasks/bulkdata/tests/test_utils.py
+++ b/cumulusci/tasks/bulkdata/tests/test_utils.py
@@ -66,6 +66,8 @@ def mock_describe_calls():
         "Opportunity",
         "OpportunityContactRole",
         "Case",
+        "account",
+        "contact",
     ]:
         mock_sobject_describe(sobject)
 

--- a/cumulusci/tasks/bulkdata/tests/test_utils.py
+++ b/cumulusci/tasks/bulkdata/tests/test_utils.py
@@ -46,12 +46,6 @@ def mock_describe_calls():
             body=read_mock(name),
             status=200,
         )
-        responses.add(
-            method="GET",
-            url=f"https://example.com/services/data/v48.0/sobjects/{name.lower()}/describe",
-            body=read_mock(name),
-            status=200,
-        )
 
     responses.add(
         method="GET",

--- a/cumulusci/tasks/bulkdata/tests/test_utils.py
+++ b/cumulusci/tasks/bulkdata/tests/test_utils.py
@@ -46,6 +46,12 @@ def mock_describe_calls():
             body=read_mock(name),
             status=200,
         )
+        responses.add(
+            method="GET",
+            url=f"https://example.com/services/data/v48.0/sobjects/{name.lower()}/describe",
+            body=read_mock(name),
+            status=200,
+        )
 
     responses.add(
         method="GET",
@@ -66,8 +72,6 @@ def mock_describe_calls():
         "Opportunity",
         "OpportunityContactRole",
         "Case",
-        "account",
-        "contact",
     ]:
         mock_sobject_describe(sobject)
 


### PR DESCRIPTION
# Changes

A pre-release (?) version of CumulusCI was very strict about requiring the case of sObjects and Fields to be exactly the same as the "canonical" Salesforce name. This puts it back to being case agnostic.
 