### PR TITLE
Feature/remove force namespace sfdxurl auth

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -351,7 +351,7 @@ Tests workflow, use your editor to create a file named
            wget -qO- https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz | tar xJ -C sfdx --strip-components 1
            ./sfdx/install
            echo ${{ secrets.SFDX_AUTH_URL }} > sfdx_auth
-           sfdx force:auth:sfdxurl:store -f sfdx_auth -d
+           sfdx auth:sfdxurl:store -f sfdx_auth -d
        - name: Set up Python
          uses: actions/setup-python@v1
          with:
@@ -509,7 +509,7 @@ Here is a complete workflow to run Robot Framework tests for any commit:
            wget -qO- https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz | tar xJ -C sfdx --strip-components 1
            ./sfdx/install
            echo ${{ secrets.SFDX_AUTH_URL }} > sfdx_auth
-           sfdx force:auth:sfdxurl:store -f sfdx_auth -d
+           sfdx auth:sfdxurl:store -f sfdx_auth -d
        - name: Set up Python
          uses: actions/setup-python@v1
          with:


### PR DESCRIPTION
auth was moved from force to it's own namespace. Even though there is an alias, I was having trouble getting this to run in Github Actions:
<img width="747" alt="Screen Shot 2021-02-05 at 7 46 44 PM" src="https://user-images.githubusercontent.com/459099/107108255-8027ce80-67eb-11eb-86de-7dde087d6153.png">

SFDX docs: https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_auth_sfdxurl.htm

# Critical Changes

# Changes
- remove "force" from "force:auth:sfdxurl:store"


# Issues Closed
