### PR TITLE
Update related list locator for Winter '21.

### DIFF
--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -567,6 +567,7 @@ class Salesforce(object):
                 break
         self.selenium.set_focus_to_element(menu_locator)
         self._jsclick(menu_locator)
+        self.wait_for_aura()
 
     def _get_input_field_locator(self, name):
         """Given an input field label, return a locator for the related input field
@@ -604,8 +605,7 @@ class Salesforce(object):
         self._focus(field)
         if field.get_attribute("value"):
             self._clear(field)
-        actions = ActionChains(self.selenium.driver)
-        actions.send_keys_to_element(field, value).perform()
+        field.send_keys(value)
 
     def _focus(self, element):
         """Set focus to an element

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -13,6 +13,7 @@ from selenium.common.exceptions import (
     StaleElementReferenceException,
     NoSuchElementException,
     JavascriptException,
+    WebDriverException,
 )
 
 import faker
@@ -256,7 +257,7 @@ class Salesforce(object):
             try:
                 self.selenium.scroll_element_into_view(locator)
                 return
-            except (ElementNotFound, JavascriptException):
+            except (ElementNotFound, JavascriptException, WebDriverException):
                 self.builtin.log(
                     f"related list '{heading}' not found; scrolling...", "DEBUG"
                 )

--- a/cumulusci/robotframework/locators_50.py
+++ b/cumulusci/robotframework/locators_50.py
@@ -3,6 +3,12 @@ import copy
 
 lex_locators = copy.deepcopy(locators_49.lex_locators)
 
+lex_locators["actions"] = (
+    "//runtime_platform_actions-actions-ribbon//ul"
+    "|"
+    "//ul[contains(concat(' ',normalize-space(@class),' '),' oneActionsRibbon ')]"
+)
+
 lex_locators["object"][
     "button"
 ] = "//div[contains(@class, 'slds-page-header')]//*[self::a[@title='{title}'] or self::button[@name='{title}']]"

--- a/cumulusci/robotframework/locators_50.py
+++ b/cumulusci/robotframework/locators_50.py
@@ -10,3 +10,7 @@ lex_locators["object"][
 lex_locators["record"]["header"][
     "field_value_link"
 ] = "//records-lwc-highlights-panel//force-highlights-details-item[.//*[.='{}']]//a"
+
+lex_locators["record"]["related"][
+    "card"
+] = "//*[@data-component-id='force_relatedListContainer']//article[.//span[@title='{}']]"

--- a/cumulusci/robotframework/locators_50.py
+++ b/cumulusci/robotframework/locators_50.py
@@ -11,6 +11,11 @@ lex_locators["record"]["header"][
     "field_value_link"
 ] = "//records-lwc-highlights-panel//force-highlights-details-item[.//*[.='{}']]//a"
 
-lex_locators["record"]["related"][
-    "card"
-] = "//*[@data-component-id='force_relatedListContainer']//article[.//span[@title='{}']]"
+
+lex_locators["record"]["related"] = {
+    "button": "//*[@data-component-id='force_relatedListContainer']//article[.//span[@title='{}']]//a[@title='{}']",
+    "card": "//*[@data-component-id='force_relatedListContainer']//article[.//span[@title='{}']]",
+    "count": "//*[@data-component-id='force_relatedListContainer']//article//span[@title='{}']/following-sibling::span",
+    "link": "//*[@data-component-id='force_relatedListContainer']//article[.//span[@title='{}']]//*[text()='{}']",
+    "popup_trigger": "//*[@data-component-id='force_relatedListContainer']//article[.//span[@title='{}']]//span[text()='Show Actions']",
+}


### PR DESCRIPTION
This has changes to all of the related list locators for winter '21, along with a few other changes that cropped up during prerelease testing. 

Related lists may be rendered in a couple of different ways, this new locator should work for either way. I also took the liberty of refactoring the 'load related list' keyword to use some features in SeleniumLibrary that weren't available when the keyword was written nearly two years ago. I also added some tests for this keyword, which we didn't previously have.

I'm still working on some automated tests. A couple of the issues can be reproduced via an NPSP test, but I can't yet reproduce them in our CumulusCI tests. 


# Critical Changes

# Changes

* The following robot keywords have been updated to work with Winter '21: 
  - `Load related list`
  - `Click related list button`
  - `Click related item link`
  - `Click related item popup link`
  - `Go to object home`
  - `Go to object list`
  - `Go to record home`
* The keyword `Load related list` has been rewritten to be slightly more efficient. It also has a new parameter `tries` which can be used if the target is more than 1000 pixels below the bottom of the window. 

# Issues Closed
