### PR TITLE
Use final releases and log a warning if include_beta is True with a persistent org

### DIFF
--- a/cumulusci/tasks/salesforce/tests/test_update_dependencies.py
+++ b/cumulusci/tasks/salesforce/tests/test_update_dependencies.py
@@ -232,17 +232,17 @@ class TestUpdateDependencies(unittest.TestCase):
             },
         ]
 
-    def test_update_dependency_latest_option_err(self):
+    def test_init_options__include_beta_with_persistent_org(self):
         project_config = create_project_config()
         project_config.config["project"]["dependencies"] = [{"namespace": "foo"}]
-        task = create_task(UpdateDependencies, project_config=project_config)
-        task.options["include_beta"] = True
-        task.org_config = mock.Mock(scratch=False)
-        task.org_config.save_if_changed.return_value.__enter__ = lambda *args: ...
-        task.org_config.save_if_changed.return_value.__exit__ = lambda *args: ...
-
-        with self.assertRaises(TaskOptionsError):
-            task()
+        org_config = mock.Mock(scratch=False)
+        task = create_task(
+            UpdateDependencies,
+            {"include_beta": True},
+            project_config=project_config,
+            org_config=org_config,
+        )
+        assert not task.options["include_beta"]
 
     def test_dependency_no_package_zip(self):
         project_config = create_project_config()


### PR DESCRIPTION
(instead of erroring)

# Critical Changes

# Changes
- When the `update_dependencies` task is run against a persistent org with the `include_beta` option enabled, it will now turn the option off and log a warning, instead of throwing an error. The result is that persistent orgs will use final versions of dependencies instead of beta versions (which can't be upgraded).

# Issues Closed
