### PR TITLE
Fix update_package_xml for folders without -meta.xml

### DIFF
--- a/cumulusci/tasks/metadata/package.py
+++ b/cumulusci/tasks/metadata/package.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import os
 import re
 import urllib.parse
@@ -226,8 +227,9 @@ class MetadataFolderParser(BaseMetadataParser):
         if not os.path.isdir(path):
             return members
 
-        # Add the member if it is not namespaced
-        if "__" not in item:
+        # Only add the folder itself if its -meta.xml is present
+        # (If there's no -meta.xml, this package is adding items to an existing folder.)
+        if Path(path + "-meta.xml").exists():
             members.append(item)
 
         for subitem in sorted(os.listdir(path)):

--- a/cumulusci/tasks/metadata/tests/test_package.py
+++ b/cumulusci/tasks/metadata/tests/test_package.py
@@ -161,6 +161,10 @@ class TestMetadataFolderParser(unittest.TestCase):
         with temporary_dir() as path:
             item_path = os.path.join(path, "Test")
             os.mkdir(item_path)
+            other_path = os.path.join(path, "FolderWithoutMetaXml")
+            os.mkdir(other_path)
+            with open(os.path.join(path, "Test-meta.xml"), "w"):
+                pass
             with open(os.path.join(item_path, ".hidden"), "w"):
                 pass
             with open(os.path.join(item_path, "Test.object"), "w"):


### PR DESCRIPTION
This adjusts the condition for when a folder should be included in package.xml. We already handled one case where an item is being added to an existing folder that is not itself in the package, by excluding folders with a namespace (indicating they came from another package). Now we look for the existence of a -meta.xml file for the folder, which should handle that case as well as the one where an item is being added to an existing folder that is unpackaged or part of a different unmanaged package (including the Public Reports folder).

# Critical Changes

# Changes

# Issues Closed
- Fixed the update_package_xml task for metadata packages that add items to folders (i.e. reports, dashboards, etc) that already exist.
