### PR TITLE
bulkdata uses org_config.is_person_accounts_enabled

### DIFF
--- a/cumulusci/tasks/bulkdata/extract.py
+++ b/cumulusci/tasks/bulkdata/extract.py
@@ -11,7 +11,6 @@ import tempfile
 
 from cumulusci.core.exceptions import TaskOptionsError, BulkDataException
 from cumulusci.tasks.bulkdata.utils import (
-    OrgInfoMixin,
     SqlAlchemyMixin,
     create_table,
     fields_for_mapping,
@@ -31,7 +30,7 @@ from cumulusci.tasks.bulkdata.mapping_parser import (
 )
 
 
-class ExtractData(SqlAlchemyMixin, OrgInfoMixin, BaseSalesforceApiTask):
+class ExtractData(SqlAlchemyMixin, BaseSalesforceApiTask):
     """Perform Bulk Queries to extract data for a mapping and persist to a SQL file or database."""
 
     task_options = {
@@ -125,7 +124,7 @@ class ExtractData(SqlAlchemyMixin, OrgInfoMixin, BaseSalesforceApiTask):
             data_operation=DataOperationType.QUERY,
             inject_namespaces=self.options["inject_namespaces"],
             drop_missing=self.options["drop_missing_schema"],
-            org_has_person_accounts_enabled=self._org_has_person_accounts_enabled(),
+            org_has_person_accounts_enabled=self.org_config.is_person_accounts_enabled,
         )
 
     def _fields_for_mapping(self, mapping):
@@ -198,7 +197,7 @@ class ExtractData(SqlAlchemyMixin, OrgInfoMixin, BaseSalesforceApiTask):
         if (
             mapping["sf_object"] == "Account"
             and "Name" in mapping.get("fields", {})
-            and self._org_has_person_accounts_enabled()
+            and self.org_config.is_person_accounts_enabled
         ):
             # Bump indices by one since record's ID is the first column.
             Name_index = columns.index(mapping["fields"]["Name"]) + 1

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -9,11 +9,7 @@ from sqlalchemy.ext.automap import automap_base
 
 from cumulusci.core.exceptions import BulkDataException, TaskOptionsError
 from cumulusci.core.utils import process_bool_arg
-from cumulusci.tasks.bulkdata.utils import (
-    OrgInfoMixin,
-    SqlAlchemyMixin,
-    RowErrorChecker,
-)
+from cumulusci.tasks.bulkdata.utils import SqlAlchemyMixin, RowErrorChecker
 from cumulusci.tasks.bulkdata.step import (
     BulkApiDmlOperation,
     DataOperationStatus,
@@ -31,7 +27,7 @@ from cumulusci.tasks.bulkdata.mapping_parser import (
 )
 
 
-class LoadData(SqlAlchemyMixin, OrgInfoMixin, BaseSalesforceApiTask):
+class LoadData(SqlAlchemyMixin, BaseSalesforceApiTask):
     """Perform Bulk API operations to load data defined by a mapping from a local store into an org."""
 
     task_options = {
@@ -558,7 +554,7 @@ class LoadData(SqlAlchemyMixin, OrgInfoMixin, BaseSalesforceApiTask):
                     self.session.query(table)
                     .filter(table.columns.get("IsPersonAccount") == "true")
                     .first()
-                    and not self._org_has_person_accounts_enabled()
+                    and not self.org_config.is_person_accounts_enabled
                 ):
                     raise BulkDataException(
                         "Your dataset contains Person Account data but Person Accounts is not enabled for your org."
@@ -579,7 +575,7 @@ class LoadData(SqlAlchemyMixin, OrgInfoMixin, BaseSalesforceApiTask):
         """
         return (
             self._db_has_person_accounts_column(mapping)
-            and self._org_has_person_accounts_enabled()
+            and self.org_config.is_person_accounts_enabled
         )
 
     def _filter_out_person_account_records(self, query, model):

--- a/cumulusci/tasks/bulkdata/tests/test_extract.py
+++ b/cumulusci/tasks/bulkdata/tests/test_extract.py
@@ -58,7 +58,7 @@ class TestExtractData(unittest.TestCase):
         )
         task.bulk = mock.Mock()
         task.sf = mock.Mock()
-        task._org_has_person_accounts_enabled = mock.Mock(return_value=False)
+        task.org_config._is_person_accounts_enabled = False
 
         mock_query_households = MockBulkQueryOperation(
             sobject="Account",
@@ -89,8 +89,6 @@ class TestExtractData(unittest.TestCase):
         self.assertFalse(hasattr(contact, "IsPersonAccount"))
         self.assertEqual("1", contact.household_id)
 
-        task._org_has_person_accounts_enabled.assert_called_once_with()
-
     @responses.activate
     @mock.patch("cumulusci.tasks.bulkdata.extract.BulkApiQueryOperation")
     def test_run__person_accounts_enabled(self, step_mock):
@@ -109,7 +107,7 @@ class TestExtractData(unittest.TestCase):
         )
         task.bulk = mock.Mock()
         task.sf = mock.Mock()
-        task._org_has_person_accounts_enabled = mock.Mock(return_value=True)
+        task.org_config._is_person_accounts_enabled = True
 
         mock_query_households = MockBulkQueryOperation(
             sobject="Account",
@@ -142,8 +140,6 @@ class TestExtractData(unittest.TestCase):
         self.assertEqual("true", contact.IsPersonAccount)
         self.assertEqual("1", contact.household_id)
 
-        task._org_has_person_accounts_enabled.assert_called_once_with()
-
     @responses.activate
     @mock.patch("cumulusci.tasks.bulkdata.extract.BulkApiQueryOperation")
     def test_run__sql(self, step_mock):
@@ -158,7 +154,7 @@ class TestExtractData(unittest.TestCase):
             )
             task.bulk = mock.Mock()
             task.sf = mock.Mock()
-            task._org_has_person_accounts_enabled = mock.Mock(return_value=False)
+            task.org_config._is_person_accounts_enabled = False
 
             mock_query_households = MockBulkQueryOperation(
                 sobject="Account",
@@ -200,7 +196,7 @@ class TestExtractData(unittest.TestCase):
         )
         task.bulk = mock.Mock()
         task.sf = mock.Mock()
-        task._org_has_person_accounts_enabled = mock.Mock(return_value=False)
+        task.org_config._is_person_accounts_enabled = False
 
         mock_query_households = MockBulkQueryOperation(
             sobject="Account",
@@ -247,7 +243,7 @@ class TestExtractData(unittest.TestCase):
         )
         task.bulk = mock.Mock()
         task.sf = mock.Mock()
-        task._org_has_person_accounts_enabled = mock.Mock(return_value=True)
+        task.org_config._is_person_accounts_enabled = True
 
         mock_query_households = MockBulkQueryOperation(
             sobject="Account",
@@ -383,7 +379,7 @@ class TestExtractData(unittest.TestCase):
         task._extract_record_types = mock.Mock()
         task._sql_bulk_insert_from_records = mock.Mock()
         task.session = mock.Mock()
-        task._org_has_person_accounts_enabled = mock.Mock(return_value=False)
+        task.org_config._is_person_accounts_enabled = False
 
         step = mock.Mock()
         step.get_results.return_value = [["000000000000001", "Test", "012000000000000"]]
@@ -404,8 +400,6 @@ class TestExtractData(unittest.TestCase):
             "Account", "test_rt", task.session.connection.return_value
         )
 
-        task._org_has_person_accounts_enabled.assert_called_once_with()
-
     def test_import_results__person_account_name_stripped(self):
         base_path = os.path.dirname(__file__)
         mapping_path = os.path.join(base_path, "recordtypes.yml")
@@ -416,7 +410,7 @@ class TestExtractData(unittest.TestCase):
         task._extract_record_types = mock.Mock()
         task._sql_bulk_insert_from_records = mock.Mock()
         task.session = mock.Mock()
-        task._org_has_person_accounts_enabled = mock.Mock(return_value=True)
+        task.org_config._is_person_accounts_enabled = True
 
         step = mock.Mock()
         step.get_results.return_value = [
@@ -440,8 +434,6 @@ class TestExtractData(unittest.TestCase):
             },
             step,
         )
-
-        task._org_has_person_accounts_enabled.assert_called_once()
 
         task._sql_bulk_insert_from_records.assert_called()
         args, kwargs = task._sql_bulk_insert_from_records.call_args_list[0]
@@ -571,7 +563,7 @@ class TestExtractData(unittest.TestCase):
                 }
             },
         )
-        task._org_has_person_accounts_enabled = mock.Mock(return_value=False)
+        task.org_config._is_person_accounts_enabled = False
 
         with self.assertRaises(BulkDataException):
             task()
@@ -598,7 +590,7 @@ class TestExtractData(unittest.TestCase):
                 "oid_as_pk": False,
             },
         }
-        task._org_has_person_accounts_enabled = mock.Mock(return_value=False)
+        task.org_config._is_person_accounts_enabled = False
 
         def create_table_mock(table_name):
             task.models[table_name] = mock.Mock()
@@ -624,7 +616,7 @@ class TestExtractData(unittest.TestCase):
         }
         task.models = {}
         task.metadata = mock.Mock()
-        task._org_has_person_accounts_enabled = mock.Mock(return_value=False)
+        task.org_config._is_person_accounts_enabled = False
 
         task._create_table(mapping)
 
@@ -696,13 +688,12 @@ class TestExtractData(unittest.TestCase):
             ExtractData,
             {"options": {"database_url": "sqlite:///", "mapping": mapping_path}},
         )
-        task._org_has_person_accounts_enabled = mock.Mock(return_value=False)
+        task.org_config._is_person_accounts_enabled = False
 
         task._init_mapping()
         assert "Insert Households" in task.mapping
 
         # Person Accounts should not be added to mapping
-        task._org_has_person_accounts_enabled.assert_called_once_with()
         self.assert_person_accounts_in_mapping(task.mapping, False)
 
     @responses.activate
@@ -714,13 +705,12 @@ class TestExtractData(unittest.TestCase):
             ExtractData,
             {"options": {"database_url": "sqlite:///", "mapping": mapping_path}},
         )
-        task._org_has_person_accounts_enabled = mock.Mock(return_value=True)
+        task.org_config._is_person_accounts_enabled = True
 
         task._init_mapping()
         assert "Insert Households" in task.mapping
 
         # Person Accounts should not be added to mapping
-        task._org_has_person_accounts_enabled.assert_called_once_with()
         self.assert_person_accounts_in_mapping(task.mapping, True)
 
     @mock.patch("cumulusci.tasks.bulkdata.extract.validate_and_inject_mapping")
@@ -738,7 +728,7 @@ class TestExtractData(unittest.TestCase):
                 }
             },
         )
-        t._org_has_person_accounts_enabled = mock.Mock()
+        t.org_config._is_person_accounts_enabled = True
 
         t._init_mapping()
 
@@ -749,10 +739,8 @@ class TestExtractData(unittest.TestCase):
             data_operation=DataOperationType.QUERY,
             inject_namespaces=True,
             drop_missing=True,
-            org_has_person_accounts_enabled=t._org_has_person_accounts_enabled.return_value,
+            org_has_person_accounts_enabled=t.org_config._is_person_accounts_enabled,
         )
-
-        t._org_has_person_accounts_enabled.assert_called_once_with()
 
     def test_fields_for_mapping(self):
         task = _make_task(

--- a/cumulusci/tasks/bulkdata/tests/test_load.py
+++ b/cumulusci/tasks/bulkdata/tests/test_load.py
@@ -1735,7 +1735,7 @@ class TestLoadData(unittest.TestCase):
         assert task.session.query.first.return_value is not None
 
         # ✅ The org does not have person accounts enabled
-        task._org_has_person_accounts_enabled = mock.Mock(return_value=False)
+        task.org_config._is_person_accounts_enabled = False
 
         with self.assertRaises(BulkDataException):
             task._validate_org_has_person_accounts_enabled_if_person_account_data_exists()
@@ -1781,7 +1781,7 @@ class TestLoadData(unittest.TestCase):
         assert task.session.query.first.return_value is not None
 
         # ✅ The org does not have person accounts enabled
-        task._org_has_person_accounts_enabled = mock.Mock(return_value=False)
+        task.org_config._is_person_accounts_enabled = False
 
         with self.assertRaises(BulkDataException):
             task._validate_org_has_person_accounts_enabled_if_person_account_data_exists()
@@ -1827,7 +1827,7 @@ class TestLoadData(unittest.TestCase):
         assert task.session.query.first.return_value is not None
 
         # ❌ The org does has person accounts enabled
-        task._org_has_person_accounts_enabled = mock.Mock(return_value=True)
+        task.org_config._is_person_accounts_enabled = True
 
         task._validate_org_has_person_accounts_enabled_if_person_account_data_exists()
 
@@ -1873,7 +1873,7 @@ class TestLoadData(unittest.TestCase):
         assert task.session.query.first.return_value is None
 
         # ✅ The org does has person accounts enabled
-        task._org_has_person_accounts_enabled = mock.Mock(return_value=True)
+        task.org_config._is_person_accounts_enabled = True
 
         task._validate_org_has_person_accounts_enabled_if_person_account_data_exists()
 
@@ -1918,7 +1918,7 @@ class TestLoadData(unittest.TestCase):
         assert task.session.query.first.return_value is not None
 
         # ✅ The org does has person accounts enabled
-        task._org_has_person_accounts_enabled = mock.Mock(return_value=True)
+        task.org_config._is_person_accounts_enabled = True
 
         task._validate_org_has_person_accounts_enabled_if_person_account_data_exists()
 
@@ -1963,7 +1963,7 @@ class TestLoadData(unittest.TestCase):
         assert task.session.query.first.return_value is not None
 
         # ✅ The org does has person accounts enabled
-        task._org_has_person_accounts_enabled = mock.Mock(return_value=True)
+        task.org_config._is_person_accounts_enabled = True
 
         task._validate_org_has_person_accounts_enabled_if_person_account_data_exists()
 

--- a/cumulusci/tasks/bulkdata/tests/test_utils.py
+++ b/cumulusci/tasks/bulkdata/tests/test_utils.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import create_session, mapper
 
 from cumulusci.tasks import bulkdata
 from cumulusci.utils import temporary_dir
-from cumulusci.tasks.bulkdata.utils import create_table, generate_batches, OrgInfoMixin
+from cumulusci.tasks.bulkdata.utils import create_table, generate_batches
 from cumulusci.tasks.bulkdata.mapping_parser import parse_from_yaml
 
 
@@ -209,31 +209,3 @@ class TestBatching(unittest.TestCase):
     def test_batching_with_remainder(self):
         batches = list(generate_batches(num_records=20, batch_size=7))
         assert batches == [(7, 0), (7, 1), (6, 2)]
-
-
-class TestOrgInfoMixin:
-    def test_org_has_person_accounts_enabled__from_cache(self):
-        mixin = OrgInfoMixin()
-        mixin.sf = mock.Mock()
-        mixin._person_accounts_enabled = True
-
-        assert mixin._org_has_person_accounts_enabled
-        mixin.sf.Account.describe.assert_not_called()
-
-    def test_org_has_person_accounts_enabled__uncached_enabled(self):
-        mixin = OrgInfoMixin()
-        mixin.sf = mock.Mock()
-        mixin.sf.Account.describe.return_value = {
-            "fields": [{"name": "Name"}, {"name": "IsPersonAccount"}]
-        }
-
-        assert mixin._org_has_person_accounts_enabled()
-        mixin.sf.Account.describe.assert_called_once_with()
-
-    def test_org_has_person_accounts_enabled__uncached_disabled(self):
-        mixin = OrgInfoMixin()
-        mixin.sf = mock.Mock()
-        mixin.sf.Account.describe.return_value = {"fields": [{"name": "Name"}]}
-
-        assert not mixin._org_has_person_accounts_enabled()
-        mixin.sf.Account.describe.assert_called_once_with()

--- a/cumulusci/tasks/bulkdata/utils.py
+++ b/cumulusci/tasks/bulkdata/utils.py
@@ -76,21 +76,6 @@ class SqlAlchemyMixin:
             )
 
 
-class OrgInfoMixin:
-    """Bulk data task mixin for accessing info about the org"""
-
-    _person_accounts_enabled = None
-
-    def _org_has_person_accounts_enabled(self):
-        """Does Account have an "IsPersonAccount" field?"""
-        if self._person_accounts_enabled is None:
-            account_fields = self.sf.Account.describe()["fields"]
-            self._person_accounts_enabled = any(
-                field["name"] == "IsPersonAccount" for field in account_fields
-            )
-        return self._person_accounts_enabled
-
-
 def _handle_primary_key(mapping, fields):
     """Provide support for legacy mappings which used the OID as the pk but
     default to using an autoincrementing int pk and a separate sf_id column"""


### PR DESCRIPTION
> Note: Is a child branch of #1949 .   Rebase to `master` after merging #1949  ✅ 

# Critical Changes

# Changes
Bulk data extraction and loading use `org_config.is_person_accounts_enabled` to identify if the org has person accounts enabled.

# Issues Closed
