### PR TITLE
Fix missing namespace_inject option when freezing deploy task

### DIFF
--- a/cumulusci/tasks/salesforce/Deploy.py
+++ b/cumulusci/tasks/salesforce/Deploy.py
@@ -69,6 +69,11 @@ class Deploy(BaseSalesforceMetadataApiTask):
                 "The specified_tests option and test_level RunSpecifiedTests must be used together."
             )
 
+        self.options["namespace_inject"] = (
+            self.options.get("namespace_inject")
+            or self.project_config.project__package__namespace
+        )
+
     def _get_api(self, path=None):
         if not path:
             path = self.options.get("path")
@@ -97,10 +102,7 @@ class Deploy(BaseSalesforceMetadataApiTask):
 
     def _get_package_zip(self, path):
         assert path, f"Path should be specified for {self.__class__.name}"
-        if "namespace_inject" in self.options:
-            namespace = self.options["namespace_inject"]
-        else:
-            namespace = self.project_config.project__package__namespace
+        namespace = self.options["namespace_inject"]
         options = {
             **self.options,
             "clean_meta_xml": process_bool_arg(

--- a/cumulusci/tasks/salesforce/install_package_version.py
+++ b/cumulusci/tasks/salesforce/install_package_version.py
@@ -3,7 +3,7 @@ from cumulusci.core.utils import process_bool_arg
 from cumulusci.salesforce_api.exceptions import MetadataApiError
 from cumulusci.salesforce_api.package_install import install_package_version
 from cumulusci.salesforce_api.package_zip import InstallPackageZipBuilder
-from cumulusci.tasks.salesforce import Deploy
+from cumulusci.tasks.salesforce.Deploy import Deploy
 
 
 class InstallPackageVersion(Deploy):
@@ -39,7 +39,8 @@ class InstallPackageVersion(Deploy):
     }
 
     def _init_options(self, kwargs):
-        super(InstallPackageVersion, self)._init_options(kwargs)
+        super()._init_options(kwargs)
+        del self.options["namespace_inject"]
         if "namespace" not in self.options:
             self.options["namespace"] = self.project_config.project__package__namespace
         if "name" not in self.options:

--- a/cumulusci/tasks/salesforce/tests/test_DeployBundles.py
+++ b/cumulusci/tasks/salesforce/tests/test_DeployBundles.py
@@ -58,6 +58,7 @@ class TestDeployBundles(unittest.TestCase):
                                         "repo_name": "TestRepo",
                                         "repo_owner": "TestOwner",
                                         "subfolder": "unpackaged/test",
+                                        "namespace_inject": None,
                                     }
                                 ]
                             },


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed
- Fixed a bug where the ``namespace_inject`` option was not included when freezing deploy steps for MetaDeploy, causing namespace injection to not work.