### PR TITLE
OrgConfig supports is_person_accounts_enabled

### DIFF
--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -277,7 +277,32 @@ class OrgConfig(BaseConfig):
 
     @property
     def is_person_accounts_enabled(self):
-        """Returns if Account has an "IsPersonAccount" field."""
+        """
+        Returns if the org has person accounts enabled, i.e. if Account has an ``IsPersonAccount`` field.
+
+        **Example**
+
+        Selectively run a task in a flow only if Person Accounts is or is not enabled.
+
+        .. code-block:: yaml
+
+            flows:
+                load_storytelling_data:
+                    steps:
+                        1:
+                            task: load_dataset
+                            options:
+                                mapping: datasets/with_person_accounts/mapping.yml
+                                sql_path: datasets/with_person_accounts/data.sql
+                            when: org_config.is_person_accounts_enabled
+                        2:
+                            task: load_dataset
+                            options:
+                                mapping: datasets/without_person_accounts/mapping.yml
+                                sql_path: datasets/without_person_accounts/data.sql
+                            when: not org_config.is_person_accounts_enabled
+
+        """
         if self._is_person_accounts_enabled is None:
             self._is_person_accounts_enabled = any(
                 field["name"] == "IsPersonAccount"

--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -33,6 +33,7 @@ class OrgConfig(BaseConfig):
         self._client = None
         self._latest_api_version = None
         self._installed_packages = None
+        self._is_person_accounts_enabled = None
         super(OrgConfig, self).__init__(config)
 
     def refresh_oauth_token(self, keychain, connected_app=None):
@@ -273,3 +274,13 @@ class OrgConfig(BaseConfig):
     def save(self):
         assert self.keychain, "Keychain was not set on OrgConfig"
         self.keychain.set_org(self, self.global_org)
+
+    @property
+    def is_person_accounts_enabled(self):
+        """Returns if Account has an "IsPersonAccount" field."""
+        if self._is_person_accounts_enabled is None:
+            self._is_person_accounts_enabled = any(
+                field["name"] == "IsPersonAccount"
+                for field in self.salesforce_client.Account.describe()["fields"]
+            )
+        return self._is_person_accounts_enabled

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -1440,3 +1440,79 @@ class TestOrgConfig(unittest.TestCase):
 
         with self.assertRaises(CumulusCIException):
             config.has_minimum_package_version("GW_Volunteers", "1.0")
+
+    @responses.activate
+    def test_is_person_accounts_enabled__not_enabled(self):
+        config = OrgConfig(
+            {
+                "instance_url": "https://example.com",
+                "access_token": "TOKEN",
+                "id": "OODxxxxxxxxxxxx/user",
+            },
+            "test",
+        )
+        self.assertIsNone(
+            config._is_person_accounts_enabled,
+            "_is_person_accounts_enabled should be initialized as None",
+        )
+
+        responses.add(
+            "GET", "https://example.com/services/data", json=[{"version": 48.0}]
+        )
+
+        responses.add(
+            "GET",
+            "https://example.com/services/data/v48.0/sobjects/Account/describe",
+            json={"fields": [{"name": "Id"}]},
+        )
+
+        # Verify checks describe if _is_person_accounts_enabled is None.
+        actual = config.is_person_accounts_enabled
+
+        self.assertEqual(False, actual, "")
+        self.assertEqual(actual, config._is_person_accounts_enabled)
+
+        # Verify subsequent calls return cached value.
+        config._is_person_accounts_enabled = True
+
+        self.assertEqual(
+            config._is_person_accounts_enabled, config.is_person_accounts_enabled
+        )
+
+    @responses.activate
+    def test_is_person_accounts_enabled__is_enabled(self):
+        config = OrgConfig(
+            {
+                "instance_url": "https://example.com",
+                "access_token": "TOKEN",
+                "id": "OODxxxxxxxxxxxx/user",
+            },
+            "test",
+        )
+        self.assertIsNone(
+            config._is_person_accounts_enabled,
+            "_is_person_accounts_enabled should be initialized as None",
+        )
+
+        responses.add(
+            "GET", "https://example.com/services/data", json=[{"version": 48.0}]
+        )
+
+        responses.add(
+            "GET",
+            "https://example.com/services/data/v48.0/sobjects/Account/describe",
+            json={"fields": [{"name": "Id"}, {"name": "IsPersonAccount"}]},
+        )
+
+        # Verify checks describe if _is_person_accounts_enabled is None.
+        actual = config.is_person_accounts_enabled
+
+        self.assertEqual(True, actual, "")
+        self.assertEqual(actual, config._is_person_accounts_enabled)
+
+        # Verify subsequent calls return cached value.
+        config._is_person_accounts_enabled = False
+
+        self.assertEqual(
+            config._is_person_accounts_enabled, config.is_person_accounts_enabled
+        )


### PR DESCRIPTION
> Note: there is a child branch #1950 that refactors bulkdata to use the feature in this Pull Request to identify if the org has person accounts enabled.

# Critical Changes

# Changes
OrgConfig supports identifying if the org has person accounts enabled via `is_person_accounts` property.

# Issues Closed
