### PR TITLE
A couple small tweaks to locators for Spring '21.

### DIFF
--- a/cumulusci/robotframework/locators_51.py
+++ b/cumulusci/robotframework/locators_51.py
@@ -3,9 +3,7 @@ import copy
 
 lex_locators = copy.deepcopy(locators_50.lex_locators)
 
-lex_locators["modal"][
-    "button"
-] = "//div[contains(@class,'uiModal')]//force-form-footer//button[.='{}']"
+lex_locators["modal"]["button"] = "//div[contains(@class,'uiModal')]//button[.='{}']"
 
 lex_locators["modal"]["has_error"] = "css: div.forceFormPageError"
 
@@ -17,3 +15,12 @@ lex_locators["modal"]["field_alert"] = "//div[contains(@class, 'forceFormPageErr
 
 # I like the new markup I'm seeing in Spring '21!
 lex_locators["object"]["field"] = "//lightning-input[.//label[text()='{}']]//input"
+
+lex_locators["record"]["related"]["button"] = (
+    # the old locator searched for an <a> element, but in spring '21
+    # the buttons are sometimes <button> elements. To be liberal in what
+    # we accept, we'll just find anything that has the exact text.
+    "//*[@data-component-id='force_relatedListContainer']"
+    "//article[contains(@class, 'slds-card slds-card_boundary')]"
+    "[.//span[@title='{}']]//*[text()='{}']"
+)


### PR DESCRIPTION
Small spring '21 locator changes. Thanks to Sravani for bringing these to our attention and offering suggested solutions.  Even without these changes our own test suites were passing, but NPSP in spring '21 is using some new markup that was causing a couple of keywords to fail. 

I was unable to find a scenario that would cause our own tests to fail without these fixes, so I haven't added any new test cases. However, our own tests still pass with these changes, and I manually verified that the failing NPSP tests were fixed with these changes. 

# Critical Changes

# Changes

* `Click related list button` keyword has been modified to be more liberal in the types of DOM elements it will click on. Prior to this change it only clicked on anchor elements, but now also works for related list buttons that use an actual button element.
* `Click modal button` keyword now attempts to find the given button anywhere on the modal rather than only inside a `force-form-footer` element.

# Issues Closed
