### PR TITLE
Feature/robot pabot fixes

### DIFF
--- a/cumulusci/tasks/robotframework/robotframework.py
+++ b/cumulusci/tasks/robotframework/robotframework.py
@@ -123,7 +123,9 @@ class Robot(BaseSalesforceTask):
                     cmd.extend([f"--{option}", str(value)])
 
             cmd.append(self.options["suites"])
-            self.logger.info(f"pabot command: {shlex.join(cmd)}")
+            self.logger.info(
+                f"pabot command: {' '.join([shlex.quote(x) for x in cmd])}"
+            )
             result = subprocess.run(cmd)
             num_failed = result.returncode
 

--- a/cumulusci/tasks/robotframework/tests/test_robotframework.py
+++ b/cumulusci/tasks/robotframework/tests/test_robotframework.py
@@ -7,6 +7,7 @@ import os.path
 import re
 import sys
 from xml.etree import ElementTree as ET
+from pathlib import Path
 
 from cumulusci.core.config import TaskConfig
 from cumulusci.core.exceptions import RobotTestFailure, TaskOptionsError
@@ -105,6 +106,8 @@ class TestRobot(unittest.TestCase):
             "--pabotlib",
             "--processes",
             "2",
+            "--pythonpath",
+            str(Path.cwd()),
             "--variable",
             "org:test",
             "--outputdir",


### PR DESCRIPTION
This fixes a bug related to the recently released `--processes` option which prevented tests from running if they used relative imports. This was caused by spawned processes not picking up the correct PYTHONPATH before executing robot.

# Critical Changes

# Changes

# Issues Closed
