### PR TITLE
Fix publishing regional translations

### DIFF
--- a/cumulusci/tasks/metadeploy.py
+++ b/cumulusci/tasks/metadeploy.py
@@ -355,12 +355,15 @@ class Publish(BaseMetaDeployTask):
     def _publish_labels(self, slug):
         """Publish labels in all languages to MetaDeploy."""
         for path in Path(self.labels_path).glob("*.json"):
-            lang = path.stem[-2:]
-            if lang == "en":
+            lang = path.stem.split("_")[-1].lower()
+            if lang in ("en", "en-us"):
                 continue
             orig_labels = json.loads(path.read_text())
             prefixed_labels = {}
             for context, labels in orig_labels.items():
                 prefixed_labels[f"{slug}:{context}"] = labels
             self.logger.info(f"Updating {lang} translations")
-            self._call_api("PATCH", f"/translations/{lang}", json=prefixed_labels)
+            try:
+                self._call_api("PATCH", f"/translations/{lang}", json=prefixed_labels)
+            except requests.exceptions.HTTPError as err:
+                self.logger.warn(f"Could not update {lang} translation: {err}")

--- a/cumulusci/tasks/metadeploy.py
+++ b/cumulusci/tasks/metadeploy.py
@@ -366,4 +366,4 @@ class Publish(BaseMetaDeployTask):
             try:
                 self._call_api("PATCH", f"/translations/{lang}", json=prefixed_labels)
             except requests.exceptions.HTTPError as err:
-                self.logger.warn(f"Could not update {lang} translation: {err}")
+                self.logger.warning(f"Could not update {lang} translation: {err}")

--- a/cumulusci/tasks/tests/test_metadeploy.py
+++ b/cumulusci/tasks/tests/test_metadeploy.py
@@ -109,6 +109,7 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
             json=self._get_expected_repo("TestOwner", "TestRepo"),
         )
         responses.add("PATCH", "https://metadeploy/translations/es", json={})
+        responses.add("PATCH", "https://metadeploy/translations/es-bogus", status=404)
         responses.add(
             "GET",
             "https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/release/1.0",
@@ -172,6 +173,8 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
         en_labels_path.write_text('{"test": {"title": {}}}')
         es_labels_path = Path(labels_path, "labels_es.json")
         es_labels_path.write_text('{"test": {"title": {}}}')
+        bogus_labels_path = Path(labels_path, "labels_es-bogus.json")
+        bogus_labels_path.write_text('{"test": {"title": {}}}')
 
         task_config = TaskConfig(
             {


### PR DESCRIPTION
Make sure language codes like es-mx get passed to MetaDeploy correctly. Also, show a warning rather than aborting if the translation couldn't be loaded.

Actually using these translations requires additional changes in MetaDeploy which are in progress in https://github.com/SFDO-Tooling/MetaDeploy/pull/1652

# Critical Changes

# Changes

# Issues Closed
- The metadeploy_publish task can now update translations for language codes with more than 2 letters.
