### PR TITLE
Skip validation for 2gp package versions for feature tests

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -990,15 +990,14 @@ flows:
         description: Create a 2gp managed package version
         steps:
             1:
-                flow: dependencies
-            2:
                 task: update_package_xml
                 when: project_config.project__source_format != "sfdx"
-            3:
+            2:
                 task: create_package_version
                 options:
                     package_type: Managed
                     package_name: $project_config.project__package__name Managed Feature Test
+                    skip_validation: True
 
     unmanaged_ee:
         group: Deployment

--- a/cumulusci/tasks/package_2gp.py
+++ b/cumulusci/tasks/package_2gp.py
@@ -315,7 +315,10 @@ class CreatePackageVersion(BaseSalesforceApiTask):
 
             # Add the dependencies for the package
             is_dependency = package_config is not self.package_config
-            if not package_config.org_dependent and not is_dependency:
+            if (
+                not (package_config.org_dependent or skip_validation)
+                and not is_dependency
+            ):
                 self.logger.info("Determining dependencies for package")
                 dependencies = self._get_dependencies()
             if dependencies:


### PR DESCRIPTION
Skipping validation is much faster, and is appropriate for the feature test use case since the ci_feature_2gp flow will test installation and operation of the package. The issues that blocked us from using it before now seem to be resolved. Also, we don't need to specify dependencies when we're skipping validation.

# Critical Changes

# Changes
- The `build_feature_test_package` flow now creates a 2gp package version with the "skip validation" option turned on.

# Issues Closed
