### PR TITLE
retrieve_changes: fix retrieving changed folders

### DIFF
--- a/cumulusci/tasks/salesforce/sourcetracking.py
+++ b/cumulusci/tasks/salesforce/sourcetracking.py
@@ -168,7 +168,11 @@ def _write_manifest(changes, path, api_version):
     """Write a package.xml for the specified changes and API version."""
     type_members = defaultdict(list)
     for change in changes:
-        type_members[change["MemberType"]].append(change["MemberName"])
+        mdtype = change["MemberType"]
+        # folders are retrieved along with their contained type
+        if mdtype.endswith("Folder"):
+            mdtype = mdtype[: -len("Folder")]
+        type_members[mdtype].append(change["MemberName"])
 
     generator = PackageXmlGenerator(
         ".",

--- a/cumulusci/tasks/salesforce/tests/test_sourcetracking.py
+++ b/cumulusci/tasks/salesforce/tests/test_sourcetracking.py
@@ -1,11 +1,13 @@
 from unittest import mock
 import json
 import os
+import pathlib
 
 from cumulusci.core.config import OrgConfig
 from cumulusci.tasks.salesforce.sourcetracking import ListChanges
 from cumulusci.tasks.salesforce.sourcetracking import RetrieveChanges
 from cumulusci.tasks.salesforce.sourcetracking import SnapshotChanges
+from cumulusci.tasks.salesforce.sourcetracking import _write_manifest
 from cumulusci.tests.util import create_project_config
 from cumulusci.utils import temporary_dir
 
@@ -222,3 +224,12 @@ class TestSnapshotChanges:
         task = create_task_fixture(SnapshotChanges)
         steps = task.freeze(None)
         assert steps == []
+
+
+def test_write_manifest__folder():
+    with temporary_dir() as path:
+        _write_manifest(
+            [{"MemberType": "ReportFolder", "MemberName": "TestFolder"}], path, "49.0"
+        )
+        package_xml = pathlib.Path(path, "package.xml").read_text()
+        assert "<name>Report</name>" in package_xml


### PR DESCRIPTION
Fix retrieving folders that have changes detected by source tracking.

Folders need to be referenced in the package.xml section for the type they contain -- https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_folder.htm

# Critical Changes

# Changes

# Issues Closed
- Fixed an issue where the retrieve_changes task did not actually retrieve folders.
