### PR TITLE
Bulk Data Relative Dates

### DIFF
--- a/cumulusci/tasks/bulkdata/dates.py
+++ b/cumulusci/tasks/bulkdata/dates.py
@@ -69,21 +69,15 @@ def adjust_relative_dates(
     return r
 
 
-# The way Salesforce formats ISO8601 date-times is not quite compatible
-# with Python's datetime. Salesforce returns, e.g., "2020-09-14T20:00:17.000+0000",
-# while Python wants a : character in the timezone: "2020-09-14T20:00:17.000000+00:00".
-
-
 def datetime_from_salesforce(d):
     """Create a Python datetime from a Salesforce-style ISO8601 string"""
-    # Convert Salesforce's `+0000`, which Python would want as `+00:00`
-    return datetime.strptime(d[:-5] + "+00:00", "%Y-%m-%dT%H:%M:%S.%f%z")
+    return datetime.strptime(d, "%Y-%m-%dT%H:%M:%S.%f%z")
 
 
 def salesforce_from_datetime(d):
     """Create a Salesforce-style ISO8601 string from a Python datetime"""
     # Convert microseconds to milliseconds. Salesforce uses 3 decimals for milliseconds;
-    # Python uses 6 for microseconds.
+    # Python uses 6 for microseconds. Truncate here; the final 3 digits should be 0.
     return d.strftime("%Y-%m-%dT%H:%M:%S.{}+0000").format(str(d.microsecond)[:3])
 
 

--- a/cumulusci/tasks/bulkdata/dates.py
+++ b/cumulusci/tasks/bulkdata/dates.py
@@ -1,0 +1,113 @@
+from datetime import date, datetime
+from typing import List, Optional
+from cumulusci.core.config.OrgConfig import OrgConfig
+from cumulusci.tasks.bulkdata.step import DataOperationType
+
+
+def get_relative_date_context(mapping, org_config: OrgConfig):
+    fields = mapping.get_field_list()
+
+    date_fields = [
+        fields.index(f)
+        for f in mapping.get_fields_by_type("date", org_config)
+        if f in mapping.fields
+    ]
+    date_time_fields = [
+        fields.index(f)
+        for f in mapping.get_fields_by_type("datetime", org_config)
+        if f in mapping.fields
+    ]
+
+    return (date_fields, date_time_fields)
+
+
+def adjust_relative_dates(
+    mapping,
+    context,
+    record: List[Optional[str]],
+    operation: DataOperationType,
+):
+    """Convert specified date and time fields (in ISO format) relative to the present moment.
+    If some date is 2020-07-30, anchor_date is 2020-07-23, and today's date is 2020-09-01,
+    that date will become 2020-09-07 - the same position in the timeline relative to today."""
+
+    date_fields, date_time_fields = context
+
+    # Determine the direction in which we are converting.
+    # For extracts, we convert the date from today-anchored to mapping.anchor_date-anchored.
+    # For loads, we do the reverse.
+
+    if operation is DataOperationType.QUERY:
+        current_anchor = date.today()
+        target_anchor = mapping.anchor_date
+    else:
+        current_anchor = mapping.anchor_date
+        target_anchor = date.today()
+
+    r = record.copy()
+
+    for index in date_fields:
+        if operation is DataOperationType.QUERY:
+            index += 1  # For the Id field.
+        if r[index]:
+            r[index] = date_to_iso(
+                _convert_date(target_anchor, current_anchor, iso_to_date(r[index]))
+            )
+
+    for index in date_time_fields:
+        if operation is DataOperationType.QUERY:
+            index += 1  # For the Id field.
+        if r[index]:
+            r[index] = salesforce_from_datetime(
+                _convert_datetime(
+                    target_anchor,
+                    current_anchor,
+                    datetime_from_salesforce(r[index]),
+                )
+            )
+
+    return r
+
+
+# The way Salesforce formats ISO8601 date-times is not quite compatible
+# with Python's datetime. Salesforce returns, e.g., "2020-09-14T20:00:17.000+0000",
+# while Python wants a : character in the timezone: "2020-09-14T20:00:17.000000+00:00".
+
+
+def datetime_from_salesforce(d):
+    """Create a Python datetime from a Salesforce-style ISO8601 string"""
+    # Convert Salesforce's `+0000`, which Python would want as `+00:00`
+    return datetime.strptime(d[:-5] + "+00:00", "%Y-%m-%dT%H:%M:%S.%f%z")
+
+
+def salesforce_from_datetime(d):
+    """Create a Salesforce-style ISO8601 string from a Python datetime"""
+    # Convert microseconds to milliseconds. Salesforce uses 3 decimals for milliseconds;
+    # Python uses 6 for microseconds.
+    return d.strftime("%Y-%m-%dT%H:%M:%S.{}+0000").format(str(d.microsecond)[:3])
+
+
+# Python 3.6 doesn't support the isoformat()/fromisoformat() methods. Shims.
+
+
+def date_to_iso(d):
+    """Convert date object to ISO8601 string"""
+    return d.strftime("%Y-%m-%d")
+
+
+def iso_to_date(s):
+    """Convert ISO8601 string to date object"""
+    return datetime.strptime(s, "%Y-%m-%d").date()
+
+
+def _convert_date(target_anchor, current_anchor, this_date):
+    """Adjust this_date to be relative to target_anchor instead of current_anchor"""
+    return target_anchor + (this_date - current_anchor)
+
+
+def _convert_datetime(target_anchor, current_anchor, this_datetime):
+    """Adjust this_datetime to be relative to target_anchor instead of current_anchor"""
+    return datetime.combine(
+        _convert_date(target_anchor, current_anchor, this_datetime.date()),
+        this_datetime.time(),
+    )

--- a/cumulusci/tasks/bulkdata/extract.py
+++ b/cumulusci/tasks/bulkdata/extract.py
@@ -22,7 +22,10 @@ from cumulusci.tasks.bulkdata.step import (
     DataOperationType,
     get_query_operation,
 )
-from cumulusci.tasks.bulkdata.utils import adjust_relative_dates
+from cumulusci.tasks.bulkdata.utils import (
+    adjust_relative_dates,
+    get_relative_date_context,
+)
 from cumulusci.utils import os_friendly_path, log_progress
 from cumulusci.tasks.bulkdata.mapping_parser import (
     parse_from_yaml,
@@ -181,8 +184,11 @@ class ExtractData(SqlAlchemyMixin, BaseSalesforceApiTask):
 
         # Convert relative dates to stable dates.
         if mapping.anchor_date:
+            date_context = get_relative_date_context(mapping, self.org_config)
             record_iterator = (
-                adjust_relative_dates(mapping, self.org_config, record)
+                adjust_relative_dates(
+                    mapping, date_context, record, DataOperationType.QUERY
+                )
                 for record in record_iterator
             )
 

--- a/cumulusci/tasks/bulkdata/extract.py
+++ b/cumulusci/tasks/bulkdata/extract.py
@@ -22,7 +22,7 @@ from cumulusci.tasks.bulkdata.step import (
     DataOperationType,
     get_query_operation,
 )
-from cumulusci.tasks.bulkdata.utils import (
+from cumulusci.tasks.bulkdata.dates import (
     adjust_relative_dates,
     get_relative_date_context,
 )

--- a/cumulusci/tasks/bulkdata/extract.py
+++ b/cumulusci/tasks/bulkdata/extract.py
@@ -24,7 +24,6 @@ from cumulusci.tasks.bulkdata.step import (
 )
 from cumulusci.tasks.bulkdata.dates import (
     adjust_relative_dates,
-    get_relative_date_context,
 )
 from cumulusci.utils import os_friendly_path, log_progress
 from cumulusci.tasks.bulkdata.mapping_parser import (
@@ -184,7 +183,7 @@ class ExtractData(SqlAlchemyMixin, BaseSalesforceApiTask):
 
         # Convert relative dates to stable dates.
         if mapping.anchor_date:
-            date_context = get_relative_date_context(mapping, self.org_config)
+            date_context = mapping.get_relative_date_context(self.org_config)
             if date_context[0] or date_context[1]:
                 record_iterator = (
                     adjust_relative_dates(

--- a/cumulusci/tasks/bulkdata/extract.py
+++ b/cumulusci/tasks/bulkdata/extract.py
@@ -22,6 +22,7 @@ from cumulusci.tasks.bulkdata.step import (
     DataOperationType,
     get_query_operation,
 )
+from cumulusci.tasks.bulkdata.utils import adjust_relative_dates
 from cumulusci.utils import os_friendly_path, log_progress
 from cumulusci.tasks.bulkdata.mapping_parser import (
     parse_from_yaml,
@@ -177,6 +178,13 @@ class ExtractData(SqlAlchemyMixin, BaseSalesforceApiTask):
         record_iterator = log_progress(step.get_results(), self.logger)
         if record_type:
             record_iterator = (record + [record_type] for record in record_iterator)
+
+        # Convert relative dates to stable dates.
+        if mapping.anchor_date:
+            record_iterator = (
+                adjust_relative_dates(mapping, self.org_config, record)
+                for record in record_iterator
+            )
 
         # Set Name field as blank for Person Account "Account" records.
         if (

--- a/cumulusci/tasks/bulkdata/extract.py
+++ b/cumulusci/tasks/bulkdata/extract.py
@@ -185,12 +185,13 @@ class ExtractData(SqlAlchemyMixin, BaseSalesforceApiTask):
         # Convert relative dates to stable dates.
         if mapping.anchor_date:
             date_context = get_relative_date_context(mapping, self.org_config)
-            record_iterator = (
-                adjust_relative_dates(
-                    mapping, date_context, record, DataOperationType.QUERY
+            if date_context[0] or date_context[1]:
+                record_iterator = (
+                    adjust_relative_dates(
+                        mapping, date_context, record, DataOperationType.QUERY
+                    )
+                    for record in record_iterator
                 )
-                for record in record_iterator
-            )
 
         # Set Name field as blank for Person Account "Account" records.
         if (

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -11,6 +11,8 @@ from cumulusci.core.utils import process_bool_arg
 from cumulusci.tasks.bulkdata.utils import (
     SqlAlchemyMixin,
     RowErrorChecker,
+)
+from cumulusci.tasks.bulkdata.dates import (
     adjust_relative_dates,
     get_relative_date_context,
 )

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -12,6 +12,7 @@ from cumulusci.tasks.bulkdata.utils import (
     SqlAlchemyMixin,
     RowErrorChecker,
     adjust_relative_dates,
+    get_relative_date_context,
 )
 from cumulusci.tasks.bulkdata.step import (
     DataOperationStatus,
@@ -167,12 +168,16 @@ class LoadData(SqlAlchemyMixin, BaseSalesforceApiTask):
         statics = self._get_statics(mapping)
         total_rows = 0
 
+        date_context = get_relative_date_context(mapping, self.org_config)
+
         for row in query.yield_per(10000):
             total_rows += 1
             # Add static values to row
             pkey = row[0]
             row = list(row[1:]) + statics
-            row = adjust_relative_dates(mapping, self.org_config, row)
+            row = adjust_relative_dates(
+                mapping, date_context, row, DataOperationType.INSERT
+            )
             if mapping.action is DataOperationType.UPDATE:
                 if len(row) > 1 and all([f is None for f in row[1:]]):
                     # Skip update rows that contain no values

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -14,7 +14,6 @@ from cumulusci.tasks.bulkdata.utils import (
 )
 from cumulusci.tasks.bulkdata.dates import (
     adjust_relative_dates,
-    get_relative_date_context,
 )
 from cumulusci.tasks.bulkdata.step import (
     DataOperationStatus,
@@ -171,7 +170,7 @@ class LoadData(SqlAlchemyMixin, BaseSalesforceApiTask):
         total_rows = 0
 
         if mapping.anchor_date:
-            date_context = get_relative_date_context(mapping, self.org_config)
+            date_context = mapping.get_relative_date_context(self.org_config)
 
         for row in query.yield_per(10000):
             total_rows += 1

--- a/cumulusci/tasks/bulkdata/mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/mapping_parser.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import datetime
 from typing import Dict, List, Union, IO, Optional, Any, Callable, Mapping
 from logging import getLogger
 from pathlib import Path
@@ -156,7 +156,7 @@ class MappingStep(CCIDictModel):
     @validator("anchor_date")
     @classmethod
     def validate_anchor_date(cls, v):
-        return date.fromisoformat(v)
+        return datetime.strptime(v, "%Y-%m-%d").date()
 
     @validator("record_type")
     @classmethod

--- a/cumulusci/tasks/bulkdata/mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/mapping_parser.py
@@ -1,3 +1,4 @@
+from datetime import date
 from typing import Dict, List, Union, IO, Optional, Any, Callable, Mapping
 from logging import getLogger
 from pathlib import Path
@@ -147,6 +148,22 @@ class MappingStep(CCIDictModel):
             columns.append("RecordTypeId")
 
         return columns
+
+    def get_relative_date_context(self, org_config: OrgConfig):
+        fields = self.get_field_list()
+
+        date_fields = [
+            fields.index(f)
+            for f in self.get_fields_by_type("date", org_config)
+            if f in self.fields
+        ]
+        date_time_fields = [
+            fields.index(f)
+            for f in self.get_fields_by_type("datetime", org_config)
+            if f in self.fields
+        ]
+
+        return (date_fields, date_time_fields, date.today())
 
     @validator("batch_size")
     @classmethod

--- a/cumulusci/tasks/bulkdata/mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/mapping_parser.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Dict, List, Union, IO, Optional, Any, Callable, Mapping
 from logging import getLogger
 from pathlib import Path
@@ -9,6 +8,7 @@ from pydantic import Field, validator, root_validator, ValidationError
 from cumulusci.core.config.OrgConfig import OrgConfig
 from cumulusci.core.exceptions import BulkDataException
 from cumulusci.tasks.bulkdata.step import DataOperationType, DataApi
+from cumulusci.tasks.bulkdata.dates import iso_to_date
 from cumulusci.utils.yaml.model_parser import CCIDictModel
 from cumulusci.utils import convert_to_snake_case
 
@@ -156,7 +156,7 @@ class MappingStep(CCIDictModel):
     @validator("anchor_date")
     @classmethod
     def validate_anchor_date(cls, v):
-        return datetime.strptime(v, "%Y-%m-%d").date()
+        return iso_to_date(v)
 
     @validator("record_type")
     @classmethod

--- a/cumulusci/tasks/bulkdata/tests/test_dates.py
+++ b/cumulusci/tasks/bulkdata/tests/test_dates.py
@@ -1,0 +1,139 @@
+from datetime import datetime, date, timedelta
+from unittest import mock
+from cumulusci.tasks.bulkdata.dates import (
+    adjust_relative_dates,
+    get_relative_date_context,
+    datetime_from_salesforce,
+    salesforce_from_datetime,
+)
+from cumulusci.tasks.bulkdata.mapping_parser import MappingStep
+from cumulusci.tasks.bulkdata.step import DataOperationType
+
+
+class TestRelativeDates:
+    def test_get_relative_date_context(self):
+        mapping = MappingStep(
+            sf_object="Account",
+            fields=["Some_Date__c", "Some_Datetime__c"],
+            anchor_date="2020-07-01",
+        )
+
+        org_config = mock.Mock()
+        org_config.salesforce_client.Account.describe.return_value = {
+            "fields": [
+                {"name": "Some_Date__c", "type": "date"},
+                {"name": "Some_Datetime__c", "type": "datetime"},
+                {"name": "Some_Bool__c", "type": "boolean"},
+            ]
+        }
+
+        assert get_relative_date_context(mapping, org_config) == (
+            [0],
+            [1],
+        )
+
+    def test_relative_dates(self):
+        mapping = MappingStep(
+            sf_object="Account", fields=["Some_Date__c"], anchor_date="2020-07-01"
+        )
+
+        target = date.today() + timedelta(days=7)
+        assert adjust_relative_dates(
+            mapping, ([0], []), ["2020-07-08"], DataOperationType.INSERT
+        ) == [target.isoformat()]
+
+        assert adjust_relative_dates(
+            mapping, ([0], []), ["2020-07-01"], DataOperationType.INSERT
+        ) == [date.today().isoformat()]
+
+        assert adjust_relative_dates(
+            mapping, ([0], []), [""], DataOperationType.INSERT
+        ) == [""]
+
+    def test_relative_dates__extract(self):
+        mapping = MappingStep(
+            sf_object="Account", fields=["Some_Date__c"], anchor_date="2020-07-01"
+        )
+
+        target = mapping.anchor_date + timedelta(days=7)
+        input_date = (date.today() + timedelta(days=7)).isoformat()
+        assert (
+            adjust_relative_dates(
+                mapping,
+                ([0], []),
+                ["001000000000000", input_date],
+                DataOperationType.QUERY,
+            )
+            == ["001000000000000", target.isoformat()]
+        )
+
+        assert (
+            adjust_relative_dates(
+                mapping,
+                ([0], []),
+                ["001000000000000", date.today().isoformat()],
+                DataOperationType.QUERY,
+            )
+            == ["001000000000000", mapping.anchor_date.isoformat()]
+        )
+
+        assert (
+            adjust_relative_dates(
+                mapping,
+                ([0], []),
+                ["001000000000000", ""],
+                DataOperationType.QUERY,
+            )
+            == ["001000000000000", ""]
+        )
+
+    def test_relative_datetimes(self):
+        mapping = MappingStep(
+            sf_object="Account", fields=["Some_Datetime__c"], anchor_date="2020-07-01"
+        )
+
+        input_dt = datetime_from_salesforce("2020-07-08T09:37:57.373+0000")
+        target = datetime.combine(date.today() + timedelta(days=7), input_dt.time())
+        assert (
+            adjust_relative_dates(
+                mapping,
+                ([], [0]),
+                [salesforce_from_datetime(input_dt)],
+                DataOperationType.INSERT,
+            )
+            == [salesforce_from_datetime(target)]
+        )
+
+        now = datetime.combine(mapping.anchor_date, datetime.now().time())
+        assert (
+            adjust_relative_dates(
+                mapping,
+                ([], [0]),
+                [salesforce_from_datetime(now)],
+                DataOperationType.INSERT,
+            )
+            == [salesforce_from_datetime(datetime.combine(date.today(), now.time()))]
+        )
+
+        assert adjust_relative_dates(
+            mapping, ([], [0]), [""], DataOperationType.INSERT
+        ) == [""]
+
+    def test_relative_datetimes_extract(self):
+        mapping = MappingStep(
+            sf_object="Account", fields=["Some_Datetime__c"], anchor_date="2020-07-01"
+        )
+
+        input_dt = datetime.now() + timedelta(days=7)
+        target = datetime.combine(
+            mapping.anchor_date + timedelta(days=7), input_dt.time()
+        )
+        assert (
+            adjust_relative_dates(
+                mapping,
+                ([], [0]),
+                ["001000000000000", salesforce_from_datetime(input_dt)],
+                DataOperationType.QUERY,
+            )
+            == ["001000000000000", salesforce_from_datetime(target)]
+        )

--- a/cumulusci/tasks/bulkdata/tests/test_mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/tests/test_mapping_parser.py
@@ -1,3 +1,4 @@
+from datetime import date
 from pathlib import Path
 from io import StringIO
 from unittest import mock
@@ -137,6 +138,24 @@ class TestMappingParser:
             "AccountSite": "AccountSite",
             "ParentId": "ParentId",
         }
+
+    def test_get_relative_date_context(self):
+        mapping = MappingStep(
+            sf_object="Account",
+            fields=["Some_Date__c", "Some_Datetime__c"],
+            anchor_date="2020-07-01",
+        )
+
+        org_config = mock.Mock()
+        org_config.salesforce_client.Account.describe.return_value = {
+            "fields": [
+                {"name": "Some_Date__c", "type": "date"},
+                {"name": "Some_Datetime__c", "type": "datetime"},
+                {"name": "Some_Bool__c", "type": "boolean"},
+            ]
+        }
+
+        assert mapping.get_relative_date_context(org_config) == ([0], [1], date.today())
 
     # Start of FLS/Namespace Injection Unit Tests
 

--- a/cumulusci/tasks/bulkdata/tests/test_utils.py
+++ b/cumulusci/tasks/bulkdata/tests/test_utils.py
@@ -16,6 +16,7 @@ from cumulusci.tasks.bulkdata.utils import (
     adjust_relative_dates,
 )
 from cumulusci.tasks.bulkdata.mapping_parser import parse_from_yaml, MappingStep
+from cumulusci.tasks.bulkdata.step import DataOperationType
 
 
 def create_db_file(filename):
@@ -203,15 +204,41 @@ class TestRelativeDates:
         }
 
         target = date.today() + timedelta(days=7)
-        assert adjust_relative_dates(mapping, org_config, ["2020-07-08"]) == [
-            target.isoformat()
-        ]
+        assert adjust_relative_dates(
+            mapping, org_config, ["2020-07-08"], DataOperationType.INSERT
+        ) == [target.isoformat()]
 
-        assert adjust_relative_dates(mapping, org_config, ["2020-07-01"]) == [
-            date.today().isoformat()
-        ]
+        assert adjust_relative_dates(
+            mapping, org_config, ["2020-07-01"], DataOperationType.INSERT
+        ) == [date.today().isoformat()]
 
-        assert adjust_relative_dates(mapping, org_config, [""]) == [""]
+        assert adjust_relative_dates(
+            mapping, org_config, [""], DataOperationType.INSERT
+        ) == [""]
+
+    def test_relative_dates__extract(self):
+        mapping = MappingStep(
+            sf_object="Account", fields=["Some_Date__c"], anchor_date="2020-07-01"
+        )
+
+        org_config = mock.Mock()
+        org_config.salesforce_client.Account.describe.return_value = {
+            "fields": [{"name": "Some_Date__c", "type": "date"}]
+        }
+
+        target = mapping.anchor_date + timedelta(days=7)
+        input_date = (date.today() + timedelta(days=7)).isoformat()
+        assert adjust_relative_dates(
+            mapping, org_config, [input_date], DataOperationType.QUERY
+        ) == [target.isoformat()]
+
+        assert adjust_relative_dates(
+            mapping, org_config, [date.today().isoformat()], DataOperationType.QUERY
+        ) == [mapping.anchor_date.isoformat()]
+
+        assert adjust_relative_dates(
+            mapping, org_config, [""], DataOperationType.QUERY
+        ) == [""]
 
     def test_relative_datetimes(self):
         mapping = MappingStep(
@@ -225,13 +252,15 @@ class TestRelativeDates:
 
         input_dt = datetime.fromisoformat("2020-07-08T09:37:57.373496")
         target = datetime.combine(date.today() + timedelta(days=7), input_dt.time())
-        assert adjust_relative_dates(mapping, org_config, [input_dt.isoformat()]) == [
-            target.isoformat()
-        ]
+        assert adjust_relative_dates(
+            mapping, org_config, [input_dt.isoformat()], DataOperationType.INSERT
+        ) == [target.isoformat()]
 
         now = datetime.combine(mapping.anchor_date, datetime.now().time())
-        assert adjust_relative_dates(mapping, org_config, [now.isoformat()]) == [
-            datetime.combine(date.today(), now.time()).isoformat()
-        ]
+        assert adjust_relative_dates(
+            mapping, org_config, [now.isoformat()], DataOperationType.INSERT
+        ) == [datetime.combine(date.today(), now.time()).isoformat()]
 
-        assert adjust_relative_dates(mapping, org_config, [""]) == [""]
+        assert adjust_relative_dates(
+            mapping, org_config, [""], DataOperationType.INSERT
+        ) == [""]

--- a/cumulusci/tasks/bulkdata/tests/test_utils.py
+++ b/cumulusci/tasks/bulkdata/tests/test_utils.py
@@ -242,26 +242,35 @@ class TestRelativeDates:
 
         target = mapping.anchor_date + timedelta(days=7)
         input_date = (date.today() + timedelta(days=7)).isoformat()
-        assert adjust_relative_dates(
-            mapping,
-            ([0], []),
-            ["001000000000000", input_date],
-            DataOperationType.QUERY,
-        ) == ["001000000000000", target.isoformat()]
+        assert (
+            adjust_relative_dates(
+                mapping,
+                ([0], []),
+                ["001000000000000", input_date],
+                DataOperationType.QUERY,
+            )
+            == ["001000000000000", target.isoformat()]
+        )
 
-        assert adjust_relative_dates(
-            mapping,
-            ([0], []),
-            ["001000000000000", date.today().isoformat()],
-            DataOperationType.QUERY,
-        ) == ["001000000000000", mapping.anchor_date.isoformat()]
+        assert (
+            adjust_relative_dates(
+                mapping,
+                ([0], []),
+                ["001000000000000", date.today().isoformat()],
+                DataOperationType.QUERY,
+            )
+            == ["001000000000000", mapping.anchor_date.isoformat()]
+        )
 
-        assert adjust_relative_dates(
-            mapping,
-            ([0], []),
-            ["001000000000000", ""],
-            DataOperationType.QUERY,
-        ) == ["001000000000000", ""]
+        assert (
+            adjust_relative_dates(
+                mapping,
+                ([0], []),
+                ["001000000000000", ""],
+                DataOperationType.QUERY,
+            )
+            == ["001000000000000", ""]
+        )
 
     def test_relative_datetimes(self):
         mapping = MappingStep(
@@ -270,20 +279,26 @@ class TestRelativeDates:
 
         input_dt = datetime_from_salesforce("2020-07-08T09:37:57.373+0000")
         target = datetime.combine(date.today() + timedelta(days=7), input_dt.time())
-        assert adjust_relative_dates(
-            mapping,
-            ([], [0]),
-            [salesforce_from_datetime(input_dt)],
-            DataOperationType.INSERT
-        ) == [salesforce_from_datetime(target)]
+        assert (
+            adjust_relative_dates(
+                mapping,
+                ([], [0]),
+                [salesforce_from_datetime(input_dt)],
+                DataOperationType.INSERT,
+            )
+            == [salesforce_from_datetime(target)]
+        )
 
         now = datetime.combine(mapping.anchor_date, datetime.now().time())
-        assert adjust_relative_dates(
-            mapping,
-            ([], [0]),
-            [salesforce_from_datetime(now)],
-            DataOperationType.INSERT
-        ) == [salesforce_from_datetime(datetime.combine(date.today(), now.time()))]
+        assert (
+            adjust_relative_dates(
+                mapping,
+                ([], [0]),
+                [salesforce_from_datetime(now)],
+                DataOperationType.INSERT,
+            )
+            == [salesforce_from_datetime(datetime.combine(date.today(), now.time()))]
+        )
 
         assert adjust_relative_dates(
             mapping, ([], [0]), [""], DataOperationType.INSERT

--- a/cumulusci/tasks/bulkdata/tests/test_utils.py
+++ b/cumulusci/tasks/bulkdata/tests/test_utils.py
@@ -229,8 +229,9 @@ class TestRelativeDates:
             target.isoformat()
         ]
 
-        assert adjust_relative_dates(
-            mapping, org_config, [datetime.now().isoformat()]
-        ) == [date.today().isoformat()]
+        now = datetime.combine(mapping.anchor_date, datetime.now().time())
+        assert adjust_relative_dates(mapping, org_config, [now.isoformat()]) == [
+            datetime.combine(date.today(), now.time()).isoformat()
+        ]
 
         assert adjust_relative_dates(mapping, org_config, [""]) == [""]

--- a/cumulusci/tasks/bulkdata/tests/test_utils.py
+++ b/cumulusci/tasks/bulkdata/tests/test_utils.py
@@ -303,3 +303,22 @@ class TestRelativeDates:
         assert adjust_relative_dates(
             mapping, ([], [0]), [""], DataOperationType.INSERT
         ) == [""]
+
+    def test_relative_datetimes_extract(self):
+        mapping = MappingStep(
+            sf_object="Account", fields=["Some_Datetime__c"], anchor_date="2020-07-01"
+        )
+
+        input_dt = datetime.now() + timedelta(days=7)
+        target = datetime.combine(
+            mapping.anchor_date + timedelta(days=7), input_dt.time()
+        )
+        assert (
+            adjust_relative_dates(
+                mapping,
+                ([], [0]),
+                ["001000000000000", salesforce_from_datetime(input_dt)],
+                DataOperationType.QUERY,
+            )
+            == ["001000000000000", salesforce_from_datetime(target)]
+        )

--- a/cumulusci/tasks/bulkdata/tests/test_utils.py
+++ b/cumulusci/tasks/bulkdata/tests/test_utils.py
@@ -1,4 +1,3 @@
-from datetime import datetime, date, timedelta
 import os
 import json
 import unittest
@@ -13,13 +12,8 @@ from cumulusci.utils import temporary_dir
 from cumulusci.tasks.bulkdata.utils import (
     create_table,
     generate_batches,
-    adjust_relative_dates,
-    get_relative_date_context,
-    datetime_from_salesforce,
-    salesforce_from_datetime,
 )
-from cumulusci.tasks.bulkdata.mapping_parser import parse_from_yaml, MappingStep
-from cumulusci.tasks.bulkdata.step import DataOperationType
+from cumulusci.tasks.bulkdata.mapping_parser import parse_from_yaml
 
 
 def create_db_file(filename):
@@ -193,132 +187,3 @@ class TestBatching(unittest.TestCase):
     def test_batching_with_remainder(self):
         batches = list(generate_batches(num_records=20, batch_size=7))
         assert batches == [(7, 0), (7, 1), (6, 2)]
-
-
-class TestRelativeDates:
-    def test_get_relative_date_context(self):
-        mapping = MappingStep(
-            sf_object="Account",
-            fields=["Some_Date__c", "Some_Datetime__c"],
-            anchor_date="2020-07-01",
-        )
-
-        org_config = mock.Mock()
-        org_config.salesforce_client.Account.describe.return_value = {
-            "fields": [
-                {"name": "Some_Date__c", "type": "date"},
-                {"name": "Some_Datetime__c", "type": "datetime"},
-                {"name": "Some_Bool__c", "type": "boolean"},
-            ]
-        }
-
-        assert get_relative_date_context(mapping, org_config) == (
-            [0],
-            [1],
-        )
-
-    def test_relative_dates(self):
-        mapping = MappingStep(
-            sf_object="Account", fields=["Some_Date__c"], anchor_date="2020-07-01"
-        )
-
-        target = date.today() + timedelta(days=7)
-        assert adjust_relative_dates(
-            mapping, ([0], []), ["2020-07-08"], DataOperationType.INSERT
-        ) == [target.isoformat()]
-
-        assert adjust_relative_dates(
-            mapping, ([0], []), ["2020-07-01"], DataOperationType.INSERT
-        ) == [date.today().isoformat()]
-
-        assert adjust_relative_dates(
-            mapping, ([0], []), [""], DataOperationType.INSERT
-        ) == [""]
-
-    def test_relative_dates__extract(self):
-        mapping = MappingStep(
-            sf_object="Account", fields=["Some_Date__c"], anchor_date="2020-07-01"
-        )
-
-        target = mapping.anchor_date + timedelta(days=7)
-        input_date = (date.today() + timedelta(days=7)).isoformat()
-        assert (
-            adjust_relative_dates(
-                mapping,
-                ([0], []),
-                ["001000000000000", input_date],
-                DataOperationType.QUERY,
-            )
-            == ["001000000000000", target.isoformat()]
-        )
-
-        assert (
-            adjust_relative_dates(
-                mapping,
-                ([0], []),
-                ["001000000000000", date.today().isoformat()],
-                DataOperationType.QUERY,
-            )
-            == ["001000000000000", mapping.anchor_date.isoformat()]
-        )
-
-        assert (
-            adjust_relative_dates(
-                mapping,
-                ([0], []),
-                ["001000000000000", ""],
-                DataOperationType.QUERY,
-            )
-            == ["001000000000000", ""]
-        )
-
-    def test_relative_datetimes(self):
-        mapping = MappingStep(
-            sf_object="Account", fields=["Some_Datetime__c"], anchor_date="2020-07-01"
-        )
-
-        input_dt = datetime_from_salesforce("2020-07-08T09:37:57.373+0000")
-        target = datetime.combine(date.today() + timedelta(days=7), input_dt.time())
-        assert (
-            adjust_relative_dates(
-                mapping,
-                ([], [0]),
-                [salesforce_from_datetime(input_dt)],
-                DataOperationType.INSERT,
-            )
-            == [salesforce_from_datetime(target)]
-        )
-
-        now = datetime.combine(mapping.anchor_date, datetime.now().time())
-        assert (
-            adjust_relative_dates(
-                mapping,
-                ([], [0]),
-                [salesforce_from_datetime(now)],
-                DataOperationType.INSERT,
-            )
-            == [salesforce_from_datetime(datetime.combine(date.today(), now.time()))]
-        )
-
-        assert adjust_relative_dates(
-            mapping, ([], [0]), [""], DataOperationType.INSERT
-        ) == [""]
-
-    def test_relative_datetimes_extract(self):
-        mapping = MappingStep(
-            sf_object="Account", fields=["Some_Datetime__c"], anchor_date="2020-07-01"
-        )
-
-        input_dt = datetime.now() + timedelta(days=7)
-        target = datetime.combine(
-            mapping.anchor_date + timedelta(days=7), input_dt.time()
-        )
-        assert (
-            adjust_relative_dates(
-                mapping,
-                ([], [0]),
-                ["001000000000000", salesforce_from_datetime(input_dt)],
-                DataOperationType.QUERY,
-            )
-            == ["001000000000000", salesforce_from_datetime(target)]
-        )

--- a/cumulusci/tasks/bulkdata/utils.py
+++ b/cumulusci/tasks/bulkdata/utils.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime
-from typing import List
+from typing import List, Optional
 
 from sqlalchemy import Column
 from sqlalchemy import Integer
@@ -146,7 +146,7 @@ def get_relative_date_context(mapping: MappingStep, org_config: OrgConfig):
 def adjust_relative_dates(
     mapping: MappingStep,
     context,
-    record: List[str],
+    record: List[Optional[str]],
     operation: DataOperationType,
 ):
     """Convert specified date and time fields (in ISO format) relative to the present moment.

--- a/cumulusci/tasks/bulkdata/utils.py
+++ b/cumulusci/tasks/bulkdata/utils.py
@@ -204,7 +204,7 @@ def datetime_from_salesforce(d):
 
 def salesforce_from_datetime(d):
     """Create a Salesforce-style ISO8601 string from a Python datetime"""
-    # Set milliseconds to 0. Salesforce uses 3 decimals for milliseconds;
+    # Convert microseconds to milliseconds. Salesforce uses 3 decimals for milliseconds;
     # Python uses 6 for microseconds.
     return d.strftime("%Y-%m-%dT%H:%M:%S.{}+0000").format(str(d.microsecond)[:3])
 

--- a/cumulusci/tasks/bulkdata/utils.py
+++ b/cumulusci/tasks/bulkdata/utils.py
@@ -1,16 +1,10 @@
-from datetime import date, datetime
-from typing import List, Optional
-
 from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy import Table
 from sqlalchemy import Unicode
 from sqlalchemy.orm import mapper
 
-from cumulusci.core.config.OrgConfig import OrgConfig
 from cumulusci.core.exceptions import BulkDataException
-from cumulusci.tasks.bulkdata.mapping_parser import MappingStep
-from cumulusci.tasks.bulkdata.step import DataOperationType
 
 
 class SqlAlchemyMixin:
@@ -124,99 +118,3 @@ class RowErrorChecker:
                 return self.row_error_count
             else:
                 raise BulkDataException(msg)
-
-
-def get_relative_date_context(mapping: MappingStep, org_config: OrgConfig):
-    fields = mapping.get_field_list()
-
-    date_fields = [
-        fields.index(f)
-        for f in mapping.get_fields_by_type("date", org_config)
-        if f in mapping.fields
-    ]
-    date_time_fields = [
-        fields.index(f)
-        for f in mapping.get_fields_by_type("datetime", org_config)
-        if f in mapping.fields
-    ]
-
-    return (date_fields, date_time_fields)
-
-
-def adjust_relative_dates(
-    mapping: MappingStep,
-    context,
-    record: List[Optional[str]],
-    operation: DataOperationType,
-):
-    """Convert specified date and time fields (in ISO format) relative to the present moment.
-    If some date is 2020-07-30, anchor_date is 2020-07-23, and today's date is 2020-09-01,
-    that date will become 2020-09-07 - the same position in the timeline relative to today."""
-
-    date_fields, date_time_fields = context
-
-    # Determine the direction in which we are converting.
-    # For extracts, we convert the date from today-anchored to mapping.anchor_date-anchored.
-    # For loads, we do the reverse.
-
-    if operation is DataOperationType.QUERY:
-        current_anchor = date.today()
-        target_anchor = mapping.anchor_date
-    else:
-        current_anchor = mapping.anchor_date
-        target_anchor = date.today()
-
-    r = record.copy()
-
-    for index in date_fields:
-        if operation is DataOperationType.QUERY:
-            index += 1  # For the Id field.
-        if r[index]:
-            r[index] = _convert_date(
-                target_anchor, current_anchor, date.fromisoformat(r[index])
-            ).isoformat()
-
-    for index in date_time_fields:
-        if operation is DataOperationType.QUERY:
-            index += 1  # For the Id field.
-        if r[index]:
-            r[index] = salesforce_from_datetime(
-                _convert_datetime(
-                    target_anchor,
-                    current_anchor,
-                    datetime_from_salesforce(r[index]),
-                )
-            )
-
-    return r
-
-
-# The way Salesforce formats ISO8601 date-times is not quite compatible
-# with Python's datetime. Salesforce returns, e.g., "2020-09-14T20:00:17.000+0000",
-# while Python wants a : character in the timezone: "2020-09-14T20:00:17.000000+00:00".
-
-
-def datetime_from_salesforce(d):
-    """Create a Python datetime from a Salesforce-style ISO8601 string"""
-    # Convert Salesforce's `+0000`, which Python would want as `+00:00`
-    return datetime.strptime(d[:-5] + "+00:00", "%Y-%m-%dT%H:%M:%S.%f%z")
-
-
-def salesforce_from_datetime(d):
-    """Create a Salesforce-style ISO8601 string from a Python datetime"""
-    # Convert microseconds to milliseconds. Salesforce uses 3 decimals for milliseconds;
-    # Python uses 6 for microseconds.
-    return d.strftime("%Y-%m-%dT%H:%M:%S.{}+0000").format(str(d.microsecond)[:3])
-
-
-def _convert_date(target_anchor, current_anchor, this_date):
-    """Adjust this_date to be relative to target_anchor instead of current_anchor"""
-    return target_anchor + (this_date - current_anchor)
-
-
-def _convert_datetime(target_anchor, current_anchor, this_datetime):
-    """Adjust this_datetime to be relative to target_anchor instead of current_anchor"""
-    return datetime.combine(
-        _convert_date(target_anchor, current_anchor, this_datetime.date()),
-        this_datetime.time(),
-    )

--- a/cumulusci/tasks/bulkdata/utils.py
+++ b/cumulusci/tasks/bulkdata/utils.py
@@ -150,20 +150,16 @@ def adjust_relative_dates(
     for index in date_fields:
         if r[index]:
             this_date = date.today() + (
-                date.fromisoformat(record[index]) - mapping.anchor_date
+                date.fromisoformat(r[index]) - mapping.anchor_date
             )
             r[index] = this_date.isoformat()
 
     for index in date_time_fields:
         if r[index]:
-            this_datetime = datetime.now() + (
-                datetime.fromisoformat(record[index])
-                - datetime(
-                    mapping.anchor_date.year,
-                    mapping.anchor_date.month,
-                    mapping.anchor_date.day,
-                )
-            )
-            record[index] = this_datetime.isoformat()
+            this_datetime = datetime.fromisoformat(r[index])
+            this_date = date.today() + (this_datetime.date() - mapping.anchor_date)
+
+            new_datetime = datetime.combine(this_date, this_datetime.time())
+            r[index] = new_datetime.isoformat()
 
     return r

--- a/docs/bulk_data.rst
+++ b/docs/bulk_data.rst
@@ -197,6 +197,22 @@ contains the ``anchor_date`` clause. If orgs are `configured <https://help.sales
 fields upon record creation and the appropriate user permission is enabled,
 CumulusCI can apply relative dating to audit fields, such as ``CreatedDate``. 
 
+For example, this mapping step:
+
+.. code-block:: yaml
+
+    Contacts:
+        sf_object: Contact
+        fields:
+            - FirstName
+            - LastName
+            - Birthdate
+        anchor_date: 1990-07-01
+
+would adjust the ``Birthdate`` field on both load and extract around the anchor date of
+July 1, 1990. Note that date and datetime fields not mapped, as well as fields on other
+steps, are unaffected.
+
 Person Accounts
 ---------------
 

--- a/docs/bulk_data.rst
+++ b/docs/bulk_data.rst
@@ -195,7 +195,9 @@ storage, keeping it relative to the anchor date.
 Relative dating is applied to all date and date-time fields on any mapping step that
 contains the ``anchor_date`` clause. If orgs are `configured <https://help.salesforce.com/articleView?id=000334139&language=en_US&type=1&mode=1>`_ to permit setting audit 
 fields upon record creation and the appropriate user permission is enabled,
-CumulusCI can apply relative dating to audit fields, such as ``CreatedDate``. 
+CumulusCI can apply relative dating to audit fields, such as ``CreatedDate``.
+For more about how to automate that setup, review the ``create_bulk_data_permission_set``
+task below.
 
 For example, this mapping step:
 

--- a/docs/bulk_data.rst
+++ b/docs/bulk_data.rst
@@ -173,6 +173,30 @@ the same Record Type upon load.
 It's recommended that new datasets use Record Type mapping by including the ``RecordTypeId`` 
 field. Using ``record_type`` will result in CumulusCI issuing a warning.
 
+Relative Dates
+--------------
+
+CumulusCI supports maintaining *relative dates*, helping to keep the dataset relevant by
+ensuring that date and date-time fields are updated when loaded.
+
+Relative dates are enabled by defining an *anchor date*, which is specified in each mapping
+step with the ``anchor_date`` key, whose value is a date in the format ``2020-07-01``.
+
+When you specify a relative date, CumulusCI modifies all date and date-time fields on the
+object such that when loaded, they have the same relationship to today as they did to the
+anchor date. Hence, given a stored date of 2020-07-10 and an anchor date of 2020-07-01,
+if you perform a load on 2020-09-10, the date field will be rendered as 2020-09-19 -
+nine days ahead of today's date, as it was nine days ahead of the anchor date.
+
+Relative dates are also adjusted upon extract so that they remain stable. Extracting the same
+data mentioned above would result in CumulusCI adjusting the date back to 2020-07-10 for
+storage, keeping it relative to the anchor date.
+
+Relative dating is applied to all date and date-time fields on any mapping step that
+contains the ``anchor_date`` clause. If orgs are `configured <https://help.salesforce.com/articleView?id=000334139&language=en_US&type=1&mode=1>`_ to permit setting audit 
+fields upon record creation and the appropriate user permission is enabled,
+CumulusCI can apply relative dating to audit fields, such as ``CreatedDate``. 
+
 Person Accounts
 ---------------
 
@@ -200,16 +224,17 @@ CumulusCI supports extracting and loading person account data.  In your dataset 
         - RecordTypeId
 
 Record Types
-************
+++++++++++++
+
 It's recommended, though not required, to extract Account Record Types to support datasets with person accounts so there is consistency in the Account record types loaded.   If Account ``RecordTypeId`` is not extracted, the default business account Record Type and default person account Record Type will be applied to business and person account records respectively.
 
 Extract
-*******
++++++++
 
 During dataset extraction, if the org has person accounts enabled, the ``IsPersonAccount`` field is extracted for **Account** and **Contact** records so CumulusCI can properly load these records later.  Additionally, ``Account.Name`` is not createable for person account **Account** records, so ``Account.Name`` is not extracted for person account **Account** records.
 
 Load
-****
+++++
 
 Before loading, CumulusCI checks if the dataset contains any person account records (i.e. any **Account** or **Contact** records with ``IsPersonAccount`` as ``true``).  If the dataset does contain any person account records, CumulusCI validates the org has person accounts enabled.
 


### PR DESCRIPTION
# Critical Changes

# Changes

- CumulusCI's `load_dataset` and `extract_dataset` tasks now support relative dates. To take advantage of relative dates, include the `anchor_date` key (with a date in `YYYY-MM-DD` format) in each mapping step you wish to relativize. On extract, dates will be modified to be the same interval from the anchor date as they are from the current date; on load, dates will be modified to be the same interval from today's date as they are from their anchor. Both date and date-time fields are supported.

# Issues Closed
