### PR TITLE
merge non-feature source into feature branches

### DIFF
--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -7,7 +7,7 @@ on:
     - master
 
 env:
-  CUMULUSCI_ORG_scratch: '{"config_file": "orgs/dev.json", "scratch": true}'
+  CUMULUSCI_ORG_scratch: '{"config_file": "orgs/prerelease.json", "scratch": true}'
   CUMULUSCI_ORG_packaging: ${{ secrets.CUMULUSCI_ORG_packaging }}
   CUMULUSCI_SERVICE_github: ${{ secrets.CUMULUSCI_SERVICE_github }}
   SFDX_CLIENT_ID: ${{ secrets.SFDX_CLIENT_ID }}

--- a/cumulusci/tasks/github/merge.py
+++ b/cumulusci/tasks/github/merge.py
@@ -311,6 +311,7 @@ class MergeBranch(BaseGithubTask):
             ):
                 release_branches.append(branch)
                 continue
+
             if branch.name == self.options["source_branch"]:
                 self.logger.debug(f"Skipping branch {branch.name}: is source branch")
                 continue
@@ -319,7 +320,12 @@ class MergeBranch(BaseGithubTask):
                     f"Skipping branch {branch.name}: does not match prefix '{self.options['branch_prefix']}'"
                 )
                 continue
-            elif self.source_branch_is_default and "__" not in branch.name:
+            elif (
+                not self.options["source_branch"].startswith(
+                    self.options["branch_prefix"]
+                )
+                and "__" not in branch.name
+            ):
                 main_descendents.append(branch)
             elif self._is_source_branch_direct_descendent(branch):
                 child_branches.append(branch)
@@ -334,7 +340,7 @@ class MergeBranch(BaseGithubTask):
                 f"Found child branches to update: {[branch.name for branch in child_branches]}"
             )
             to_merge = child_branches
-        elif not self.source_branch_is_default:
+        elif self.options["source_branch"].startswith(self.options["branch_prefix"]):
             self.logger.debug(
                 f"No children found for branch {self.options['source_branch']}"
             )
@@ -347,7 +353,7 @@ class MergeBranch(BaseGithubTask):
 
         if main_descendents:
             self.logger.debug(
-                f"Found descendents of main to update: {[branch.name for branch in main_descendents]}"
+                f"Found descendents of {self.options['source_branch']} to update: {[branch.name for branch in main_descendents]}"
             )
             to_merge = to_merge + main_descendents
 

--- a/cumulusci/tasks/github/merge.py
+++ b/cumulusci/tasks/github/merge.py
@@ -220,6 +220,14 @@ class MergeBranchOld(BaseGithubTask):
 
 
 class MergeBranch(BaseGithubTask):
+    task_docs = """
+    Merges the most recent commit on the current branch into other branches depending on the value of source_branch.
+
+    If source_branch is a branch that does not start with the specified branch_prefix, then the commit will be
+    merged to all branches that begin with branch_prefix and are not themselves child branches (i.e. branches don't contain '__' in their name).
+
+    If source_branch begins with branch_prefix, then the commit is merged to all child branches of source_branch.
+    """
     task_options = {
         "commit": {
             "description": "The commit to merge into feature branches.  Defaults to the current head commit."

--- a/cumulusci/tasks/github/tests/test_merge.py
+++ b/cumulusci/tasks/github/tests/test_merge.py
@@ -697,9 +697,7 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
                 ),
             ]
             actual_log = self._get_log_lines(log)
-            # assert expected_log == actual_log
-            for i in range(len(actual_log)):
-                assert expected_log[i] == actual_log[i]
+            assert expected_log == actual_log
         assert 6 == len(responses.calls)
 
     @responses.activate

--- a/cumulusci/tasks/github/tests/test_merge.py
+++ b/cumulusci/tasks/github/tests/test_merge.py
@@ -448,6 +448,36 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
         self.assertEqual(10, len(responses.calls))
 
     @responses.activate
+    def test_no_prefix_merge_to_feature(self):
+        """Tests that when source_branch is a branch other than main
+        and doesn't start with 'feature/', that it is merged
+        to all non-child feature/ branches"""
+
+        source_branch = "some-branch"
+        expected_branches_to_merge = ["feature/work-a", "feature/work-b"]
+        other_branches = [
+            "feature/work-a__child",
+            "some-branch__child",
+            "main",
+        ]
+        self._setup_mocks([source_branch] + expected_branches_to_merge + other_branches)
+
+        task = self._create_task(
+            task_config={
+                "options": {
+                    "source_branch": source_branch,
+                }
+            }
+        )
+        task._init_task()
+        task.repo = task.get_repo()
+        task.source_branch_is_default = False
+
+        actual_branches = [branch.name for branch in task._get_branches_to_merge()]
+        assert expected_branches_to_merge == actual_branches
+        assert 2 == len(responses.calls)
+
+    @responses.activate
     def test_merge_feature_to_children(self):
         """Tests that only direct descendents of a branch
         with the given branch_prefix receive merges."""
@@ -613,7 +643,7 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
         assert 2 == len(responses.calls)
 
     @responses.activate
-    def test_merge_to_children_not_future_releases(self):
+    def test_merge_to_children_not_future_releases_output(self):
         """Tests that commits to the main branch are merged to child feature branches
         and not to future prerelease branches."""
 
@@ -651,7 +681,7 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
                 ),
                 (
                     "DEBUG",
-                    "Skipping branch prefix-mistmatch/230__child2: does not match prefix 'jupiter/'",
+                    "Skipping branch prefix-mismatch/230__child2: does not match prefix 'jupiter/'",
                 ),
                 (
                     "DEBUG",
@@ -667,7 +697,9 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
                 ),
             ]
             actual_log = self._get_log_lines(log)
-            assert expected_log == actual_log
+            # assert expected_log == actual_log
+            for i in range(len(actual_log)):
+                assert expected_log[i] == actual_log[i]
         assert 6 == len(responses.calls)
 
     @responses.activate

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -633,7 +633,12 @@ Options
 ``-o values VALUES``
 	 *Required*
 
-	 Field names and values in the format 'aa:bb,cc:dd'
+	 Field names and values in the format 'aa:bb,cc:dd', or a YAML dict in cumulusci.yml.
+
+``-o tooling TOOLING``
+	 *Optional*
+
+	 If True, use the Tooling API instead of REST API.
 
 **create_package**
 ==========================================
@@ -703,11 +708,6 @@ Options
 	 *Optional*
 
 	 The part of the version number to increment. Options are major, minor, patch.  Defaults to minor
-
-``-o dependency_org DEPENDENCYORG``
-	 *Optional*
-
-	 The org name of the org to use for project dependencies lookup. If not provided, a scratch org will be created with the org name 2gp_dependencies.
 
 ``-o skip_validation SKIPVALIDATION``
 	 *Optional*
@@ -1710,6 +1710,13 @@ Options
 
 **Class:** cumulusci.tasks.github.MergeBranch
 
+Merges the most recent commit on the current branch into other branches depending on the value of source_branch.
+
+If source_branch is a branch that does not start with the specified branch_prefix, then the commit will be
+merged to all branches that begin with branch_prefix and are not themselves child branches (i.e. branches don't contain '__' in their name).
+
+If source_branch begins with branch_prefix, then the commit is merged to all child branches of source_branch.
+
 Command Syntax
 ------------------------------------------
 
@@ -1746,6 +1753,13 @@ Options
 **Description:** Merges the latest commit on a source branch to all child branches.
 
 **Class:** cumulusci.tasks.github.MergeBranch
+
+Merges the most recent commit on the current branch into other branches depending on the value of source_branch.
+
+If source_branch is a branch that does not start with the specified branch_prefix, then the commit will be
+merged to all branches that begin with branch_prefix and are not themselves child branches (i.e. branches don't contain '__' in their name).
+
+If source_branch begins with branch_prefix, then the commit is merged to all child branches of source_branch.
 
 Command Syntax
 ------------------------------------------


### PR DESCRIPTION
# Changes
* The task `github_automerge_main` now merges the most recent commit into branches that begin with the `feature_prefix` when the source branch is a non-feature branch (includeing main/master).