### PR TITLE
Fix JWT aud for instanceless sandboxes

### DIFF
--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -57,7 +57,11 @@ class OrgConfig(BaseConfig):
             SFDX_HUB_KEY = os.environ.get("SFDX_HUB_KEY")
             if SFDX_CLIENT_ID and SFDX_HUB_KEY:
                 info = jwt_session(
-                    SFDX_CLIENT_ID, SFDX_HUB_KEY, self.username, self.instance_url
+                    SFDX_CLIENT_ID,
+                    SFDX_HUB_KEY,
+                    self.username,
+                    self.instance_url,
+                    auth_url=self.id,
                 )
             else:
                 info = self._refresh_token(keychain, connected_app)

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -1158,7 +1158,7 @@ class TestOrgConfig(unittest.TestCase):
 
     @mock.patch("jwt.encode", mock.Mock(return_value="JWT"))
     @responses.activate
-    def test_refresh_oauth_token_jwt(self):
+    def test_refresh_oauth_token__jwt(self):
         responses.add(
             "POST",
             "https://login.salesforce.com/services/oauth2/token",
@@ -1179,7 +1179,7 @@ class TestOrgConfig(unittest.TestCase):
 
     @mock.patch("jwt.encode", mock.Mock(return_value="JWT"))
     @responses.activate
-    def test_refresh_oauth_token_jwt_sandbox(self):
+    def test_refresh_oauth_token__jwt_sandbox(self):
         responses.add(
             "POST",
             "https://cs00.salesforce.com/services/oauth2/token",
@@ -1192,7 +1192,39 @@ class TestOrgConfig(unittest.TestCase):
             os.environ,
             {"SFDX_CLIENT_ID": "some client id", "SFDX_HUB_KEY": "some private key"},
         ):
-            config = OrgConfig({"instance_url": "https://cs00.salesforce.com"}, "test")
+            config = OrgConfig(
+                {
+                    "instance_url": "https://cs00.salesforce.com",
+                },
+                "test",
+            )
+            config._load_userinfo = mock.Mock()
+            config._load_orginfo = mock.Mock()
+            config.refresh_oauth_token(None)
+            assert config.access_token == "TOKEN"
+
+    @mock.patch("jwt.encode", mock.Mock(return_value="JWT"))
+    @responses.activate
+    def test_refresh_oauth_token__jwt_sandbox_instanceless_url(self):
+        responses.add(
+            "POST",
+            "https://nonobvious--sandbox.my.salesforce.com/services/oauth2/token",
+            json={
+                "access_token": "TOKEN",
+                "instance_url": "https://nonobvious--sandbox.my.salesforce.com",
+            },
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"SFDX_CLIENT_ID": "some client id", "SFDX_HUB_KEY": "some private key"},
+        ):
+            config = OrgConfig(
+                {
+                    "instance_url": "https://nonobvious--sandbox.my.salesforce.com",
+                    "id": "https://test.salesforce.com/asdf",
+                },
+                "test",
+            )
             config._load_userinfo = mock.Mock()
             config._load_orginfo = mock.Mock()
             config.refresh_oauth_token(None)

--- a/cumulusci/oauth/salesforce.py
+++ b/cumulusci/oauth/salesforce.py
@@ -25,7 +25,7 @@ SANDBOX_LOGIN_URL = (
 PROD_LOGIN_URL = os.environ.get("SF_PROD_LOGIN_URL") or "https://login.salesforce.com"
 
 
-def jwt_session(client_id, private_key, username, url=None):
+def jwt_session(client_id, private_key, username, url=None, auth_url=None):
     """Complete the JWT Token Oauth flow to obtain an access token for an org.
 
     :param client_id: Client Id for the connected app
@@ -33,24 +33,31 @@ def jwt_session(client_id, private_key, username, url=None):
     :param username: Username to authenticate as
     :param url: Org's instance_url
     """
-    aud = PROD_LOGIN_URL
-    if url is None:
-        url = PROD_LOGIN_URL
+    if auth_url:
+        aud = (
+            SANDBOX_LOGIN_URL
+            if auth_url.startswith(SANDBOX_LOGIN_URL)
+            else PROD_LOGIN_URL
+        )
     else:
-        m = SANDBOX_DOMAIN_RE.match(url)
-        if m is not None:
-            # sandbox
-            aud = SANDBOX_LOGIN_URL
-            # There can be a delay in syncing scratch org credentials
-            # between instances, so let's use the specific one for this org.
-            instance = m.group(2)
-            url = f"https://{instance}.salesforce.com"
+        aud = PROD_LOGIN_URL
+        if url is None:
+            url = PROD_LOGIN_URL
+        else:
+            m = SANDBOX_DOMAIN_RE.match(url)
+            if m is not None:
+                # sandbox
+                aud = SANDBOX_LOGIN_URL
+                # There can be a delay in syncing scratch org credentials
+                # between instances, so let's use the specific one for this org.
+                instance = m.group(2)
+                url = f"https://{instance}.salesforce.com"
 
     payload = {
         "alg": "RS256",
         "iss": client_id,
         "sub": username,
-        "aud": aud,  # jwt aud is NOT mydomain
+        "aud": aud,
         "exp": timegm(datetime.utcnow().utctimetuple()),
     }
     encoded_jwt = jwt.encode(payload, private_key, algorithm="RS256")
@@ -59,8 +66,8 @@ def jwt_session(client_id, private_key, username, url=None):
         "assertion": encoded_jwt,
     }
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
-    auth_url = urljoin(url, "services/oauth2/token")
-    response = requests.post(url=auth_url, data=data, headers=headers)
+    token_url = urljoin(url, "services/oauth2/token")
+    response = requests.post(url=token_url, data=data, headers=headers)
     response.raise_for_status()
     return response.json()
 


### PR DESCRIPTION
When the SFDX_CLIENT_ID and SFDX_HUB_KEY environment variables are set, CumulusCI uses the JWT oauth flow to get a fresh access token for an org. In order to do that, it needs to correctly specify `aud` in the JWT as either https://login.salesforce.com or https://test.salesforce.com

Previously, we used the instance URL to pick the `aud` value (based on whether the URL contained a sandbox instance name like cs22, or not). But lately it is possible for there to be sandboxes with "instanceless" instance URLs that do not include the instance name.

As an alternative, this passes the `id` from the org config into the jwt_session function. It will not always be present, but it should be for orgs that were connected using oauth, and it also starts with either the production or sandbox login URL (login.salesforce.com or test.salesforce.com). If it is present, jwt_session uses it as the signal for which of those to use for the `aud`, instead of using the instance_url.

This is the first step in fixing https://github.com/SFDO-Tooling/MetaCI/issues/1497. The remaining step will be to update MetaCI to use jwt_session from CumulusCI instead of its own copy so that we don't have to maintain it in 2 different places.

# Critical Changes

# Changes

# Issues Closed
- Fixed a bug that prevented using JWT auth with sandboxes if the sandbox's instance_url did not include an instance name.