### PR TITLE
Fix silly bugs in custom_settings_value_wait

### DIFF
--- a/cumulusci/tasks/salesforce/custom_settings_wait.py
+++ b/cumulusci/tasks/salesforce/custom_settings_wait.py
@@ -92,13 +92,21 @@ class CustomSettingValueWait(BaseSalesforceApiTask):
 
     def _apply_namespace(self):
         # Process namespace tokens
-        managed = process_bool_arg(self.options.get("managed", False))
-        namespaced = process_bool_arg(self.options.get("namespaced", False))
         namespace = self.project_config.project__package__namespace
-        namespace_prefix = ""
-        if managed or namespaced:
-            namespace_prefix = namespace + "__"
+        if "managed" in self.options:
+            managed = process_bool_arg(self.options["managed"])
+        else:
+            managed = (
+                bool(namespace) and namespace in self.org_config.installed_packages
+            )
+        if "namespaced" in self.options:
+            namespaced = process_bool_arg(self.options["namespaced"])
+        else:
+            namespaced = bool(namespace) and self.org_config.namespace == namespace
 
+        namespace_prefix = ""
+        if namespace and (managed or namespaced):
+            namespace_prefix = namespace + "__"
         self.object_name = self.object_name.replace("%%%NAMESPACE%%%", namespace_prefix)
         self.field_name = self.field_name.replace("%%%NAMESPACE%%%", namespace_prefix)
 

--- a/cumulusci/tasks/salesforce/custom_settings_wait.py
+++ b/cumulusci/tasks/salesforce/custom_settings_wait.py
@@ -3,7 +3,6 @@
 from simple_salesforce.exceptions import SalesforceError
 
 from cumulusci.tasks.salesforce import BaseSalesforceApiTask
-from cumulusci.core.exceptions import SalesforceException
 from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.core.utils import process_bool_arg
 
@@ -78,12 +77,8 @@ class CustomSettingValueWait(BaseSalesforceApiTask):
 
         self.record = None
         for row in query_results["records"]:
-            if "SetupOwnerId" in row:
-                setupOwnerId = str(row["SetupOwnerId"])
-                if setupOwnerId.startswith("00D"):
-                    self.record = row
-            else:
-                raise TaskOptionsError("Only Hierarchical Custom Settings objects are supported.")
+            if row["SetupOwnerId"].startswith("00D"):
+                self.record = row
 
         if self.record:
             self.poll_complete = not self._poll_again()

--- a/cumulusci/tasks/salesforce/custom_settings_wait.py
+++ b/cumulusci/tasks/salesforce/custom_settings_wait.py
@@ -73,7 +73,7 @@ class CustomSettingValueWait(BaseSalesforceApiTask):
         except SalesforceError as e:
             message = e.content[0]["message"]
             if "No such column 'SetupOwnerId'" in message:
-                message = "Only Custom Settings objects are supported."
+                message = "Only Hierarchical Custom Settings objects are supported."
             raise TaskOptionsError(f"Query Error: {message}")
 
         self.record = None
@@ -83,7 +83,7 @@ class CustomSettingValueWait(BaseSalesforceApiTask):
                 if setupOwnerId.startswith("00D"):
                     self.record = row
             else:
-                raise TaskOptionsError("Only Custom Settings objects are supported.")
+                raise TaskOptionsError("Only Hierarchical Custom Settings objects are supported.")
 
         if self.record:
             self.poll_complete = not self._poll_again()
@@ -109,8 +109,8 @@ class CustomSettingValueWait(BaseSalesforceApiTask):
 
     @property
     def success(self):
-        lowerCaseRecord = {k.lower(): v for k, v in self.record.items()}
-        self.field_value = lowerCaseRecord[self.field_name.lower()]
+        lower_case_record = {k.lower(): v for k, v in self.record.items()}
+        self.field_value = lower_case_record[self.field_name.lower()]
 
         if isinstance(self.field_value, bool):
             self.check_value = process_bool_arg(self.check_value)

--- a/cumulusci/tasks/salesforce/tests/test_custom_settings_wait.py
+++ b/cumulusci/tasks/salesforce/tests/test_custom_settings_wait.py
@@ -130,9 +130,17 @@ class TestRunCustomSettingsWait(MockLoggerMixin, unittest.TestCase):
         }
 
         task, url = self._get_url_and_task()
-        response = self._get_query_resp()
-        del response["records"][0]["SetupOwnerId"]
-        responses.add(responses.GET, url, json=response)
+        responses.add(
+            responses.GET,
+            url,
+            status=400,
+            json=[
+                {
+                    "message": "\nSELECT SetupOwnerId FROM npe5__Affiliation__c\n       ^\nERROR at Row:1:Column:8\nNo such column 'SetupOwnerId' on entity 'npe5__Affiliation__c'. If you are attempting to use a custom field, be sure to append the '__c' after the custom field name. Please reference your WSDL or the describe call for the appropriate names.",
+                    "errorCode": "INVALID_FIELD",
+                }
+            ],
+        )
 
         with self.assertRaises(TaskOptionsError) as e:
             task()

--- a/cumulusci/tasks/salesforce/tests/test_custom_settings_wait.py
+++ b/cumulusci/tasks/salesforce/tests/test_custom_settings_wait.py
@@ -79,7 +79,11 @@ class TestRunCustomSettingsWait(MockLoggerMixin, unittest.TestCase):
             "poll_interval": 1,
         }
 
+        # simulate finding no settings record and then finding one with the expected value
         task, url = self._get_url_and_task()
+        responses.add(
+            responses.GET, url, json={"totalSize": 0, "done": True, "records": []}
+        )
         response = self._get_query_resp()
         response["records"][0]["Customizable_Rollups_Enabled__c"] = True
         responses.add(responses.GET, url, json=response)
@@ -112,6 +116,21 @@ class TestRunCustomSettingsWait(MockLoggerMixin, unittest.TestCase):
         task, url = self._get_url_and_task()
         response = self._get_query_resp()
         response["records"][0]["Rollups_Account_Batch_Size__c"] = 200
+        responses.add(responses.GET, url, json=response)
+        task()
+
+    @responses.activate
+    def test_run_custom_settings_wait_match_str(self):
+        self.task_config.config["options"] = {
+            "object": "Customizable_Rollup_Setings__c",
+            "field": "Rollups_Account_Batch_Size__c",
+            "value": "asdf",
+            "poll_interval": 1,
+        }
+
+        task, url = self._get_url_and_task()
+        response = self._get_query_resp()
+        response["records"][0]["Rollups_Account_Batch_Size__c"] = "asdf"
         responses.add(responses.GET, url, json=response)
         task()
 


### PR DESCRIPTION
# Critical Changes

# Changes

- Fix the `custom_settings_value_wait` task to not throw an exception if a custom settings record doesn't yet exist. Instead it'll continue to query the object until the record exists and the value matches
- Fix the `custom_settings_value_wait` task to not throw an exception if the field api name passed as an option doesn't exactly match the case of the field api name in the object.

# Issues Closed
