### PR TITLE
Flow Groups

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1316,7 +1316,6 @@ def org_shell(runtime, org_name, script=None, python=None):
 @click.option("--json", "print_json", is_flag=True, help="Print a json string")
 @pass_runtime(require_project=False)
 def task_list(runtime, plain, print_json):
-    task_groups = {}
     tasks = (
         runtime.project_config.list_tasks()
         if runtime.project_config is not None
@@ -1328,6 +1327,7 @@ def task_list(runtime, plain, print_json):
         click.echo(json.dumps(tasks))
         return None
 
+    task_groups = {}
     for task in tasks:
         group = task["group"] or "Other"
         if group not in task_groups:

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -12,11 +12,11 @@ import shutil
 import sys
 import time
 import traceback
-from datetime import datetime
+import runpy
 import webbrowser
 import contextlib
 from pathlib import Path
-import runpy
+from datetime import datetime
 
 import click
 import github3
@@ -1637,11 +1637,9 @@ def gist(runtime):
 
 
 def group_items(items):
-    groups = {}
+    groups = defaultdict(list)
     for item in items:
-        group = item["group"] or "Other"
-        if group not in groups:
-            groups[group] = []
-        groups[group].append([item["name"], item["description"]])
+        group_name = item["group"] or "Other"
+        groups[group_name].append([item["name"], item["description"]])
 
     return groups

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1473,11 +1473,18 @@ def flow_list(runtime, plain, print_json):
         click.echo(json.dumps(flows))
         return None
 
-    data = [["Name", "Description"]]
-    data.extend([flow["name"], flow["description"]] for flow in flows)
+    flow_groups = {}
+    for flow in flows:
+        group = flow["group"] or "Other"
+        if group not in flow_groups:
+            flow_groups[group] = []
+        flow_groups[group].append([flow["name"], flow["description"]])
 
-    table = CliTable(data, title="Flows", wrap_cols=["Description"])
-    table.echo(plain=plain)
+    for group, flows in flow_groups.items():
+        data = [["Flow", "Description"]]
+        data.extend(sorted(flows))
+        table = CliTable(data, group, wrap_cols=["Description"])
+        table.echo(plain)
 
     click.echo(
         "Use "

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1327,13 +1327,7 @@ def task_list(runtime, plain, print_json):
         click.echo(json.dumps(tasks))
         return None
 
-    task_groups = {}
-    for task in tasks:
-        group = task["group"] or "Other"
-        if group not in task_groups:
-            task_groups[group] = []
-        task_groups[group].append([task["name"], task["description"]])
-
+    task_groups = group_items(tasks)
     for group, tasks in task_groups.items():
         data = [["Task", "Description"]]
         data.extend(sorted(tasks))
@@ -1473,13 +1467,7 @@ def flow_list(runtime, plain, print_json):
         click.echo(json.dumps(flows))
         return None
 
-    flow_groups = {}
-    for flow in flows:
-        group = flow["group"] or "Other"
-        if group not in flow_groups:
-            flow_groups[group] = []
-        flow_groups[group].append([flow["name"], flow["description"]])
-
+    flow_groups = group_items(flows)
     for group, flows in flow_groups.items():
         data = [["Flow", "Description"]]
         data.extend(sorted(flows))
@@ -1646,3 +1634,14 @@ def gist(runtime):
     else:
         click.echo(f"Gist created: {gist.html_url}")
         webbrowser.open(gist.html_url)
+
+
+def group_items(items):
+    groups = {}
+    for item in items:
+        group = item["group"] or "Other"
+        if group not in groups:
+            groups[group] = []
+        groups[group].append([item["name"], item["description"]])
+
+    return groups

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -1918,14 +1918,14 @@ Environment Info: Rossian / x68_46
     def test_flow_list(self, cli_tbl):
         runtime = mock.Mock()
         runtime.project_config.list_flows.return_value = [
-            {"name": "test_flow", "description": "Test Flow"}
+            {"name": "test_flow", "description": "Test Flow", "group": "Testing"}
         ]
         runtime.universal_config.cli__plain_output = None
         run_click_command(cci.flow_list, runtime=runtime, plain=False, print_json=False)
 
         cli_tbl.assert_called_with(
-            [["Name", "Description"], ["test_flow", "Test Flow"]],
-            title="Flows",
+            [["Flow", "Description"], ["test_flow", "Test Flow"]],
+            "Testing",
             wrap_cols=["Description"],
         )
 

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -984,28 +984,6 @@ flows:
                     package_type: Managed
                     package_name: $project_config.project__package__name Managed Feature Test
 
-    retrieve_scratch:
-        description: Retrieves declarative changes made in a scratch org and converts to src directory
-        steps:
-            1:
-                task: dx_convert_to
-            2:
-                task: dx_pull
-            3:
-                task: dx_convert_from
-            4:
-                task: update_package_xml
-            # The conversion reorders elements in .object files and others.
-            # Retrieve from the org using the new package.xml and then rewrite
-            # the package.xml
-            5:
-                task: retrieve_unpackaged
-                options:
-                    package_xml: src/package.xml
-                    path: src
-            6:
-                task: update_package_xml
-
     unmanaged_ee:
         group: Deployment
         description: Deploy the unmanaged package metadata and all dependencies to the target EE org

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -564,7 +564,7 @@ flows:
                     managed: True
 
     ci_feature:
-        group: Continous Integration
+        group: Continuous Integration
         description: Prepare an unmanaged metadata test org and run Apex tests. Intended for use against feature branch commits.
         steps:
             0.5:
@@ -584,7 +584,7 @@ flows:
                 task: github_parent_to_children
 
     ci_feature_beta_deps:
-        group: Continous Integration
+        group: Continuous Integration
         description: Install the latest beta version of dependencies and run apex tests.
         steps:
             0.5:
@@ -604,7 +604,7 @@ flows:
                 task: github_parent_to_children
 
     ci_feature_2gp:
-        group: Continous Integration
+        group: Continuous Integration
         description: Install as a managed 2gp package and run Apex tests. Intended for use after build_feature_test_package.
         steps:
             1:
@@ -631,7 +631,7 @@ flows:
 
 
     ci_master:
-        group: Continous Integration
+        group: Continuous Integration
         description: Deploy the package metadata to the packaging org and prepare for managed package version upload.  Intended for use against main branch commits.
         steps:
             1:
@@ -645,7 +645,7 @@ flows:
                 flow: config_packaging
 
     ci_release:
-        group: Continous Integration
+        group: Continuous Integration
         description: Install a production release version and runs tests from the managed package
         steps:
             1:

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -927,7 +927,7 @@ flows:
                 task: install_managed_beta
 
     release_beta:
-        group: Release Management
+        group: Release Operations
         description: Upload and release a beta version of the metadata currently in packaging
         steps:
             1:
@@ -953,7 +953,7 @@ flows:
                 task: github_master_to_feature
 
     release_production:
-        group: Release Management
+        group: Release Operations
         description: Upload and release a production version of the metadata currently in packaging
         steps:
             1:
@@ -973,6 +973,7 @@ flows:
                     version_id: ^^upload_production.version_id
 
     build_feature_test_package:
+        group: Release Operations
         description: Create a 2gp managed package version
         steps:
             1:

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -553,6 +553,7 @@ tasks:
 
 flows:
     ci_beta:
+        group: Continous Integration
         description: Install the latest beta version and runs apex tests from the managed package
         steps:
             1:
@@ -563,6 +564,7 @@ flows:
                     managed: True
 
     ci_feature:
+        group: Continous Integration
         description: Prepare an unmanaged metadata test org and run Apex tests. Intended for use against feature branch commits.
         steps:
             0.5:
@@ -582,6 +584,7 @@ flows:
                 task: github_parent_to_children
 
     ci_feature_beta_deps:
+        group: Continous Integration
         description: Install the latest beta version of dependencies and run apex tests.
         steps:
             0.5:
@@ -601,6 +604,7 @@ flows:
                 task: github_parent_to_children
 
     ci_feature_2gp:
+        group: Continous Integration
         description: Install as a managed 2gp package and run Apex tests. Intended for use after build_feature_test_package.
         steps:
             1:
@@ -627,6 +631,7 @@ flows:
 
 
     ci_master:
+        group: Continous Integration
         description: Deploy the package metadata to the packaging org and prepare for managed package version upload.  Intended for use against main branch commits.
         steps:
             1:
@@ -640,6 +645,7 @@ flows:
                 flow: config_packaging
 
     ci_release:
+        group: Continous Integration
         description: Install a production release version and runs tests from the managed package
         steps:
             1:
@@ -650,6 +656,7 @@ flows:
                     managed: True
 
     config_apextest:
+        group: Org Configuraiton 
         description: Configure an org to run apex tests after package metadata is deployed
         steps:
             1:
@@ -658,6 +665,7 @@ flows:
                 task: update_admin_profile
 
     config_dev:
+        group: Org Configuraiton 
         description: Configure an org for use as a dev org after package metadata is deployed
         steps:
             1:
@@ -666,6 +674,7 @@ flows:
                 task: update_admin_profile
 
     config_managed:
+        group: Org Configuraiton 
         description: Configure an org for use as a dev org after package metadata is deployed
         steps:
             1:
@@ -678,6 +687,7 @@ flows:
                     managed: true
 
     config_packaging:
+        group: Org Configuraiton 
         description: Configure packaging org for upload after package metadata is deployed
         steps:
             1:
@@ -686,6 +696,7 @@ flows:
                     managed: True
 
     config_qa:
+        group: Org Configuraiton 
         description: Configure an org for use as a QA org after package metadata is deployed
         steps:
             1:
@@ -694,12 +705,14 @@ flows:
                 task: update_admin_profile
 
     config_regression:
+        group: Org Configuraiton 
         description: Configure an org for QA regression after the package is installed
         steps:
             1:
                 flow: config_managed
 
     dependencies:
+        group: Dependency Management
         description: Deploy dependencies to prepare the org environment for the package metadata
         steps:
             1:
@@ -708,6 +721,7 @@ flows:
                 task: deploy_pre
 
     beta_dependencies:
+        group: Dependency Management
         description: Deploy the latest (beta) version of dependencies to prepare the org environment for the package metadata
         steps:
             1:
@@ -718,6 +732,7 @@ flows:
                 task: deploy_pre
 
     deploy_unmanaged:
+        group: Deployment
         description: Deploy the unmanaged metadata from the package
         steps:
             0:
@@ -739,6 +754,7 @@ flows:
                 when: project_config.project__source_format != "sfdx" or not org_config.scratch
 
     deploy_unmanaged_ee:
+        group: Deployment
         description: Deploy the unmanaged metadata from the package to an Enterprise Edition org
         steps:
             0:
@@ -760,6 +776,7 @@ flows:
                     purge_on_delete: False
 
     deploy_packaging:
+        group: Deployment
         description: Process and deploy the package metadata to the packaging org
         steps:
             0:
@@ -781,6 +798,7 @@ flows:
                 task: uninstall_packaged_incremental
 
     dev_org:
+        group: Org Creation
         description: Set up an org as a development environment for unmanaged metadata
         steps:
             1:
@@ -793,6 +811,7 @@ flows:
                 task: snapshot_changes
 
     dev_org_beta_deps:
+        group: Org Creation
         description: Set up an org as a development environment for unmanaged metadata based on the latest dependencies (including betas).
         steps:
             1:
@@ -803,6 +822,7 @@ flows:
                 flow: config_dev
 
     dev_org_namespaced:
+        group: Org Creation
         description: Set up a namespaced scratch org as a development environment for unmanaged metadata
         steps:
             1:
@@ -824,6 +844,7 @@ flows:
                 task: snapshot_changes
 
     qa_org:
+        group: Org Creation
         description: Set up an org as a QA environment for unmanaged metadata
         steps:
             1:
@@ -836,6 +857,7 @@ flows:
                 task: snapshot_changes
 
     regression_org:
+        group: Org Creation
         description: Simulates an org that has been upgraded from the latest release of to the current beta and its dependencies, but deploys any unmanaged metadata from the current beta.
         steps:
             1:
@@ -846,6 +868,7 @@ flows:
                 task: snapshot_changes
 
     uninstall_managed:
+        group: Install / Uninstall
         description: Uninstall the installed managed version of the package.  Run this before install_beta or install_prod if a version is already installed in the target org.
         steps:
             1:
@@ -854,6 +877,7 @@ flows:
                 task: uninstall_managed
 
     install_beta:
+        group: Install / Uninstall
         description: Install and configure the latest beta version
         steps:
             1:
@@ -866,6 +890,7 @@ flows:
                 task: snapshot_changes
 
     install_prod:
+        group: Install / Uninstall
         description: Install and configure the latest production version
         steps:
             1:
@@ -878,6 +903,7 @@ flows:
                 task: snapshot_changes
 
     install_prod_no_config:
+        group: Install / Uninstall
         description: Install but do not configure the latest production version
         steps:
             1:
@@ -890,6 +916,7 @@ flows:
                     unmanaged: False
 
     install_regression:
+        group: Install / Uninstall
         description: Install the latest beta dependencies and upgrade to the latest beta version from the most recent production version
         steps:
             1:
@@ -900,6 +927,7 @@ flows:
                 task: install_managed_beta
 
     release_beta:
+        group: Release Management
         description: Upload and release a beta version of the metadata currently in packaging
         steps:
             1:
@@ -925,6 +953,7 @@ flows:
                 task: github_master_to_feature
 
     release_production:
+        group: Release Management
         description: Upload and release a production version of the metadata currently in packaging
         steps:
             1:
@@ -978,6 +1007,7 @@ flows:
                 task: update_package_xml
 
     unmanaged_ee:
+        group: Deployment
         description: Deploy the unmanaged package metadata and all dependencies to the target EE org
         steps:
             1:

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -656,7 +656,7 @@ flows:
                     managed: True
 
     config_apextest:
-        group: Org Configuraiton 
+        group: Post-Install Configuration
         description: Configure an org to run apex tests after package metadata is deployed
         steps:
             1:
@@ -665,7 +665,7 @@ flows:
                 task: update_admin_profile
 
     config_dev:
-        group: Org Configuraiton 
+        group: Post-Install Configuration
         description: Configure an org for use as a dev org after package metadata is deployed
         steps:
             1:
@@ -674,7 +674,7 @@ flows:
                 task: update_admin_profile
 
     config_managed:
-        group: Org Configuraiton 
+        group: Post-Install Configuration 
         description: Configure an org for use as a dev org after package metadata is deployed
         steps:
             1:
@@ -687,7 +687,7 @@ flows:
                     managed: true
 
     config_packaging:
-        group: Org Configuraiton 
+        group: Post-Install Configuration 
         description: Configure packaging org for upload after package metadata is deployed
         steps:
             1:
@@ -696,7 +696,7 @@ flows:
                     managed: True
 
     config_qa:
-        group: Org Configuraiton 
+        group: Post-Install Configuration 
         description: Configure an org for use as a QA org after package metadata is deployed
         steps:
             1:
@@ -705,7 +705,7 @@ flows:
                 task: update_admin_profile
 
     config_regression:
-        group: Org Configuraiton 
+        group: Post-Install Configuration 
         description: Configure an org for QA regression after the package is installed
         steps:
             1:

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -553,7 +553,7 @@ tasks:
 
 flows:
     ci_beta:
-        group: Continous Integration
+        group: Continuous Integration
         description: Install the latest beta version and runs apex tests from the managed package
         steps:
             1:

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -798,7 +798,7 @@ flows:
                 task: uninstall_packaged_incremental
 
     dev_org:
-        group: Org Creation
+        group: Org Setup
         description: Set up an org as a development environment for unmanaged metadata
         steps:
             1:
@@ -811,7 +811,7 @@ flows:
                 task: snapshot_changes
 
     dev_org_beta_deps:
-        group: Org Creation
+        group: Org Setup
         description: Set up an org as a development environment for unmanaged metadata based on the latest dependencies (including betas).
         steps:
             1:
@@ -822,7 +822,7 @@ flows:
                 flow: config_dev
 
     dev_org_namespaced:
-        group: Org Creation
+        group: Org Setup
         description: Set up a namespaced scratch org as a development environment for unmanaged metadata
         steps:
             1:
@@ -844,7 +844,7 @@ flows:
                 task: snapshot_changes
 
     qa_org:
-        group: Org Creation
+        group: Org Setup
         description: Set up an org as a QA environment for unmanaged metadata
         steps:
             1:
@@ -857,7 +857,7 @@ flows:
                 task: snapshot_changes
 
     regression_org:
-        group: Org Creation
+        group: Org Setup
         description: Simulates an org that has been upgraded from the latest release of to the current beta and its dependencies, but deploys any unmanaged metadata from the current beta.
         steps:
             1:
@@ -877,7 +877,7 @@ flows:
                 task: uninstall_managed
 
     install_beta:
-        group: Install / Uninstall
+        group: Org Setup
         description: Install and configure the latest beta version
         steps:
             1:
@@ -890,7 +890,7 @@ flows:
                 task: snapshot_changes
 
     install_prod:
-        group: Install / Uninstall
+        group: Org Setup
         description: Install and configure the latest production version
         steps:
             1:

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -283,7 +283,7 @@ tasks:
     metadeploy_publish:
         description: Publish a release to the MetaDeploy web installer
         class_path: cumulusci.tasks.metadeploy.Publish
-        group: Release Management
+        group: Release Operations
     org_settings:
         description: Apply org settings from a scratch org definition file
         class_path: cumulusci.tasks.salesforce.org_settings.DeployOrgSettings
@@ -485,14 +485,14 @@ tasks:
     upload_beta:
         description: Uploads a beta release of the metadata currently in the packaging org
         class_path: cumulusci.tasks.salesforce.PackageUpload
-        group: Release Management
+        group: Release Operations
     upload_production:
         description: Uploads a production release of the metadata currently in the packaging org
         class_path: cumulusci.tasks.salesforce.PackageUpload
         options:
             name: Release
             production: True
-        group: Release Management
+        group: Release Operations
     upload_user_profile_photo:
         group: Salesforce Users
         description: Uploads a profile photo for a specified or default User.


### PR DESCRIPTION
Closes #1833

Please comment on initial group names / groupings, they are malleable.

# Changes
* `cci flow list` now displays flows in groups (like `cci task list`)
* Removed the `retrieve_scratch` flow. This predated the `retrieve_changes` task which is the current recommendation for retrieving source-tracked changes.