### PR TITLE
EnsureRecordTypes supports Record Type Description

### DIFF
--- a/cumulusci/tasks/salesforce/EnsureRecordTypes.py
+++ b/cumulusci/tasks/salesforce/EnsureRecordTypes.py
@@ -25,6 +25,7 @@ SOBJECT_METADATA = """<?xml version="1.0" encoding="utf-8"?>
         <active>true</active>
         {business_process_link}
         <label>{record_type_label}</label>
+        <description>{record_type_description}</description>
     </recordTypes>
 </CustomObject>
 """
@@ -56,6 +57,10 @@ class EnsureRecordTypes(BaseSalesforceApiTask):
             "description": "The Label of the Record Type.",
             "required": True,
         },
+        "record_type_description": {
+            "description": "The Description of the Record Type.  Only uses the first 255 characters.",
+            "required": False,
+        },
         "sobject": {
             "description": "The sObject on which to deploy the Record Type and optional Business Process.",
             "required": True,
@@ -73,6 +78,11 @@ class EnsureRecordTypes(BaseSalesforceApiTask):
             raise TaskOptionsError(
                 "Record Type Developer Name value must contain only alphanumeric or underscore characters"
             )
+
+        # Validate Description has 255 characters
+        self.options["record_type_description"] = (
+            str(self.options.get("record_type_description") or "")
+        )[:255]
 
         # We don't currently support standard objects
         if self.options["sobject"].endswith("__c"):
@@ -152,6 +162,7 @@ class EnsureRecordTypes(BaseSalesforceApiTask):
                         "record_type_developer_name"
                     ],
                     record_type_label=self.options["record_type_label"],
+                    record_type_description=self.options["record_type_description"],
                     business_process_metadata=business_process_metadata,
                     business_process_link=business_process_link,
                 )

--- a/cumulusci/tasks/salesforce/tests/test_EnsureRecordTypes.py
+++ b/cumulusci/tasks/salesforce/tests/test_EnsureRecordTypes.py
@@ -154,9 +154,7 @@ class TestEnsureRecordTypes(unittest.TestCase):
         self.assertNotIn("stage_name", task.options)
 
     def test_generates_record_type_and_business_process(self):
-        """
-        Asserts Record Type Description is optional.
-        """
+        # Asserts Record Type Description is optional.
         task = create_task(
             EnsureRecordTypes,
             {
@@ -184,9 +182,7 @@ class TestEnsureRecordTypes(unittest.TestCase):
                 self.assertMultiLineEqual(PACKAGE_XML, pkg_contents)
 
     def test_generates_record_type_and_business_process__case(self):
-        """
-        Asserts Record Type Description is added and truncated to 255 characters.
-        """
+        # Asserts Record Type Description is added and truncated to 255 characters.
         task = create_task(
             EnsureRecordTypes,
             {
@@ -212,9 +208,7 @@ class TestEnsureRecordTypes(unittest.TestCase):
                 self.assertMultiLineEqual(PACKAGE_XML, pkg_contents)
 
     def test_generates_record_type_only(self):
-        """
-        Asserts Record Type Description is added when the Description is less than 255 characters.
-        """
+        # Asserts Record Type Description is added when the Description is less than 255 characters.
         task = create_task(
             EnsureRecordTypes,
             {

--- a/cumulusci/tasks/salesforce/tests/test_EnsureRecordTypes.py
+++ b/cumulusci/tasks/salesforce/tests/test_EnsureRecordTypes.py
@@ -22,6 +22,7 @@ OPPORTUNITY_METADATA = """<?xml version="1.0" encoding="utf-8"?>
         <active>true</active>
         <businessProcess>NPSP_Default</businessProcess>
         <label>NPSP Default</label>
+        <description></description>
     </recordTypes>
 </CustomObject>
 """
@@ -41,6 +42,7 @@ CASE_METADATA = """<?xml version="1.0" encoding="utf-8"?>
         <active>true</active>
         <businessProcess>NPSP_Default</businessProcess>
         <label>NPSP Default</label>
+        <description>The first 255 characters of record_type_descirption option-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------</description>
     </recordTypes>
 </CustomObject>
 """
@@ -53,6 +55,7 @@ ACCOUNT_METADATA = """<?xml version="1.0" encoding="utf-8"?>
         <active>true</active>
         
         <label>NPSP Default</label>
+        <description>Default Account Record Type created by NPSP.</description>
     </recordTypes>
 </CustomObject>
 """  # noqa: W293
@@ -151,6 +154,9 @@ class TestEnsureRecordTypes(unittest.TestCase):
         self.assertNotIn("stage_name", task.options)
 
     def test_generates_record_type_and_business_process(self):
+        """
+        Asserts Record Type Description is optional.
+        """
         task = create_task(
             EnsureRecordTypes,
             {
@@ -171,17 +177,22 @@ class TestEnsureRecordTypes(unittest.TestCase):
             task._build_package()
             with open(os.path.join("objects", "Opportunity.object"), "r") as f:
                 opp_contents = f.read()
+                self.assertEqual(OPPORTUNITY_METADATA, opp_contents)
                 self.assertMultiLineEqual(OPPORTUNITY_METADATA, opp_contents)
             with open(os.path.join("package.xml"), "r") as f:
                 pkg_contents = f.read()
                 self.assertMultiLineEqual(PACKAGE_XML, pkg_contents)
 
     def test_generates_record_type_and_business_process__case(self):
+        """
+        Asserts Record Type Description is added and truncated to 255 characters.
+        """
         task = create_task(
             EnsureRecordTypes,
             {
                 "record_type_developer_name": "NPSP_Default",
                 "record_type_label": "NPSP Default",
+                "record_type_description": "The first 255 characters of record_type_descirption option-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------Everything past here is more than 255 characters",
                 "sobject": "Case",
             },
         )
@@ -201,11 +212,15 @@ class TestEnsureRecordTypes(unittest.TestCase):
                 self.assertMultiLineEqual(PACKAGE_XML, pkg_contents)
 
     def test_generates_record_type_only(self):
+        """
+        Asserts Record Type Description is added when the Description is less than 255 characters.
+        """
         task = create_task(
             EnsureRecordTypes,
             {
                 "record_type_developer_name": "NPSP_Default",
                 "record_type_label": "NPSP Default",
+                "record_type_description": "Default Account Record Type created by NPSP.",
                 "sobject": "Account",
             },
         )


### PR DESCRIPTION
- Added optional `record_type_description` option that sets the new Record Type's Description.
- If no option is provided, the Description is blank which is the previous behavior.

# Critical Changes

# Changes
`ensure_record_types` supports an optional `record_type_description` option that sets the new Record Type's Description if a Record Type is created.    If no option is provided, the Description is blank.

# Issues Closed
