### PR TITLE
Fix a couple places where utf-8 was not specified explicitly for Path.read_text/write_text

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1571,7 +1571,7 @@ CCI_LOGFILE_PATH = Path.home() / ".cumulusci" / "logs" / "cci.log"
     help="Outputs the most recent traceback (if one exists in the most recent log)",
 )
 @click.option("--max-lines", "-m", type=int)
-def error_info(max_lines=None):
+def error_info(max_lines: int = 0):
     if not CCI_LOGFILE_PATH.is_file():
         click.echo(f"No logfile found at: {CCI_LOGFILE_PATH}")
     else:
@@ -1581,7 +1581,7 @@ def error_info(max_lines=None):
         click.echo(output)
 
 
-def lines_from_traceback(log_content: str, max_lines: int = None) -> str:
+def lines_from_traceback(log_content: str, max_lines: int = 0) -> str:
     """Returns the the last max_lines of the logfile,
     or the whole traceback, whichever is shorter. If
     no stacktrace is found in the logfile, the user is
@@ -1592,11 +1592,11 @@ def lines_from_traceback(log_content: str, max_lines: int = None) -> str:
         return f"\nNo stacktrace found in: {CCI_LOGFILE_PATH}\n"
 
     stacktrace = ""
-    for i, line in enumerate(reversed(log_content.split("\n"))):
+    for i, line in enumerate(reversed(log_content.split("\n")), 1):
         stacktrace = "\n" + line + stacktrace
         if stacktrace_start in line:
             break
-        if max_lines is not None and i + 1 == max_lines:
+        if i == max_lines:
             break
 
     return stacktrace

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1568,18 +1568,20 @@ CCI_LOGFILE_PATH = Path.home() / ".cumulusci" / "logs" / "cci.log"
 
 @error.command(
     name="info",
-    help="Outputs the last part of the most recent traceback (if one exists in the most recent log)",
+    help="Outputs the most recent traceback (if one exists in the most recent log)",
 )
-@click.option("--max-lines", "-m", default=30, show_default=True, type=int)
-def error_info(max_lines):
+@click.option("--max-lines", "-m", type=int)
+def error_info(max_lines=None):
     if not CCI_LOGFILE_PATH.is_file():
         click.echo(f"No logfile found at: {CCI_LOGFILE_PATH}")
     else:
-        output = lines_from_traceback(CCI_LOGFILE_PATH.read_text(), max_lines)
+        output = lines_from_traceback(
+            CCI_LOGFILE_PATH.read_text(encoding="utf-8"), max_lines
+        )
         click.echo(output)
 
 
-def lines_from_traceback(log_content, num_lines):
+def lines_from_traceback(log_content: str, max_lines: int = None) -> str:
     """Returns the the last max_lines of the logfile,
     or the whole traceback, whichever is shorter. If
     no stacktrace is found in the logfile, the user is
@@ -1590,12 +1592,11 @@ def lines_from_traceback(log_content, num_lines):
         return f"\nNo stacktrace found in: {CCI_LOGFILE_PATH}\n"
 
     stacktrace = ""
-    for line in reversed(log_content.split("\n")):
+    for i, line in enumerate(reversed(log_content.split("\n"))):
         stacktrace = "\n" + line + stacktrace
         if stacktrace_start in line:
             break
-        num_lines -= 1
-        if num_lines == -1:
+        if max_lines is not None and i + 1 == max_lines:
             break
 
     return stacktrace
@@ -1605,7 +1606,7 @@ def lines_from_traceback(log_content, num_lines):
 @pass_runtime(require_project=False, require_keychain=True)
 def gist(runtime):
     if CCI_LOGFILE_PATH.is_file():
-        log_content = CCI_LOGFILE_PATH.read_text()
+        log_content = CCI_LOGFILE_PATH.read_text(encoding="utf-8")
     else:
         log_not_found_msg = """No logfile to open at path: {}
         Please ensure you're running this command from the same directory you were experiencing an issue."""

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -1984,7 +1984,7 @@ Environment Info: Rossian / x68_46
 
     def test_flow_run_o_error(self):
         org_config = mock.Mock(scratch=True, config={})
-        runtime = CliRuntime(config={"noop": {}}, load_keychain=False,)
+        runtime = CliRuntime(config={"noop": {}}, load_keychain=False)
         runtime.get_org = mock.Mock(return_value=("test", org_config))
 
         with pytest.raises(click.UsageError) as e:
@@ -2060,31 +2060,34 @@ Environment Info: Rossian / x68_46
     @mock.patch("cumulusci.cli.cci.CCI_LOGFILE_PATH")
     def test_error_info_no_logfile_present(self, log_path, echo):
         log_path.is_file.return_value = False
-        run_click_command(cci.error_info, max_lines=30)
+        run_click_command(cci.error_info)
 
         echo.assert_called_once_with(f"No logfile found at: {cci.CCI_LOGFILE_PATH}")
 
     @mock.patch("cumulusci.cli.cci.click.echo")
-    @mock.patch("cumulusci.cli.cci.CCI_LOGFILE_PATH")
-    def test_error_info(self, log_path, echo):
-        log_path.is_file.return_value = True
-        log_path.read_text.return_value = (
-            "This\nis\na\ntest\nTraceback (most recent call last):\n1\n2\n3\n4"
+    def test_error_info(self, echo):
+        with temporary_dir() as path:
+            logfile = Path(path) / "cci.log"
+            logfile.write_text(
+                "This\nis\na\ntest\nTraceback (most recent call last):\n1\n2\n3\n\u2603",
+                encoding="utf-8",
+            )
+            with mock.patch("cumulusci.cli.cci.CCI_LOGFILE_PATH", logfile):
+                run_click_command(cci.error_info)
+        echo.assert_called_once_with(
+            "\nTraceback (most recent call last):\n1\n2\n3\n\u2603"
         )
-
-        run_click_command(cci.error_info, max_lines=30)
-        echo.assert_called_once_with("\nTraceback (most recent call last):\n1\n2\n3\n4")
 
     @mock.patch("cumulusci.cli.cci.click.echo")
     @mock.patch("cumulusci.cli.cci.CCI_LOGFILE_PATH")
-    def test_error_info_output_less(self, log_path, echo):
+    def test_error_info__output_less(self, log_path, echo):
         log_path.is_file.return_value = True
         log_path.read_text.return_value = (
             "This\nis\na\ntest\nTraceback (most recent call last):\n1\n2\n3\n4"
         )
 
         run_click_command(cci.error_info, max_lines=3)
-        echo.assert_called_once_with("\n1\n2\n3\n4")
+        echo.assert_called_once_with("\n2\n3\n4")
 
     def test_lines_from_traceback_no_traceback(self):
         output = cci.lines_from_traceback("test_content", 10)

--- a/cumulusci/tasks/metadata_etl/base.py
+++ b/cumulusci/tasks/metadata_etl/base.py
@@ -98,7 +98,7 @@ class BaseMetadataETLTask(BaseSalesforceTask, metaclass=ABCMeta):
         self.logger.info("Loading transformed metadata...")
         target_profile_xml = Path(self.deploy_dir, "package.xml")
         target_profile_xml.write_text(
-            self._generate_package_xml(MetadataOperation.DEPLOY)
+            self._generate_package_xml(MetadataOperation.DEPLOY), encoding="utf-8"
         )
 
         # import is here to avoid an import cycle


### PR DESCRIPTION
Without this it would use locale.getpreferredencoding(), which at least in some cases is cp1252 in Windows.

Also includes a fix for #1514 to make `cci error info` show the full traceback by default.

# Critical Changes

# Changes
- The `cci error info` command now defaults to showing the entire traceback when it is more than 30 lines.

# Issues Closed
- Fixed a bug where `cci error gist` could throw a UnicodeDecodeError (fixes #1977)
