### PR TITLE
Support mixin for namespace injection

### DIFF
--- a/cumulusci/tasks/salesforce/namespaces.py
+++ b/cumulusci/tasks/salesforce/namespaces.py
@@ -1,0 +1,61 @@
+from cumulusci.core.utils import process_bool_arg
+from cumulusci.utils import inject_namespace
+from typing import Optional, Tuple
+
+namespace_injection_options = {
+    "managed": {
+        "description": "If False, changes namespace_inject to replace tokens with a blank string",
+        "required": False,
+    },
+    "namespaced_org": {
+        "description": "If True, the tokens %%%NAMESPACED_ORG%%% and ___NAMESPACED_ORG___ will get replaced with the namespace.  The default is false causing those tokens to get stripped and replaced with an empty string.  Set this if deploying to a namespaced scratch org or packaging org.",
+        "required": False,
+    },
+    "namespace_inject": {
+        "description": "If set, the namespace tokens in files and filenames are replaced with the namespace's prefix",
+        "required": False,
+    },
+}
+
+
+class NamespaceInjectionMixin:
+    def _inject_namespace(
+        self,
+        filename: str,
+        content: str,
+        namespace: Optional[str] = None,
+        managed: Optional[bool] = None,
+        namespaced_org: Optional[bool] = None,
+    ) -> Tuple[Optional[str], Optional[str]]:
+        _namespace = (
+            namespace
+            or self.options.get("namespace_inject")
+            or self.project_config.project__package__namespace
+        )
+
+        if managed is not None:
+            _managed = managed
+        elif "managed" in self.options:
+            _managed = process_bool_arg(self.options["managed"])
+        else:
+            _managed = (
+                bool(_namespace) and _namespace in self.org_config.installed_packages
+            )
+
+        if namespaced_org is not None:
+            _namespaced_org = namespaced_org
+        elif "namespaced_org" in self.options:
+            _namespaced_org = process_bool_arg(self.options["namespaced_org"])
+        else:
+            _namespaced_org = (
+                bool(_namespace) and _namespace == self.org_config.namespace
+            )
+
+        return inject_namespace(
+            filename,
+            content,
+            namespace=_namespace,
+            managed=_managed,
+            namespaced_org=_namespaced_org,
+            logger=self.logger,
+        )

--- a/cumulusci/tasks/salesforce/tests/test_namspaces.py
+++ b/cumulusci/tasks/salesforce/tests/test_namspaces.py
@@ -1,0 +1,373 @@
+import pytest  # noqa: F401
+from unittest import mock
+from cumulusci.tests.util import create_project_config
+from collections import defaultdict
+from cumulusci.tasks.salesforce.tests.util import create_task
+
+from cumulusci.tasks.salesforce.namespaces import (
+    NamespaceInjectionMixin,
+    namespace_injection_options,
+)
+from cumulusci.tasks.salesforce import BaseSalesforceMetadataApiTask
+
+
+class NamespaceInjectionTask(BaseSalesforceMetadataApiTask, NamespaceInjectionMixin):
+    task_options = {**namespace_injection_options}
+
+    def _run_task(self):
+        pass
+
+
+class TestNamespaceInjectionMixin:
+    def setup_method(self):
+        self.namespace = "namespace_prefix"
+
+        # NOTE: Most tests mock inject_namespace, so we are only asserting we pass in the arguments we expect.  There is not explicit use of these variables.  There are tests asserting we get the return values we expect from inject_namespace that use hard-coded values.
+        self.filename = "___NAMESPACE__filename"
+        self.content = "%%%NAMESPACE%%%CustomObject__c"
+
+    def _create_task_in_managed_context(
+        self, options: dict, project_namespace: str = None
+    ) -> NamespaceInjectionTask:
+        task = create_task(
+            NamespaceInjectionTask,
+            options,
+            project_config=create_project_config(
+                "TestRepo", "TestOwner", namespace=project_namespace
+            ),
+        )
+
+        # Set OrgConfig.installed_packages so no callouts are performed.
+        task.org_config._installed_packages = defaultdict(list)
+        task.org_config._installed_packages[self.namespace].append(mock.Mock())
+
+        return task
+
+    def _create_task_in_namespaced_org_context(
+        self, options: dict, project_namespace: str = None
+    ) -> NamespaceInjectionTask:
+        task = create_task(
+            NamespaceInjectionTask,
+            options,
+            project_config=create_project_config(
+                "TestRepo", "TestOwner", namespace=project_namespace
+            ),
+        )
+
+        # Set OrgConfig.installed_packages so no callouts are performed.
+        task.org_config._installed_packages = defaultdict(list)
+
+        # Set OrgConfig as a namespaced org.
+        task.org_config.config.update({"namespace": self.namespace})
+
+        return task
+
+    def _create_task_in_non_namespaced_org_context(
+        self, options: dict, project_namespace: str = None
+    ) -> NamespaceInjectionTask:
+        task = create_task(
+            NamespaceInjectionTask,
+            options,
+            project_config=create_project_config(
+                "TestRepo", "TestOwner", namespace=project_namespace
+            ),
+        )
+
+        # Set OrgConfig.installed_packages so no callouts are performed.
+        task.org_config._installed_packages = defaultdict(list)
+
+        return task
+
+    @mock.patch("cumulusci.tasks.salesforce.namespaces.inject_namespace")
+    def test_inject_namespace__defaults__managed_context(self, inject_namespace):
+        task = self._create_task_in_managed_context(
+            {}, project_namespace=self.namespace
+        )
+
+        actual = task._inject_namespace(self.filename, self.content)
+
+        inject_namespace.assert_called_once_with(
+            self.filename,
+            self.content,
+            namespace=self.namespace,
+            managed=True,
+            namespaced_org=False,
+            logger=task.logger,
+        )
+
+        assert inject_namespace.return_value == actual
+
+    @mock.patch("cumulusci.tasks.salesforce.namespaces.inject_namespace")
+    def test_inject_namespace__defaults__managed_context__no_project_namespace(
+        self, inject_namespace
+    ):
+        task = self._create_task_in_managed_context({}, project_namespace=None)
+
+        actual = task._inject_namespace(self.filename, self.content)
+
+        inject_namespace.assert_called_once_with(
+            self.filename,
+            self.content,
+            namespace=None,
+            managed=False,
+            namespaced_org=False,
+            logger=task.logger,
+        )
+
+        assert inject_namespace.return_value == actual
+
+    @mock.patch("cumulusci.tasks.salesforce.namespaces.inject_namespace")
+    def test_inject_namespace__defaults__namespaced_org_context(self, inject_namespace):
+        task = self._create_task_in_namespaced_org_context(
+            {}, project_namespace=self.namespace
+        )
+
+        actual = task._inject_namespace(self.filename, self.content)
+
+        inject_namespace.assert_called_once_with(
+            self.filename,
+            self.content,
+            namespace=self.namespace,
+            managed=False,
+            namespaced_org=True,
+            logger=task.logger,
+        )
+
+        assert inject_namespace.return_value == actual
+
+    @mock.patch("cumulusci.tasks.salesforce.namespaces.inject_namespace")
+    def test_inject_namespace__defaults__namespaced_org_context__no_package_namespace(
+        self, inject_namespace
+    ):
+        task = self._create_task_in_namespaced_org_context({}, project_namespace=None)
+
+        actual = task._inject_namespace(self.filename, self.content)
+
+        inject_namespace.assert_called_once_with(
+            self.filename,
+            self.content,
+            namespace=None,
+            managed=False,
+            namespaced_org=False,
+            logger=task.logger,
+        )
+
+        assert inject_namespace.return_value == actual
+
+    @mock.patch("cumulusci.tasks.salesforce.namespaces.inject_namespace")
+    def test_inject_namespace__defaults__non_namespaced_org_context(
+        self, inject_namespace
+    ):
+        task = self._create_task_in_non_namespaced_org_context(
+            {}, project_namespace=self.namespace
+        )
+
+        actual = task._inject_namespace(self.filename, self.content)
+
+        inject_namespace.assert_called_once_with(
+            self.filename,
+            self.content,
+            namespace=self.namespace,
+            managed=False,
+            namespaced_org=False,
+            logger=task.logger,
+        )
+
+        assert inject_namespace.return_value == actual
+
+    @mock.patch("cumulusci.tasks.salesforce.namespaces.inject_namespace")
+    def test_inject_namespace__override_managed_option(self, inject_namespace):
+        task = self._create_task_in_non_namespaced_org_context(
+            {"managed": True}, project_namespace=self.namespace
+        )
+
+        actual = task._inject_namespace(self.filename, self.content)
+
+        inject_namespace.assert_called_once_with(
+            self.filename,
+            self.content,
+            namespace=self.namespace,
+            managed=True,
+            namespaced_org=False,
+            logger=task.logger,
+        )
+
+        assert inject_namespace.return_value == actual
+
+    @mock.patch("cumulusci.tasks.salesforce.namespaces.inject_namespace")
+    def test_inject_namespace__override_namespaced_org_option(self, inject_namespace):
+        task = self._create_task_in_non_namespaced_org_context(
+            {"namespaced_org": True}, project_namespace=self.namespace
+        )
+
+        actual = task._inject_namespace(self.filename, self.content)
+
+        inject_namespace.assert_called_once_with(
+            self.filename,
+            self.content,
+            namespace=self.namespace,
+            managed=False,
+            namespaced_org=True,
+            logger=task.logger,
+        )
+
+        assert inject_namespace.return_value == actual
+
+    @mock.patch("cumulusci.tasks.salesforce.namespaces.inject_namespace")
+    def test_inject_namespace__override_namespace_inject_option(self, inject_namespace):
+        different_namespace = "different_namespace_prefix"
+        task = self._create_task_in_non_namespaced_org_context(
+            {"namespace_inject": different_namespace}, project_namespace=self.namespace
+        )
+
+        actual = task._inject_namespace(self.filename, self.content)
+
+        inject_namespace.assert_called_once_with(
+            self.filename,
+            self.content,
+            namespace=different_namespace,
+            managed=False,
+            namespaced_org=False,
+            logger=task.logger,
+        )
+
+        assert inject_namespace.return_value == actual
+
+    @mock.patch("cumulusci.tasks.salesforce.namespaces.inject_namespace")
+    def test_inject_namespace__override_managed_arg(self, inject_namespace):
+        task = self._create_task_in_non_namespaced_org_context(
+            {}, project_namespace=self.namespace
+        )
+
+        actual = task._inject_namespace(self.filename, self.content, managed=True)
+
+        inject_namespace.assert_called_once_with(
+            self.filename,
+            self.content,
+            namespace=self.namespace,
+            managed=True,
+            namespaced_org=False,
+            logger=task.logger,
+        )
+
+        assert inject_namespace.return_value == actual
+
+    @mock.patch("cumulusci.tasks.salesforce.namespaces.inject_namespace")
+    def test_inject_namespace__override_namespaced_org_arg(self, inject_namespace):
+        task = self._create_task_in_non_namespaced_org_context(
+            {}, project_namespace=self.namespace
+        )
+
+        actual = task._inject_namespace(
+            self.filename, self.content, namespaced_org=True
+        )
+
+        inject_namespace.assert_called_once_with(
+            self.filename,
+            self.content,
+            namespace=self.namespace,
+            managed=False,
+            namespaced_org=True,
+            logger=task.logger,
+        )
+
+        assert inject_namespace.return_value == actual
+
+    @mock.patch("cumulusci.tasks.salesforce.namespaces.inject_namespace")
+    def test_inject_namespace__override_namespace_arg(self, inject_namespace):
+        different_namespace = "different_namespace_prefix"
+        task = self._create_task_in_non_namespaced_org_context(
+            {}, project_namespace=self.namespace
+        )
+
+        actual = task._inject_namespace(
+            self.filename, self.content, namespace=different_namespace
+        )
+
+        inject_namespace.assert_called_once_with(
+            self.filename,
+            self.content,
+            namespace=different_namespace,
+            managed=False,
+            namespaced_org=False,
+            logger=task.logger,
+        )
+
+        assert inject_namespace.return_value == actual
+
+    def test_inject_namespace__return_values__namespace(self):
+        task = self._create_task_in_non_namespaced_org_context(
+            {}, project_namespace=self.namespace
+        )
+
+        filename, content = task._inject_namespace(
+            "___NAMESPACE___CustomObject__c.object-meta.xml",
+            "%%%NAMESPACE%%%CustomObject__c",
+            managed=True,
+            namespaced_org=False,
+            namespace=self.namespace,
+        )
+
+        assert f"{self.namespace}__CustomObject__c.object-meta.xml" == filename
+        assert f"{self.namespace}__CustomObject__c" == content
+
+    def test_inject_namespace__return_values__namespace_dot(self):
+        task = self._create_task_in_non_namespaced_org_context(
+            {}, project_namespace=self.namespace
+        )
+
+        _, content = task._inject_namespace(
+            "",
+            "%%%NAMESPACE_DOT%%%ApexClass",
+            managed=True,
+            namespaced_org=False,
+            namespace=self.namespace,
+        )
+
+        assert f"{self.namespace}.ApexClass" == content
+
+    def test_inject_namespace__return_values__namespaced_org(self):
+        task = self._create_task_in_non_namespaced_org_context(
+            {}, project_namespace=self.namespace
+        )
+
+        filename, content = task._inject_namespace(
+            "___NAMESPACED_ORG___CustomObject__c.object-meta.xml",
+            "%%%NAMESPACED_ORG%%%CustomObject__c",
+            managed=False,
+            namespaced_org=True,
+            namespace=self.namespace,
+        )
+
+        assert f"{self.namespace}__CustomObject__c.object-meta.xml" == filename
+        assert f"{self.namespace}__CustomObject__c" == content
+
+    def test_inject_namespace__return_values__namespace_or_c__namespace(self):
+        task = self._create_task_in_non_namespaced_org_context(
+            {}, project_namespace=self.namespace
+        )
+
+        _, content = task._inject_namespace(
+            "",
+            "%%%NAMESPACE_OR_C%%%-lwc",
+            managed=True,
+            namespaced_org=False,
+            namespace=self.namespace,
+        )
+
+        assert f"{self.namespace}-lwc" == content
+
+    def test_inject_namespace__return_values__namespaced_org_or_c__namespace(self):
+        task = self._create_task_in_non_namespaced_org_context(
+            {}, project_namespace=self.namespace
+        )
+
+        _, content = task._inject_namespace(
+            "",
+            "%%%NAMESPACED_ORG_OR_C%%%-lwc",
+            managed=False,
+            namespaced_org=True,
+            namespace=self.namespace,
+        )
+
+        assert f"{self.namespace}-lwc" == content


### PR DESCRIPTION
`NamespaceInjectionMixin` from `cumulusci.tasks.salesforce.namespaces` supports a `_inject_namespace` method that calls `inject_namespace` from `cumulusci.utils` while automatically detecting the org context for default `namespace`, `managed`, and `namespaced_org` arguments.

Implementations can reuse the `namespace_injection_options` from `cumulusci.tasks.salesforce.namespaces` in `task_options` to support `_inject_namespace`.


# Critical Changes

# Changes

# Issues Closed
