### PR TITLE
Patch around issue with null SubscriberPackageVersion

### DIFF
--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -269,6 +269,10 @@ class OrgConfig(BaseConfig):
             for package in response["records"]:
                 sp = package["SubscriberPackage"]
                 spv = package["SubscriberPackageVersion"]
+                if spv is None:
+                    # This _shouldn't_ happen, but it is possible in customer orgs.
+                    continue
+
                 version = f"{spv['MajorVersion']}.{spv['MinorVersion']}"
                 if spv["PatchVersion"]:
                     version += f".{spv['PatchVersion']}"

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -1425,6 +1425,13 @@ class TestOrgConfig(unittest.TestCase):
                     "IsBeta": True,
                 },
             },
+            {
+                "SubscriberPackage": {
+                    "Id": "03350000000DEz4AAG",
+                    "NamespacePrefix": "blah",
+                },
+                "SubscriberPackageVersion": None,  # This shouldn't happen but has in real orgs.
+            },
         ],
     }
 


### PR DESCRIPTION
# Critical Changes

# Changes

- CumulusCI handles a rare situation where installed packages could be in a state that causes failures while fetching installed versions.

# Issues Closed
