### PR TITLE
Clean up DB connections carefully for Windows.

### DIFF
--- a/cumulusci/tasks/bulkdata/extract.py
+++ b/cumulusci/tasks/bulkdata/extract.py
@@ -99,8 +99,6 @@ class ExtractData(SqlAlchemyMixin, BaseSalesforceApiTask):
             # initialize the DB engine
             parent_engine = create_engine(database_url)
             with parent_engine.connect() as connection:
-                self.engine = connection
-
                 # initialize DB metadata
                 self.metadata = MetaData()
                 self.metadata.bind = connection

--- a/cumulusci/tasks/bulkdata/extract.py
+++ b/cumulusci/tasks/bulkdata/extract.py
@@ -97,8 +97,9 @@ class ExtractData(SqlAlchemyMixin, BaseSalesforceApiTask):
         with self._database_url() as database_url:
 
             # initialize the DB engine
-            self.engine = create_engine(database_url)
-            with self.engine.connect() as connection:
+            parent_engine = create_engine(database_url)
+            with parent_engine.connect() as connection:
+                self.engine = connection
 
                 # initialize DB metadata
                 self.metadata = MetaData()

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -413,21 +413,19 @@ class LoadData(SqlAlchemyMixin, BaseSalesforceApiTask):
         with self._database_url() as database_url:
             parent_engine = create_engine(database_url)
             with parent_engine.connect() as connection:
-                self.engine = connection
-
                 # initialize the DB session
-                self.session = Session(self.engine)
+                self.session = Session(connection)
 
                 if self.options.get("sql_path"):
                     self._sqlite_load()
 
                 # initialize DB metadata
                 self.metadata = MetaData()
-                self.metadata.bind = self.engine
+                self.metadata.bind = connection
 
                 # initialize the automap mapping
-                self.base = automap_base(bind=self.engine, metadata=self.metadata)
-                self.base.prepare(self.engine, reflect=True)
+                self.base = automap_base(bind=connection, metadata=self.metadata)
+                self.base.prepare(connection, reflect=True)
 
                 # Loop through mappings and reflect each referenced table
                 self.models = {}

--- a/cumulusci/tasks/bulkdata/tests/test_extract.py
+++ b/cumulusci/tasks/bulkdata/tests/test_extract.py
@@ -389,7 +389,9 @@ class TestExtractData:
         task.mapping["Opportunity"] = mapping
         with task._init_db():
             task._import_results(mapping, step)
-            output_Opportunties = list(task.engine.execute("select * from Opportunity"))
+            output_Opportunties = list(
+                task.session.execute("select * from Opportunity")
+            )
             assert output_Opportunties == [(1,), (2,)]
 
     @responses.activate
@@ -716,7 +718,6 @@ class TestExtractData:
         with task._init_db():
             assert task.models == {}
             assert task.session.query
-            assert task.engine.execute
 
     def assert_person_accounts_in_mapping(
         self, mapping, org_has_person_accounts_enabled


### PR DESCRIPTION
Previously: During the load and extract tasks, on Windows 10 if there is an error triggered by a load or extract task, CCI masks the error message by throwing a second error related to cleaning up the temp data that was built for the process.

This should fix it. I'll do tests to checks whether it also fixes `generate_and_load_from_yaml`. Maybe, maybe not

For release notes:

During the load and extract tasks, on Windows 10 if there is an error triggered by a load or extract task, CCI would mask the real error message by throwing a second error related to cleaning up the temp data that was built for the process. Now the real error will be reported correctly.
