### PR TITLE
quick coverage improvements

### DIFF
--- a/cumulusci/core/tests/test_sfdx.py
+++ b/cumulusci/core/tests/test_sfdx.py
@@ -1,6 +1,5 @@
 from unittest import mock
 import io
-import sys
 
 import pytest
 
@@ -10,19 +9,14 @@ from cumulusci.core.sfdx import sfdx
 
 
 class TestSfdx:
-    @pytest.mark.skipif(
-        sys.platform.startswith("win"), reason="This tests quoting on POSIX systems"
-    )
+    @mock.patch("platform.system", mock.Mock(return_value="Linux"))
     @mock.patch("sarge.Command")
     def test_posix_quoting(self, Command):
         sfdx("cmd", args=["a'b"])
         cmd = Command.call_args[0][0]
         assert cmd == r"sfdx cmd 'a'\''b'"
 
-    @pytest.mark.skipif(
-        not sys.platform.startswith("win"),
-        reason="This tests quoting on Windows systems",
-    )
+    @mock.patch("platform.system", mock.Mock(return_value="Windows"))
     @mock.patch("sarge.Command")
     def test_windows_quoting(self, Command):
         sfdx("cmd", args=['a"b'], access_token="token")

--- a/cumulusci/robotframework/utils.py
+++ b/cumulusci/robotframework/utils.py
@@ -13,7 +13,7 @@ from robot.libraries.BuiltIn import BuiltIn
 import robot.api as robot_api
 
 
-def set_pdb_trace(pm=False):
+def set_pdb_trace(pm=False):  # pragma: no cover
     """Start the Python debugger when robotframework is running.
 
     This makes sure that pdb can use stdin/stdout even though

--- a/cumulusci/tasks/bulkdata/extract.py
+++ b/cumulusci/tasks/bulkdata/extract.py
@@ -271,18 +271,6 @@ class ExtractData(SqlAlchemyMixin, BaseSalesforceApiTask):
             if mapping["table"] == table:
                 return mapping
 
-    def _split_batch_csv(self, records, f_values, f_ids):
-        """Split the record generator and return two files,
-        one containing Ids only and the other record data."""
-        writer_values = csv.writer(f_values)
-        writer_ids = csv.writer(f_ids)
-        for row in records:
-            writer_values.writerow(row[1:])
-            writer_ids.writerow(row[:1])
-        f_values.seek(0)
-        f_ids.seek(0)
-        return f_values, f_ids
-
     def _convert_lookups_to_id(self, mapping, lookup_keys):
         """Rewrite persisted Salesforce Ids to refer to auto-PKs."""
         for lookup_key in lookup_keys:

--- a/cumulusci/utils/xml/test/test_salesforce_encoding.py
+++ b/cumulusci/utils/xml/test/test_salesforce_encoding.py
@@ -52,11 +52,11 @@ class TestSalesforceEncoding:
                 orig = etree.canonicalize(orig)
                 out = etree.canonicalize(out)
                 c19n_succeeded = True
-            except Exception:
+            except Exception:  # pragma: no cover
                 c19n_succeeded = False
             try:
                 assert orig == out, file
-            except Exception as e:
+            except Exception as e:  # pragma: no cover
                 details = self._save_exception_for_inspection(
                     file, temp_directory, orig, out, c19n_succeeded, e
                 )
@@ -67,7 +67,7 @@ class TestSalesforceEncoding:
 
     def _save_exception_for_inspection(
         self, file, temp_directory, orig, out, c19n_succeeded, exception
-    ):
+    ):  # pragma: no cover
         filename = Path(file).name
         infile_copy = str(Path(temp_directory) / filename)
         with open(infile_copy, "w") as f:


### PR DESCRIPTION
Some quick coverage improvements.
- Ignore coverage for some code that is only used for testing.
- Remove extract_dataset's _split_batch_csv method which is no longer used
- Use a mock to test both branches of the shell quoting util regardless of actual platform

# Critical Changes

# Changes

# Issues Closed
