### PR TITLE
Don't automerge from 2gp feature builds yet

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -625,8 +625,6 @@ flows:
                 task: run_tests
                 options:
                     managed: True
-            6:
-                task: github_automerge_feature
 
 
     ci_master:


### PR DESCRIPTION
For a while we'll be using the ci_feature_2gp flow in parallel with the existing ci_feature flow, so let's avoid a race condition where they're both trying to automerge.

# Critical Changes

# Changes

# Issues Closed
