### PR TITLE
Fix CCI+Snowfakery Continuation Tempfile handling on Windows

### DIFF
--- a/cumulusci/tasks/bulkdata/tests/test_generate_from_snowfakery_task.py
+++ b/cumulusci/tasks/bulkdata/tests/test_generate_from_snowfakery_task.py
@@ -8,6 +8,7 @@ from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.tasks.bulkdata.tests.utils import _make_task
 
 import yaml
+import pytest
 from sqlalchemy import create_engine
 
 from cumulusci.tasks.bulkdata.generate_and_load_data_from_yaml import (
@@ -142,6 +143,41 @@ class TestGenerateFromDataTask(unittest.TestCase):
             )
             task()
             assert len(self.assertRowsCreated(database_url)) == 11
+
+    @mock.patch(
+        "cumulusci.tasks.bulkdata.generate_and_load_data_from_yaml.GenerateAndLoadDataFromYaml._dataload"
+    )
+    def test_simple_generate_and_load(self, _dataload):
+        task = _make_task(
+            GenerateAndLoadDataFromYaml,
+            {
+                "options": {
+                    "generator_yaml": simple_yaml,
+                    "num_records": 11,
+                    "num_records_tablename": "Account",
+                }
+            },
+        )
+        task()
+        assert len(_dataload.mock_calls) == 1
+
+    @mock.patch("cumulusci.tasks.bulkdata.generate_from_yaml.generate")
+    def test_exception_handled_cleanly(self, generate):
+        generate.side_effect = AssertionError("Foo")
+        with pytest.raises(AssertionError) as e:
+            task = _make_task(
+                GenerateAndLoadDataFromYaml,
+                {
+                    "options": {
+                        "generator_yaml": simple_yaml,
+                        "num_records": 11,
+                        "num_records_tablename": "Account",
+                    }
+                },
+            )
+            task()
+            assert "Foo" in str(e.value)
+        assert len(generate.mock_calls) == 1
 
     @mock.patch(
         "cumulusci.tasks.bulkdata.generate_and_load_data_from_yaml.GenerateAndLoadDataFromYaml._dataload"


### PR DESCRIPTION
There is a bug reported by a Windows user relating to Tempfile handling of CCI+Snowfakery. If an exception is thrown by Snowfakery, the continuation file is not closed before the TempDirectory is deleted. This causes another Windows error which obscures the first one and makes it nearly impossible to detect and fix or workaround. This PR fixes that.

I added some test cases, one of which provokes the bug.

I turned the method that opens the continuation file into a context manager and nested everything inside of it.
