### PR TITLE
Allow update_admin_profile to use a custom package with extra Profile names

### DIFF
--- a/cumulusci/tasks/salesforce/update_profile.py
+++ b/cumulusci/tasks/salesforce/update_profile.py
@@ -137,7 +137,7 @@ class ProfileGrantAllAccess(MetadataSingleEntityTransformTask, BaseSalesforceApi
 
     def _generate_package_xml(self, operation):
         if operation is MetadataOperation.RETRIEVE:
-            with open(self.package_xml_path, "r") as f:
+            with open(self.package_xml_path, "r", encoding="utf-8") as f:
                 package_xml_content = f.read()
 
             package_xml_content = package_xml_content.format(**self.namespace_prefixes)
@@ -164,9 +164,9 @@ class ProfileGrantAllAccess(MetadataSingleEntityTransformTask, BaseSalesforceApi
     def _expand_profile_members(self, package_xml):
         profile_names = package_xml.find("types", name="Profile")
         if not profile_names:
-            raise CumulusCIException(
-                "The package.xml does not contain a Profiles member."
-            )
+            profile_names = package_xml.append("types")
+            profile_names.append("name", "Profile")
+
         listed_api_names = {p.text for p in profile_names.findall("members")}
 
         for profile in self.api_names:

--- a/cumulusci/tasks/salesforce/update_profile.py
+++ b/cumulusci/tasks/salesforce/update_profile.py
@@ -98,39 +98,33 @@ class ProfileGrantAllAccess(MetadataSingleEntityTransformTask, BaseSalesforceApi
         )
 
         # Build the api_names list, taking into account legacy behavior.
-        # If we're using a custom package.xml, Profiles to alter should be
-        # specified there.
+        # If we're using a custom package.xml, we will union the api_names list with
+        # any Profiles specified there.
         self.api_names = set(process_list_arg(self.options.get("api_names", [])))
-        if "package_xml" in self.options:
-            if self.api_names or "profile_name" in self.options:
-                raise TaskOptionsError(
-                    "The package_xml option is not compatible with the profile_name or api_names options. "
-                    "Specify desired profiles in the custom package.xml"
-                )
+        if "profile_name" in self.options:
+            self.api_names.add(self.options["profile_name"])
+        if not self.api_names and "package_xml" not in self.options:
+            self.api_names.add(
+                "Admin"
+            )  # Don't add a default if using custom package.xml
 
-            # Infer items to affect from what is retrieved.
-            self.api_names = {"*"}
+        if "package_xml" in self.options:
             self.package_xml_path = self.options["package_xml"]
         else:
-            if "profile_name" in self.options:
-                self.api_names.add(self.options["profile_name"])
-
-            if not self.api_names:
-                self.api_names.add("Admin")
-
-            if self.options["namespaced_org"]:
-                # Namespaced orgs don't use the explicit namespace references in `package.xml`.
-                # Preserving historic behavior but guarding here
-                self.options["managed"] = False
-
-            self.api_names = {self._inject_namespace(x) for x in self.api_names}
-
-            if self.options["namespaced_org"]:
-                self.options["managed"] = True
-
             self.package_xml_path = os.path.join(
                 CUMULUSCI_PATH, "cumulusci", "files", "admin_profile.xml"
             )
+
+        # Namespace injection.
+        if self.options["namespaced_org"]:
+            # Namespaced orgs don't use the explicit namespace references in `package.xml`.
+            # Preserving historic behavior but guarding here
+            self.options["managed"] = False
+
+        self.api_names = {self._inject_namespace(x) for x in self.api_names}
+
+        if self.options["namespaced_org"]:
+            self.options["managed"] = True
 
     def freeze(self, step):
         # Preserve behavior from when we subclassed Deploy.
@@ -148,27 +142,20 @@ class ProfileGrantAllAccess(MetadataSingleEntityTransformTask, BaseSalesforceApi
 
             package_xml_content = package_xml_content.format(**self.namespace_prefixes)
 
-            if (
-                self.options["include_packaged_objects"]
-                or "package_xml" not in self.options
-            ):
-                # We need to rewrite the package.xml for one or two reasons.
-                # Either we are using packaged-object expansion, or we're using
-                # the built-in admin_profile.xml and need to substitute in
-                # profile API names.
+            # We need to rewrite the package.xml for one or two reasons.
+            # Either we are using packaged-object expansion, or we're using
+            # a package.xml and need to substitute in profile API names.
 
-                # Convert to bytes because stored `package.xml`s typically have an encoding declaration,
-                # which `fromstring()` doesn't like.
-                package_xml = metadata_tree.fromstring(
-                    package_xml_content.encode("utf-8")
-                )
+            # Convert to bytes because stored `package.xml`s typically have an encoding declaration,
+            # which `fromstring()` doesn't like.
+            package_xml = metadata_tree.fromstring(package_xml_content.encode("utf-8"))
 
-                if self.options["include_packaged_objects"]:
-                    self._expand_package_xml(package_xml)
-                if "package_xml" not in self.options:
-                    self._expand_profile_members(package_xml)
+            if self.options["include_packaged_objects"]:
+                self._expand_package_xml(package_xml)
 
-                package_xml_content = package_xml.tostring(xml_declaration=True)
+            self._expand_profile_members(package_xml)
+
+            package_xml_content = package_xml.tostring(xml_declaration=True)
 
             return package_xml_content
         else:
@@ -180,8 +167,13 @@ class ProfileGrantAllAccess(MetadataSingleEntityTransformTask, BaseSalesforceApi
             raise CumulusCIException(
                 "The package.xml does not contain a Profiles member."
             )
+        listed_api_names = {p.text for p in profile_names.findall("members")}
+
         for profile in self.api_names:
-            profile_names.append("members", text=profile)
+            if profile not in listed_api_names:
+                profile_names.append("members", text=profile)
+
+        self.api_names.update(listed_api_names)
 
     def _expand_package_xml(self, package_xml):
         # Query the target org for all namespaced objects


### PR DESCRIPTION
# Critical Changes

# Changes

- The `update_admin_profile` task now accepts the `api_names` option to target extra Profiles, even when using a custom `package.xml`.

# Issues Closed
