### PR TITLE
Add assign_permission_sets task

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -38,6 +38,10 @@ tasks:
             namespace_inject: $project_config.project__package__namespace
             metadata_type: CustomObject
             tag: compactLayoutAssignment
+    assign_permission_sets:
+        group: Salesforce Users
+        description: "Assigns specified Permission Sets to the current user, if not already assigned."
+        class_path: cumulusci.tasks.salesforce.users.permsets.AssignPermissionSets
     batch_apex_wait:
         description: Waits on a batch apex job to finish.
         class_path: cumulusci.tasks.apex.batch.BatchApexWait

--- a/cumulusci/tasks/salesforce/users/permsets.py
+++ b/cumulusci/tasks/salesforce/users/permsets.py
@@ -1,0 +1,53 @@
+from cumulusci.tasks.salesforce import BaseSalesforceApiTask
+from cumulusci.core.exceptions import CumulusCIException
+from cumulusci.core.utils import process_list_arg
+
+
+class AssignPermissionSets(BaseSalesforceApiTask):
+    task_options = {
+        "api_names": {
+            "description": "API names of desired Permission Sets, separated by commas.",
+            "required": True,
+        },
+    }
+
+    def _init_options(self, kwargs):
+        super()._init_options(kwargs)
+
+        self.options["api_names"] = process_list_arg(self.options["api_names"])
+
+    def _run_task(self):
+        # Determine existing assignments
+        query = f"""SELECT Id,
+                           (SELECT PermissionSetId
+                            FROM PermissionSetAssignments)
+                    FROM User
+                    WHERE Id = '{self.org_config.user_id}'"""
+
+        user = self.sf.query(query)["records"][0]
+
+        assigned_permsets = {
+            r["PermissionSetId"] for r in user["PermissionSetAssignments"]["records"]
+        }
+
+        # Find Ids for requested Perm Sets
+        api_names = "', '".join(self.options["api_names"])
+        permsets = self.sf.query(
+            f"SELECT Id, Name FROM PermissionSet WHERE Name IN ('{api_names}')"
+        )
+        permsets = {p["Name"]: p["Id"] for p in permsets["records"]}
+
+        # Raise for missing permsets
+        for api_name in self.options["api_names"]:
+            if api_name not in permsets:
+                raise CumulusCIException(f"Permission Set {api_name} was not found.")
+
+        # Assign all not already assigned
+        for api_name in self.options["api_names"]:
+            if permsets[api_name] not in assigned_permsets:
+                self.sf.PermissionSetAssignment.create(
+                    {
+                        "AssigneeId": self.org_config.user_id,
+                        "PermissionSetId": permsets[api_name],
+                    }
+                )

--- a/cumulusci/tasks/salesforce/users/permsets.py
+++ b/cumulusci/tasks/salesforce/users/permsets.py
@@ -22,7 +22,7 @@ class AssignPermissionSets(BaseSalesforceApiTask):
                            (SELECT PermissionSetId
                             FROM PermissionSetAssignments)
                     FROM User
-                    WHERE Id = '{self.org_config.user_id}'"""
+                    WHERE Username = '{self.org_config.username}'"""
 
         user = self.sf.query(query)["records"][0]
 
@@ -45,9 +45,13 @@ class AssignPermissionSets(BaseSalesforceApiTask):
         # Assign all not already assigned
         for api_name in self.options["api_names"]:
             if permsets[api_name] not in assigned_permsets:
+                self.logger.info(f"Assigning permission set {api_name}.")
                 self.sf.PermissionSetAssignment.create(
                     {
                         "AssigneeId": self.org_config.user_id,
                         "PermissionSetId": permsets[api_name],
                     }
                 )
+            else:
+                self.logger.info(f"Permission set {api_name} is already assigned.")
+

--- a/cumulusci/tasks/salesforce/users/tests/test_permsets.py
+++ b/cumulusci/tasks/salesforce/users/tests/test_permsets.py
@@ -18,7 +18,7 @@ class TestCreatePermissionSet:
 
         responses.add(
             method="GET",
-            url=f"{task.org_config.instance_url}/services/data/v50.0/query/?q=SELECT+Id%2C%0A+++++++++++++++++++++++++++%28SELECT+PermissionSetId%0A++++++++++++++++++++++++++++FROM+PermissionSetAssignments%29%0A++++++++++++++++++++FROM+User%0A++++++++++++++++++++WHERE+Id+%3D+%27None%27",
+            url=f"{task.org_config.instance_url}/services/data/v50.0/query/?q=SELECT+Id%2C%0A+++++++++++++++++++++++++++%28SELECT+PermissionSetId%0A++++++++++++++++++++++++++++FROM+PermissionSetAssignments%29%0A++++++++++++++++++++FROM+User%0A++++++++++++++++++++WHERE+Username+%3D+%27test-cci%40example.com%27",
             status=200,
             json={
                 "done": True,
@@ -77,7 +77,7 @@ class TestCreatePermissionSet:
 
         responses.add(
             method="GET",
-            url=f"{task.org_config.instance_url}/services/data/v50.0/query/?q=SELECT+Id%2C%0A+++++++++++++++++++++++++++%28SELECT+PermissionSetId%0A++++++++++++++++++++++++++++FROM+PermissionSetAssignments%29%0A++++++++++++++++++++FROM+User%0A++++++++++++++++++++WHERE+Id+%3D+%27None%27",
+            url=f"{task.org_config.instance_url}/services/data/v50.0/query/?q=SELECT+Id%2C%0A+++++++++++++++++++++++++++%28SELECT+PermissionSetId%0A++++++++++++++++++++++++++++FROM+PermissionSetAssignments%29%0A++++++++++++++++++++FROM+User%0A++++++++++++++++++++WHERE+Username+%3D+%27test-cci%40example.com%27",
             status=200,
             json={
                 "done": True,

--- a/cumulusci/tasks/salesforce/users/tests/test_permsets.py
+++ b/cumulusci/tasks/salesforce/users/tests/test_permsets.py
@@ -1,0 +1,64 @@
+import responses
+from cumulusci.tasks.salesforce.users.permsets import AssignPermissionSets
+from cumulusci.tasks.salesforce.tests.util import create_task
+
+
+class TestCreatePermissionSet:
+    @responses.activate
+    def test_create_permset(self):
+        task = create_task(
+            AssignPermissionSets,
+            {
+                "api_names": "PermSet1,PermSet2",
+            },
+        )
+
+        responses.add(
+            method="GET",
+            url=f"{task.org_config.instance_url}/services/data/v50.0/query/?q=SELECT+Id%2C%0A+++++++++++++++++++++++++++%28SELECT+PermissionSetId%0A++++++++++++++++++++++++++++FROM+PermissionSetAssignments%29%0A++++++++++++++++++++FROM+User%0A++++++++++++++++++++WHERE+Id+%3D+%27None%27",
+            status=200,
+            json={
+                "done": True,
+                "totalSize": 1,
+                "records": [
+                    {
+                        "Id": "005000000000000",
+                        "PermissionSetAssignments": {
+                            "done": True,
+                            "totalSize": 1,
+                            "records": [{"PermissionSetId": "0PS000000000000"}],
+                        },
+                    }
+                ],
+            },
+        )
+        responses.add(
+            method="GET",
+            url=f"{task.org_config.instance_url}/services/data/v50.0/query/?q=SELECT+Id%2C+Name+FROM+PermissionSet+WHERE+Name+IN+%28%27PermSet1%27%2C+%27PermSet2%27%29",
+            status=200,
+            json={
+                "done": True,
+                "totalSize": 1,
+                "records": [
+                    {
+                        "Id": "0PS000000000000",
+                        "Name": "PermSet1",
+                    },
+                    {
+                        "Id": "0PS000000000001",
+                        "Name": "PermSet2",
+                    },
+                ],
+            },
+        )
+        responses.add(
+            method="POST",
+            url=f"{task.org_config.instance_url}/services/data/v50.0/sobjects/PermissionSetAssignment/",
+            status=200,
+            json={"id": "0Pa000000000001", "success": True, "errors": []},
+        )
+
+        task()
+
+        assert len(responses.calls) == 3
+        assert "0PS000000000001" in responses.calls[2].request.body

--- a/cumulusci/tasks/salesforce/users/tests/test_permsets.py
+++ b/cumulusci/tasks/salesforce/users/tests/test_permsets.py
@@ -18,7 +18,7 @@ class TestCreatePermissionSet:
 
         responses.add(
             method="GET",
-            url=f"{task.org_config.instance_url}/services/data/v50.0/query/?q=SELECT+Id%2C%0A+++++++++++++++++++++++++++%28SELECT+PermissionSetId%0A++++++++++++++++++++++++++++FROM+PermissionSetAssignments%29%0A++++++++++++++++++++FROM+User%0A++++++++++++++++++++WHERE+Username+%3D+%27test-cci%40example.com%27",
+            url=f"{task.org_config.instance_url}/services/data/v50.0/query/?q=SELECT+Id%2C%0A++++++++++++++++++++++++++++%28SELECT+PermissionSetId%0A+++++++++++++++++++++++++++++FROM+PermissionSetAssignments%29%0A++++++++++++++++++++++++FROM+User%0A++++++++++++++++++++++++WHERE+Username+%3D+%27test-cci%40example.com%27",
             status=200,
             json={
                 "done": True,
@@ -67,6 +67,90 @@ class TestCreatePermissionSet:
         assert "0PS000000000001" in responses.calls[2].request.body
 
     @responses.activate
+    def test_create_permset__alias(self):
+        task = create_task(
+            AssignPermissionSets,
+            {
+                "api_names": "PermSet1,PermSet2",
+                "user_alias": "test",
+            },
+        )
+
+        responses.add(
+            method="GET",
+            url=f"{task.org_config.instance_url}/services/data/v50.0/query/?q=SELECT+Id%2C%0A++++++++++++++++++++++++++++%28SELECT+PermissionSetId%0A+++++++++++++++++++++++++++++FROM+PermissionSetAssignments%29%0A++++++++++++++++++++++++FROM+User%0A++++++++++++++++++++++++WHERE+Alias+%3D+%27test%27",
+            status=200,
+            json={
+                "done": True,
+                "totalSize": 1,
+                "records": [
+                    {
+                        "Id": "005000000000000",
+                        "PermissionSetAssignments": {
+                            "done": True,
+                            "totalSize": 1,
+                            "records": [{"PermissionSetId": "0PS000000000000"}],
+                        },
+                    }
+                ],
+            },
+        )
+        responses.add(
+            method="GET",
+            url=f"{task.org_config.instance_url}/services/data/v50.0/query/?q=SELECT+Id%2C+Name+FROM+PermissionSet+WHERE+Name+IN+%28%27PermSet1%27%2C+%27PermSet2%27%29",
+            status=200,
+            json={
+                "done": True,
+                "totalSize": 1,
+                "records": [
+                    {
+                        "Id": "0PS000000000000",
+                        "Name": "PermSet1",
+                    },
+                    {
+                        "Id": "0PS000000000001",
+                        "Name": "PermSet2",
+                    },
+                ],
+            },
+        )
+        responses.add(
+            method="POST",
+            url=f"{task.org_config.instance_url}/services/data/v50.0/sobjects/PermissionSetAssignment/",
+            status=200,
+            json={"id": "0Pa000000000001", "success": True, "errors": []},
+        )
+
+        task()
+
+        assert len(responses.calls) == 3
+        assert "0PS000000000001" in responses.calls[2].request.body
+
+    @responses.activate
+    def test_create_permset__alias_raises(self):
+        task = create_task(
+            AssignPermissionSets,
+            {
+                "api_names": "PermSet1,PermSet2",
+                "user_alias": "test",
+            },
+        )
+
+        responses.add(
+            method="GET",
+            url=f"{task.org_config.instance_url}/services/data/v50.0/query/?q=SELECT+Id%2C%0A++++++++++++++++++++++++++++%28SELECT+PermissionSetId%0A+++++++++++++++++++++++++++++FROM+PermissionSetAssignments%29%0A++++++++++++++++++++++++FROM+User%0A++++++++++++++++++++++++WHERE+Alias+%3D+%27test%27",
+            status=200,
+            json={
+                "done": True,
+                "totalSize": 0,
+                "records": [],
+            },
+        )
+        with pytest.raises(CumulusCIException):
+            task()
+
+
+    @responses.activate
     def test_create_permset_raises(self):
         task = create_task(
             AssignPermissionSets,
@@ -77,7 +161,7 @@ class TestCreatePermissionSet:
 
         responses.add(
             method="GET",
-            url=f"{task.org_config.instance_url}/services/data/v50.0/query/?q=SELECT+Id%2C%0A+++++++++++++++++++++++++++%28SELECT+PermissionSetId%0A++++++++++++++++++++++++++++FROM+PermissionSetAssignments%29%0A++++++++++++++++++++FROM+User%0A++++++++++++++++++++WHERE+Username+%3D+%27test-cci%40example.com%27",
+            url=f"{task.org_config.instance_url}/services/data/v50.0/query/?q=SELECT+Id%2C%0A++++++++++++++++++++++++++++%28SELECT+PermissionSetId%0A+++++++++++++++++++++++++++++FROM+PermissionSetAssignments%29%0A++++++++++++++++++++++++FROM+User%0A++++++++++++++++++++++++WHERE+Username+%3D+%27test-cci%40example.com%27",
             status=200,
             json={
                 "done": True,

--- a/cumulusci/tasks/salesforce/users/tests/test_permsets.py
+++ b/cumulusci/tasks/salesforce/users/tests/test_permsets.py
@@ -1,4 +1,7 @@
 import responses
+import pytest
+
+from cumulusci.core.exceptions import CumulusCIException
 from cumulusci.tasks.salesforce.users.permsets import AssignPermissionSets
 from cumulusci.tasks.salesforce.tests.util import create_task
 
@@ -62,3 +65,54 @@ class TestCreatePermissionSet:
 
         assert len(responses.calls) == 3
         assert "0PS000000000001" in responses.calls[2].request.body
+
+    @responses.activate
+    def test_create_permset_raises(self):
+        task = create_task(
+            AssignPermissionSets,
+            {
+                "api_names": "PermSet1,PermSet2,PermSet3",
+            },
+        )
+
+        responses.add(
+            method="GET",
+            url=f"{task.org_config.instance_url}/services/data/v50.0/query/?q=SELECT+Id%2C%0A+++++++++++++++++++++++++++%28SELECT+PermissionSetId%0A++++++++++++++++++++++++++++FROM+PermissionSetAssignments%29%0A++++++++++++++++++++FROM+User%0A++++++++++++++++++++WHERE+Id+%3D+%27None%27",
+            status=200,
+            json={
+                "done": True,
+                "totalSize": 1,
+                "records": [
+                    {
+                        "Id": "005000000000000",
+                        "PermissionSetAssignments": {
+                            "done": True,
+                            "totalSize": 1,
+                            "records": [{"PermissionSetId": "0PS000000000000"}],
+                        },
+                    }
+                ],
+            },
+        )
+        responses.add(
+            method="GET",
+            url=f"{task.org_config.instance_url}/services/data/v50.0/query/?q=SELECT+Id%2C+Name+FROM+PermissionSet+WHERE+Name+IN+%28%27PermSet1%27%2C+%27PermSet2%27%2C+%27PermSet3%27%29",
+            status=200,
+            json={
+                "done": True,
+                "totalSize": 1,
+                "records": [
+                    {
+                        "Id": "0PS000000000000",
+                        "Name": "PermSet1",
+                    },
+                    {
+                        "Id": "0PS000000000001",
+                        "Name": "PermSet2",
+                    },
+                ],
+            },
+        )
+
+        with pytest.raises(CumulusCIException):
+            task()

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -358,6 +358,11 @@ Options
 
 	 API names of desired Permission Sets, separated by commas.
 
+``-o user_alias USERALIAS``
+	 *Optional*
+
+	 Alias of target user (if not the current running user, the default).
+
 **batch_apex_wait**
 ==========================================
 

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -336,6 +336,28 @@ Options
 
 	 Metadata API version to use, if not project__package__api_version.
 
+**assign_permission_sets**
+==========================================
+
+**Description:** Assigns specified Permission Sets to the current user, if not already assigned.
+
+**Class:** cumulusci.tasks.salesforce.users.permsets.AssignPermissionSets
+
+Command Syntax
+------------------------------------------
+
+``$ cci task run assign_permission_sets``
+
+
+Options
+------------------------------------------
+
+
+``-o api_names APINAMES``
+	 *Required*
+
+	 API names of desired Permission Sets, separated by commas.
+
 **batch_apex_wait**
 ==========================================
 


### PR DESCRIPTION
# Critical Changes

# Changes

- CumulusCI offers an `assign_permission_sets` task, which assigns one or more Permission Sets to the running user if not already assigned. This task may replace invocations of `dx`.

# Issues Closed
