### PR TITLE
Fixed bug related to using tagstatexclude in cumulusci.yml

### DIFF
--- a/cumulusci/tasks/robotframework/robotframework.py
+++ b/cumulusci/tasks/robotframework/robotframework.py
@@ -81,10 +81,10 @@ class Robot(BaseSalesforceTask):
             )
 
         # There are potentially many robot options that are or could
-        # be lists, but the only one we currently care about is the
-        # listener option since we may need to append additional values
-        # onto it.
-        for option in ("listener",):
+        # be lists. The only ones we currently care about are the
+        # listener and tagstatexlude options since we may need to
+        # append additional values onto it.
+        for option in ("listener", "tagstatexclude"):
             if option in self.options["options"]:
                 self.options["options"][option] = process_list_arg(
                     self.options["options"][option]

--- a/cumulusci/tasks/robotframework/tests/test_robotframework.py
+++ b/cumulusci/tasks/robotframework/tests/test_robotframework.py
@@ -157,6 +157,29 @@ class TestRobot(unittest.TestCase):
             tagstatexclude=["cci_metric_elapsed_time", "cci_metric"],
         )
 
+    @mock.patch("cumulusci.tasks.robotframework.robotframework.robot_run")
+    def test_tagstatexclude(self, mock_robot_run):
+        """Verify tagstatexclude is treated as a list"""
+        mock_robot_run.return_value = 0
+        task = create_task(
+            Robot,
+            {
+                "suites": "test",  # required, or the task will raise an exception
+                "options": {
+                    "tagstatexclude": "this,that",
+                },
+            },
+        )
+        assert type(task.options["options"]["tagstatexclude"]) == list
+        task()
+        mock_robot_run.assert_called_once_with(
+            "test",
+            listener=[],
+            outputdir=".",
+            variable=["org:test"],
+            tagstatexclude=["this", "that", "cci_metric_elapsed_time", "cci_metric"],
+        )
+
     def test_default_listeners(self):
         # first, verify that not specifying any listener options
         # results in no listeners...


### PR DESCRIPTION
This fixes a bug that would cause the robot task to crash if you set the robot option 'tagstatexclude' in cumulusci.yml. I added a test case which fails without the fix and passes with.

# Critical Changes

# Changes


# Issues Closed
