### PR TITLE
fix .sql extract/load with non-ASCII characters on Windows

### DIFF
--- a/cumulusci/tasks/bulkdata/extract.py
+++ b/cumulusci/tasks/bulkdata/extract.py
@@ -343,6 +343,6 @@ class ExtractData(SqlAlchemyMixin, BaseSalesforceApiTask):
     def _sqlite_dump(self):
         """Write a SQLite script output file."""
         path = self.options["sql_path"]
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             for line in self.session.connection().connection.iterdump():
                 f.write(line + "\n")

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -429,7 +429,7 @@ class LoadData(SqlAlchemyMixin, BaseSalesforceApiTask):
         """Read a SQLite script and initialize the in-memory database."""
         conn = self.session.connection()
         cursor = conn.connection.cursor()
-        with open(self.options["sql_path"], "r") as f:
+        with open(self.options["sql_path"], "r", encoding="utf-8") as f:
             try:
                 cursor.executescript(f.read())
             finally:

--- a/cumulusci/tasks/bulkdata/tests/test_extract.py
+++ b/cumulusci/tasks/bulkdata/tests/test_extract.py
@@ -170,7 +170,7 @@ class TestExtractData(unittest.TestCase):
             )
             mock_query_households.results = [["1"]]
             mock_query_contacts.results = [
-                ["2", "First", "Last", "test@example.com", "1"]
+                ["2", "First☃", "Last", "test@example.com", "1"]
             ]
             step_mock.side_effect = [mock_query_households, mock_query_contacts]
 

--- a/cumulusci/tasks/bulkdata/tests/test_load.py
+++ b/cumulusci/tasks/bulkdata/tests/test_load.py
@@ -246,7 +246,7 @@ class TestLoadData(unittest.TestCase):
 
         assert step.records == [
             ["TestHousehold", "1"],
-            ["Test", "User", "test@example.com", "001000000000000"],
+            ["Test☃", "User", "test@example.com", "001000000000000"],
             ["Error", "User", "error@example.com", "001000000000000"],
         ]
 

--- a/cumulusci/tasks/bulkdata/tests/testdata.sql
+++ b/cumulusci/tasks/bulkdata/tests/testdata.sql
@@ -7,7 +7,7 @@ CREATE TABLE contacts (
 	household_id VARCHAR(255), 
 	PRIMARY KEY (sf_id)
 );
-INSERT INTO "contacts" VALUES('1','Test','User','test@example.com','1');
+INSERT INTO "contacts" VALUES('1','Test☃','User','test@example.com','1');
 INSERT INTO "contacts" VALUES('2','Error','User','error@example.com','1');
 CREATE TABLE households (
 	sf_id VARCHAR(255) NOT NULL, 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -742,7 +742,6 @@ Create the file **tasks/salesforce.py** with the following content:
 .. code-block:: python
 
     from cumulusci.tasks.salesforce import BaseSalesforceApiTask
-    from cumulusci.tasks.salesforce import BaseSalesforceToolingApiTask
 
     class ListContacts(BaseSalesforceApiTask):
 
@@ -751,7 +750,7 @@ Create the file **tasks/salesforce.py** with the following content:
             for contact in res['records']:
                 self.logger.info('{Id}: {FirstName} {LastName}'.format(**contact))
 
-    class ListApexClasses(BaseSalesforceToolingApiTask):
+    class ListApexClasses(BaseSalesforceApiTask):
 
         def _run_task(self):
             res = self.tooling.query('Select Id, Name, NamespacePrefix from ApexClass LIMIT 10')


### PR DESCRIPTION
See https://powerofus.force.com/s/feed/0D51E00005PC9lE?fromEmail=1&s1oid=00D00000000hWLM&s1nid=0DB800000004Fa7&s1uid=0058000000FMbc6&s1ext=0&emkind=chatterCommentNotification&emtm=1598910073619

# Critical Changes

# Changes

# Issues Closed
- Fixed a bug where the `extract_dataset` task could fail with a UnicodeEncodeError on Windows.