### PR TITLE
warning instead of error if Deploy path doesn't exist

### DIFF
--- a/cumulusci/robotframework/tests/salesforce/api.robot
+++ b/cumulusci/robotframework/tests/salesforce/api.robot
@@ -74,7 +74,7 @@ Salesforce Query Where Not Equal
     @{records} =  Salesforce Query  Contact
     ...              select=Id,FirstName,LastName
     ...              where= LastName!='${new_contact}[LastName]'
-    ...              FirstName=${new_contact}[FirstName]
+    ...              Id=${new_contact}[Id]
     ${cnt}=    Get length    ${records}
     Should Be Equal As Numbers   ${cnt}  0
 

--- a/cumulusci/tasks/salesforce/Deploy.py
+++ b/cumulusci/tasks/salesforce/Deploy.py
@@ -78,9 +78,6 @@ class Deploy(BaseSalesforceMetadataApiTask):
     def _get_api(self, path=None):
         if not path:
             path = self.options.get("path")
-        if not pathlib.Path(path).exists():
-            self.logger.warning(f"{path} not found; skipping deployment.")
-            return
 
         package_zip = self._get_package_zip(path)
         if package_zip is not None:
@@ -110,6 +107,9 @@ class Deploy(BaseSalesforceMetadataApiTask):
 
     def _get_package_zip(self, path):
         assert path, f"Path should be specified for {self.__class__.name}"
+        if not pathlib.Path(path).exists():
+            self.logger.warning(f"{path} not found.")
+            return
         namespace = self.options["namespace_inject"]
         options = {
             **self.options,

--- a/cumulusci/tasks/salesforce/Deploy.py
+++ b/cumulusci/tasks/salesforce/Deploy.py
@@ -1,3 +1,4 @@
+import pathlib
 from typing import Optional
 
 from cumulusci.core.exceptions import TaskOptionsError
@@ -77,6 +78,9 @@ class Deploy(BaseSalesforceMetadataApiTask):
     def _get_api(self, path=None):
         if not path:
             path = self.options.get("path")
+        if not pathlib.Path(path).exists():
+            self.logger.warning(f"{path} not found; skipping deployment.")
+            return
 
         package_zip = self._get_package_zip(path)
         if package_zip is not None:

--- a/cumulusci/tasks/salesforce/tests/test_Deploy.py
+++ b/cumulusci/tasks/salesforce/tests/test_Deploy.py
@@ -114,6 +114,18 @@ class TestDeploy(unittest.TestCase):
                 self.assertIn("<name>StaticResource</name>", package_xml)
                 self.assertIn("<members>TestBundle</members>", package_xml)
 
+    def test_get_api__missing_path(self):
+        task = create_task(
+            Deploy,
+            {
+                "path": "BOGUS",
+                "unmanaged": True,
+            },
+        )
+
+        api = task._get_api()
+        assert api is None
+
     def test_get_api__empty_package_zip(self):
         with temporary_dir() as path:
             task = create_task(


### PR DESCRIPTION
(I don't love this change, since it will make typos less obvious, but it solves a particular case that is common immediately after initializing a new project when the force-app directory doesn't exist yet. I'd say we should make `cci project init` create the directory, but it's not possible to add an empty directory to git.)

# Critical Changes

# Changes
- Running the `deploy` task with the `path` option set to a path that doesn't exist will log a warning instead of raising an error.

# Issues Closed
