### PR TITLE
handle gack while collecting installed packages

### DIFF
--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -273,7 +273,10 @@ class OrgConfig(BaseConfig):
                         "tooling/query/?q=SELECT Id, MajorVersion, MinorVersion, PatchVersion, BuildNumber, "
                         f"IsBeta FROM SubscriberPackageVersion WHERE Id='{isp['SubscriberPackageVersionId']}'"
                     )
-                except SalesforceError:
+                except SalesforceError as err:
+                    self.logger.warning(
+                        f"Ignoring error while trying to check installed package {isp['SubscriberPackageVersionId']}: {err.content}"
+                    )
                     continue
                 if not spv_result["records"]:
                     # This _shouldn't_ happen, but it is possible in customer orgs.

--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 
 import requests
 from simple_salesforce import Salesforce
-from simple_salesforce.exceptions import SalesforceResourceNotFound
+from simple_salesforce.exceptions import SalesforceError, SalesforceResourceNotFound
 
 from cumulusci.core.config import BaseConfig
 from cumulusci.core.exceptions import CumulusCIException
@@ -268,10 +268,13 @@ class OrgConfig(BaseConfig):
             _installed_packages = defaultdict(list)
             for isp in isp_result["records"]:
                 sp = isp["SubscriberPackage"]
-                spv_result = self.salesforce_client.restful(
-                    "tooling/query/?q=SELECT Id, MajorVersion, MinorVersion, PatchVersion, BuildNumber, "
-                    f"IsBeta FROM SubscriberPackageVersion WHERE Id='{isp['SubscriberPackageVersionId']}'"
-                )
+                try:
+                    spv_result = self.salesforce_client.restful(
+                        "tooling/query/?q=SELECT Id, MajorVersion, MinorVersion, PatchVersion, BuildNumber, "
+                        f"IsBeta FROM SubscriberPackageVersion WHERE Id='{isp['SubscriberPackageVersionId']}'"
+                    )
+                except SalesforceError:
+                    continue
                 if not spv_result["records"]:
                     # This _shouldn't_ happen, but it is possible in customer orgs.
                     continue

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -6,13 +6,14 @@ import pathlib
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
-
-import pytest
 from unittest import mock
+
+from github3.exceptions import NotFoundError
+from simple_salesforce.exceptions import SalesforceError
+import pytest
 import responses
 import yaml
 
-from github3.exceptions import NotFoundError
 from cumulusci.core.config import BaseConfig
 from cumulusci.core.config import UniversalConfig
 from cumulusci.core.config import BaseProjectConfig
@@ -1646,6 +1647,13 @@ class TestOrgConfig(unittest.TestCase):
                     },
                     "SubscriberPackageVersionId": "04t0000000BOGUSAAA",
                 },
+                {
+                    "SubscriberPackage": {
+                        "Id": "03350000000DEz8AAG",
+                        "NamespacePrefix": "error",
+                    },
+                    "SubscriberPackageVersionId": "04t0000000ERRORAAA",
+                },
             ],
         },
         {
@@ -1694,6 +1702,7 @@ class TestOrgConfig(unittest.TestCase):
             ],
         },
         {"size": 0, "totalSize": 0, "done": True, "records": []},
+        SalesforceError(None, None, None, None),
     ]
 
     @mock.patch("cumulusci.core.config.OrgConfig.salesforce_client")


### PR DESCRIPTION
It's possible to encounter a gack while retrieving details about a specific installed package that was found by querying InstalledSubscriberPackage. Let's handle that so that it doesn't get in the way of detecting packages that are not broken.

# Critical Changes

# Changes

# Issues Closed
- Handle a possible gack while collecting info about installed packages