### PR TITLE
2GP Standard Library

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -904,7 +904,7 @@ flows:
                 options:
                     context: "Build Feature Test Package"
             2:
-                flow: beta_dependencies
+                flow: dependencies
                 options:
                     update_dependencies:
                         dependencies: ^^github_package_data.dependencies

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -615,21 +615,10 @@ flows:
         description: Install as a managed 2gp package and run Apex tests. Intended for use after build_feature_test_package.
         steps:
             1:
-                task: github_package_data
-                options:
-                    context: "Build Feature Test Package"
+                flow: install_2gp_commit
             2:
-                flow: beta_dependencies
-                options:
-                    update_dependencies:
-                        dependencies: ^^github_package_data.dependencies
+                flow: config_apextest
             3:
-                task: install_managed
-                options:
-                    version: ^^github_package_data.version_id
-            4:
-                flow: config_managed
-            5:
                 task: run_tests
 
     ci_master:
@@ -845,6 +834,17 @@ flows:
             4:
                 task: snapshot_changes
 
+    qa_org_2gp:
+        group: Org Setup
+        description: Set up an org as a QA environment using a second-generation package
+        steps:
+            1:
+                flow: install_2gp_commit
+            2:
+                flow: config_qa
+            3:
+                task: snapshot_changes
+
     regression_org:
         group: Org Setup
         description: Simulates an org that has been upgraded from the latest release of to the current beta and its dependencies, but deploys any unmanaged metadata from the current beta.
@@ -864,6 +864,24 @@ flows:
                 task: uninstall_post
             2:
                 task: uninstall_managed
+
+    install_2gp_commit:
+        group: Install / Uninstall
+        description: Install the 2GP package for the current commit
+        steps:
+            1:
+                task: github_package_data
+                options:
+                    context: "Build Feature Test Package"
+            2:
+                flow: beta_dependencies
+                options:
+                    update_dependencies:
+                        dependencies: ^^github_package_data.dependencies
+            3:
+                task: install_managed
+                options:
+                    version: ^^github_package_data.version_id
 
     install_beta:
         group: Org Setup


### PR DESCRIPTION
# Critical Changes

# Changes

- An experimental `qa_org_2gp` flow is provided in the standard library. This flow uses `config_qa`, meaning that `config_qa` must be tokenized and not include explicit `managed` or `unmanaged` options so that CumulusCI can manage performing the appropriate injection. This flow may change at any time.
- The `ci_feature_2gp` flow has been changed to use `config_apextest` instead of `config_managed`. This means that `config_apextest` must be tokenized and not include explicit `managed` or `unmanaged` options so that CumulusCI can manage performing the appropriate injection.

# Issues Closed
