### PR TITLE
tostring() works for individual elements and parent namespaces can be printed

### DIFF
--- a/cumulusci/utils/xml/metadata_tree.py
+++ b/cumulusci/utils/xml/metadata_tree.py
@@ -255,13 +255,17 @@ class MetadataElement:
             if matches(e)
         )
 
-    def tostring(self, xml_declaration=False):
+    def tostring(self, xml_declaration=False, include_parent_namespaces=False):
         """Serialize back to XML.
 
         The XML Declaration is optional and can be controlled by `xml_declaration`"""
         doc = etree.ElementTree(self._element)
         etree.indent(doc, space="    ")
-        return serialize_xml_for_salesforce(doc, xml_declaration=xml_declaration)
+        return serialize_xml_for_salesforce(
+            doc,
+            xml_declaration=xml_declaration,
+            include_parent_namespaces=include_parent_namespaces,
+        )
 
     def __eq__(self, other: "MetadataElement"):
         eq = self._element == other._element

--- a/cumulusci/utils/xml/salesforce_encoding.py
+++ b/cumulusci/utils/xml/salesforce_encoding.py
@@ -7,12 +7,17 @@ METADATA_NAMESPACE = "http://soap.sforce.com/2006/04/metadata"
 _supported_events = ("start", "end", "start-ns", "end-ns", "comment")
 
 
-def serialize_xml_for_salesforce(xdoc, xml_declaration=True):
+def serialize_xml_for_salesforce(
+    xdoc, xml_declaration=True, include_parent_namespaces=False
+):
     r = xml_encoding if xml_declaration else ""
-
-    new_namespace_declarations = {}
-    all_namespaces = {}
-
+    if include_parent_namespaces:
+        new_namespace_declarations = {
+            prefix: url for prefix, url in xdoc.getroot().nsmap.items()
+        }
+    else:
+        new_namespace_declarations = {}
+    all_namespaces = {url: prefix for prefix, url in xdoc.getroot().nsmap.items()}
     for action, elem in etree.iterwalk(xdoc, events=_supported_events):
         if action == "start-ns":
             prefix, ns = elem

--- a/cumulusci/utils/xml/test/test_metadata_tree.py
+++ b/cumulusci/utils/xml/test/test_metadata_tree.py
@@ -211,3 +211,30 @@ class TestMetadataTree:
 </CustomMetadata>""".strip()
         CustomMetadata = fromstring(xml)
         assert xml.strip() == CustomMetadata.tostring().strip()
+
+    def test_namespaced_to_string(self):
+        xml = """
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <label>Account MD Isolation Rollup</label>
+    <protected>false</protected>
+    <values>
+        <field>dlrs__Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+</CustomMetadata>""".strip()
+
+        CustomMetadata = fromstring(xml)
+
+        xml_out = CustomMetadata.find("values").find("field").tostring()
+        assert xml_out.strip() == "<field>dlrs__Active__c</field>", xml_out.strip()
+
+        xml_out = (
+            CustomMetadata.find("values")
+            .find("field")
+            .tostring(xml_declaration=True, include_parent_namespaces=True)
+        )
+        expected_out = """<?xml version="1.0" encoding="UTF-8"?>
+             <field xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">dlrs__Active__c</field>"""
+        assert (
+            " ".join(xml_out.split()).strip() == " ".join(expected_out.split()).strip()
+        ), xml_out.strip()

--- a/cumulusci/utils/xml/test/test_metadata_tree.py
+++ b/cumulusci/utils/xml/test/test_metadata_tree.py
@@ -212,29 +212,20 @@ class TestMetadataTree:
         CustomMetadata = fromstring(xml)
         assert xml.strip() == CustomMetadata.tostring().strip()
 
-    def test_namespaced_to_string(self):
-        xml = """
-<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <label>Account MD Isolation Rollup</label>
-    <protected>false</protected>
-    <values>
-        <field>dlrs__Active__c</field>
-        <value xsi:type="xsd:boolean">true</value>
-    </values>
-</CustomMetadata>""".strip()
+    def test_namespaced_to_string__do_not_output_namespaces(self):
+        CustomMetadata = fromstring(standard_xml)
 
-        CustomMetadata = fromstring(xml)
+        xml_out = CustomMetadata.find("bar").find("name").tostring()
+        assert xml_out.strip() == "<name>Bar1</name>", xml_out.strip()
 
-        xml_out = CustomMetadata.find("values").find("field").tostring()
-        assert xml_out.strip() == "<field>dlrs__Active__c</field>", xml_out.strip()
-
+    def test_namespaced_to_string__output_namespaces(self):
+        CustomMetadata = fromstring(standard_xml)
         xml_out = (
-            CustomMetadata.find("values")
-            .find("field")
+            CustomMetadata.find("bar")
+            .find("name")
             .tostring(xml_declaration=True, include_parent_namespaces=True)
         )
-        expected_out = """<?xml version="1.0" encoding="UTF-8"?>
-             <field xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">dlrs__Active__c</field>"""
+        expected_out = """<?xml version="1.0" encoding="UTF-8"?> <name xmlns="http://soap.sforce.com/2006/04/metadata">Bar1</name>"""
         assert (
             " ".join(xml_out.split()).strip() == " ".join(expected_out.split()).strip()
         ), xml_out.strip()


### PR DESCRIPTION
@bethbrains found a bug whereby the tostring() method would crash due to trying to look up namespace prefixes for a namespace.

This raised the question of whether elements like that should be printed with or without a namespace. I decided to make it a user-option.