### PR TITLE
Use betas when building 2GP orgs

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -929,6 +929,7 @@ flows:
                 flow: dependencies
                 options:
                     update_dependencies:
+                        include_beta: True
                         dependencies: ^^github_package_data.dependencies
             3:
                 task: install_managed


### PR DESCRIPTION
# Critical Changes

# Changes

- CumulusCI installs beta dependencies when building 2GP feature test and QA orgs.

# Issues Closed
