### PR TITLE
Remove nonsensical namespace options

### DIFF
--- a/cumulusci/core/config/project_config.py
+++ b/cumulusci/core/config/project_config.py
@@ -638,7 +638,6 @@ class BaseProjectConfig(BaseTaskFlowConfig):
                         "ref": ref,
                         "subfolder": subfolder,
                         "unmanaged": dependency.get("unmanaged"),
-                        "namespace_tokenize": dependency.get("namespace_tokenize"),
                         "namespace_inject": dependency.get("namespace_inject"),
                         "namespace_strip": dependency.get("namespace_strip"),
                     }
@@ -658,7 +657,6 @@ class BaseProjectConfig(BaseTaskFlowConfig):
                     "ref": ref,
                     "subfolder": subfolder,
                     "unmanaged": dependency.get("unmanaged"),
-                    "namespace_tokenize": dependency.get("namespace_tokenize"),
                     "namespace_inject": dependency.get("namespace_inject"),
                     "namespace_strip": dependency.get("namespace_strip"),
                 }
@@ -685,7 +683,6 @@ class BaseProjectConfig(BaseTaskFlowConfig):
                     "ref": ref,
                     "subfolder": subfolder,
                     "unmanaged": dependency.get("unmanaged"),
-                    "namespace_tokenize": dependency.get("namespace_tokenize"),
                     "namespace_inject": dependency.get("namespace_inject"),
                     "namespace_strip": dependency.get("namespace_strip"),
                 }

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -627,7 +627,6 @@ class TestBaseProjectConfig(unittest.TestCase):
                     "unmanaged": True,
                     "namespace_inject": None,
                     "namespace_strip": None,
-                    "namespace_tokenize": None,
                 },
                 {
                     "name": "Install CumulusCI-Test-Dep 2.0",
@@ -643,7 +642,6 @@ class TestBaseProjectConfig(unittest.TestCase):
                     "unmanaged": True,
                     "namespace_inject": None,
                     "namespace_strip": None,
-                    "namespace_tokenize": None,
                 },
                 {
                     "name": "Deploy unpackaged/post/post",
@@ -654,7 +652,6 @@ class TestBaseProjectConfig(unittest.TestCase):
                     "unmanaged": True,
                     "namespace_inject": "ccitest",
                     "namespace_strip": None,
-                    "namespace_tokenize": None,
                 },
             ],
         )
@@ -690,7 +687,6 @@ class TestBaseProjectConfig(unittest.TestCase):
                     "unmanaged": True,
                     "namespace_inject": None,
                     "namespace_strip": None,
-                    "namespace_tokenize": None,
                 },
             ],
         )
@@ -759,7 +755,6 @@ class TestBaseProjectConfig(unittest.TestCase):
                     "unmanaged": True,
                     "namespace_inject": None,
                     "namespace_strip": None,
-                    "namespace_tokenize": None,
                 },
                 {
                     "name": "Install CumulusCI-Test-Dep 1.1 (Beta 1)",
@@ -775,7 +770,6 @@ class TestBaseProjectConfig(unittest.TestCase):
                     "unmanaged": True,
                     "namespace_inject": None,
                     "namespace_strip": None,
-                    "namespace_tokenize": None,
                 },
                 {
                     "name": "Deploy unpackaged/post/post",
@@ -786,7 +780,6 @@ class TestBaseProjectConfig(unittest.TestCase):
                     "unmanaged": True,
                     "namespace_inject": "ccitest",
                     "namespace_strip": None,
-                    "namespace_tokenize": None,
                 },
             ],
         )
@@ -818,7 +811,6 @@ class TestBaseProjectConfig(unittest.TestCase):
                     "unmanaged": True,
                     "namespace_inject": None,
                     "namespace_strip": None,
-                    "namespace_tokenize": None,
                 },
                 {
                     "name": "Install CumulusCI-Test-Dep 2.0",
@@ -834,7 +826,6 @@ class TestBaseProjectConfig(unittest.TestCase):
                     "unmanaged": True,
                     "namespace_inject": None,
                     "namespace_strip": None,
-                    "namespace_tokenize": None,
                 },
                 {
                     "name": "Deploy unpackaged/post/post",
@@ -845,7 +836,6 @@ class TestBaseProjectConfig(unittest.TestCase):
                     "unmanaged": True,
                     "namespace_inject": "ccitest",
                     "namespace_strip": None,
-                    "namespace_tokenize": None,
                 },
             ],
         )
@@ -878,7 +868,6 @@ class TestBaseProjectConfig(unittest.TestCase):
                     "unmanaged": True,
                     "namespace_inject": None,
                     "namespace_strip": None,
-                    "namespace_tokenize": None,
                 },
                 {
                     "name": "Deploy CumulusCI-Test",
@@ -889,7 +878,6 @@ class TestBaseProjectConfig(unittest.TestCase):
                     "unmanaged": True,
                     "namespace_inject": None,
                     "namespace_strip": None,
-                    "namespace_tokenize": None,
                 },
                 {
                     "name": "Deploy unpackaged/post/post",
@@ -900,7 +888,6 @@ class TestBaseProjectConfig(unittest.TestCase):
                     "unmanaged": True,
                     "namespace_inject": "ccitest",
                     "namespace_strip": None,
-                    "namespace_tokenize": None,
                 },
             ],
         )

--- a/cumulusci/tasks/salesforce/BaseRetrieveMetadata.py
+++ b/cumulusci/tasks/salesforce/BaseRetrieveMetadata.py
@@ -1,8 +1,8 @@
 import functools
 
-from cumulusci.core.utils import process_bool_arg
-from cumulusci.tasks.salesforce import BaseSalesforceMetadataApiTask
-from cumulusci.utils import inject_namespace
+from cumulusci.tasks.salesforce.BaseSalesforceMetadataApiTask import (
+    BaseSalesforceMetadataApiTask,
+)
 from cumulusci.utils import strip_namespace
 from cumulusci.utils import process_text_in_zipfile
 from cumulusci.utils import tokenize_namespace
@@ -13,12 +13,6 @@ class BaseRetrieveMetadata(BaseSalesforceMetadataApiTask):
         "path": {
             "description": "The path to write the retrieved metadata",
             "required": True,
-        },
-        "unmanaged": {
-            "description": "If True, changes namespace_inject to replace tokens with a blank string"
-        },
-        "namespace_inject": {
-            "description": "If set, the namespace tokens in files and filenames are replaced with the namespace's prefix"
         },
         "namespace_strip": {
             "description": "If set, all namespace prefixes for the namespace specified are stripped from files and filenames"
@@ -46,19 +40,6 @@ class BaseRetrieveMetadata(BaseSalesforceMetadataApiTask):
                 functools.partial(
                     tokenize_namespace,
                     namespace=self.options["namespace_tokenize"],
-                    logger=self.logger,
-                ),
-            )
-        if self.options.get("namespace_inject"):
-            src_zip = process_text_in_zipfile(
-                src_zip,
-                functools.partial(
-                    inject_namespace,
-                    namespace=self.options["namespace_inject"],
-                    managed=not process_bool_arg(self.options.get("unmanaged", True)),
-                    namespaced_org=process_bool_arg(
-                        self.options.get("namespaced_org", False)
-                    ),
                     logger=self.logger,
                 ),
             )

--- a/cumulusci/tasks/salesforce/Deploy.py
+++ b/cumulusci/tasks/salesforce/Deploy.py
@@ -7,13 +7,14 @@ import zipfile
 from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.core.utils import process_bool_arg, process_list_arg
 from cumulusci.salesforce_api.metadata import ApiDeploy
-from cumulusci.tasks.salesforce import BaseSalesforceMetadataApiTask
+from cumulusci.tasks.salesforce.BaseSalesforceMetadataApiTask import (
+    BaseSalesforceMetadataApiTask,
+)
 from cumulusci.utils import cd
 from cumulusci.utils import temporary_dir
 from cumulusci.utils import zip_clean_metaxml
 from cumulusci.utils import inject_namespace
 from cumulusci.utils import strip_namespace
-from cumulusci.utils import tokenize_namespace
 from cumulusci.utils import process_text_in_zipfile
 from cumulusci.utils.xml import metadata_tree
 
@@ -33,9 +34,6 @@ class Deploy(BaseSalesforceMetadataApiTask):
         },
         "namespace_strip": {
             "description": "If set, all namespace prefixes for the namespace specified are stripped from files and filenames"
-        },
-        "namespace_tokenize": {
-            "description": "If set, all namespace prefixes for the namespace specified are replaced with tokens for use with namespace_inject"
         },
         "check_only": {
             "description": "If True, performs a test deployment (validation) of components without saving the components in the target org"
@@ -144,20 +142,6 @@ class Deploy(BaseSalesforceMetadataApiTask):
         return zipf
 
     def _process_namespace(self, zipf):
-        if self.options.get("namespace_tokenize"):
-            self.logger.info(
-                "Tokenizing namespace prefix {}__".format(
-                    self.options["namespace_tokenize"]
-                )
-            )
-            zipf = process_text_in_zipfile(
-                zipf,
-                functools.partial(
-                    tokenize_namespace,
-                    namespace=self.options["namespace_tokenize"],
-                    logger=self.logger,
-                ),
-            )
         if self.options.get("namespace_inject"):
             managed = not process_bool_arg(self.options.get("unmanaged", True))
             if managed:

--- a/cumulusci/tasks/salesforce/UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/UpdateDependencies.py
@@ -8,13 +8,14 @@ from cumulusci.salesforce_api.metadata import ApiRetrieveInstalledPackages
 from cumulusci.salesforce_api.package_zip import InstallPackageZipBuilder
 from cumulusci.salesforce_api.package_zip import UninstallPackageZipBuilder
 from cumulusci.salesforce_api.package_zip import ZipfilePackageZipBuilder
-from cumulusci.tasks.salesforce import BaseSalesforceMetadataApiTask
+from cumulusci.tasks.salesforce.BaseSalesforceMetadataApiTask import (
+    BaseSalesforceMetadataApiTask,
+)
 from cumulusci.utils import download_extract_zip
 from cumulusci.utils import download_extract_github
 from cumulusci.utils import inject_namespace
 from cumulusci.utils import strip_namespace
 from cumulusci.utils import process_text_in_zipfile
-from cumulusci.utils import tokenize_namespace
 
 
 class UpdateDependencies(BaseSalesforceMetadataApiTask):
@@ -276,21 +277,6 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
                 )
 
             if package_zip:
-                if dependency.get("namespace_tokenize"):
-                    self.logger.info(
-                        "Replacing namespace prefix {}__ in files and filenames with namespace token strings".format(
-                            "{}__".format(dependency["namespace_tokenize"])
-                        )
-                    )
-                    package_zip = process_text_in_zipfile(
-                        package_zip,
-                        functools.partial(
-                            tokenize_namespace,
-                            namespace=dependency["namespace_tokenize"],
-                            logger=self.logger,
-                        ),
-                    )
-
                 if dependency.get("namespace_inject"):
                     self.logger.info(
                         "Replacing namespace tokens with {}".format(

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -810,11 +810,6 @@ Options
 
 	 If set, all namespace prefixes for the namespace specified are stripped from files and filenames
 
-``-o namespace_tokenize NAMESPACETOKENIZE``
-	 *Optional*
-
-	 If set, all namespace prefixes for the namespace specified are replaced with tokens for use with namespace_inject
-
 ``-o check_only CHECKONLY``
 	 *Optional*
 
@@ -883,11 +878,6 @@ Options
 	 *Optional*
 
 	 If set, all namespace prefixes for the namespace specified are stripped from files and filenames
-
-``-o namespace_tokenize NAMESPACETOKENIZE``
-	 *Optional*
-
-	 If set, all namespace prefixes for the namespace specified are replaced with tokens for use with namespace_inject
 
 ``-o check_only CHECKONLY``
 	 *Optional*
@@ -962,11 +952,6 @@ Options
 
 	 If set, all namespace prefixes for the namespace specified are stripped from files and filenames
 
-``-o namespace_tokenize NAMESPACETOKENIZE``
-	 *Optional*
-
-	 If set, all namespace prefixes for the namespace specified are replaced with tokens for use with namespace_inject
-
 ``-o check_only CHECKONLY``
 	 *Optional*
 
@@ -1039,11 +1024,6 @@ Options
 	 *Optional*
 
 	 If set, all namespace prefixes for the namespace specified are stripped from files and filenames
-
-``-o namespace_tokenize NAMESPACETOKENIZE``
-	 *Optional*
-
-	 If set, all namespace prefixes for the namespace specified are replaced with tokens for use with namespace_inject
 
 ``-o check_only CHECKONLY``
 	 *Optional*
@@ -2540,16 +2520,6 @@ Options
 
 	 The package name to retrieve.  Defaults to project__package__name
 
-``-o unmanaged UNMANAGED``
-	 *Optional*
-
-	 If True, changes namespace_inject to replace tokens with a blank string
-
-``-o namespace_inject NAMESPACEINJECT``
-	 *Optional*
-
-	 If set, the namespace tokens in files and filenames are replaced with the namespace's prefix
-
 ``-o namespace_strip NAMESPACESTRIP``
 	 *Optional*
 
@@ -2599,16 +2569,6 @@ Options
 
 	 The package name to retrieve.  Defaults to project__package__name
 
-``-o unmanaged UNMANAGED``
-	 *Optional*
-
-	 If True, changes namespace_inject to replace tokens with a blank string
-
-``-o namespace_inject NAMESPACEINJECT``
-	 *Optional*
-
-	 If set, the namespace tokens in files and filenames are replaced with the namespace's prefix
-
 ``-o namespace_strip NAMESPACESTRIP``
 	 *Optional*
 
@@ -2655,16 +2615,6 @@ Options
 	 *Required*
 
 	 The path to a package.xml manifest to use for the retrieve.
-
-``-o unmanaged UNMANAGED``
-	 *Optional*
-
-	 If True, changes namespace_inject to replace tokens with a blank string
-
-``-o namespace_inject NAMESPACEINJECT``
-	 *Optional*
-
-	 If set, the namespace tokens in files and filenames are replaced with the namespace's prefix
 
 ``-o namespace_strip NAMESPACESTRIP``
 	 *Optional*
@@ -3491,11 +3441,6 @@ Options
 
 	 If set, all namespace prefixes for the namespace specified are stripped from files and filenames
 
-``-o namespace_tokenize NAMESPACETOKENIZE``
-	 *Optional*
-
-	 If set, all namespace prefixes for the namespace specified are replaced with tokens for use with namespace_inject
-
 ``-o check_only CHECKONLY``
 	 *Optional*
 
@@ -3569,11 +3514,6 @@ Options
 	 *Optional*
 
 	 If set, all namespace prefixes for the namespace specified are stripped from files and filenames
-
-``-o namespace_tokenize NAMESPACETOKENIZE``
-	 *Optional*
-
-	 If set, all namespace prefixes for the namespace specified are replaced with tokens for use with namespace_inject
 
 ``-o check_only CHECKONLY``
 	 *Optional*


### PR DESCRIPTION
(There is a small chance that these could be used creatively to tokenize one namespace and then inject another, but I'm not aware of that being done in the wild.)

# Critical Changes

# Changes
- Removed the `namespace_tokenize` option from tasks that deploy metadata, and removed the `namespace_inject` option from tasks that retrieve metadata, because it's unclear when they would be useful.

# Issues Closed
