### PR TITLE
Feature/robot locator manager

### DIFF
--- a/cumulusci/robotframework/locator_manager.py
+++ b/cumulusci/robotframework/locator_manager.py
@@ -130,11 +130,18 @@ def translate_locator(prefix, locator):
     try:
         for key in path.split("."):
             breadcrumbs.append(key)
+            # this assumes that loc is a dictionary rather than a
+            # string. If we've hit the leaf node of the locator and
+            # there are still more keys, this will fail with a TypeError
             loc = loc[key.strip()]
 
-    except KeyError:
+    except (KeyError, TypeError):
+        # TypeError: if the user passes in foo.bar.baz, but foo or foo.bar
+        # resolves to a string rather than a nested dict.
+        # KeyError if user passes in foo.bar and either 'foo' or 'bar' isn't
+        # a valid key for a nested dictionary
         breadcrumb_path = ".".join(breadcrumbs)
-        raise KeyError(f"locator {prefix}:{breadcrumb_path} not found")
+        raise Exception(f"locator {prefix}:{breadcrumb_path} not found")
 
     if not isinstance(loc, str):
         raise TypeError(f"Expected locator to be of type string, but was {type(loc)}")

--- a/cumulusci/robotframework/locator_manager.py
+++ b/cumulusci/robotframework/locator_manager.py
@@ -1,6 +1,7 @@
 from robot.libraries.BuiltIn import BuiltIn
 import functools
 from cumulusci.core.utils import dictmerge
+from robot.api import logger
 
 """
 This module supports managing multiple location strategies. It
@@ -48,10 +49,10 @@ def register_locators(prefix, locators):
     If the prefix is already known, merge in the new locators.
     """
     if prefix in LOCATORS:
-        BuiltIn().log(f"merging keywords for prefix {prefix}", "DEBUG")
+        logger.debug(f"merging keywords for prefix {prefix}")
         dictmerge(LOCATORS[prefix], locators)
     else:
-        BuiltIn().log(f"registering keywords for prefix {prefix}", "DEBUG")
+        logger.debug(f"registering keywords for prefix {prefix}")
         LOCATORS[prefix] = locators
 
 
@@ -64,7 +65,7 @@ def add_location_strategies():
     selenium = BuiltIn().get_library_instance("SeleniumLibrary")
     for (prefix, strategy) in LOCATORS.items():
         try:
-            BuiltIn().log(f"adding location strategy for '{prefix}'", "DEBUG")
+            logger.debug(f"adding location strategy for '{prefix}'")
             if isinstance(strategy, dict):
                 selenium.add_location_strategy(
                     prefix, functools.partial(locate_element, prefix)
@@ -74,7 +75,7 @@ def add_location_strategies():
                 # so that this function can register normal keywords
                 selenium.add_location_strategy(prefix, strategy)
         except Exception as e:
-            BuiltIn().log(f"unable to register locators: {e}", "DEBUG")
+            logger.debug(f"unable to register locators: {e}")
 
 
 def locate_element(prefix, parent, locator, tag, constraints):
@@ -94,7 +95,7 @@ def locate_element(prefix, parent, locator, tag, constraints):
     # practice it probably won't matter <shrug>.
     selenium = BuiltIn().get_library_instance("SeleniumLibrary")
     loc = translate_locator(prefix, locator)
-    BuiltIn().log(f"locator: '{prefix}:{locator}' => '{loc}'")
+    logger.info(f"locator: '{prefix}:{locator}' => '{loc}'")
 
     try:
         element = selenium.get_webelement(loc)
@@ -104,7 +105,7 @@ def locate_element(prefix, parent, locator, tag, constraints):
         # in this case. If we throw an error, that prevents the custom
         # locators from being used negatively (eg: Page should not
         # contain element  custom:whatever).
-        BuiltIn().log(f"caught exception in locate_element: {e}", "DEBUG")
+        logger.debug(f"caught exception in locate_element: {e}")
         return None
     return element
 

--- a/cumulusci/robotframework/locator_manager.py
+++ b/cumulusci/robotframework/locator_manager.py
@@ -94,13 +94,18 @@ def locate_element(prefix, parent, locator, tag, constraints):
     # practice it probably won't matter <shrug>.
     selenium = BuiltIn().get_library_instance("SeleniumLibrary")
     loc = translate_locator(prefix, locator)
-    BuiltIn().log(f"locate_element: '{prefix}:{locator}' => {loc}", "DEBUG")
+    BuiltIn().log(f"locator: '{prefix}:{locator}' => '{loc}'")
+
     try:
         element = selenium.get_webelement(loc)
-    except Exception:
-        raise Exception(
-            f"Element with locator '{prefix}:{locator}' not found\ntranslated: '{loc}'"
-        )
+    except Exception as e:
+        # the SeleniumLibrary documentation doesn't say, but I'm
+        # pretty sure we should return None rather than throwing an error
+        # in this case. If we throw an error, that prevents the custom
+        # locators from being used negatively (eg: Page should not
+        # contain element  custom:whatever).
+        BuiltIn().log(f"caught exception in locate_element: {e}", "DEBUG")
+        return None
     return element
 
 

--- a/cumulusci/robotframework/tests/salesforce/TestLibraryA.py
+++ b/cumulusci/robotframework/tests/salesforce/TestLibraryA.py
@@ -9,7 +9,8 @@ from cumulusci.robotframework.locator_manager import (
 
 locators = {
     # eg: A:breadcrumb:Home
-    "breadcrumb": "//span[contains(@class, 'breadcrumbDetail') and text()='{}']"
+    "breadcrumb": "//span[contains(@class, 'breadcrumbDetail') and text()='{}']",
+    "something": "//whatever",
 }
 
 

--- a/cumulusci/robotframework/tests/salesforce/locators.robot
+++ b/cumulusci/robotframework/tests/salesforce/locators.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 
 Resource        cumulusci/robotframework/Salesforce.robot
+Library         cumulusci/robotframework/tests/salesforce/TestListener.py
 Library         TestLibraryA.py
 Library         TestLibraryB.py
 Library         Dialogs
@@ -44,16 +45,25 @@ Keyword library locators
     Wait until page contains element  A:breadcrumb: Home
     Wait until page contains element  B:appname:Setup
 
-Show translated locator on error
+Show translated locator in the log
     [Documentation]
-    ...  Verify the translated locator appears in the error message
+    ...  Verify the translated locator appears in the log
 
-    [Setup]     Register keyword to run on failure  NONE
-    [Teardown]  Register keyword to run on failure  Capture page screenshot
+    Page should not contain element  A:something
+    assert robot log                 locator: 'A:something' => '//whatever'
 
-    ${expected error}=  Catenate  SEPARATOR=${\n}
-    ...  Element with locator 'B:appname:Sorry Charlie' not found
-    ...  translated: '//div[contains(@class, 'appName') and .='Sorry Charlie']'
+Page should not contain custom locator
+    [Documentation]
+    ...  Verify that a custom locator can be used in a context where
+    ...  the locator doesn't exist.
+    ...
+    ...  It used to be that the locator manager would itself throw
+    ...  an error if it couldn't find a locator. Now, it returns None
+    ...  so that the keyword can be responsible for deciding if an
+    ...  error should be thrown or not
 
-    Run keyword and expect error  EQUALS:${expected error}
-    ...  Page should contain element  B:appname:Sorry Charlie
+    # we know this locator doesn't exist, but the keyword should
+    # pass. Prior to the fix when this test was introduced, this would
+    # give an error
+
+    Page should not contain element  B:appname:Sorry Charlie

--- a/cumulusci/robotframework/tests/salesforce/locators.robot
+++ b/cumulusci/robotframework/tests/salesforce/locators.robot
@@ -45,6 +45,28 @@ Keyword library locators
     Wait until page contains element  A:breadcrumb: Home
     Wait until page contains element  B:appname:Setup
 
+Invalid locator
+    [Documentation]
+    ...  Verify we give a reasonable error message if the locator
+    ...  isn't found
+
+    # Note: a:breadcrumb is valid, but it doesn't have a child
+    # locator named 'bogus'
+    Run keyword and expect error
+    ...  locator A:breadcrumb.bogus not found
+    ...  Page should not contain element  a:breadcrumb.bogus
+
+Not enough arguments in locator
+    [Documentation]
+    ...  Verify that we give a reasonable error message if a locator
+    ...  requires more arguments than it gets
+
+    # Note: a:breadcrumb requires an argument
+    Run keyword and expect error
+    ...  Not enough arguments were supplied
+    ...  Page should not contain element  a:breadcrumb
+
+
 Show translated locator in the log
     [Documentation]
     ...  Verify the translated locator appears in the log

--- a/cumulusci/robotframework/tests/test_locator_manager.py
+++ b/cumulusci/robotframework/tests/test_locator_manager.py
@@ -84,7 +84,7 @@ class TestTranslateLocator(unittest.TestCase):
         the first part of the locator key that wasn't found.
         """
         expected_error = "locator test:foo.not not found"
-        with pytest.raises(KeyError, match=expected_error):
+        with pytest.raises(Exception, match=expected_error):
             translate_locator("test", "foo.not.valid")
 
 


### PR DESCRIPTION
Prior to this change, using a custom locator that is not on a page would always throw an error even if you didn't expect it to be on a page (eg: `Page should not contain     custom:locator`). This changes the locator manager so that it lets the keyword using the locator be responsible for throwing the error.

As an unfortunate side effect, the translated locator isn't included as part of the error message. Therefore, every time a custom locator is used, the translated locator will be logged to aid in debugging.

# Critical Changes

# Changes

# Issues Closed
