### PR TITLE
Stop memoizing the salesforce_client on OrgConfig

### DIFF
--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -116,12 +116,9 @@ class OrgConfig(BaseConfig):
         else:
             return self.instance_url.split(".")[0] + ".lightning.force.com"
 
-    # to simplify mocking for tests
-    _Salesforce = Salesforce
-
     @property
     def salesforce_client(self):
-        return self._Salesforce(
+        return Salesforce(
             instance=self.instance_url.replace("https://", ""),
             session_id=self.access_token,
             version=self.latest_api_version,

--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -38,7 +38,6 @@ class OrgConfig(BaseConfig):
 
         self.name = name
         self._community_info_cache = {}
-        self._client = None
         self._latest_api_version = None
         self._installed_packages = None
         self._is_person_accounts_enabled = None
@@ -55,9 +54,6 @@ class OrgConfig(BaseConfig):
 
         Also refreshes user and org info that is cached in the org config.
         """
-        # invalidate memoized simple-salesforce client with old token
-        self._client = None
-
         if not SKIP_REFRESH:
             SFDX_CLIENT_ID = os.environ.get("SFDX_CLIENT_ID")
             SFDX_HUB_KEY = os.environ.get("SFDX_HUB_KEY")
@@ -120,16 +116,16 @@ class OrgConfig(BaseConfig):
         else:
             return self.instance_url.split(".")[0] + ".lightning.force.com"
 
+    # to simplify mocking for tests
+    _Salesforce = Salesforce
+
     @property
     def salesforce_client(self):
-        if not self._client:
-            self._client = Salesforce(
-                instance=self.instance_url.replace("https://", ""),
-                session_id=self.access_token,
-                version=self.latest_api_version,
-            )
-
-        return self._client
+        return self._Salesforce(
+            instance=self.instance_url.replace("https://", ""),
+            session_id=self.access_token,
+            version=self.latest_api_version,
+        )
 
     @property
     def latest_api_version(self):

--- a/cumulusci/core/config/SfdxOrgConfig.py
+++ b/cumulusci/core/config/SfdxOrgConfig.py
@@ -137,7 +137,6 @@ class SfdxOrgConfig(OrgConfig):
 
     def refresh_oauth_token(self, keychain):
         """ Use sfdx force:org:describe to refresh token instead of built in OAuth handling """
-        self._client = None
         if hasattr(self, "_sfdx_info"):
             # Cache the sfdx_info for 1 hour to avoid unnecessary calls out to sfdx CLI
             delta = datetime.datetime.utcnow() - self._sfdx_info_date

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -1151,7 +1151,6 @@ class TestOrgConfig(unittest.TestCase):
     @mock.patch("cumulusci.core.config.OrgConfig.SalesforceOAuth2")
     def test_refresh_oauth_token(self, SalesforceOAuth2):
         config = OrgConfig({"refresh_token": mock.sentinel.refresh_token}, "test")
-        config._client = mock.Mock()
         config._load_userinfo = mock.Mock()
         config._load_orginfo = mock.Mock()
         keychain = mock.Mock()
@@ -1162,7 +1161,6 @@ class TestOrgConfig(unittest.TestCase):
         config.refresh_oauth_token(keychain)
 
         oauth.refresh_token.assert_called_once_with(mock.sentinel.refresh_token)
-        assert config._client is None
 
     def test_refresh_oauth_token_no_connected_app(self):
         config = OrgConfig({}, "test")
@@ -1435,10 +1433,10 @@ class TestOrgConfig(unittest.TestCase):
         ],
     }
 
-    def test_installed_packages(self):
+    @mock.patch("cumulusci.core.config.OrgConfig.salesforce_client")
+    def test_installed_packages(self, sf):
         config = OrgConfig({}, "test")
-        config._client = mock.Mock()
-        config._client.restful.return_value = self.MOCK_TOOLING_PACKAGE_RESULTS
+        sf.restful.return_value = self.MOCK_TOOLING_PACKAGE_RESULTS
 
         expected = {
             "GW_Volunteers": [
@@ -1468,7 +1466,7 @@ class TestOrgConfig(unittest.TestCase):
         # get it twice so we can make sure it is cached
         assert config.installed_packages == expected
         assert config.installed_packages == expected
-        config._client.restful.assert_called_once_with(
+        sf.restful.assert_called_once_with(
             "tooling/query/?q=SELECT SubscriberPackage.Id, SubscriberPackage.NamespacePrefix, "
             "SubscriberPackageVersion.Id, SubscriberPackageVersion.MajorVersion, "
             "SubscriberPackageVersion.MinorVersion, SubscriberPackageVersion.PatchVersion,  "
@@ -1476,15 +1474,15 @@ class TestOrgConfig(unittest.TestCase):
             "FROM InstalledSubscriberPackage"
         )
 
-        config._client.restful.reset_mock()
+        sf.restful.reset_mock()
         config.reset_installed_packages()
         assert config.installed_packages == expected
-        config._client.restful.assert_called_once()
+        sf.restful.assert_called_once()
 
-    def test_has_minimum_package_version(self):
+    @mock.patch("cumulusci.core.config.OrgConfig.salesforce_client")
+    def test_has_minimum_package_version(self, sf):
         config = OrgConfig({}, "test")
-        config._client = mock.Mock()
-        config._client.restful.return_value = self.MOCK_TOOLING_PACKAGE_RESULTS
+        sf.restful.return_value = self.MOCK_TOOLING_PACKAGE_RESULTS
 
         assert config.has_minimum_package_version("TESTY", "1.9")
         assert config.has_minimum_package_version("TESTY", "1.10b5")


### PR DESCRIPTION
Constructing a new one is cheap (it doesn't make a request when instantiated with an existing access token) and avoids the potential for using an old connection that was closed by the server.

# Critical Changes

# Changes

# Issues Closed
- Fixed a connection error which could occur if uploading a package took over 10 minutes.
