### PR TITLE
WIP: CLI improvements for Robot

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -7,8 +7,6 @@ tasks:
     robot:
         options:
             suites: cumulusci/robotframework/tests
-            options:
-                outputdir: robot/CumulusCI/results
     robot_testdoc:
         options:
             path: cumulusci/robotframework/tests

--- a/cumulusci/tasks/robotframework/robotframework.py
+++ b/cumulusci/tasks/robotframework/robotframework.py
@@ -46,7 +46,7 @@ class Robot(BaseSalesforceTask):
         "options": {
             "description": "In simple cases this can be specified on the command line using "
             "name:value,name:value syntax. More commplex cases can be specified "
-            "in cumuuluci.yml using YAML dictionary syntax.",
+            "in cumulusci.yml using YAML dictionary syntax.",
             "required": False,
         },
         "outputdir": {


### PR DESCRIPTION
1. Allow passing Robot --options X:Y,A:B on the CLI.
2. Allow passing --outputdir on the CLI. Takes precedence over --options outputdir and YAML.
3. Allow using $CUMULUSCI_ROBOT_OUTPUT_DIR for MetaCI and other CI contexts
4. Default robot/{self.project_config.repo_name}/results

Before I write tests I would like feedback on the semantics.