### PR TITLE
Feature/doc reorg  unlocked

### DIFF
--- a/docs/unlocked_package.rst
+++ b/docs/unlocked_package.rst
@@ -59,7 +59,40 @@ CumulusCI does not yet provide tools to help promote an unlocked package version
 Install the Unlocked Package
 ----------------------------
 
-These are the available methods for installing a package in an org. 
+There are two methods that can be used to install an unlocked package with CumulusCI.
+You can configure the ``update_dependencies`` and ``install_managed`` tasks to use a specific unlocked package by providing the 04t Id of the desired package.
+
+For the ``update_dependencies`` task this would be:
+
+.. code-block::console
+
+    $ cci run task update_dependencies --dependencies [{'version_id': '04t000000000'}]
+
+Or configured in ``cumulusci.yml`` like:
+
+.. code-block::yaml
+
+    task: update_dependencies
+    options:
+        dependencies:
+            - version_id: 04t000000000
+
+For the ``install_managed`` task this would be:
+
+.. code-block::console
+
+    $ cci task run intsall_managed --version 04t000000000
+
+Or configured in ``cumulusci.yml``:
+
+.. code-block::yaml
+
+    task: install_managed
+    options:
+        version: 04t000000000
+
+These are the other methods available for installing unlocked packages in an org that do not use CumulusCI: 
 
 * `Install via the Salesforce CLI <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_install_pkg_cli.htm>`_
 * `Install via an Installation URL <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_install_pkg_ui.htm>`_
+

--- a/docs/unlocked_package.rst
+++ b/docs/unlocked_package.rst
@@ -70,5 +70,3 @@ There are two methods available for installing a package in an org:
 
 * `Install via the Salesforce CLI <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_install_pkg_cli.htm>`_
 * `Install via an installation URL <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_install_pkg_ui.htm>`_
-
-.. note:: Packages can only be installed in Scratch orgs, Sandbox orgs, DE orgs, and Production orgs.

--- a/docs/unlocked_package.rst
+++ b/docs/unlocked_package.rst
@@ -8,7 +8,7 @@ While CumulusCI was originally created to develop managed packages, it can also 
 Prerequisites
 -------------
 
-To create unlocked package versions, first complete these steps.
+To create unlocked package versions, complete these steps.
 
 * `Enable DevHub Features in Your Org <https://developer.salesforce.com/docs/atlas.en-us.packagingGuide.meta/packagingGuide/sfdx_setup_enable_devhub.htm>`_.
 * `Enable Unlocked and Second-Generation Managed Packaging <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_setup_enable_secondgen_pkg.htm>`_.
@@ -26,16 +26,16 @@ To create a new unlocked package version, run the ``create_package_version`` tas
 
     $ cci task run create_package_version --org <org_name> --package_type Unlocked
 
-This task looks in your default DevHub org (as configured in ``sfdx``) for an unlocked package with the name and namespace specified in the task options (defaulting to the name and namespace from the ``project__package`` section of the ``cumulusci.yml`` file). If a matching package doesn't exist, the task then submits a request to create the package version. When completed (which can take some time), the task outputs a ``SubscriberPackageVersion`` id, which can be used to install the package in another org.
+This task looks in your default DevHub org (as configured in ``sfdx``) for an unlocked package with the name and namespace specified in the task options (defaulting to the name and namespace from the ``project__package`` section of the ``cumulusci.yml`` file). If a matching package doesn't exist, CumulusCI first creates a `Package2 <https://developer.salesforce.com/docs/atlas.en-us.api_tooling.meta/api_tooling/tooling_api_objects_package2.htm>`_ object, and then submits a `request <https://developer.salesforce.com/docs/atlas.en-us.api_tooling.meta/api_tooling/tooling_api_objects_package2versioncreaterequest.htm>`_ to create the package version. When completed (which can take some time), the task outputs a ``SubscriberPackageVersion`` ID, which can be used to install the package in another org.
 
-If a package version already exists with the exact same contents, its ``SubscriberPackageVersion`` id is returned.
+If a package version already exists with the exact same contents, as determined by the hash of the package metadata, its ``SubscriberPackageVersion`` ID is returned rather than creating a new version.
 
 
 
 Handle Dependencies
 ---------------------
 
-CumulusCI tries to convert dependencies configured under the ``project`` section of the ``cumulusci.yml`` file into a ``SubscriberPackageVersion`` id (``04t`` key prefix). This format is required for dependencies in the API to create a package version.
+CumulusCI tries to convert dependencies configured under the ``project`` section of the ``cumulusci.yml`` file into a ``SubscriberPackageVersion`` ID (``04t`` key prefix). This format is required for dependencies in the API to create a package version.
 
 For dependencies that are specified as a managed package namespace and version, or dependencies specified as a GitHub repository with releases that can be resolved to a namespace and version, CumulusCI needs a scratch org with the dependencies installed to execute this conversion in the ``create_package_version`` task.
 
@@ -62,4 +62,4 @@ Install the Unlocked Package
 These are the available methods for installing a package in an org. 
 
 * `Install via the Salesforce CLI <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_install_pkg_cli.htm>`_
-* `Install via an installation URL <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_install_pkg_ui.htm>`_
+* `Install via an Installation URL <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_install_pkg_ui.htm>`_

--- a/docs/unlocked_package.rst
+++ b/docs/unlocked_package.rst
@@ -62,13 +62,7 @@ Install the Unlocked Package
 There are two methods that can be used to install an unlocked package with CumulusCI.
 You can configure the ``update_dependencies`` and ``install_managed`` tasks to use a specific unlocked package by providing the 04t Id of the desired package.
 
-For the ``update_dependencies`` task this would be:
-
-.. code-block::console
-
-    $ cci run task update_dependencies --dependencies [{'version_id': '04t000000000'}]
-
-Or configured in ``cumulusci.yml`` like:
+The ``update_dependencies`` task can be configured in the ``cumulusci.yml`` file like so:
 
 .. code-block::yaml
 
@@ -77,13 +71,13 @@ Or configured in ``cumulusci.yml`` like:
         dependencies:
             - version_id: 04t000000000
 
-For the ``install_managed`` task this would be:
+For the ``install_managed`` task you can run it via ``cci``:
 
 .. code-block::console
 
-    $ cci task run intsall_managed --version 04t000000000
+    $ cci task run intsall_managed --version 04t000000000 --org <org_name>
 
-Or configured in ``cumulusci.yml``:
+Or configure it in the ``cumulusci.yml`` file:
 
 .. code-block::yaml
 

--- a/docs/unlocked_package.rst
+++ b/docs/unlocked_package.rst
@@ -26,18 +26,18 @@ To create a new unlocked package version, run the ``create_package_version`` tas
 
     $ cci task run create_package_version --org <org_name> --package_type Unlocked
 
-This task looks in your default DevHub org (as configured in ``sfdx``) for an unlocked package with the name and namespace specified in the task options (defaulting to the name and namespace from the ``project__package`` section of the ``cumulusci.yml`` file). If a matching package doesn't exist, the task then submits a request to create the package version. When completed (which can take some time), the task outputs a ``SubscriberPackageVersion Id``, which can be used to install the package in another org.
+This task looks in your default DevHub org (as configured in ``sfdx``) for an unlocked package with the name and namespace specified in the task options (defaulting to the name and namespace from the ``project__package`` section of the ``cumulusci.yml`` file). If a matching package doesn't exist, the task then submits a request to create the package version. When completed (which can take some time), the task outputs a ``SubscriberPackageVersion`` id, which can be used to install the package in another org.
 
-If a package version already exists with the exact same contents, its ``SubscriberPackageVersion Id`` is returned.
+If a package version already exists with the exact same contents, its ``SubscriberPackageVersion`` id is returned.
 
 
 
 Handle Dependencies
 ---------------------
 
-CumulusCI tries to convert dependencies configured under the ``project`` section of the ``cumulusci.yml`` file into a ``Subscriber Package Version Id`` (``04t`` key prefix). This format is required for dependencies in the API to create a package version.
+CumulusCI tries to convert dependencies configured under the ``project`` section of the ``cumulusci.yml`` file into a ``SubscriberPackageVersion`` id (``04t`` key prefix). This format is required for dependencies in the API to create a package version.
 
-For dependencies that are specified as a managed package namespace and version, or dependencies specified as a GitHub repository with releases that can be resolved to a namespace and version, CumulusCI needs a scratch org with the dependencies installed to execute this conversion in ``create_package_version`` task.
+For dependencies that are specified as a managed package namespace and version, or dependencies specified as a GitHub repository with releases that can be resolved to a namespace and version, CumulusCI needs a scratch org with the dependencies installed to execute this conversion in the ``create_package_version`` task.
 
 .. important:: Install the dependencies in this scratch org *before* running the ``create_package_version`` task! 
 

--- a/docs/unlocked_package.rst
+++ b/docs/unlocked_package.rst
@@ -59,10 +59,11 @@ CumulusCI does not yet provide tools to help promote an unlocked package version
 Install the Unlocked Package
 ----------------------------
 
-There are two methods that can be used to install an unlocked package with CumulusCI.
-You can configure the ``update_dependencies`` and ``install_managed`` tasks to use a specific unlocked package by providing the 04t Id of the desired package.
+To install an unlocked package with Cumulus:
 
-The ``update_dependencies`` task can be configured in the ``cumulusci.yml`` file like so:
+Configure either the ``update_dependencies`` or the ``install_managed`` task to provide the ``SubscriberPackageVersion`` ID of the unlocked package to be used.
+
+The ``update_dependencies`` task can be configured in the ``cumulusci.yml`` file.
 
 .. code-block::yaml
 
@@ -71,13 +72,13 @@ The ``update_dependencies`` task can be configured in the ``cumulusci.yml`` file
         dependencies:
             - version_id: 04t000000000
 
-For the ``install_managed`` task you can run it via ``cci``:
+For the ``install_managed`` task, run it via ``cci``...
 
 .. code-block::console
 
     $ cci task run intsall_managed --version 04t000000000 --org <org_name>
 
-Or configure it in the ``cumulusci.yml`` file:
+Or configure it in the ``cumulusci.yml`` file.
 
 .. code-block::yaml
 
@@ -85,7 +86,7 @@ Or configure it in the ``cumulusci.yml`` file:
     options:
         version: 04t000000000
 
-These are the other methods available for installing unlocked packages in an org that do not use CumulusCI: 
+To install unlocked packages in an org that doesn't use CumulusCI, use one of these methods. 
 
 * `Install via the Salesforce CLI <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_install_pkg_cli.htm>`_
 * `Install via an Installation URL <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_install_pkg_ui.htm>`_

--- a/docs/unlocked_package.rst
+++ b/docs/unlocked_package.rst
@@ -59,9 +59,9 @@ CumulusCI does not yet provide tools to help promote an unlocked package version
 Install the Unlocked Package
 ----------------------------
 
-To install an unlocked package with Cumulus:
+To install an unlocked package with CumulusCI:
 
-Configure either the ``update_dependencies`` or the ``install_managed`` task to provide the ``SubscriberPackageVersion`` ID of the unlocked package to be used.
+Configure either the ``update_dependencies`` or the ``install_managed`` task and provide the ``SubscriberPackageVersion`` ID of the unlocked package to be used.
 
 The ``update_dependencies`` task can be configured in the ``cumulusci.yml`` file.
 

--- a/docs/unlocked_package.rst
+++ b/docs/unlocked_package.rst
@@ -1,72 +1,65 @@
 Release an Unlocked Package
 ===========================
-While CumulusCI was originally created with a focus on developing managed packages,
-it can also be used to develop and release `unlocked packages <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_intro.htm>`_.
+
+While CumulusCI was originally created to develop managed packages, it can also be used to develop and release `unlocked packages <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_intro.htm>`_.
 
 
 
 Prerequisites
 -------------
-In order to create unlocked package versions, you need to have a few things set up:
 
-1. `Enable Dev Hub in Your Org <https://developer.salesforce.com/docs/atlas.en-us.packagingGuide.meta/packagingGuide/sfdx_setup_enable_devhub.htm>`_
-2. `Enable Unlocked and Second-Generation Managed Packaging <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_setup_enable_secondgen_pkg.htm>`_
-3. Connect the Dev Hub org to the CumulusCI keychain by running ``cci org connect devhub`` (this is necessary even if sfdx has already authenticated to the Dev Hub).
-4. If you want to create an unlocked package with a namespace, you must also create a new Developer Edition org to `Create and Register Your Namespace <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_create_namespace.htm>`_, and link the namespace to your Dev Hub.
+To create unlocked package versions, first complete these steps.
+
+* `Enable DevHub Features in Your Org <https://developer.salesforce.com/docs/atlas.en-us.packagingGuide.meta/packagingGuide/sfdx_setup_enable_devhub.htm>`_.
+* `Enable Unlocked and Second-Generation Managed Packaging <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_setup_enable_secondgen_pkg.htm>`_.
+* Connect the DevHub org to the CumulusCI keychain by running ``cci org connect devhub``. (This is necessary even if ``sfdx`` has already authenticated to the DevHub.)
+* To create an unlocked package with a namespace, you must also create a new Developer Edition org to `Create and Register Your Namespace <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_create_namespace.htm>`_, and link the namespace to your DevHub.
 
 
 
 Create a Package Version
 ------------------------
-To create a new unlocked package version, run the ``create_package_version`` task against a scratch org:
+
+To create a new unlocked package version, run the ``create_package_version`` task against a scratch org.
 
 .. code-block:: console
 
-    $ cci task run create_package_version --org dev --package_type Unlocked
+    $ cci task run create_package_version --org <org_name> --package_type Unlocked
 
-This task will look in your default Dev Hub org (as configured in sfdx) for an unlocked package with the
-name and namespace specified in the task options (defaulting to the name and namespace from the 
-``project__package`` section of ``cumulusci.yml``). If a matching package doesn't exist yet, it will be created.
+This task looks in your default DevHub org (as configured in ``sfdx``) for an unlocked package with the name and namespace specified in the task options (defaulting to the name and namespace from the ``project__package`` section of the ``cumulusci.yml`` file). If a matching package doesn't exist, the task then submits a request to create the package version. When completed (which can take some time), the task outputs a ``SubscriberPackageVersion Id``, which can be used to install the package in another org.
 
-The task then submits a request to create the package version, and once completed (which can take some time), 
-the task will output some information including the SubscriberPackageVersion Id, which can be used to install the package in another org.
-
-If a package version already exists with the exact same contents, its Id will be returned instead of creating a new package version.
+If a package version already exists with the exact same contents, its ``SubscriberPackageVersion Id`` is returned.
 
 
 
-Handling Dependencies
+Handle Dependencies
 ---------------------
-If your project has dependencies configured in the ``project`` section of ``cumulusci.yml``, 
-CumulusCI will try to convert them into a Subscriber Package Version Id (``04t`` key prefix), 
-which is the format required for dependencies in the API for creating a package version.
 
-For dependencies that are specified as a managed package namespace and version, 
-or dependencies specified as a GitHub repository with releases that can be resolved to a namespace and version, 
-CumulusCI needs a scratch org with the dependencies installed in order to do this conversion.
-This is the purpose of the scratch org passed to the ``create_package_version`` task (``dev`` in the example above).
-You must make sure the dependencies are installed in this org before running the 
-``create_package_version`` task. The scratch org definition file from this scratch org 
-will also be used to specify the correct org shape when building the new package version.
+CumulusCI tries to convert dependencies configured under the ``project`` section of the ``cumulusci.yml`` file into a ``Subscriber Package Version Id`` (``04t`` key prefix). This format is required for dependencies in the API to create a package version.
 
-For dependencies that are an unpackaged bundle of metadata, CumulusCI will create an additional unlocked package to contain them.
+For dependencies that are specified as a managed package namespace and version, or dependencies specified as a GitHub repository with releases that can be resolved to a namespace and version, CumulusCI needs a scratch org with the dependencies installed to execute this conversion in ``create_package_version`` task.
+
+.. important:: Install the dependencies in this scratch org *before* running the ``create_package_version`` task! 
+
+The scratch org's definition file also specifies the correct org shape when building the new package version.
+
+For dependencies that are an unpackaged bundle of metadata, CumulusCI creates an additional unlocked package to contain them.
 
 
 
 Promote a Package Version
 -------------------------
-In order to be installed in a production org, an unlocked package version must be
-`promoted <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_create_pkg_ver_promote.htm>`_
-to mark it as released.
 
-CumulusCI does not yet provide any tools to help with this, so for now you must use the ``sfdx force:package:version:promote`` command.
-If additional unlocked packages were created to hold unpackaged dependencies, they must be promoted as well.
+To be installed in a production org, an unlocked package version must be `promoted <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_create_pkg_ver_promote.htm>`_ to mark it as released.
+
+CumulusCI does not yet provide tools to help promote an unlocked package version, so for now use the ``sfdx force:package:version:promote`` command. If additional unlocked packages were created to hold unpackaged dependencies, they must be promoted as well.
 
 
 
 Install the Unlocked Package
 ----------------------------
-There are two methods available for installing a package in an org: 
+
+These are the available methods for installing a package in an org. 
 
 * `Install via the Salesforce CLI <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_install_pkg_cli.htm>`_
 * `Install via an installation URL <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_install_pkg_ui.htm>`_

--- a/docs/unlocked_package.rst
+++ b/docs/unlocked_package.rst
@@ -1,14 +1,74 @@
-Release an unlocked package
+Release an Unlocked Package
 ===========================
+While CumulusCI was originally created with a focus on developing managed packages,
+it can also be used to develop and release `unlocked packages <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_intro.htm>`_.
+
+
 
 Prerequisites
 -------------
+In order to create unlocked package versions, you need to have a few things set up:
 
-Create a package version
+1. `Enable Dev Hub in Your Org <https://developer.salesforce.com/docs/atlas.en-us.packagingGuide.meta/packagingGuide/sfdx_setup_enable_devhub.htm>`_
+2. `Enable Unlocked and Second-Generation Managed Packaging <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_setup_enable_secondgen_pkg.htm>`_
+3. Connect the Dev Hub org to the CumulusCI keychain by running ``cci org connect devhub`` (this is necessary even if sfdx has already authenticated to the Dev Hub).
+4. If you want to create an unlocked package with a namespace, you must also create a new Developer Edition org to `Create and Register Your Namespace <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_create_namespace.htm>`_, and link the namespace to your Dev Hub.
+
+
+
+Create a Package Version
 ------------------------
+To create a new unlocked package version, run the ``create_package_version`` task against a scratch org:
 
-Promote a package version
+.. code-block:: console
+
+    $ cci task run create_package_version --org dev --package_type Unlocked
+
+This task will look in your default Dev Hub org (as configured in sfdx) for an unlocked package with the
+name and namespace specified in the task options (defaulting to the name and namespace from the 
+``project__package`` section of ``cumulusci.yml``). If a matching package doesn't exist yet, it will be created.
+
+The task then submits a request to create the package version, and once completed (which can take some time), 
+the task will output some information including the SubscriberPackageVersion Id, which can be used to install the package in another org.
+
+If a package version already exists with the exact same contents, its Id will be returned instead of creating a new package version.
+
+
+
+Handling Dependencies
+---------------------
+If your project has dependencies configured in the ``project`` section of ``cumulusci.yml``, 
+CumulusCI will try to convert them into a Subscriber Package Version Id (``04t`` key prefix), 
+which is the format required for dependencies in the API for creating a package version.
+
+For dependencies that are specified as a managed package namespace and version, 
+or dependencies specified as a GitHub repository with releases that can be resolved to a namespace and version, 
+CumulusCI needs a scratch org with the dependencies installed in order to do this conversion.
+This is the purpose of the scratch org passed to the ``create_package_version`` task (``dev`` in the example above).
+You must make sure the dependencies are installed in this org before running the 
+``create_package_version`` task. The scratch org definition file from this scratch org 
+will also be used to specify the correct org shape when building the new package version.
+
+For dependencies that are an unpackaged bundle of metadata, CumulusCI will create an additional unlocked package to contain them.
+
+
+
+Promote a Package Version
 -------------------------
+In order to be installed in a production org, an unlocked package version must be
+`promoted <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_create_pkg_ver_promote.htm>`_
+to mark it as released.
 
-Install the unlocked package
+CumulusCI does not yet provide any tools to help with this, so for now you must use the ``sfdx force:package:version:promote`` command.
+If additional unlocked packages were created to hold unpackaged dependencies, they must be promoted as well.
+
+
+
+Install the Unlocked Package
 ----------------------------
+There are two methods available for installing a package in an org: 
+
+* `Install via the Salesforce CLI <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_install_pkg_cli.htm>`_
+* `Install via an installation URL <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_install_pkg_ui.htm>`_
+
+.. note:: Packages can only be installed in Scratch orgs, Sandbox orgs, DE orgs, and Production orgs.


### PR DESCRIPTION
# Changes
* Content for the `unlocked.rst` section of the docs. The vast majority of this content was from what already existed in `features.rst`.

