### PR TITLE
Issue #2093: Fix confusing warning message about record_types

### DIFF
--- a/cumulusci/tasks/bulkdata/generate_and_load_data_from_yaml.py
+++ b/cumulusci/tasks/bulkdata/generate_and_load_data_from_yaml.py
@@ -1,5 +1,8 @@
+from unittest import mock
+
 from cumulusci.tasks.bulkdata import GenerateAndLoadData
 from cumulusci.tasks.bulkdata.generate_from_yaml import GenerateDataFromYaml
+from cumulusci.tasks.bulkdata import mapping_parser
 
 
 bulkgen_task = "cumulusci.tasks.bulkdata.generate_from_yaml.GenerateDataFromYaml"
@@ -18,3 +21,34 @@ class GenerateAndLoadDataFromYaml(GenerateAndLoadData):
     def _init_options(self, kwargs):
         args = {"data_generation_task": bulkgen_task, **kwargs}
         super()._init_options(args)
+
+    def _run_task(self, *args, **kwargs):
+        with _disable_confusing_record_type_warning():
+            super()._run_task(*args, **kwargs)
+
+
+def _disable_confusing_record_type_warning():
+    """
+    Currently Snowfakery uses a feature that is technically deprecated
+    in mapping files. CumulusCI "warns" the user not to use a feature
+    that they didn't mean to use.
+
+    https://github.com/SFDO-Tooling/CumulusCI/issues/2093
+
+    This is a bit of a hack but doing it "right" is fairly hard with
+    Pydantic and all of the layers of CumulusCI and the hack seems
+    pretty low risk. The correct option would need to be threaded
+    through about 6-8 layers of CumulusCI/Pydantic stack frames.
+
+    Also the whole thing should be fixed in a better way some time
+    in 2021: CumulusCI should support record names in a column rather
+    than just indirected record IDs. Then Snowfakery will just
+    output the record names in an intuitive fashion.
+    """
+
+    # not thread-safe but hardly anything in CumulusCI is.
+    return mock.patch.object(
+        mapping_parser,
+        "SHOULD_REPORT_RECORD_TYPE_DEPRECATION",
+        False,
+    )

--- a/cumulusci/tasks/bulkdata/mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/mapping_parser.py
@@ -65,6 +65,9 @@ class MappingLookup(CCIDictModel):
         )
 
 
+SHOULD_REPORT_RECORD_TYPE_DEPRECATION = True
+
+
 class MappingStep(CCIDictModel):
     "Step in a load or extract process"
     sf_object: str
@@ -179,10 +182,11 @@ class MappingStep(CCIDictModel):
     @validator("record_type")
     @classmethod
     def record_type_is_deprecated(cls, v):
-        logger.warning(
-            "record_type is deprecated. Just supply a RecordTypeId column declaration and it will be inferred"
-        )
-        return v
+        if SHOULD_REPORT_RECORD_TYPE_DEPRECATION:
+            logger.warning(
+                "record_type is deprecated. Just supply a RecordTypeId column declaration and it will be inferred"
+            )
+            return v
 
     @validator("oid_as_pk")
     @classmethod


### PR DESCRIPTION
Currently Snowfakery uses a feature that is technically deprecated in mapping files. CumulusCI "warns" the user not to use a feature that they didn't mean to use.

    https://github.com/SFDO-Tooling/CumulusCI/issues/2093

This is a bit of a hack but doing it "right" is fairly hard with Pydantic and all of the layers of CumulusCI and the hack seems pretty low risk. The correct option would need to be threaded through about 6-8 layers of CumulusCI/Pydantic stack frames.

Also the whole thing should be fixed in a better way some time soon: CumulusCI should support record names in a column rather than just indirected record IDs. Then Snowfakery will just output the record names in an intuitive fashion.
