### PR TITLE
NamespaceInjectionMixin supports _get_namespaced_filename and _get_namespaced_content

### DIFF
--- a/cumulusci/tasks/salesforce/namespaces.py
+++ b/cumulusci/tasks/salesforce/namespaces.py
@@ -59,3 +59,35 @@ class NamespaceInjectionMixin:
             namespaced_org=_namespaced_org,
             logger=self.logger,
         )
+
+    def _get_namespaced_filename(
+        self,
+        filename,
+        namespace: Optional[str] = None,
+        managed: Optional[bool] = None,
+        namespaced_org: Optional[bool] = None,
+    ):
+        filename, _ = self._inject_namespace(
+            filename,
+            "",
+            namespace=namespace,
+            managed=managed,
+            namespaced_org=namespaced_org,
+        )
+        return filename
+
+    def _get_namespaced_content(
+        self,
+        content,
+        namespace: Optional[str] = None,
+        managed: Optional[bool] = None,
+        namespaced_org: Optional[bool] = None,
+    ):
+        _, content = self._inject_namespace(
+            "",
+            content,
+            namespace=namespace,
+            managed=managed,
+            namespaced_org=namespaced_org,
+        )
+        return content

--- a/cumulusci/tasks/salesforce/tests/test_namspaces.py
+++ b/cumulusci/tasks/salesforce/tests/test_namspaces.py
@@ -371,3 +371,67 @@ class TestNamespaceInjectionMixin:
         )
 
         assert f"{self.namespace}-lwc" == content
+
+    def test_get_namespaced_filename(self):
+        task = self._create_task_in_non_namespaced_org_context(
+            {}, project_namespace=self.namespace
+        )
+        namespace = mock.Mock()
+        managed = mock.Mock()
+        namespaced_org = mock.Mock()
+
+        expected_filename = mock.Mock()
+        expected_content = mock.Mock()
+
+        task._inject_namespace = mock.Mock(
+            return_value=(expected_filename, expected_content)
+        )
+
+        filename = task._get_namespaced_filename(
+            "filename",
+            namespace=namespace,
+            managed=managed,
+            namespaced_org=namespaced_org,
+        )
+
+        assert expected_filename == filename
+
+        task._inject_namespace.assert_called_once_with(
+            "filename",
+            "",
+            namespace=namespace,
+            managed=managed,
+            namespaced_org=namespaced_org,
+        )
+
+    def test_get_namespaced_content(self):
+        task = self._create_task_in_non_namespaced_org_context(
+            {}, project_namespace=self.namespace
+        )
+        namespace = mock.Mock()
+        managed = mock.Mock()
+        namespaced_org = mock.Mock()
+
+        expected_filename = mock.Mock()
+        expected_content = mock.Mock()
+
+        task._inject_namespace = mock.Mock(
+            return_value=(expected_filename, expected_content)
+        )
+
+        filename = task._get_namespaced_content(
+            "content",
+            namespace=namespace,
+            managed=managed,
+            namespaced_org=namespaced_org,
+        )
+
+        assert expected_content == filename
+
+        task._inject_namespace.assert_called_once_with(
+            "",
+            "content",
+            namespace=namespace,
+            managed=managed,
+            namespaced_org=namespaced_org,
+        )


### PR DESCRIPTION
> NOTE: Child branch of #2313 

`_inject_namespace` method of `NamespaceInjectionMixin` from `cumulusci.tasks.salesforce.namespaces` returns multiple values for namespace injecting both a file's name and the file's content simultaneously.   However, there are many use cases where a task only wants to namespace inject a string "content".   `NamespaceInjectionMixin` now supports individual methods to namespace inject a filename and content separately using the same functionality from `_inject_namespace`:
- `_get_namespaced_filename`
- `_get_namespaced_content`


# Critical Changes

# Changes

# Issues Closed
