### PR TITLE
Fix adding the username to the connected app cmd

### DIFF
--- a/cumulusci/tasks/connectedapp.py
+++ b/cumulusci/tasks/connectedapp.py
@@ -166,7 +166,7 @@ class CreateConnectedApp(SFDXBaseTask):
         # Default to sfdx defaultdevhubusername
         if "username" not in self.options:
             self._set_default_username()
-        self.options["command"] += " -u {}".format(self.options.get("username"))
+        command += " -u {}".format(self.options.get("username"))
         command += " -d {}".format(self.tempdir)
         return command
 


### PR DESCRIPTION
# Critical Changes

# Changes
Prior to this change, the username is being added to the option, but not the command. I believe _init_options runs before _get_command. The result is that the username is omitted.

# Issues Closed
