### PR TITLE
Fix flaky push API memoization

### DIFF
--- a/cumulusci/tasks/push/push_api.py
+++ b/cumulusci/tasks/push/push_api.py
@@ -291,14 +291,14 @@ class SalesforcePushApi(object):
 
         return "%s LIMIT %s" % (query, limit)
 
-    @lru_cache
+    @lru_cache(32)
     def get_packages(self, where=None, limit=None):
         where = self.format_where_clause(where)
         query = f"SELECT id, name, namespaceprefix FROM MetadataPackage{where}"
         query = self.add_query_limit(query, limit)
         return self.return_query_records(query)
 
-    @lru_cache
+    @lru_cache(32)
     def get_package_objs(self, where=None, limit=None):
         package_objs = []
         for package in self.get_packages(where, limit):
@@ -312,14 +312,14 @@ class SalesforcePushApi(object):
             )
         return package_objs
 
-    @lru_cache
+    @lru_cache(32)
     def get_packages_by_id(self, where=None, limit=None):
         packages = {}
         for package in self.get_package_objs(where, limit):
             packages[package.sf_id] = package
         return packages
 
-    @lru_cache
+    @lru_cache(32)
     def get_package_versions(self, where=None, limit=None):
         where = self.format_where_clause(where)
         query = (
@@ -329,7 +329,7 @@ class SalesforcePushApi(object):
         query = self.add_query_limit(query, limit)
         return self.return_query_records(query)
 
-    @lru_cache
+    @lru_cache(32)
     def get_package_version_objs(self, where=None, limit=None):
         package_version_objs = []
         packages = self.get_packages_by_id()
@@ -349,14 +349,14 @@ class SalesforcePushApi(object):
             )
         return package_version_objs
 
-    @lru_cache
+    @lru_cache(32)
     def get_package_versions_by_id(self, where=None, limit=None):
         package_versions = {}
         for package_version in self.get_package_version_objs(where, limit):
             package_versions[package_version.sf_id] = package_version
         return package_versions
 
-    @lru_cache
+    @lru_cache(32)
     def get_subscribers(self, where=None, limit=None):
         where = self.format_where_clause(where, obj="PackageSubscriber")
         query = (
@@ -366,7 +366,7 @@ class SalesforcePushApi(object):
         query = self.add_query_limit(query, limit)
         return self.return_query_records(query)
 
-    @lru_cache
+    @lru_cache(32)
     def get_subscriber_objs(self, where=None, limit=None):
         subscriber_objs = []
         package_versions = self.get_package_versions_by_id()
@@ -385,14 +385,14 @@ class SalesforcePushApi(object):
             )
         return subscriber_objs
 
-    @lru_cache
+    @lru_cache(32)
     def get_subscribers_by_org_key(self, where=None, limit=None):
         subscribers = {}
         for subscriber in self.get_subscriber_objs(where, limit):
             subscribers[subscriber.org_key] = subscriber
         return subscribers
 
-    @lru_cache
+    @lru_cache(32)
     def get_push_requests(self, where=None, limit=None):
         where = self.format_where_clause(where, obj="PackagePushRequest")
         query = (
@@ -402,7 +402,7 @@ class SalesforcePushApi(object):
         query = self.add_query_limit(query, limit)
         return self.return_query_records(query)
 
-    @lru_cache
+    @lru_cache(32)
     def get_push_request_objs(self, where=None, limit=None):
         push_request_objs = []
         package_versions = self.get_package_versions_by_id()
@@ -418,14 +418,14 @@ class SalesforcePushApi(object):
             )
         return push_request_objs
 
-    @lru_cache
+    @lru_cache(32)
     def get_push_requests_by_id(self, where=None, limit=None):
         push_requests = {}
         for push_request in self.get_push_request_objs(where, limit):
             push_requests[push_request.sf_id] = push_request
         return push_requests
 
-    @lru_cache
+    @lru_cache(32)
     def get_push_jobs(self, where=None, limit=None):
         where = self.format_where_clause(where)
         query = (
@@ -435,7 +435,7 @@ class SalesforcePushApi(object):
         query = self.add_query_limit(query, limit)
         return self.return_query_records(query)
 
-    @lru_cache
+    @lru_cache(32)
     def get_push_job_objs(self, where=None, limit=None):
         push_job_objs = []
         lazy = "subscribers" in self.lazy
@@ -467,14 +467,14 @@ class SalesforcePushApi(object):
             )
         return push_job_objs
 
-    @lru_cache
+    @lru_cache(32)
     def get_push_jobs_by_id(self, where=None, limit=None):
         push_jobs = {}
         for push_job in self.get_push_job_objs(where, limit):
             push_jobs[push_job.sf_id] = push_job
         return push_jobs
 
-    @lru_cache
+    @lru_cache(32)
     def get_push_errors(self, where=None, limit=None):
         where = self.format_where_clause(where)
         query = (
@@ -484,7 +484,7 @@ class SalesforcePushApi(object):
         query = self.add_query_limit(query, limit)
         return self.return_query_records(query)
 
-    @lru_cache
+    @lru_cache(32)
     def get_push_error_objs(self, where=None, limit=None):
         push_error_objs = []
         lazy = "jobs" in self.lazy
@@ -511,7 +511,7 @@ class SalesforcePushApi(object):
             )
         return push_error_objs
 
-    @lru_cache
+    @lru_cache(32)
     def get_push_errors_by_id(self, where=None, limit=None):
         push_errors = {}
         for push_error in self.get_push_error_objs(where, limit):

--- a/cumulusci/tasks/push/push_api.py
+++ b/cumulusci/tasks/push/push_api.py
@@ -1,20 +1,7 @@
-import functools
 import json
+from functools import lru_cache
 
 from simple_salesforce import SalesforceMalformedRequest
-
-
-def memoize(obj):
-    cache = obj.cache = {}
-
-    @functools.wraps(obj)
-    def memoizer(*args, **kwargs):
-        key = str(args) + str(kwargs)
-        if key not in cache:
-            cache[key] = obj(*args, **kwargs)
-        return cache[key]
-
-    return memoizer
 
 
 def batch_list(data, batch_size):
@@ -304,14 +291,14 @@ class SalesforcePushApi(object):
 
         return "%s LIMIT %s" % (query, limit)
 
-    @memoize
+    @lru_cache
     def get_packages(self, where=None, limit=None):
         where = self.format_where_clause(where)
         query = f"SELECT id, name, namespaceprefix FROM MetadataPackage{where}"
         query = self.add_query_limit(query, limit)
         return self.return_query_records(query)
 
-    @memoize
+    @lru_cache
     def get_package_objs(self, where=None, limit=None):
         package_objs = []
         for package in self.get_packages(where, limit):
@@ -325,14 +312,14 @@ class SalesforcePushApi(object):
             )
         return package_objs
 
-    @memoize
+    @lru_cache
     def get_packages_by_id(self, where=None, limit=None):
         packages = {}
         for package in self.get_package_objs(where, limit):
             packages[package.sf_id] = package
         return packages
 
-    @memoize
+    @lru_cache
     def get_package_versions(self, where=None, limit=None):
         where = self.format_where_clause(where)
         query = (
@@ -342,19 +329,7 @@ class SalesforcePushApi(object):
         query = self.add_query_limit(query, limit)
         return self.return_query_records(query)
 
-    @memoize
-    def get_where_last_version(self, major=None, minor=None, beta=None):
-        if beta:
-            where = "ReleaseState = 'Beta'"
-        else:
-            where = "ReleaseState = 'Released'"
-        if major:
-            where += " AND MajorVersion=%s" % int(major)
-        if minor:
-            where += " AND MinorVersion=%s" % int(minor)
-        return where
-
-    @memoize
+    @lru_cache
     def get_package_version_objs(self, where=None, limit=None):
         package_version_objs = []
         packages = self.get_packages_by_id()
@@ -374,14 +349,14 @@ class SalesforcePushApi(object):
             )
         return package_version_objs
 
-    @memoize
+    @lru_cache
     def get_package_versions_by_id(self, where=None, limit=None):
         package_versions = {}
         for package_version in self.get_package_version_objs(where, limit):
             package_versions[package_version.sf_id] = package_version
         return package_versions
 
-    @memoize
+    @lru_cache
     def get_subscribers(self, where=None, limit=None):
         where = self.format_where_clause(where, obj="PackageSubscriber")
         query = (
@@ -391,7 +366,7 @@ class SalesforcePushApi(object):
         query = self.add_query_limit(query, limit)
         return self.return_query_records(query)
 
-    @memoize
+    @lru_cache
     def get_subscriber_objs(self, where=None, limit=None):
         subscriber_objs = []
         package_versions = self.get_package_versions_by_id()
@@ -410,14 +385,14 @@ class SalesforcePushApi(object):
             )
         return subscriber_objs
 
-    @memoize
+    @lru_cache
     def get_subscribers_by_org_key(self, where=None, limit=None):
         subscribers = {}
         for subscriber in self.get_subscriber_objs(where, limit):
             subscribers[subscriber.org_key] = subscriber
         return subscribers
 
-    @memoize
+    @lru_cache
     def get_push_requests(self, where=None, limit=None):
         where = self.format_where_clause(where, obj="PackagePushRequest")
         query = (
@@ -427,7 +402,7 @@ class SalesforcePushApi(object):
         query = self.add_query_limit(query, limit)
         return self.return_query_records(query)
 
-    @memoize
+    @lru_cache
     def get_push_request_objs(self, where=None, limit=None):
         push_request_objs = []
         package_versions = self.get_package_versions_by_id()
@@ -443,14 +418,14 @@ class SalesforcePushApi(object):
             )
         return push_request_objs
 
-    @memoize
+    @lru_cache
     def get_push_requests_by_id(self, where=None, limit=None):
         push_requests = {}
         for push_request in self.get_push_request_objs(where, limit):
             push_requests[push_request.sf_id] = push_request
         return push_requests
 
-    @memoize
+    @lru_cache
     def get_push_jobs(self, where=None, limit=None):
         where = self.format_where_clause(where)
         query = (
@@ -460,7 +435,7 @@ class SalesforcePushApi(object):
         query = self.add_query_limit(query, limit)
         return self.return_query_records(query)
 
-    @memoize
+    @lru_cache
     def get_push_job_objs(self, where=None, limit=None):
         push_job_objs = []
         lazy = "subscribers" in self.lazy
@@ -492,14 +467,14 @@ class SalesforcePushApi(object):
             )
         return push_job_objs
 
-    @memoize
+    @lru_cache
     def get_push_jobs_by_id(self, where=None, limit=None):
         push_jobs = {}
         for push_job in self.get_push_job_objs(where, limit):
             push_jobs[push_job.sf_id] = push_job
         return push_jobs
 
-    @memoize
+    @lru_cache
     def get_push_errors(self, where=None, limit=None):
         where = self.format_where_clause(where)
         query = (
@@ -509,7 +484,7 @@ class SalesforcePushApi(object):
         query = self.add_query_limit(query, limit)
         return self.return_query_records(query)
 
-    @memoize
+    @lru_cache
     def get_push_error_objs(self, where=None, limit=None):
         push_error_objs = []
         lazy = "jobs" in self.lazy
@@ -536,7 +511,7 @@ class SalesforcePushApi(object):
             )
         return push_error_objs
 
-    @memoize
+    @lru_cache
     def get_push_errors_by_id(self, where=None, limit=None):
         push_errors = {}
         for push_error in self.get_push_error_objs(where, limit):

--- a/cumulusci/tasks/push/tasks.py
+++ b/cumulusci/tasks/push/tasks.py
@@ -182,8 +182,8 @@ class BaseSalesforcePushTask(BaseSalesforceApiTask):
 
             # Clear the method level cache on get_push_requests and
             # get_push_request_objs
-            self.push_report.get_push_requests.cache.clear()
-            self.push_report.get_push_request_objs.cache.clear()
+            self.push_report.get_push_requests.cache_clear()
+            self.push_report.get_push_request_objs.cache_clear()
             # Get the push_request again
             self.push_request = self.push_report.get_push_request_objs(
                 "Id = '{}'".format(request_id), limit=1
@@ -390,7 +390,7 @@ class SchedulePushOrgQuery(SchedulePushOrgList):
             # query timeout errors with querying multiple versions
             for included_version in included_versions:
                 # Clear the get_subscribers method cache before each call
-                push_api.get_subscribers.cache.clear()
+                push_api.get_subscribers.cache_clear()
                 push_api.default_where[
                     "PackageSubscriber"
                 ] = "{} AND MetadataPackageVersionId = '{}'".format(

--- a/cumulusci/tasks/push/tests/test_push_api.py
+++ b/cumulusci/tasks/push/tests/test_push_api.py
@@ -15,7 +15,6 @@ from cumulusci.tasks.push.push_api import (
     PackageSubscriber,
     SalesforcePushApi,
     batch_list,
-    memoize,
 )
 
 NAME = "Chewbacca"
@@ -210,14 +209,6 @@ def test_sf_push_add_query_no_limit(sf_push_api):
     query = "SELECT Id FROM Account"
     returned = sf_push_api.add_query_limit(query, None)
     assert f"{query}" == returned
-
-
-def test_sf_push_get_where_last_version(sf_push_api):
-    assert (
-        sf_push_api.get_where_last_version(major="1", minor="2", beta="3")
-        == "ReleaseState = 'Beta' AND MajorVersion=1 AND MinorVersion=2"
-    )
-    assert sf_push_api.get_where_last_version() == "ReleaseState = 'Released'"
 
 
 def test_sf_push_get_packages(sf_push_api):
@@ -514,23 +505,6 @@ def test_sf_push_add_push_batch_retry(sf_push_api, metadata_package_version):
 
     assert [orgs[0]] == returned_batch  # only remaining org should be retry-able
     assert 4 == sf_push_api.sf._call_salesforce.call_count
-
-
-def test_push_memoize():
-    def test_func(number):
-        return number
-
-    memoized_func = memoize(test_func)
-    memoized_func(10)
-    memoized_func(20)
-
-    expected_cache = {"(10,){}": 10, "(20,){}": 20}
-    assert expected_cache == memoized_func.cache
-
-    memoized_func(10)
-    memoized_func(20)
-    # No new items introduced, cache should be same
-    assert expected_cache == memoized_func.cache
 
 
 def test_push_batch_list():

--- a/cumulusci/tasks/push/tests/test_push_tasks.py
+++ b/cumulusci/tasks/push/tests/test_push_tasks.py
@@ -496,7 +496,7 @@ def test_schedule_push_org_list_run_task_with_time_assertion(org_file):
     task.push = mock.MagicMock()
     task.sf = mock.MagicMock()
     task.sf.query_all.return_value = PACKAGE_OBJS
-    task.push.create_push_request.return_value = (task.sf.query_all.return_value, 2)
+    task.push.create_push_request.return_value = ("0DV000000000001", 2)
     task._run_task()
     task.push.create_push_request.assert_called_once_with(
         mock.ANY,
@@ -513,7 +513,7 @@ def test_schedule_push_org_list_run_task_without_time(org_file):
     task.push = mock.MagicMock()
     task.sf = mock.MagicMock()
     task.sf.query_all.return_value = PACKAGE_OBJS
-    task.push.create_push_request.return_value = (task.sf.query_all.return_value, 2)
+    task.push.create_push_request.return_value = ("0DV000000000001", 2)
     task._run_task()
     task.push.create_push_request.assert_called_once()
 
@@ -534,7 +534,7 @@ def test_schedule_push_org_list_run_task_without_orgs(empty_org_file):
     task.push_request = mock.MagicMock()
     task.sf = mock.MagicMock()
     task.sf.query_all.return_value = PACKAGE_OBJS
-    task.push.create_push_request.return_value = (task.sf.query_all.return_value, 0)
+    task.push.create_push_request.return_value = ("0DV000000000001", 0)
     task._run_task()
     task.push.create_push_request.assert_called_once_with(
         mock.ANY, [], datetime.datetime(2021, 8, 19, 23, 18)
@@ -556,7 +556,7 @@ def test_schedule_push_org_list_run_task_many_orgs(org_file):
     task.push = mock.MagicMock()
     task.sf = mock.MagicMock()
     task.sf.query_all.return_value = PACKAGE_OBJS
-    task.push.create_push_request.return_value = (task.sf.query_all.return_value, 1001)
+    task.push.create_push_request.return_value = ("0DV000000000001", 1001)
     task._run_task()
     task.push.create_push_request.assert_called_once_with(
         mock.ANY,
@@ -579,6 +579,6 @@ def test_schedule_push_org_list_run_task_many_orgs_now(org_file):
     task.push = mock.MagicMock()
     task.sf = mock.MagicMock()
     task.sf.query_all.return_value = PACKAGE_OBJS
-    task.push.create_push_request.return_value = (task.sf.query_all.return_value, 1001)
+    task.push.create_push_request.return_value = ("0DV000000000001", 1001)
     task._run_task()
     task.sf.query_all.assert_called_with(query)


### PR DESCRIPTION
This is an alternative to #2307 which attempts to simply fix the existing memoization rather than switch to a query cache. I switched from our own `memoize` decorator to `functools.lru_cache`. `lru_cache` uses a cache key with an actual reference to the function arguments rather than stringifying them, so I believe it should avoid the problem with cache collisions due to object ids being reused -- both by no longer using the stringified id, and by preventing the object from getting garbage collected, so its id won't be reused.

I think we're still doing more memoization than really makes sense and probably want to revisit that the next time we're doing bigger work on the push tasks, but for now I'm just looking for a quick fix to avoid the flaky tests.

I also removed the `get_where_last_version` method which was not used anywhere other than tests.

Also fixes #2303 

# Critical Changes

# Changes

# Issues Closed
