### PR TITLE
Don't error on deploy if sfdx folder is empty

### DIFF
--- a/cumulusci/salesforce_api/package_zip.py
+++ b/cumulusci/salesforce_api/package_zip.py
@@ -117,7 +117,8 @@ class MetadataPackageZipBuilder(BasePackageZipBuilder):
     def _convert_sfdx_format(self, path, name):
         orig_path = path
         with contextlib.ExitStack() as stack:
-            if not pathlib.Path(path, "package.xml").exists():
+            # convert sfdx -> mdapi format if path exists but does not have package.xml
+            if len(os.listdir(path)) and not pathlib.Path(path, "package.xml").exists():
                 self.logger.info("Converting from sfdx to mdapi format")
                 path = stack.enter_context(temporary_dir(chdir=False))
                 args = ["-r", str(orig_path), "-d", path]

--- a/cumulusci/salesforce_api/tests/test_package_zip.py
+++ b/cumulusci/salesforce_api/tests/test_package_zip.py
@@ -317,11 +317,20 @@ class TestMetadataPackageZipBuilder:
 
     def test_convert_sfdx(self):
         with temporary_dir() as path:
+            touch("README.md")  # make sure there's something in the directory
             with mock.patch("cumulusci.salesforce_api.package_zip.sfdx") as sfdx:
                 builder = MetadataPackageZipBuilder()
                 with builder._convert_sfdx_format(path, "Test Package"):
                     pass
         sfdx.assert_called_once()
+
+    def test_convert_sfdx__skipped_if_directory_empty(self):
+        with temporary_dir() as path:
+            with mock.patch("cumulusci.salesforce_api.package_zip.sfdx") as sfdx:
+                builder = MetadataPackageZipBuilder()
+                with builder._convert_sfdx_format(path, "Test Package"):
+                    pass
+        sfdx.assert_not_called()
 
     def test_removes_feature_parameters_from_unlocked_package(self):
         with temporary_dir() as path:

--- a/cumulusci/tasks/salesforce/tests/test_Deploy.py
+++ b/cumulusci/tasks/salesforce/tests/test_Deploy.py
@@ -114,6 +114,19 @@ class TestDeploy(unittest.TestCase):
                 self.assertIn("<name>StaticResource</name>", package_xml)
                 self.assertIn("<members>TestBundle</members>", package_xml)
 
+    def test_get_api__empty_package_zip(self):
+        with temporary_dir() as path:
+            task = create_task(
+                Deploy,
+                {
+                    "path": path,
+                    "unmanaged": True,
+                },
+            )
+
+            api = task._get_api()
+            assert api is None
+
     def test_init_options(self):
         with self.assertRaises(TaskOptionsError):
             create_task(


### PR DESCRIPTION
This fixes an error which would happen if you run `dev_org` immediately after starting a project with `cci project init`.

- added a condition to avoid running sfdx force:source:convert if the folder is empty
- added a condition to avoid trying to deploy if the package zip is empty (i.e. not even package.xml)

# Critical Changes

# Changes

# Issues Closed
- Fixed the `deploy` task so that deploying an empty metadata directory does not error.