### PR TITLE
Feature/windows shutdown nicely

### DIFF
--- a/cumulusci/oauth/salesforce.py
+++ b/cumulusci/oauth/salesforce.py
@@ -167,8 +167,10 @@ class OAuthCallbackHandler(BaseHTTPRequestHandler):
                 http_status = self.parent.response.status_code
                 http_body = self.parent.response.text
         self.send_response(http_status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+
         self.end_headers()
-        self.wfile.write(http_body.encode("ascii"))
+        self.wfile.write(http_body.encode("utf-8"))
         if self.parent.response is None:
             response = requests.Response()
             response.status_code = http_status

--- a/cumulusci/oauth/salesforce.py
+++ b/cumulusci/oauth/salesforce.py
@@ -157,16 +157,10 @@ class OAuthCallbackHandler(BaseHTTPRequestHandler):
             http_body = f"error: {args['error'][0]}\nerror description: {args['error_description'][0]}"
         else:
             http_status = http.client.OK
-            gif = random.choice(
-                [
-                    "tMUMi4Ylnzk88",
-                    "Cj3Ce7e8h2EKY",
-                    "3MibWRcT0AOYG7HUeT",
-                    "9uoYC7cjcU6w8",
-                ]
-            )
-            http_body = f"""<html><p>Congratulations! Your authentication succeeded.</p>
-            <iframe src="https://giphy.com/embed/{gif}" width="480" height="360" frameBorder="0"></iframe></html>"""
+            emoji = random.choice(["🎉", "👍", "👍🏿", "🥳", "🎈"])
+            http_body = f"""<html>
+            <h1 style="font-size: large">{emoji}</h1>
+            <p>Congratulations! Your authentication succeeded.</p>"""
             code = args["code"]
             self.parent.response = self.parent.oauth_api.get_token(code)
             if self.parent.response.status_code >= http.client.BAD_REQUEST:

--- a/cumulusci/oauth/salesforce.py
+++ b/cumulusci/oauth/salesforce.py
@@ -143,7 +143,6 @@ class HTTPDTimeout(threading.Thread):
             self.httpd.shutdown()
 
     def quit(self):
-        print("Quittiing")
         self.httpd = None
 
 

--- a/cumulusci/oauth/salesforce.py
+++ b/cumulusci/oauth/salesforce.py
@@ -134,7 +134,8 @@ class HTTPDTimeout(threading.Thread):
         super().__init__()
 
     def run(self):
-        for i in range(self.timeout):
+        target_time = time.time() + self.timeout
+        while time.time() < target_time:
             time.sleep(1)
             if not self.httpd:
                 break
@@ -182,11 +183,7 @@ class OAuthCallbackHandler(BaseHTTPRequestHandler):
 
         #  https://docs.python.org/3/library/socketserver.html#socketserver.BaseServer.shutdown
         # shutdown() must be called while serve_forever() is running in a different thread otherwise it will deadlock.
-        def delayed_shutdown():
-            time.sleep(1)
-            self.server.shutdown()
-
-        threading.Thread(target=delayed_shutdown).start()
+        threading.Thread(target=self.server.shutdown).start()
 
 
 class CaptureSalesforceOAuth(object):

--- a/cumulusci/oauth/salesforce.py
+++ b/cumulusci/oauth/salesforce.py
@@ -182,8 +182,11 @@ class OAuthCallbackHandler(BaseHTTPRequestHandler):
 
         #  https://docs.python.org/3/library/socketserver.html#socketserver.BaseServer.shutdown
         # shutdown() must be called while serve_forever() is running in a different thread otherwise it will deadlock.
-        t = threading.Thread(target=self.server.shutdown)
-        t.start()
+        def delayed_shutdown():
+            time.sleep(1)
+            self.server.shutdown()
+
+        threading.Thread(target=delayed_shutdown).start()
 
 
 class CaptureSalesforceOAuth(object):
@@ -208,7 +211,7 @@ class CaptureSalesforceOAuth(object):
             + "press ctrl+c to kill the server and return to the command line."
         )
         timeout_thread = HTTPDTimeout(self.httpd, self.httpd_timeout)
-        # use serve_forever because it is smarter abot polling for Ctrl-C
+        # use serve_forever because it is smarter about polling for Ctrl-C
         # on Windows
         timeout_thread.start()
         self.httpd.serve_forever()

--- a/cumulusci/oauth/tests/test_salesforce.py
+++ b/cumulusci/oauth/tests/test_salesforce.py
@@ -63,7 +63,7 @@ class TestCaptureSalesforceOAuth(unittest.TestCase):
         self.auth_site = "https://login.salesforce.com"
 
     @responses.activate
-    @mock.patch("time.sleep", time.sleep)
+    @mock.patch("time.sleep", time.sleep)  # undo mock from conftest
     def test_oauth_flow_simple(self):
 
         # mock response to URL validation
@@ -114,7 +114,7 @@ class TestCaptureSalesforceOAuth(unittest.TestCase):
         self.assertEqual(o.response.json(), expected_response)
         self.assertIn(b"Congratulations", response.read())
 
-    @mock.patch("time.sleep", time.sleep)
+    @mock.patch("time.sleep", time.sleep)  # undo mock from conftest
     @responses.activate
     def test_oauth_flow_error_from_auth(self):
 
@@ -165,7 +165,7 @@ class TestCaptureSalesforceOAuth(unittest.TestCase):
         # wait for thread to complete
         t.join()
 
-    @mock.patch("time.sleep", time.sleep)
+    @mock.patch("time.sleep", time.sleep)  # undo mock from conftest
     @responses.activate
     def test_oauth_flow_error_from_token(self):
 

--- a/cumulusci/oauth/tests/test_salesforce.py
+++ b/cumulusci/oauth/tests/test_salesforce.py
@@ -63,7 +63,8 @@ class TestCaptureSalesforceOAuth(unittest.TestCase):
         self.auth_site = "https://login.salesforce.com"
 
     @responses.activate
-    def test_oauth_flow(self):
+    @mock.patch("time.sleep", time.sleep)
+    def test_oauth_flow_simple(self):
 
         # mock response to URL validation
         responses.add(
@@ -113,6 +114,7 @@ class TestCaptureSalesforceOAuth(unittest.TestCase):
         self.assertEqual(o.response.json(), expected_response)
         self.assertIn(b"Congratulations", response.read())
 
+    @mock.patch("time.sleep", time.sleep)
     @responses.activate
     def test_oauth_flow_error_from_auth(self):
 
@@ -163,6 +165,7 @@ class TestCaptureSalesforceOAuth(unittest.TestCase):
         # wait for thread to complete
         t.join()
 
+    @mock.patch("time.sleep", time.sleep)
     @responses.activate
     def test_oauth_flow_error_from_token(self):
 


### PR DESCRIPTION
# Changes

When connecting to an org with `cci org connect`, Ctrl-C often could not kill the server on Windows in case the user wanted to exit without finishing. Now Ctrl-C works as expected.

# Issues Closed

https://github.com/SFDO-Tooling/CumulusCI/issues/2027

