### PR TITLE
Double number of package install retries

### DIFF
--- a/cumulusci/tasks/salesforce/InstallPackageVersion.py
+++ b/cumulusci/tasks/salesforce/InstallPackageVersion.py
@@ -48,7 +48,7 @@ class InstallPackageVersion(Deploy):
                 or self.options["namespace"]
             )
         if "retries" not in self.options:
-            self.options["retries"] = 5
+            self.options["retries"] = 10
         if "retry_interval" not in self.options:
             self.options["retry_interval"] = 5
         if "retry_interval_add" not in self.options:

--- a/cumulusci/tasks/tests/test_metadeploy.py
+++ b/cumulusci/tasks/tests/test_metadeploy.py
@@ -203,7 +203,7 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
                         "options": {
                             "activateRSS": True,
                             "namespace": "ns",
-                            "retries": 5,
+                            "retries": 10,
                             "retry_interval": 5,
                             "retry_interval_add": 30,
                             "security_type": "FULL",


### PR DESCRIPTION
# Critical Changes

# Changes

- CumulusCI now tries 10 times (instead of 5) to install managed package versions, which helps ameliorate timeouts when new versions are released.

# Issues Closed
