### PR TITLE
Cci org name  and cci org default improvements

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -869,7 +869,7 @@ def set_org_name(required):
             )
         ctx.params.setdefault("org_name", value)
         if required and not ctx.params.get("org_name"):
-            raise click.UsageError("Missing argument 'ORGNAME'")
+            raise click.UsageError("Please specify ORGNAME or --org ORGNAME")
 
     return callback
 

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -856,7 +856,7 @@ def service_info(runtime, service_name, plain):
 
 def set_org_name(required):
     """Generate a callback for processing the `org_name` option or argument
-    
+
     `required` is a boolean for whether org_name is required
     """
     # could be generalized to work for any mutex pair (or list) but no obvious need
@@ -867,7 +867,6 @@ def set_org_name(required):
             raise click.UsageError(
                 f"Either ORGNAME or --org ORGNAME should be supplied, not both ({value}, {prev_value})"
             )
-        ctx.params.setdefault("org_name", value)
         ctx.params["org_name"] = value or prev_value
         if required and not ctx.params.get("org_name"):
             raise click.UsageError("Please specify ORGNAME or --org ORGNAME")
@@ -876,7 +875,7 @@ def set_org_name(required):
 
 
 def orgname_option_or_argument(*, required):
-    "Create decorator that allows org_name to be an option or an argument"
+    """Create decorator that allows org_name to be an option or an argument"""
 
     def decorator(func):
         if required:

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -855,7 +855,10 @@ def service_info(runtime, service_name, plain):
 
 
 def set_org_name(required):
-    """Generate a callback that enforces the 'required' rule as required"""
+    """Generate a callback for processing the `org_name` option or argument
+    
+    `required` is a boolean for whether org_name is required
+    """
     # could be generalized to work for any mutex pair (or list) but no obvious need
     def callback(ctx, param, value):
         """Callback which enforces mutex and 'required' behaviour (if required)."""

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -868,6 +868,7 @@ def set_org_name(required):
                 f"Either ORGNAME or --org ORGNAME should be supplied, not both ({value}, {prev_value})"
             )
         ctx.params.setdefault("org_name", value)
+        ctx.params["org_name"] = value or prev_value
         if required and not ctx.params.get("org_name"):
             raise click.UsageError("Please specify ORGNAME or --org ORGNAME")
 

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -318,7 +318,9 @@ class TestCCI(unittest.TestCase):
         # cci org remove should really need an attached org
         with contextlib.redirect_stderr(io.StringIO()) as stderr:
             cci.main(["cci", "org", "remove"])
-        assert "Missing argument" in stderr.getvalue(), stderr.getvalue()
+        assert (
+            "Please specify ORGNAME or --org ORGNAME" in stderr.getvalue()
+        ), stderr.getvalue()
 
     @mock.patch("cumulusci.cli.cci.init_logger")  # side effects break other tests
     @mock.patch("cumulusci.cli.cci.get_tempfile_logger")


### PR DESCRIPTION
One can now use --org for commands like `cci org info`, `cci org default`, `cci org remove` etc. This is a usability improvement requested by users on Slack.

One can now pass no org_name to cci org default to print the default.

One can now pass arguments too cci.main and have those arguments go to Click, which is useful in unit testing and generally a good design.
