### PR TITLE
Fix missing use of process_bool_arg()

### DIFF
--- a/cumulusci/tasks/apex/anon.py
+++ b/cumulusci/tasks/apex/anon.py
@@ -2,6 +2,7 @@ from cumulusci.core.exceptions import ApexCompilationException
 from cumulusci.core.exceptions import ApexException
 from cumulusci.core.exceptions import SalesforceException
 from cumulusci.core.exceptions import TaskOptionsError
+from cumulusci.core.utils import process_bool_arg
 from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 from cumulusci.utils import in_directory
 
@@ -95,8 +96,8 @@ class AnonymousApexTask(BaseSalesforceApiTask):
 
     def _prepare_apex(self, apex):
         # Process namespace tokens
-        managed = self.options.get("managed") or False
-        namespaced = self.options.get("namespaced") or False
+        managed = process_bool_arg(self.options.get("managed", False))
+        namespaced = process_bool_arg(self.options.get("namespaced", False))
         namespace = self.project_config.project__package__namespace
         namespace_prefix = ""
         record_type_prefix = ""

--- a/cumulusci/tasks/salesforce/UninstallLocalNamespacedBundles.py
+++ b/cumulusci/tasks/salesforce/UninstallLocalNamespacedBundles.py
@@ -29,7 +29,7 @@ class UninstallLocalNamespacedBundles(UninstallLocalBundles):
     def _init_options(self, kwargs):
         super(UninstallLocalNamespacedBundles, self)._init_options(kwargs)
 
-        self.options["managed"] = self.options.get("managed") or False
+        self.options["managed"] = process_bool_arg(self.options.get("managed", False))
         if "namespace" not in self.options:
             self.options["namespace"] = self.project_config.project__package__namespace
         self.options["purge_on_delete"] = process_bool_arg(
@@ -46,7 +46,7 @@ class UninstallLocalNamespacedBundles(UninstallLocalBundles):
             delete=True,
         )
         namespace = ""
-        if self.options["managed"] in [True, "True", "true"]:
+        if self.options["managed"]:
             if self.options["namespace"]:
                 namespace = self.options["namespace"] + "__"
 

--- a/cumulusci/tasks/salesforce/custom_settings_wait.py
+++ b/cumulusci/tasks/salesforce/custom_settings_wait.py
@@ -94,8 +94,8 @@ class CustomSettingValueWait(BaseSalesforceApiTask):
 
     def _apply_namespace(self):
         # Process namespace tokens
-        managed = self.options.get("managed") or False
-        namespaced = self.options.get("namespaced") or False
+        managed = process_bool_arg(self.options.get("managed", False))
+        namespaced = process_bool_arg(self.options.get("namespaced", False))
         namespace = self.project_config.project__package__namespace
         namespace_prefix = ""
         if managed or namespaced:


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed

- We corrected edge cases in how we processed Boolean options for the `custom_settings_wait`, `exec_anon`, and `uninstall_post` tasks. (Thanks to @davidjray)