### PR TITLE
Add task for creating Permission Set with specific User Permissions

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -85,6 +85,20 @@ tasks:
             path: src
             revert_path: src.orig
         group: Salesforce Metadata
+    create_permission_set:
+        group: Metadata Transformations
+        description: Creates a Permission Set with specified User Permissions and assigns it to the running user.
+        class_path: cumulusci.tasks.salesforce.create_permission_sets.CreatePermissionSet
+    create_bulk_data_permission_set:
+        group: Data Operations
+        description: "Creates a Permission Set with the Hard Delete and Set Audit Fields user permissions. NOTE: the org setting to allow Set Audit Fields must be turned on."
+        class_path: cumulusci.tasks.salesforce.create_permission_sets.CreatePermissionSet
+        options:
+            api_name: CumulusCI_Bulk_Data
+            label: CumulusCI Bulk Data
+            user_permissions:
+                - PermissionsBulkApiHardDelete
+                - PermissionsCreateAuditFields
     create_unmanaged_ee_src:
         description: Modifies the src directory for unmanaged deployment to an EE org
         class_path: cumulusci.tasks.metadata.ee_src.CreateUnmanagedEESrc

--- a/cumulusci/tasks/salesforce/create_permission_sets.py
+++ b/cumulusci/tasks/salesforce/create_permission_sets.py
@@ -30,6 +30,6 @@ class CreatePermissionSet(BaseSalesforceApiTask):
                 **{perm: True for perm in self.options["user_permissions"]},
             }
         )
-        result = self.sf.PermissionSetAssignment.create(
+        self.sf.PermissionSetAssignment.create(
             {"AssigneeId": self.org_config.user_id, "PermissionSetId": result["id"]}
         )

--- a/cumulusci/tasks/salesforce/create_permission_sets.py
+++ b/cumulusci/tasks/salesforce/create_permission_sets.py
@@ -5,7 +5,7 @@ from cumulusci.core.utils import process_list_arg
 class CreatePermissionSet(BaseSalesforceApiTask):
     task_options = {
         "api_name": {
-            "description": "API names of generated Permission Set",
+            "description": "API name of generated Permission Set",
             "required": True,
         },
         "label": {"description": "Label of generated Permission Set"},

--- a/cumulusci/tasks/salesforce/create_permission_sets.py
+++ b/cumulusci/tasks/salesforce/create_permission_sets.py
@@ -1,0 +1,35 @@
+from cumulusci.tasks.salesforce.BaseSalesforceApiTask import BaseSalesforceApiTask
+from cumulusci.core.utils import process_list_arg
+
+
+class CreatePermissionSet(BaseSalesforceApiTask):
+    task_options = {
+        "api_name": {
+            "description": "API names of generated Permission Set",
+            "required": True,
+        },
+        "label": {"description": "Label of generated Permission Set"},
+        "user_permissions": {
+            "description": "List of User Permissions to include in the Permission Set.",
+            "required": True,
+        },
+    }
+
+    def _init_options(self, kwargs):
+        super()._init_options(kwargs)
+
+        self.options["user_permissions"] = process_list_arg(
+            self.options["user_permissions"]
+        )
+
+    def _run_task(self):
+        result = self.sf.PermissionSet.create(
+            {
+                "Name": self.options["api_name"],
+                "Label": self.options.get("label") or self.options["api_name"],
+                **{perm: True for perm in self.options["user_permissions"]},
+            }
+        )
+        result = self.sf.PermissionSetAssignment.create(
+            {"AssigneeId": self.org_config.user_id, "PermissionSetId": result["id"]}
+        )

--- a/cumulusci/tasks/salesforce/tests/test_create_permission_sets.py
+++ b/cumulusci/tasks/salesforce/tests/test_create_permission_sets.py
@@ -1,0 +1,38 @@
+import responses
+from cumulusci.tasks.salesforce.create_permission_sets import CreatePermissionSet
+from .util import create_task
+
+
+class TestCreatePermissionSet:
+    @responses.activate
+    def test_create_permset(self):
+        task = create_task(
+            CreatePermissionSet,
+            {
+                "api_name": "PermSet",
+                "label": "Permission Set",
+                "user_permissions": [
+                    "PermissionsBulkApiHardDelete",
+                    "PermissionsCreateAuditFields",
+                ],
+            },
+        )
+
+        responses.add(
+            method="POST",
+            url=f"{task.org_config.instance_url}/services/data/v49.0/sobjects/PermissionSet/",
+            status=200,
+            json={"id": "0PS3F000000fCNPWA2", "success": True, "errors": []},
+        )
+        responses.add(
+            method="POST",
+            url=f"{task.org_config.instance_url}/services/data/v49.0/sobjects/PermissionSetAssignment/",
+            status=200,
+            json={"id": "0Pa000000000001", "success": True, "errors": []},
+        )
+
+        task()
+
+        assert len(responses.calls) == 2
+        assert "PermissionsBulkApiHardDelete" in responses.calls[0].request.body
+        assert "PermissionsCreateAuditFields" in responses.calls[0].request.body

--- a/docs/bulk_data.rst
+++ b/docs/bulk_data.rst
@@ -375,6 +375,29 @@ name (List) or setup owner (Hierarchy) will be updated with the given data.
 Dataset Tasks
 =============
 
+``create_bulk_data_permission_set``
+-----------------------------------
+
+Create and assign a Permission Set that enables key features used in Bulk Data
+tasks (Hard Delete and Set Audit Fields) for the current user. The Permission
+Set will be called ``CumulusCI Bulk Data``.
+
+Note that prior to running this task you must ensure that your org is configured
+to allow the use of Set Audit Fields. You can do so by manually updating
+the required setting in the User Interface section of Saleforce Setup, or by
+updating your scratch org configuration to include ::
+
+    "securitySettings": {
+      "enableAuditFieldsInactiveOwner": true
+    }
+
+For more information about the Set Audit Fields feature, review `this Knowledge
+article <https://help.salesforce.com/articleView?id=000213290&type=1>`_.
+
+After this task runs, you'll be able to run the ``delete_data`` task with the
+``hardDelete`` option, and you'll be able to map audit fields like ``CreatedDate``.
+
+
 ``extract_dataset``
 -------------------
 

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -693,6 +693,76 @@ Options
 
 	 Default: src.orig
 
+**create_permission_set**
+==========================================
+
+**Description:** Creates a Permission Set with specified User Permissions and assigns it to the running user.
+
+**Class:** cumulusci.tasks.salesforce.create_permission_sets.CreatePermissionSet
+
+Command Syntax
+------------------------------------------
+
+``$ cci task run create_permission_set``
+
+
+Options
+------------------------------------------
+
+
+``-o api_name APINAME``
+	 *Required*
+
+	 API names of generated Permission Set
+
+``-o user_permissions USERPERMISSIONS``
+	 *Required*
+
+	 List of User Permissions to include in the Permission Set.
+
+``-o label LABEL``
+	 *Optional*
+
+	 Label of generated Permission Set
+
+**create_bulk_data_permission_set**
+==========================================
+
+**Description:** Creates a Permission Set with the Hard Delete and Set Audit Fields user permissions. NOTE: the org setting to allow Set Audit Fields must be turned on.
+
+**Class:** cumulusci.tasks.salesforce.create_permission_sets.CreatePermissionSet
+
+Command Syntax
+------------------------------------------
+
+``$ cci task run create_bulk_data_permission_set``
+
+
+Options
+------------------------------------------
+
+
+``-o api_name APINAME``
+	 *Required*
+
+	 API names of generated Permission Set
+
+	 Default: CumulusCI_Bulk_Data
+
+``-o user_permissions USERPERMISSIONS``
+	 *Required*
+
+	 List of User Permissions to include in the Permission Set.
+
+	 Default: ['PermissionsBulkApiHardDelete', 'PermissionsCreateAuditFields']
+
+``-o label LABEL``
+	 *Optional*
+
+	 Label of generated Permission Set
+
+	 Default: CumulusCI Bulk Data
+
 **create_unmanaged_ee_src**
 ==========================================
 

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -745,7 +745,7 @@ Options
 ``-o api_name APINAME``
 	 *Required*
 
-	 API names of generated Permission Set
+	 API name of generated Permission Set
 
 	 Default: CumulusCI_Bulk_Data
 
@@ -4536,3 +4536,4 @@ Options
 	 If True, restore the state of Trigger Handlers to that stored in the (specified or default) restore file.
 
 	 Default: True
+

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -713,7 +713,7 @@ Options
 ``-o api_name APINAME``
 	 *Required*
 
-	 API names of generated Permission Set
+	 API name of generated Permission Set
 
 ``-o user_permissions USERPERMISSIONS``
 	 *Required*
@@ -4536,4 +4536,3 @@ Options
 	 If True, restore the state of Trigger Handlers to that stored in the (specified or default) restore file.
 
 	 Default: True
-


### PR DESCRIPTION
# Critical Changes

# Changes

- The task `create_permission_set` allows for creating and assigning a Permission Set that enables specific User Permissions. (Note: other types of permissions are not yet supported).
- The task `create_bulk_data_permission_set` creates a Permission Set with the Hard Delete and Set Audit Fields permissions for use with data load operations. The org permission to allow Set Audit Fields must be turned on. 

# Issues Closed
