### PR TITLE
Remove raven, which hasn't been an actual requirement for some time

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ PyJWT==2.0.1
 python-dateutil==2.8.1
 pytz==2020.5
 PyYAML==5.4
-raven==6.10.0
 requests==2.25.1
 robotframework==3.2.2
 robotframework-pabot==1.10.1


### PR DESCRIPTION
(This is the _old_ library for reporting to sentry, and we removed CumulusCI's support for doing that a while back.)

# Critical Changes

# Changes

# Issues Closed
