### PR TITLE
Make all tests independent of home directory

### DIFF
--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -67,7 +67,6 @@ class TestCCI(unittest.TestCase):
         cls.environ_mock = mock.patch.dict(
             os.environ, {"HOME": tempfile.mkdtemp(), "CUMULUSCI_KEY": ""}
         )
-        assert cls.global_tempdir not in os.environ.get("HOME", "")
         cls.environ_mock.start()
         assert cls.global_tempdir in os.environ["HOME"]
 
@@ -76,7 +75,6 @@ class TestCCI(unittest.TestCase):
         assert cls.global_tempdir in os.environ["HOME"]
         cls.environ_mock.stop()
         shutil.rmtree(cls.tempdir)
-        assert cls.global_tempdir not in os.environ.get("HOME", "")
 
     def setUp(self):
         self.cleanup_org_cache_dirs = mock.Mock(name="cleanup_org_cache_dirs")

--- a/cumulusci/conftest.py
+++ b/cumulusci/conftest.py
@@ -85,7 +85,7 @@ create_task_fixture = fixture(create_task_fixture, scope="function")
 #       test case changes.
 @pytest.fixture(autouse=True, scope="session")
 def patch_home(request):
-    with TemporaryDirectory() as home, mock.patch(
+    with TemporaryDirectory(prefix="fake_home_") as home, mock.patch(
         "pathlib.Path.home", lambda: Path(home)
     ), mock.patch.dict(
         os.environ,

--- a/cumulusci/conftest.py
+++ b/cumulusci/conftest.py
@@ -2,6 +2,9 @@ import io
 import os
 from http.client import HTTPMessage
 from unittest import mock
+import pytest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from pytest import fixture
 from cumulusci.core.github import get_github_api
@@ -75,3 +78,19 @@ vcr_config = fixture(vcr_config, scope="module")
 vcr = fixture(salesforce_vcr, scope="module")
 
 create_task_fixture = fixture(create_task_fixture, scope="function")
+
+
+# TODO: This should also chdir to a temp directory which
+#       can represent the repo-root, but that will require
+#       test case changes.
+@pytest.fixture(autouse=True, scope="session")
+def patch_home(request):
+    with TemporaryDirectory() as home, mock.patch(
+        "pathlib.Path.home", lambda: Path(home)
+    ), mock.patch.dict(
+        os.environ,
+        {"HOME": home, "USERPROFILE": home, "CUMULUSCI_KEY": "0123456789ABCDEF"},
+    ):
+        Path(home, ".cumulusci").mkdir()
+        Path(home, ".cumulusci/cumulusci.yml").touch()
+        yield

--- a/cumulusci/conftest.py
+++ b/cumulusci/conftest.py
@@ -84,7 +84,7 @@ create_task_fixture = fixture(create_task_fixture, scope="function")
 #       can represent the repo-root, but that will require
 #       test case changes.
 @pytest.fixture(autouse=True, scope="session")
-def patch_home(request):
+def patch_home_and_env(request):
     with TemporaryDirectory(prefix="fake_home_") as home, mock.patch(
         "pathlib.Path.home", lambda: Path(home)
     ), mock.patch.dict(

--- a/cumulusci/conftest.py
+++ b/cumulusci/conftest.py
@@ -85,6 +85,7 @@ create_task_fixture = fixture(create_task_fixture, scope="function")
 #       test case changes.
 @pytest.fixture(autouse=True, scope="session")
 def patch_home_and_env(request):
+    "Patch the default home directory and $HOME environment for all tests at once."
     with TemporaryDirectory(prefix="fake_home_") as home, mock.patch(
         "pathlib.Path.home", lambda: Path(home)
     ), mock.patch.dict(

--- a/cumulusci/core/tests/test_config_expensive.py
+++ b/cumulusci/core/tests/test_config_expensive.py
@@ -25,10 +25,10 @@ __location__ = os.path.dirname(os.path.realpath(__file__))
 
 @mock.patch("pathlib.Path.home")
 class TestUniversalConfig(unittest.TestCase):
-    def setup_method(self, method):
+    def setUp(self):
         self.tempdir_home = Path(tempfile.mkdtemp())
 
-    def teardown_method(self, method):
+    def tearDown(self):
         shutil.rmtree(self.tempdir_home)
 
     def _create_universal_config_local(self, content):
@@ -52,8 +52,9 @@ class TestUniversalConfig(unittest.TestCase):
 
     def test_load_universal_config_empty_local(self, mock_class):
         self._create_universal_config_local("")
+        # clear cache
+        UniversalConfig.config = None
         mock_class.return_value = self.tempdir_home
-
         config = UniversalConfig()
         with open(__location__ + "/../../cumulusci.yml", "r") as f_expected_config:
             expected_config = yaml.safe_load(f_expected_config)
@@ -77,6 +78,17 @@ class TestUniversalConfig(unittest.TestCase):
 
 @mock.patch("pathlib.Path.home")
 class TestBaseProjectConfig(unittest.TestCase):
+    def setUp(self):
+        self.tempdir_home = Path(tempfile.mkdtemp())
+        self.tempdir_project = tempfile.mkdtemp()
+        self.project_name = "TestRepo"
+        self.current_commit = "abcdefg1234567890"
+        self.current_branch = "main"
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir_home)
+        shutil.rmtree(self.tempdir_project)
+
     def _create_git_config(self):
 
         filename = os.path.join(self.tempdir_project, ".git", "config")
@@ -123,17 +135,6 @@ class TestBaseProjectConfig(unittest.TestCase):
     def _write_file(self, filename, content):
         with open(filename, "w") as f:
             f.write(content)
-
-    def setup_method(self, method):
-        self.tempdir_home = Path(tempfile.mkdtemp())
-        self.tempdir_project = tempfile.mkdtemp()
-        self.project_name = "TestRepo"
-        self.current_commit = "abcdefg1234567890"
-        self.current_branch = "main"
-
-    def teardown_method(self, method):
-        shutil.rmtree(self.tempdir_home)
-        shutil.rmtree(self.tempdir_project)
 
     def test_load_project_config_not_repo(self, mock_class):
         mock_class.return_value = self.tempdir_home


### PR DESCRIPTION
Create a fake HOME directory to insulate all tests from the user's real HOME directory (and vice versa).