### PR TITLE
Workaround for slow SPV query by splitting it apart

### DIFF
--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -7,7 +7,7 @@ on:
     - master
 
 env:
-  CUMULUSCI_ORG_scratch: '{"config_file": "orgs/prerelease.json", "scratch": true}'
+  CUMULUSCI_ORG_scratch: '{"config_file": "orgs/dev.json", "scratch": true}'
   CUMULUSCI_ORG_packaging: ${{ secrets.CUMULUSCI_ORG_packaging }}
   CUMULUSCI_SERVICE_github: ${{ secrets.CUMULUSCI_SERVICE_github }}
   SFDX_CLIENT_ID: ${{ secrets.SFDX_CLIENT_ID }}

--- a/cumulusci/tasks/tests/test_package_2gp.py
+++ b/cumulusci/tasks/tests/test_package_2gp.py
@@ -181,29 +181,49 @@ class TestCreatePackageVersion:
                             "Id": "033000000000002AAA",
                             "NamespacePrefix": "pub",
                         },
-                        "SubscriberPackageVersion": {
-                            "Id": "04t000000000002AAA",
-                            "MajorVersion": 1,
-                            "MinorVersion": 5,
-                            "PatchVersion": 0,
-                            "BuildNumber": 1,
-                            "IsBeta": False,
-                        },
+                        "SubscriberPackageVersionId": "04t000000000002AAA",
                     },
                     {
                         "SubscriberPackage": {
                             "Id": "033000000000003AAA",
                             "NamespacePrefix": "hed",
                         },
-                        "SubscriberPackageVersion": {
-                            "Id": "04t000000000003AAA",
-                            "MajorVersion": 1,
-                            "MinorVersion": 99,
-                            "PatchVersion": 0,
-                            "BuildNumber": 1,
-                            "IsBeta": False,
-                        },
+                        "SubscriberPackageVersionId": "04t000000000003AAA",
                     },
+                ],
+            },
+        )
+        responses.add(  # query dependency org for installed package 1)
+            "GET",
+            f"{self.scratch_base_url}/tooling/query/",
+            json={
+                "size": 1,
+                "records": [
+                    {
+                        "Id": "04t000000000002AAA",
+                        "MajorVersion": 1,
+                        "MinorVersion": 5,
+                        "PatchVersion": 0,
+                        "BuildNumber": 1,
+                        "IsBeta": False,
+                    }
+                ],
+            },
+        ),
+        responses.add(  # query dependency org for installed package 2)
+            "GET",
+            f"{self.scratch_base_url}/tooling/query/",
+            json={
+                "size": 1,
+                "records": [
+                    {
+                        "Id": "04t000000000003AAA",
+                        "MajorVersion": 1,
+                        "MinorVersion": 99,
+                        "PatchVersion": 0,
+                        "BuildNumber": 1,
+                        "IsBeta": False,
+                    }
                 ],
             },
         )


### PR DESCRIPTION
We won't want this in the long term, because it adds more queries, but I think it will help avoid the query timeout we're currently seeing with InstalledSubscriberPackage

# Critical Changes

# Changes

# Issues Closed
