### PR TITLE
Fix running a task in a non-main thread

### DIFF
--- a/cumulusci/core/tasks.py
+++ b/cumulusci/core/tasks.py
@@ -16,13 +16,14 @@ from cumulusci.core.exceptions import TaskRequiresSalesforceOrg
 from cumulusci.core.exceptions import TaskOptionsError
 
 CURRENT_TASK = threading.local()
-CURRENT_TASK.stack = []
 
 PROJECT_CONFIG_RE = re.compile(r"\$project_config.(\w+)")
 
 
 @contextlib.contextmanager
 def stacked_task(task):
+    if not hasattr(CURRENT_TASK, "stack"):
+        CURRENT_TASK.stack = []
     CURRENT_TASK.stack.append(task)
     try:
         yield

--- a/cumulusci/robotframework/CumulusCI.py
+++ b/cumulusci/robotframework/CumulusCI.py
@@ -49,7 +49,9 @@ class CumulusCI(object):
     @property
     def project_config(self):
         if self._project_config is None:
-            if CURRENT_TASK.stack and isinstance(CURRENT_TASK.stack[0], Robot):
+            if getattr(CURRENT_TASK, "stack", None) and isinstance(
+                CURRENT_TASK.stack[0], Robot
+            ):
                 # If CumulusCI is running a task, use that task's config
                 return CURRENT_TASK.stack[0].project_config
             else:
@@ -68,7 +70,9 @@ class CumulusCI(object):
     @property
     def org(self):
         if self._org is None:
-            if CURRENT_TASK.stack and isinstance(CURRENT_TASK.stack[0], Robot):
+            if getattr(CURRENT_TASK, "stack", None) and isinstance(
+                CURRENT_TASK.stack[0], Robot
+            ):
                 # If CumulusCI is running a task, use that task's org
                 return CURRENT_TASK.stack[0].org_config
             else:


### PR DESCRIPTION
CumulusCI uses this global CURRENT_TASK to store a stack of which tasks are currently running, and it uses a threadlocal to make it safe if there are multiple threads each running a different flow. But that wasn't actually working because CURRENT_TASK.stack was only initialized in the main thread, so there was an AttributeError when trying to access it in other threads.

# Critical Changes

# Changes

# Issues Closed
- Fixed a possible error when running CumulusCI flows embedded in a multi-threaded context.