### PR TITLE
Revert accidental change in previous commit.

### DIFF
--- a/docs/robotframework.rst
+++ b/docs/robotframework.rst
@@ -271,7 +271,8 @@ Full Documentation
 Full documentation of the keywords in the CumulusCI and Salesforce
 keyword libraries can be found here:
 
-* `CumulusCI and Salesforce keyword libraries <Keywords.html>`_
+* :download:`CumulusCI and Salesforce Keyword Documentation <../docs/robot/Keywords.html>`
+
 
 .. _salesforce-library-overview:
 


### PR DESCRIPTION
I was experimenting with a different way to do the linking and didn't intend to check it in. This reverts one line of documentation to what it was previously.

# Critical Changes

# Changes

# Issues Closed
