### PR TITLE
only automerge if the branch is a feature branch

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -624,6 +624,7 @@ flows:
                 task: run_tests
             5:
                 task: github_automerge_feature
+                when: project_config.repo_branch.startswith(project_config.project__git__prefix_feature)
 
     ci_feature_beta_deps:
         group: Continuous Integration
@@ -647,6 +648,7 @@ flows:
                 task: run_tests
             5:
                 task: github_automerge_feature
+                when: project_config.repo_branch.startswith(project_config.project__git__prefix_feature)
 
     ci_feature_2gp:
         group: Continuous Integration

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -624,7 +624,7 @@ flows:
                 task: run_tests
             5:
                 task: github_automerge_feature
-                when: project_config.repo_branch.startswith(project_config.project__git__prefix_feature)
+                when: project_config.repo_branch and project_config.repo_branch.startswith(project_config.project__git__prefix_feature)
 
     ci_feature_beta_deps:
         group: Continuous Integration
@@ -648,7 +648,7 @@ flows:
                 task: run_tests
             5:
                 task: github_automerge_feature
-                when: project_config.repo_branch.startswith(project_config.project__git__prefix_feature)
+                when: project_config.repo_branch and project_config.repo_branch.startswith(project_config.project__git__prefix_feature)
 
     ci_feature_2gp:
         group: Continuous Integration


### PR DESCRIPTION
# Changes
* Flows `ci_feature` and `ci_feature_beta_deps` now only run `github_automerge_feature` if the branch begins with the configured feature branch prefix.