### PR TITLE
Robot Doc Title Changes

### DIFF
--- a/docs/robotframework-debugger.rst
+++ b/docs/robotframework-debugger.rst
@@ -1,6 +1,6 @@
-========================
-Robot Framework Debugger
-========================
+==============
+Robot Debugger
+==============
 
 CumulusCI includes a rudimentary debugger which can be enabled by
 setting the ``debug`` option of the **robot** task to ``True``. When

--- a/docs/robotframework-tutorial.rst
+++ b/docs/robotframework-tutorial.rst
@@ -1,6 +1,6 @@
-========================
-Robot Framework Tutorial
-========================
+==============
+Robot Tutorial
+==============
 
 This tutorial will step you through writing your first test, then
 enhancing that test with a custom keyword implemented as a page


### PR DESCRIPTION
# Changes
This is intended to improve the readability of the navigation sidebar that sphinx creates with the Alabaster theme. The title "Robot Framework Debugger" currently has the word "Debugger" wrapped underneath, which makes it look like there are two separate sections—"Robot Framework" and "Debugger". I removed the word "framework" from the "Robot Framework Tutorial" section as well for consistency. 

Current state looks like this:
<img width="230" alt="Screen Shot 2020-09-20 at 7 02 19 AM" src="https://user-images.githubusercontent.com/6100538/93713227-48a3d880-fb0f-11ea-9d34-0b46dfa38655.png">


The proposed changes  look like this:
<img width="208" alt="Screen Shot 2020-09-20 at 7 06 26 AM" src="https://user-images.githubusercontent.com/6100538/93713322-d67fc380-fb0f-11ea-97c0-6dffaecf550c.png">

