### PR TITLE
fix release notes bug: reset subheading when a new heading is found

### DIFF
--- a/cumulusci/tasks/release_notes/parser.py
+++ b/cumulusci/tasks/release_notes/parser.py
@@ -49,6 +49,7 @@ class ChangeNotesLinesParser(BaseChangeNotesParser):
             # Look for the starting line of the section
             if self._is_start_line(line):
                 self._in_section = True
+                self.h2_title = None
                 continue
 
             # Look for h2

--- a/cumulusci/tasks/release_notes/tests/test_parser.py
+++ b/cumulusci/tasks/release_notes/tests/test_parser.py
@@ -117,6 +117,14 @@ class TestChangeNotesLinesParser(unittest.TestCase):
         self.assertEqual({"Subheading": ["foo"]}, parser.h2)
         self.assertTrue(line_added)
 
+    def test_parse_subheading_from_another_section(self):
+        change_note = "## Subheading\r\n# {0}\r\nfoo".format(self.title)
+        parser = ChangeNotesLinesParser(None, self.title)
+        line_added = parser.parse(change_note)
+        self.assertEqual(["foo"], parser.content)
+        self.assertEqual({}, parser.h2)
+        self.assertTrue(line_added)
+
     def test_render_no_content(self):
         parser = ChangeNotesLinesParser(None, self.title)
         self.assertEqual(parser.render(), "")


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed
- Fixed a bug in the `github_release_notes` task where a note could be listed under a subheading from another section.