### PR TITLE
Add rst-lint to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,7 @@ repos:
     hooks:
     - id: check-merge-conflict
     - id: flake8
+-   repo: https://github.com/Lucas-C/pre-commit-hooks-markup
+    rev: v1.0.0
+    hooks:
+    - id: rst-linter


### PR DESCRIPTION
This PR adds `rst-lint` to our pre-commit checks. When run with `pre-commit run --all-files` it'll catch the currently broken HISTORY.rst file (and several others).

# Critical Changes

# Changes

# Issues Closed
