### PR TITLE
use stderr for outputting some notices

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -115,15 +115,15 @@ def check_latest_version():
         try:
             latest_version = get_latest_final_version()
         except requests.exceptions.RequestException as e:
-            click.echo("Error checking cci version:")
-            click.echo(str(e))
+            click.echo("Error checking cci version:", err=True)
+            click.echo(str(e), err=True)
             return
 
         result = latest_version > get_installed_version()
-        click.echo("Checking the version!")
         if result:
             click.echo(
-                f"""An update to CumulusCI is available. To install the update, run this command: {get_cci_upgrade_command()}"""
+                f"""An update to CumulusCI is available. To install the update, run this command: {get_cci_upgrade_command()}""",
+                err=True,
             )
 
 
@@ -224,7 +224,7 @@ def main(args=None):
         try:
             cli(standalone_mode=False)
         except click.Abort:  # Keyboard interrupt
-            show_debug_info() if debug else click.echo("\nAborted!")
+            show_debug_info() if debug else click.echo("\nAborted!", err=True)
             sys.exit(1)
         except Exception as e:
             if debug:
@@ -243,12 +243,12 @@ def handle_exception(error, is_error_cmd, logfile_path, should_show_stacktraces=
     if isinstance(error, exceptions.ConnectionError):
         connection_error_message()
     elif isinstance(error, click.ClickException):
-        click.echo(click.style(f"Error: {error.format_message()}", fg="red"))
+        click.echo(click.style(f"Error: {error.format_message()}", fg="red"), err=True)
     else:
-        click.echo(click.style(f"Error: {error}", fg="red"))
+        click.echo(click.style(f"Error: {error}", fg="red"), err=True)
     # Only suggest gist command if it wasn't run
     if not is_error_cmd:
-        click.echo(click.style(SUGGEST_ERROR_COMMAND, fg="yellow"))
+        click.echo(click.style(SUGGEST_ERROR_COMMAND, fg="yellow"), err=True)
 
     # This is None if we're handling an exception for a
     # `cci error` command.
@@ -265,7 +265,7 @@ def connection_error_message():
         "We encountered an error with your internet connection. "
         "Please check your connection and try the last cci command again."
     )
-    click.echo(click.style(message, fg="red"))
+    click.echo(click.style(message, fg="red"), err=True)
 
 
 def show_debug_info():

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -108,7 +108,7 @@ class TestCCI(unittest.TestCase):
 
         cci.check_latest_version()
 
-        self.assertEqual(2, click.echo.call_count)
+        click.echo.assert_called_once()
 
     @mock.patch("cumulusci.cli.cci.get_latest_final_version")
     @mock.patch("cumulusci.cli.cci.click")
@@ -119,7 +119,7 @@ class TestCCI(unittest.TestCase):
 
         cci.check_latest_version()
 
-        click.echo.assert_any_call("Error checking cci version:")
+        click.echo.assert_any_call("Error checking cci version:", err=True)
 
     def test_render_recursive(self):
         out = []


### PR DESCRIPTION
This avoids accidentally including the "time to upgrade" notice when piping `cci task doc` to docs/tasks.rst to update the generated task docs.

I also changed a few other calls to click.echo where it seemed like stderr would be more appropriate, and removed the "Checking the version!" output which doesn't seem necessary.

# Critical Changes

# Changes

# Issues Closed

