### PR TITLE
Tighten up handling of boolean in data loads, CLIs and YAMLs.

### DIFF
--- a/cumulusci/core/tests/test_utils.py
+++ b/cumulusci/core/tests/test_utils.py
@@ -6,6 +6,7 @@ from tempfile import TemporaryDirectory
 from pathlib import Path
 
 import pytz
+import pytest
 
 from .. import utils
 
@@ -27,8 +28,13 @@ class TestUtils(unittest.TestCase):
         for arg in (False, "False", "false", "0"):
             self.assertFalse(utils.process_bool_arg(arg))
 
-        for arg in (None, datetime.datetime.now()):
-            self.assertIsNone(utils.process_bool_arg(arg))
+        assert utils.process_bool_arg(None) is False
+
+        with pytest.raises(TypeError):
+            utils.process_bool_arg(datetime.datetime.now())
+
+        with pytest.raises(TypeError):
+            utils.process_bool_arg("xyzzy")
 
     def test_process_list_arg(self):
         self.assertEqual([1, 2], utils.process_list_arg([1, 2]))

--- a/cumulusci/core/utils.py
+++ b/cumulusci/core/utils.py
@@ -10,6 +10,7 @@ import glob
 import pytz
 import time
 from shutil import rmtree
+from typing import Union
 
 from cumulusci.core.exceptions import ConfigMergeError, TaskOptionsError
 
@@ -33,15 +34,27 @@ def parse_datetime(dt_str, format):
     return datetime(t[0], t[1], t[2], t[3], t[4], t[5], t[6], pytz.UTC)
 
 
-def process_bool_arg(arg):
-    """ Determine True/False from argument """
-    if isinstance(arg, bool):
-        return arg
+def process_bool_arg(arg: Union[int, str, None]):
+    """Determine True/False from argument.
+
+    None is considered false.
+    Similar to parts of the Salesforce API, there are a few true-ish and false-ish strings,
+        but "True" and "False" are the canonical ones."""
+    if isinstance(arg, (int, bool)):
+        return bool(arg)
+    elif arg is None:
+        # backwards compatible behaviour that some tasks
+        # rely upon.
+        return False
     elif isinstance(arg, str):
-        if arg.lower() in ["true", "1"]:
+        # these are values that Salesforce's bulk loader accepts
+        # there doesn't seem to be any harm in acccepting the
+        # full list to be coordinated with a "Salesforce standard"
+        if arg.lower() in ["yes", "y", "true", "on", "1"]:
             return True
-        elif arg.lower() in ["false", "0"]:
+        elif arg.lower() in ["no", "n", "false", "off", "0"]:
             return False
+    raise TypeError(f"Cannot interpret as boolean: `{arg}`")
 
 
 def process_glob_list_arg(arg):

--- a/cumulusci/tasks/bulkdata/step.py
+++ b/cumulusci/tasks/bulkdata/step.py
@@ -420,10 +420,12 @@ class RestApiDmlOperation(BaseDmlOperation):
         def _convert(rec):
             result = dict(zip(self.fields, rec))
             for boolean_field in self.boolean_fields:
-                # This is clumsy but required since Booleans are stored as.
-                result[boolean_field] = (
-                    result[boolean_field] or "false"
-                ).lower() == "true"
+                try:
+                    result[boolean_field] = process_bool_arg(
+                        result[boolean_field] or False
+                    )
+                except TypeError as e:
+                    raise BulkDataException(e)
 
             # Remove empty fields (different semantics in REST API)
             # We do this for insert only - on update, any fields set to `null`


### PR DESCRIPTION
For dataloads: previously only a "True" and "true" were considered true and everything else was false. Now, we use the same set of true and false strings, ints and bools that the Salesforce Data Loader uses. Anything else throws an exception. One additional argument for this open stance is that the "SQLite standard" string representation of True is "1" and False is "0" and in postgres it is "true" and "false".

For command lines: previously it could return True for known-true values, False for known-false values and None for anything else. Of course the "None" was generally interpreted as "False" so, for example, "yes" was "False". Now it uses the same rules as above.

None is considered a known-false value because many tasks are coded that way. I am open to fixing the ones in our control and adding a deprecation warning to the others but I didn't know if that would be the team consensus so I pulled back from that plan.
