### PR TITLE
Add preflight checks for org settings, including Chatter

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -50,6 +50,18 @@ tasks:
         description: Runs as a preflight check to validate Organization-Wide Defaults.
         class_path: cumulusci.tasks.preflight.sobjects.CheckSObjectOWDs
         group: Salesforce Preflight Checks
+    check_org_settings_value:
+        description: Runs as a preflight check to validate organization settings.
+        class_path: cumulusci.tasks.preflight.settings.CheckSettingsValue
+        group: Salesforce Preflight Checks
+    check_chatter_enabled:
+        description: Runs as a preflight check to validate Chatter is enabled.
+        class_path: cumulusci.tasks.preflight.settings.CheckSettingsValue
+        group: Salesforce Preflight Checks
+        options:
+            settings_type: ChatterSettings
+            settings_field: IsChatterEnabled
+            value: True
     custom_settings_value_wait:
         description: Waits for a specific field value on the specified custom settings object and field
         class_path: cumulusci.tasks.salesforce.custom_settings_wait.CustomSettingValueWait

--- a/cumulusci/tasks/preflight/settings.py
+++ b/cumulusci/tasks/preflight/settings.py
@@ -1,0 +1,49 @@
+from cumulusci.tasks.salesforce import BaseSalesforceApiTask
+from cumulusci.core.utils import process_bool_arg
+
+from simple_salesforce.exceptions import SalesforceMalformedRequest
+
+
+class CheckSettingsValue(BaseSalesforceApiTask):
+    task_options = {
+        "settings_type": {
+            "description": "The API name of the Settings entity to be checked, such as ChatterSettings.",
+            "required": True,
+        },
+        "settings_field": {
+            "description": "The API name of the field on the Settings entity to check.",
+            "required": True,
+        },
+        "value": {"description": "The value to check for", "required": True},
+    }
+
+    def _run_task(self):
+        try:
+            results = self.tooling.query(
+                f"SELECT {self.options['settings_field']} FROM {self.options['settings_type']}"
+            )["records"]
+        except SalesforceMalformedRequest:
+            self.logger.error(
+                "The specified settings entity or field could not be queried."
+            )
+            self.return_values = False
+            return
+
+        value = results[0].get(self.options["settings_field"])
+        # Type-sensitive compare.
+        if type(value) is bool:
+            comparand = process_bool_arg(self.options["value"])
+        elif type(value) is float:
+            comparand = float(self.options["value"])
+        elif type(value) is int:
+            comparand = int(self.options["value"])
+        else:
+            comparand = self.options["value"]
+
+        self.return_values = value == comparand
+
+        self.logger.info(
+            "Completed Settings preflight check with result {}".format(
+                self.return_values
+            )
+        )

--- a/cumulusci/tasks/preflight/tests/test_settings.py
+++ b/cumulusci/tasks/preflight/tests/test_settings.py
@@ -1,0 +1,65 @@
+from cumulusci.tasks.preflight.settings import CheckSettingsValue
+from cumulusci.tasks.salesforce.tests.util import create_task
+
+import pytest
+import responses
+
+
+JSON_RESPONSE = {
+    "records": [{"IntVal": 3, "FloatVal": 3.0, "BoolVal": True, "StringVal": "foo"}],
+    "done": True,
+    "totalSize": 1,
+}
+
+
+@responses.activate
+@pytest.mark.parametrize(
+    "settings_field,value,outcome",
+    [
+        ("IntVal", 3, True),
+        ("FloatVal", 3.0, True),
+        ("BoolVal", "true", True),
+        ("StringVal", "foo", True),
+        ("StringVal", "bad", False),
+    ],
+)
+def test_check_settings(settings_field, value, outcome):
+    responses.add(
+        "GET",
+        f"https://test.salesforce.com/services/data/v49.0/tooling/query/?q=SELECT+{settings_field}+FROM+ChatterSettings",
+        json=JSON_RESPONSE,
+    )
+    task = create_task(
+        CheckSettingsValue,
+        {
+            "settings_type": "ChatterSettings",
+            "settings_field": settings_field,
+            "value": value,
+        },
+    )
+
+    task()
+
+    assert task.return_values is outcome
+
+
+@responses.activate
+def test_check_settings__failure():
+    responses.add(
+        "GET",
+        status=400,
+        url="https://test.salesforce.com/services/data/v49.0/tooling/query/?q=SELECT+Test+FROM+NoSettings",
+        json={},
+    )
+    task = create_task(
+        CheckSettingsValue,
+        {
+            "settings_type": "NoSettings",
+            "settings_field": "Test",
+            "value": True,
+        },
+    )
+
+    task()
+
+    assert task.return_values is False

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -399,6 +399,76 @@ Options
 
 	 The Organization-Wide Defaults to check, organized as a list with each element containing the keys api_name, internal_sharing_model, and external_sharing_model. NOTE: you must have External Sharing Model turned on in Sharing Settings to use the latter feature. Checking External Sharing Model when it is turned off will fail the preflight.
 
+**check_org_settings_value**
+==========================================
+
+**Description:** Runs as a preflight check to validate organization settings.
+
+**Class:** cumulusci.tasks.preflight.settings.CheckSettingsValue
+
+Command Syntax
+------------------------------------------
+
+``$ cci task run check_org_settings_value``
+
+
+Options
+------------------------------------------
+
+
+``-o settings_type SETTINGSTYPE``
+	 *Required*
+
+	 The API name of the Settings entity to be checked, such as ChatterSettings.
+
+``-o settings_field SETTINGSFIELD``
+	 *Required*
+
+	 The API name of the field on the Settings entity to check.
+
+``-o value VALUE``
+	 *Required*
+
+	 The value to check for
+
+**check_chatter_enabled**
+==========================================
+
+**Description:** Runs as a preflight check to validate Chatter is enabled.
+
+**Class:** cumulusci.tasks.preflight.settings.CheckSettingsValue
+
+Command Syntax
+------------------------------------------
+
+``$ cci task run check_chatter_enabled``
+
+
+Options
+------------------------------------------
+
+
+``-o settings_type SETTINGSTYPE``
+	 *Required*
+
+	 The API name of the Settings entity to be checked, such as ChatterSettings.
+
+	 Default: ChatterSettings
+
+``-o settings_field SETTINGSFIELD``
+	 *Required*
+
+	 The API name of the field on the Settings entity to check.
+
+	 Default: IsChatterEnabled
+
+``-o value VALUE``
+	 *Required*
+
+	 The value to check for
+
+	 Default: True
+
 **custom_settings_value_wait**
 ==========================================
 
@@ -633,7 +703,12 @@ Options
 ``-o values VALUES``
 	 *Required*
 
-	 Field names and values in the format 'aa:bb,cc:dd'
+	 Field names and values in the format 'aa:bb,cc:dd', or a YAML dict in cumulusci.yml.
+
+``-o tooling TOOLING``
+	 *Optional*
+
+	 If True, use the Tooling API instead of REST API.
 
 **create_package**
 ==========================================
@@ -703,11 +778,6 @@ Options
 	 *Optional*
 
 	 The part of the version number to increment. Options are major, minor, patch.  Defaults to minor
-
-``-o dependency_org DEPENDENCYORG``
-	 *Optional*
-
-	 The org name of the org to use for project dependencies lookup. If not provided, a scratch org will be created with the org name 2gp_dependencies.
 
 ``-o skip_validation SKIPVALIDATION``
 	 *Optional*


### PR DESCRIPTION
# Critical Changes

# Changes

- CumulusCI offers preflight checks to validate org settings (`check_org_settings_value`) and to check that Chatter is enabled (`check_chatter_enabled`).

# Issues Closed
