### PR TITLE
upload doc artifact

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -29,3 +29,8 @@ jobs:
         pip install -r requirements_dev.txt
     - name: Make docs
       run: make docs
+    - name: Upload docs
+      uses: actions/upload-artifact@v2
+      with:
+        name: docs
+        path: docs/_build

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -5,7 +5,6 @@ on:
     paths:
     - 'docs/**'
 
-
 jobs:
   lint:
     name: Build docs
@@ -33,4 +32,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: docs
-        path: docs/_build
+        path: docs/_build/html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,3 +24,4 @@ Contents
    cookbook
    reference
    about
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,4 +24,3 @@ Contents
    cookbook
    reference
    about
-


### PR DESCRIPTION
This makes the built docs available for download. It's not super obvious (you have to click into the Details for the Build Docs action, then look for the Artifacts menu, download the docs, unzip and open index.html) but at least it's available.

# Critical Changes

# Changes

# Issues Closed
