### PR TITLE
Recover gracefully from missing default orgs

### DIFF
--- a/cumulusci/core/keychain/encrypted_file_project_keychain.py
+++ b/cumulusci/core/keychain/encrypted_file_project_keychain.py
@@ -133,8 +133,11 @@ class EncryptedFileProjectKeychain(BaseEncryptedProjectKeychain):
         default_org_path = self._default_org_path
         if default_org_path.exists():
             org_name = default_org_path.read_text().strip()
-            org_config = self.get_org(org_name)
-            return org_name, org_config
+            try:
+                org_config = self.get_org(org_name)
+                return org_name, org_config
+            except OrgNotFound:  # org was deleted
+                default_org_path.unlink()  # we don't really have a usable default anymore
 
         # fallback to old way of doing it
         org_name, org_config = super().get_default_org()

--- a/cumulusci/core/tests/test_keychain.py
+++ b/cumulusci/core/tests/test_keychain.py
@@ -519,8 +519,18 @@ class TestEncryptedFileProjectKeychain(ProjectKeychainTestMixin):
         org_config.save()
         with open(self._default_org_path(), "w") as f:
             f.write("test")
-        self.assertEqual(keychain.get_default_org()[1].config, org_config.config)
-        self._default_org_path().unlink()
+        try:
+            self.assertEqual(keychain.get_default_org()[1].config, org_config.config)
+        finally:
+            self._default_org_path().unlink()
+
+    def test_get_default_org__with_files__missing_org(self):
+        keychain = self.keychain_class(self.project_config, self.key)
+        with open(self._default_org_path(), "w") as f:
+            f.write("should_not_exist")
+        assert self._default_org_path().exists()
+        assert keychain.get_default_org() == (None, None)
+        assert not self._default_org_path().exists()
 
     @mock.patch("sarge.Command")
     def test_set_default_org__with_files(self, Command):


### PR DESCRIPTION
If the file that designates the default org points to an org that can't be loaded, treat that the same as simply having no default at all.