### PR TITLE
fix more problems with using the wrong encoding on Windows

### DIFF
--- a/cumulusci/core/config/project_config.py
+++ b/cumulusci/core/config/project_config.py
@@ -97,7 +97,7 @@ class BaseProjectConfig(BaseTaskFlowConfig):
             )
 
         # Load the project's yaml config file
-        with open(self.config_project_path, "r") as f_config:
+        with open(self.config_project_path, "r", encoding="utf-8") as f_config:
             project_config = cci_safe_load(f_config)
 
         if project_config:
@@ -105,7 +105,9 @@ class BaseProjectConfig(BaseTaskFlowConfig):
 
         # Load the local project yaml config file if it exists
         if self.config_project_local_path:
-            with open(self.config_project_local_path, "r") as f_local_config:
+            with open(
+                self.config_project_local_path, "r", encoding="utf-8"
+            ) as f_local_config:
                 local_config = cci_safe_load(f_local_config)
             if local_config:
                 self.config_project_local.update(local_config)
@@ -449,7 +451,9 @@ class BaseProjectConfig(BaseTaskFlowConfig):
 
     @property
     def sfdx_project_config(self):
-        with open(Path(self.repo_root) / "sfdx-project.json", "r") as f:
+        with open(
+            Path(self.repo_root) / "sfdx-project.json", "r", encoding="utf-8"
+        ) as f:
             config = json.load(f)
         return config
 

--- a/cumulusci/core/config/universal_config.py
+++ b/cumulusci/core/config/universal_config.py
@@ -64,13 +64,13 @@ class UniversalConfig(BaseTaskFlowConfig):
             return
 
         # load the global config
-        with open(self.config_universal_path, "r") as f_config:
+        with open(self.config_universal_path, "r", encoding="utf-8") as f_config:
             config = yaml.safe_load(f_config)
         UniversalConfig.config_universal = config
 
         # Load the local config
         if self.config_global_path:
-            with open(self.config_global_path, "r") as f:
+            with open(self.config_global_path, "r", encoding="utf-8") as f:
                 config = yaml.safe_load(f)
         else:
             config = {}


### PR DESCRIPTION
Make sure we're opening config files as utf-8

# Critical Changes

# Changes

# Issues Closed
- Fixed UnicodeDecodeError while opening config files on Windows.