### PR TITLE
fix automatic namespace injection for unmanaged dependencies

### DIFF
--- a/cumulusci/tasks/salesforce/tests/test_update_dependencies.py
+++ b/cumulusci/tasks/salesforce/tests/test_update_dependencies.py
@@ -315,6 +315,40 @@ class TestUpdateDependencies(unittest.TestCase):
         )
         api.assert_called_once()
 
+    @mock.patch(
+        "cumulusci.tasks.salesforce.update_dependencies.MetadataPackageZipBuilder"
+    )
+    def test_install_dependency__autoinject(self, MetadataPackageZipBuilder):
+        project_config = create_project_config(namespace="ns")
+        project_config.get_github_api = mock.Mock()
+        task = create_task(
+            UpdateDependencies,
+            {},
+            project_config=project_config,
+        )
+        task.org_config._installed_packages = {"ns": "1.0"}
+        task._download_extract_github = make_fake_zipfile
+        api = mock.Mock()
+        task.api_class = mock.Mock(return_value=api)
+        task._install_dependency(
+            {
+                "repo_owner": "SFDO-Tooling",
+                "repo_name": "CumulusCI-Test",
+                "ref": "abcdef",
+                "subfolder": "src",
+                "namespace_inject": "ns",
+            }
+        )
+        assert MetadataPackageZipBuilder.from_zipfile.call_args[1]["options"] == {
+            "repo_owner": "SFDO-Tooling",
+            "repo_name": "CumulusCI-Test",
+            "ref": "abcdef",
+            "subfolder": "src",
+            "namespace_inject": "ns",
+            "unmanaged": False,
+        }
+        api.assert_called_once()
+
     def test_run_task__version_id(self):
         project_config = create_project_config()
         project_config.get_github_api = mock.Mock()

--- a/cumulusci/tasks/salesforce/update_dependencies.py
+++ b/cumulusci/tasks/salesforce/update_dependencies.py
@@ -287,7 +287,7 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
                 ) or namespace not in self.org_config.installed_packages
 
             package_zip = MetadataPackageZipBuilder.from_zipfile(
-                zip_src, options=dependency, logger=self.logger
+                zip_src, options=options, logger=self.logger
             ).as_base64()
         elif "namespace" in dependency:
             self.logger.info(


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed
- Fixed the update_dependencies task to handle automatic injection of namespace prefixes when deploying an unpackaged dependency. The fix for the same issue in cumulusci 3.25.0 was incomplete.