### PR TITLE
query_all instead of query

### DIFF
--- a/cumulusci/tasks/preflight/recordtypes.py
+++ b/cumulusci/tasks/preflight/recordtypes.py
@@ -5,9 +5,9 @@ from collections import defaultdict
 class CheckSObjectRecordTypes(BaseSalesforceApiTask):
     def _run_task(self):
         rts = defaultdict(list)
-        records = self.tooling.query("Select SobjectType, FullName FROM RecordType")[
-            "records"
-        ]
+        records = self.tooling.query_all(
+            "Select SobjectType, FullName FROM RecordType"
+        )["records"]
         for r in records:
             rts[r["SobjectType"]].append(r["FullName"].split(".")[1])
 

--- a/cumulusci/tasks/preflight/tests/test_recordtypes.py
+++ b/cumulusci/tasks/preflight/tests/test_recordtypes.py
@@ -9,7 +9,7 @@ class TestRecordTypePreflights(unittest.TestCase):
     def test_record_type_preflight(self):
         task = create_task(CheckSObjectRecordTypes, {})
         task.tooling = Mock()
-        task.tooling.query.return_value = {
+        task.tooling.query_all.return_value = {
             "totalSize": 3,
             "records": [
                 {"SobjectType": "Account", "FullName": "Account.Business_Account"},
@@ -22,7 +22,7 @@ class TestRecordTypePreflights(unittest.TestCase):
         }
         task._run_task()
 
-        task.tooling.query.assert_called_once_with(
+        task.tooling.query_all.assert_called_once_with(
             "Select SobjectType, FullName FROM RecordType"
         )
         assert task.return_values == {


### PR DESCRIPTION
Fixes a problem in #2371 , missing the use of `query()` instead of `query_all()`.

# Critical Changes

# Changes

# Issues Closed
