### PR TITLE
Clarify what to do if scratch org can't be deleted

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1173,7 +1173,7 @@ def org_remove(runtime, org_name, global_org):
     if org_config.can_delete():
         click.echo("A scratch org was already created, attempting to delete...")
         try:
-            org_config.delete_org()
+            org_config.delete_org(force=True)
         except Exception as e:
             click.echo("Deleting scratch org failed with error:")
             click.echo(e)

--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -177,7 +177,7 @@ class ScratchOrgConfig(SfdxOrgConfig):
     def can_delete(self):
         return bool(self.date_created)
 
-    def delete_org(self):
+    def delete_org(self, force=False):
         """ Uses sfdx force:org:delete to delete the org """
         if not self.created:
             self.logger.info(
@@ -197,7 +197,15 @@ class ScratchOrgConfig(SfdxOrgConfig):
 
         if p.returncode:
             message = f"Failed to delete scratch org: \n{''.join(stdout)}"
-            raise ScratchOrgException(message)
+            message += "\nPerhaps it was already deleted?"
+            if force:
+                message += "\nRemoving org regardless."
+                self.logger.info(message)
+            else:
+                message += (
+                    "\nUse `cci org remove {orgname}` to remove it from CumulusCI."
+                )
+                raise ScratchOrgException(message)
 
         # Flag that this org has been deleted
         self.config["created"] = False


### PR DESCRIPTION
# Critical Changes

Improve the error messaging around scratch_delete of an org that throws an exception from sfdx.

Force cci_org_remove to remove the org whether SFDX is able to delete it or not.

