### PR TITLE
Add dict option for org_settings task

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -325,7 +325,7 @@ tasks:
         class_path: cumulusci.tasks.metadeploy.Publish
         group: Release Operations
     org_settings:
-        description: Apply org settings from a scratch org definition file
+        description: Apply org settings from a scratch org definition file or dict
         class_path: cumulusci.tasks.salesforce.org_settings.DeployOrgSettings
         group: Salesforce DX
     publish_community:

--- a/cumulusci/tasks/salesforce/org_settings.py
+++ b/cumulusci/tasks/salesforce/org_settings.py
@@ -30,6 +30,7 @@ class DeployOrgSettings(Deploy):
 
     task_options = {
         "definition_file": {"description": "sfdx scratch org definition file"},
+        "settings": {"description": "A dict of settings to apply"},
         "api_version": {"description": "API version used to deploy the settings"},
     }
 
@@ -42,10 +43,16 @@ class DeployOrgSettings(Deploy):
         self.options["namespaced_org"] = False
 
     def _run_task(self):
-        with open(self.options["definition_file"], "r") as f:
-            scratch_org_definition = json.load(f)
+        settings = {}
 
-        settings = scratch_org_definition.get("settings", {})
+        if self.options.get("definition_file"):
+            with open(self.options["definition_file"], "r") as f:
+                scratch_org_definition = json.load(f)
+                settings.update(scratch_org_definition.get("settings", {}))
+
+        if self.options.get("settings"):
+            settings.update(self.options["settings"])
+
         if not settings:
             return
 

--- a/cumulusci/tasks/salesforce/org_settings.py
+++ b/cumulusci/tasks/salesforce/org_settings.py
@@ -5,6 +5,7 @@ import textwrap
 
 from cumulusci.tasks.salesforce import Deploy
 from cumulusci.utils import temporary_dir
+from cumulusci.core.utils import dictmerge
 
 
 SETTINGS_XML = """<?xml version="1.0" encoding="UTF-8"?>
@@ -44,16 +45,15 @@ class DeployOrgSettings(Deploy):
 
     def _run_task(self):
         settings = {}
-
         if self.options.get("definition_file"):
             with open(self.options["definition_file"], "r") as f:
                 scratch_org_definition = json.load(f)
-                settings.update(scratch_org_definition.get("settings", {}))
+                settings = scratch_org_definition.get("settings", {})
 
-        if self.options.get("settings"):
-            settings.update(self.options["settings"])
+        dictmerge(settings, self.options.get("settings", {}))
 
         if not settings:
+            self.logger.info(f"No settings provided to deploy.")
             return
 
         api_version = (

--- a/cumulusci/tasks/salesforce/tests/test_org_settings.py
+++ b/cumulusci/tasks/salesforce/tests/test_org_settings.py
@@ -13,7 +13,7 @@ from .util import create_task
 
 
 class TestDeployOrgSettings:
-    def test_run_task(self):
+    def test_run_task__json_only(self):
         with temporary_dir() as d:
             with open("dev.json", "w") as f:
                 json.dump(
@@ -32,6 +32,118 @@ class TestDeployOrgSettings:
                 )
             path = os.path.join(d, "dev.json")
             task_options = {"definition_file": path, "api_version": "48.0"}
+            task = create_task(DeployOrgSettings, task_options)
+            task.api_class = Mock()
+            task()
+
+        package_zip = task.api_class.call_args[0][1]
+        zf = zipfile.ZipFile(io.BytesIO(base64.b64decode(package_zip)), "r")
+        assert (
+            readtext(zf, "package.xml")
+            == """<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>*</members>
+        <name>Settings</name>
+    </types>
+    <version>48.0</version>
+</Package>"""
+        )
+        assert (
+            readtext(zf, "settings/OrgPreference.settings")
+            == """<?xml version="1.0" encoding="UTF-8"?>
+<OrgPreferenceSettings xmlns="http://soap.sforce.com/2006/04/metadata">
+    <preferences>
+        <settingName>S1DesktopEnabled</settingName>
+        <settingValue>True</settingValue>
+    </preferences>
+</OrgPreferenceSettings>"""
+        )
+        assert (
+            readtext(zf, "settings/Other.settings")
+            == """<?xml version="1.0" encoding="UTF-8"?>
+<OtherSettings xmlns="http://soap.sforce.com/2006/04/metadata">
+    <nested>
+        <boolValue>true</boolValue>
+        <stringValue>string</stringValue>
+    </nested>
+</OtherSettings>"""
+        )
+
+    def test_run_task__settings_only(self):
+        settings = {
+            "orgPreferenceSettings": {"s1DesktopEnabled": True},
+            "otherSettings": {
+                "nested": {
+                    "boolValue": True,
+                    "stringValue": "string",
+                },
+            },
+        }
+        task_options = {"settings": settings, "api_version": "48.0"}
+        task = create_task(DeployOrgSettings, task_options)
+        task.api_class = Mock()
+        task()
+
+        package_zip = task.api_class.call_args[0][1]
+        zf = zipfile.ZipFile(io.BytesIO(base64.b64decode(package_zip)), "r")
+        assert (
+            readtext(zf, "package.xml")
+            == """<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>*</members>
+        <name>Settings</name>
+    </types>
+    <version>48.0</version>
+</Package>"""
+        )
+        assert (
+            readtext(zf, "settings/OrgPreference.settings")
+            == """<?xml version="1.0" encoding="UTF-8"?>
+<OrgPreferenceSettings xmlns="http://soap.sforce.com/2006/04/metadata">
+    <preferences>
+        <settingName>S1DesktopEnabled</settingName>
+        <settingValue>True</settingValue>
+    </preferences>
+</OrgPreferenceSettings>"""
+        )
+        assert (
+            readtext(zf, "settings/Other.settings")
+            == """<?xml version="1.0" encoding="UTF-8"?>
+<OtherSettings xmlns="http://soap.sforce.com/2006/04/metadata">
+    <nested>
+        <boolValue>true</boolValue>
+        <stringValue>string</stringValue>
+    </nested>
+</OtherSettings>"""
+        )
+
+    def test_run_task__json_and_settings(self):
+        with temporary_dir() as d:
+            with open("dev.json", "w") as f:
+                json.dump(
+                    {
+                        "settings": {
+                            "orgPreferenceSettings": {"s1DesktopEnabled": True},
+                        },
+                    },
+                    f,
+                )
+            path = os.path.join(d, "dev.json")
+            settings = {
+                "otherSettings": {
+                    "nested": {
+                        "boolValue": True,
+                        "stringValue": "string",
+                    },
+                },
+            }
+            task_options = {
+                "definition_file": path,
+                "settings": settings,
+                "api_version": "48.0",
+            }
             task = create_task(DeployOrgSettings, task_options)
             task.api_class = Mock()
             task()

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -1880,12 +1880,12 @@ Options
 ``--num_records NUMRECORDS``
 	 *Optional*
 
-	 How many records to generate: total number of opportunities.
+	 Target number of records. You will get at least this many records, but may get more. The recipe will always execute to completion, so if it creates 3 records per execution and you ask for 5, you will get 6.
 
 ``--num_records_tablename NUMRECORDSTABLENAME``
 	 *Optional*
 
-	 A string representing which table to count records in.
+	 A string representing which table determines when the recipe execution is done.
 
 ``--batch_size BATCHSIZE``
 	 *Optional*
@@ -2704,7 +2704,7 @@ Options
 **org_settings**
 ==========================================
 
-**Description:** Apply org settings from a scratch org definition file
+**Description:** Apply org settings from a scratch org definition file or dict
 
 **Class:** cumulusci.tasks.salesforce.org_settings.DeployOrgSettings
 
@@ -2722,6 +2722,11 @@ Options
 	 *Optional*
 
 	 sfdx scratch org definition file
+
+``--settings SETTINGS``
+	 *Optional*
+
+	 A dict of settings to apply
 
 ``--api_version APIVERSION``
 	 *Optional*
@@ -3541,7 +3546,7 @@ Options
 ``--options OPTIONS``
 	 *Optional*
 
-	 A dictionary of options to robot.run method.  See docs here for format.  NOTE: There is no cci CLI support for this option since it requires a dictionary.  Use this option in the cumulusci.yml when defining custom tasks where you can easily create a dictionary in yaml.
+	 A dictionary of options to robot.run method. In simple cases this can be specified on the comand line using name:value,name:value syntax. More complex cases can be specified in cumulusci.yml using YAML dictionary syntax.
 
 ``--name NAME``
 	 *Optional*


### PR DESCRIPTION
# Critical Changes

# Changes
- `org_settings` accepts a dict option called `settings` in addition to (or instead of) the existing `definition_file` option.

# Issues Closed
