### PR TITLE
Improve yaml parse error handling

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -25,6 +25,7 @@ import requests
 from rst2ansi import rst2ansi
 from jinja2 import Environment
 from jinja2 import PackageLoader
+from yaml.scanner import ScannerError
 
 import cumulusci
 from cumulusci.core.config import OrgConfig
@@ -204,24 +205,28 @@ def main(args=None):
         if "--json" not in args and not is_version_command:
             check_latest_version()
 
-        # Load CCI config
-        global RUNTIME
-        RUNTIME = CliRuntime(load_keychain=False)
-        RUNTIME.check_cumulusci_version()
-
-        # Configure logging
-        debug = "--debug" in args
-        if debug:
-            args.remove("--debug")
-        should_show_stacktraces = RUNTIME.universal_config.cli__show_stacktraces
-
-        # Only create logfiles for commands
-        # that are not `cci error`
+        # Only create logfiles for commands that are not `cci error`
         is_error_command = len(args) > 2 and args[1] == "error"
         tempfile_path = None
         if not is_error_command:
             logger, tempfile_path = get_tempfile_logger()
             stack.enter_context(tee_stdout_stderr(args, logger, tempfile_path))
+
+        debug = "--debug" in args
+        if debug:
+            args.remove("--debug")
+
+        # Load CCI config
+        global RUNTIME
+        try:
+            RUNTIME = CliRuntime(load_keychain=False)
+        except Exception as e:
+            handle_exception(e, is_error_command, tempfile_path, debug)
+            sys.exit(1)
+
+        RUNTIME.check_cumulusci_version()
+
+        should_show_stacktraces = RUNTIME.universal_config.cli__show_stacktraces
 
         init_logger(log_requests=debug)
         # Hand CLI processing over to click, but handle exceptions
@@ -248,6 +253,8 @@ def handle_exception(error, is_error_cmd, logfile_path, should_show_stacktraces=
         connection_error_message()
     elif isinstance(error, click.ClickException):
         click.echo(click.style(f"Error: {error.format_message()}", fg="red"), err=True)
+    elif isinstance(error, ScannerError):
+        yaml_parse_error_message(error)
     else:
         click.echo(click.style(f"Error: {error}", fg="red"), err=True)
     # Only suggest gist command if it wasn't run
@@ -270,6 +277,17 @@ def connection_error_message():
         "Please check your connection and try the last cci command again."
     )
     click.echo(click.style(message, fg="red"), err=True)
+
+
+def yaml_parse_error_message(error):
+    message = f"An error occurred while parsing a yaml file (likely cumulusci.yml). Check around line {error.problem_mark.line} for the issue."
+    click.echo(
+        click.style(
+            message,
+            fg="red",
+        ),
+        err=True,
+    )
 
 
 def show_debug_info():

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -25,7 +25,6 @@ import requests
 from rst2ansi import rst2ansi
 from jinja2 import Environment
 from jinja2 import PackageLoader
-from yaml.scanner import ScannerError
 
 import cumulusci
 from cumulusci.core.config import OrgConfig
@@ -253,16 +252,13 @@ def handle_exception(error, is_error_cmd, logfile_path, should_show_stacktraces=
         connection_error_message()
     elif isinstance(error, click.ClickException):
         click.echo(click.style(f"Error: {error.format_message()}", fg="red"), err=True)
-    elif isinstance(error, ScannerError):
-        yaml_parse_error_message(error)
     else:
-        click.echo(click.style(f"Error: {error}", fg="red"), err=True)
+        click.echo(click.style(f"{error}", fg="red"), err=True)
     # Only suggest gist command if it wasn't run
     if not is_error_cmd:
         click.echo(click.style(SUGGEST_ERROR_COMMAND, fg="yellow"), err=True)
 
-    # This is None if we're handling an exception for a
-    # `cci error` command.
+    # This is None if we're handling an exception for a `cci error` command.
     if logfile_path:
         with open(logfile_path, "a") as log_file:
             traceback.print_exc(file=log_file)  # log stacktrace silently
@@ -277,17 +273,6 @@ def connection_error_message():
         "Please check your connection and try the last cci command again."
     )
     click.echo(click.style(message, fg="red"), err=True)
-
-
-def yaml_parse_error_message(error):
-    message = f"An error occurred while parsing a yaml file (likely cumulusci.yml). Check around line {error.problem_mark.line} for the issue."
-    click.echo(
-        click.style(
-            message,
-            fg="red",
-        ),
-        err=True,
-    )
 
 
 def show_debug_info():

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -306,7 +306,8 @@ class TestCCI(unittest.TestCase):
             message = "An error occurred while parsing a yaml file (likely cumulusci.yml). Check around line 12345 for the issue."
             assert message in stderr.getvalue()
 
-        Path.unlink("tempfile.log")
+        tempfile = Path("tempfile.log")
+        tempfile.unlink()
 
     @mock.patch("cumulusci.cli.cci.init_logger")  # side effects break other tests
     @mock.patch("cumulusci.cli.cci.get_tempfile_logger")

--- a/cumulusci/utils/yaml/cumulusci_yml.py
+++ b/cumulusci/utils/yaml/cumulusci_yml.py
@@ -4,7 +4,7 @@ import yaml
 from io import StringIO
 from logging import getLogger
 from typing import IO, Text
-from yaml.scanner import ScannerError
+from yaml.error import MarkedYAMLError
 
 from cumulusci.core.exceptions import CumulusCIException
 
@@ -45,7 +45,7 @@ def cci_safe_load(f_config: IO[Text]):
     data = _replace_nbsp(f_config.read())
     try:
         rc = yaml.safe_load(StringIO(data))
-    except ScannerError as e:
+    except MarkedYAMLError as e:
         line_num = e.problem_mark.line
         column_num = e.problem_mark.column
         message = f"An error occurred parsing {f_config.name} at line {line_num}, column {column_num}.\nError message: {e.problem}"

--- a/cumulusci/utils/yaml/tests/test_cumulusci_yml.py
+++ b/cumulusci/utils/yaml/tests/test_cumulusci_yml.py
@@ -43,7 +43,7 @@ def test_converter():
     inp = """xyz:
         \u00A0 y: abc"""
     outp = """xyz:
-            y: abc"""
+          y: abc"""
 
     rc = _replace_nbsp(inp)
     assert rc == outp

--- a/cumulusci/utils/yaml/tests/test_cumulusci_yml.py
+++ b/cumulusci/utils/yaml/tests/test_cumulusci_yml.py
@@ -1,4 +1,9 @@
+from cumulusci.core.exceptions import CumulusCIException
+import pytest
+
 from io import StringIO
+from unittest.mock import Mock, PropertyMock, patch
+from yaml.scanner import ScannerError
 
 from cumulusci.utils.yaml.cumulusci_yml import cci_safe_load, _replace_nbsp
 
@@ -37,3 +42,39 @@ class TestCumulusciYml:
 
         rc = _replace_nbsp(inp)
         assert rc == inp
+
+    @patch("cumulusci.utils.yaml.cumulusci_yml.yaml.safe_load")
+    def test_scanner_error(self, safe_load):
+        problem_mark = Mock(line=12345, column=54321)
+        safe_load.side_effect = ScannerError(problem_mark=problem_mark)
+
+        f_config = Mock()
+        f_config.read.return_value = "xyz: abc \n >+>:>%*"  # return invalid yaml
+        # mock f_config.name
+        type(f_config).name = PropertyMock(return_value="cumulusci.yml")
+
+        with pytest.raises(CumulusCIException) as error:
+            cci_safe_load(f_config)
+
+        assert error.typename == "CumulusCIException"
+        assert (
+            "An error occurred parsing cumulusci.yml at line 12345, column 54321.\nError message: None"
+            == error.value.args[0]
+        )
+
+    @patch("cumulusci.utils.yaml.cumulusci_yml.yaml.safe_load")
+    def test_generic_exception(self, safe_load):
+        f_config = Mock()
+        f_config.read.return_value = "xyz: abc \n >+>:>%*"  # return invalid yaml
+        # Mock objects already have a `name` attribute so we need to mock it specially
+        type(f_config).name = PropertyMock(return_value="cumulusci.yml")
+
+        safe_load.side_effect = Exception("generic")
+        with pytest.raises(CumulusCIException) as error:
+            cci_safe_load(f_config)
+
+        assert error.typename == "CumulusCIException"
+        assert (
+            "An error occurred parsing cumulusci.yml.\nError message: generic"
+            == error.value.args[0]
+        )

--- a/cumulusci/utils/yaml/tests/test_cumulusci_yml.py
+++ b/cumulusci/utils/yaml/tests/test_cumulusci_yml.py
@@ -9,93 +9,93 @@ from cumulusci.utils import temporary_dir
 from cumulusci.utils.yaml.cumulusci_yml import cci_safe_load, _replace_nbsp
 
 
-class TestCumulusciYml:
-    def test_simple_load(self, caplog):
-        yaml = """xyz:
+@pytest.fixture
+def cci_yml_file():
+    "Yields a cumulusci file obj for writing to. Cleans up when finished."
+    with temporary_dir() as temp_dir:
+        cumulusci_yml_filepath = Path(temp_dir) / "cumulusci.yml"
+
+        with open(cumulusci_yml_filepath, "w+") as cumulusci_yml:
+            yield cumulusci_yml
+
+
+def test_simple_load(caplog):
+    yaml = """xyz:
+        y: abc"""
+    cciyml = cci_safe_load(StringIO(yaml))
+    assert not caplog.text
+
+    assert isinstance(cciyml, dict)  # should parse despite funny character
+    assert cciyml["xyz"]["y"] == "abc", cciyml
+
+
+def test_convert_nbsp(caplog):
+    yaml = """xyz:
+        \u00A0 y: abc"""
+    cciyml = cci_safe_load(StringIO(yaml))
+    assert "space character" in caplog.text
+
+    assert isinstance(cciyml, dict)  # should parse despite funny character
+    assert cciyml["xyz"]["y"] == "abc", cciyml
+
+
+def test_converter():
+    inp = """xyz:
+        \u00A0 y: abc"""
+    outp = """xyz:
             y: abc"""
-        cciyml = cci_safe_load(StringIO(yaml))
-        assert not caplog.text
 
-        assert isinstance(cciyml, dict)  # should parse despite funny character
-        assert cciyml["xyz"]["y"] == "abc", cciyml
+    rc = _replace_nbsp(inp)
+    assert rc == outp
 
-    def test_convert_nbsp(self, caplog):
-        yaml = """xyz:
-           \u00A0 y: abc"""
-        cciyml = cci_safe_load(StringIO(yaml))
-        assert "space character" in caplog.text
 
-        assert isinstance(cciyml, dict)  # should parse despite funny character
-        assert cciyml["xyz"]["y"] == "abc", cciyml
+def test_converter_is_selective():
+    inp = """xyz:
+            y: abc\u00A0"""
 
-    def test_converter(self):
-        inp = """xyz:
-           \u00A0 y: abc"""
-        outp = """xyz:
-             y: abc"""
+    rc = _replace_nbsp(inp)
+    assert rc == inp
 
-        rc = _replace_nbsp(inp)
-        assert rc == outp
 
-    def test_converter_is_selective(self):
-        inp = """xyz:
-             y: abc\u00A0"""
+def test_invalid_cumulusci_yml_file(cci_yml_file):
+    invalid_yml = """xyz: abc   \n>>>\nefg: lmn\n"""
+    cci_yml_file.write(invalid_yml)
+    cci_yml_file.seek(0)
 
-        rc = _replace_nbsp(inp)
-        assert rc == inp
+    with pytest.raises(
+        CumulusCIException,
+        match="cumulusci.yml at line 1, column 1.\nError message: expected chomping or indentation indicators, but found '>'",
+    ):
+        cci_safe_load(cci_yml_file)
 
-    def test_invalid_cumulusci_yml_file(self):
-        with temporary_dir() as temp_dir:
-            cumulusci_yml_filepath = Path(temp_dir) / "cumulusci.yml"
 
-            with open(cumulusci_yml_filepath, "w+") as cumulusci_yml:
-                invalid_yml = """xyz: abc   \n>>>\nefg: lmn\n"""
-                cumulusci_yml.write(invalid_yml)
-                cumulusci_yml.seek(0)
+def test_invalid_string_io():
+    invalid_yml_string = """xyz: abc   \n>>>\nefg: lmn\n"""
+    with pytest.raises(CumulusCIException) as error:
+        cci_safe_load(StringIO(invalid_yml_string))
 
-                with pytest.raises(CumulusCIException) as error:
-                    cci_safe_load(cumulusci_yml)
+    assert "Error message: " in error.value.args[0]
 
-        assert error.typename == "CumulusCIException"
-        assert (
-            "cumulusci.yml at line 1, column 1.\nError message: expected chomping or indentation indicators, but found '>'"
-            in error.value.args[0]
-        )
 
-    def test_invalid_string_io(self):
-        invalid_yml_string = """xyz: abc   \n>>>\nefg: lmn\n"""
-        with pytest.raises(CumulusCIException) as error:
-            cci_safe_load(StringIO(invalid_yml_string))
+@patch("cumulusci.utils.yaml.cumulusci_yml.yaml.safe_load")
+def test_generic_exception__with_name_attr(safe_load, cci_yml_file):
+    invalid_yml = """xyz: abc   \n>>>\nefg: lmn\n"""
+    cci_yml_file.write(invalid_yml)
+    cci_yml_file.seek(0)
 
-        assert error.typename == "CumulusCIException"
-        assert "Error message: " in error.value.args[0]
+    safe_load.side_effect = Exception("generic")
+    with pytest.raises(CumulusCIException) as error:
+        cci_safe_load(cci_yml_file)
 
-    @patch("cumulusci.utils.yaml.cumulusci_yml.yaml.safe_load")
-    def test_generic_exception__with_name_attr(self, safe_load):
-        with temporary_dir() as temp_dir:
-            cumulusci_yml_filepath = Path(temp_dir) / "cumulusci.yml"
+    assert "cumulusci.yml.\nError message: generic" in error.value.args[0]
 
-            with open(cumulusci_yml_filepath, "w+") as cumulusci_yml:
-                invalid_yml = """xyz: abc   \n>>>\nefg: lmn\n"""
-                cumulusci_yml.write(invalid_yml)
-                cumulusci_yml.seek(0)
 
-                safe_load.side_effect = Exception("generic")
-                with pytest.raises(CumulusCIException) as error:
-                    cci_safe_load(cumulusci_yml)
-
-        assert error.typename == "CumulusCIException"
-        assert "cumulusci.yml.\nError message: generic" in error.value.args[0]
-
-    @patch("cumulusci.utils.yaml.cumulusci_yml.yaml.safe_load")
-    def test_generic_exception__without_name_attr(self, safe_load):
-        invalid_yaml = """xyz: abc   \n>>>\nefg: lmn\n"""
-        safe_load.side_effect = Exception("generic")
-        with pytest.raises(CumulusCIException) as error:
-            cci_safe_load(StringIO(invalid_yaml))
-
-        assert error.typename == "CumulusCIException"
-        assert (
-            "An error occurred parsing a yaml file. Error message: generic"
-            == error.value.args[0]
-        )
+@patch("cumulusci.utils.yaml.cumulusci_yml.yaml.safe_load")
+def test_generic_exception__without_name_attr(safe_load):
+    invalid_yaml = """xyz: abc   \n>>>\nefg: lmn\n"""
+    safe_load.side_effect = Exception("generic")
+    with pytest.raises(
+        CumulusCIException,
+        match="An error occurred parsing a yaml file. Error message: generic",
+    ):
+        cci_safe_load(StringIO(invalid_yaml))


### PR DESCRIPTION
I was unable to find an attribute on `ScannerError` for the name of the file being parsed.  I included "likely cumulusci.yml" in the error messaging, because we can't be sure which call to `handle_exception()` is being invoked.

# Changes
* CumulusCI displays more user friendly error message when encountering parsing errors in `cumulusci.yml`. 
