### PR TITLE
Move factory-boy to requirements_dev

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,4 +40,3 @@ uritemplate==3.0.1
 urllib3==1.25.10
 xmltodict==0.12.0
 robotframework-lint==1.1
-factory-boy==2.12.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,3 +15,4 @@ twine==3.2.0
 typeguard==2.9.1
 vcrpy==4.1.0
 wheel==0.34.2
+factory-boy==2.12.0


### PR DESCRIPTION
Remove factory-boy as a runtime requirement of CumulusCI

Its runtime uses have been replaced by Snowfakery now.