### PR TITLE
Display Response Body on 400 errors

### DIFF
--- a/cumulusci/oauth/salesforce.py
+++ b/cumulusci/oauth/salesforce.py
@@ -18,7 +18,10 @@ import time
 import socket
 
 from cumulusci.oauth.exceptions import SalesforceOAuthError
-from cumulusci.core.exceptions import CumulusCIException, CumulusCIUsageError
+from cumulusci.core.exceptions import (
+    CumulusCIUsageError,
+    SalesforceCredentialsException,
+)
 from cumulusci.utils.http.requests_utils import safe_json_from_response
 
 HTTP_HEADERS = {"Content-Type": "application/x-www-form-urlencoded"}
@@ -29,10 +32,6 @@ SANDBOX_LOGIN_URL = (
     os.environ.get("SF_SANDBOX_LOGIN_URL") or "https://test.salesforce.com"
 )
 PROD_LOGIN_URL = os.environ.get("SF_PROD_LOGIN_URL") or "https://login.salesforce.com"
-
-ERROR_MESSAGE_400 = (
-    "Error: 400 status code received attempting to obtain access token: {}"
-)
 
 
 def jwt_session(client_id, private_key, username, url=None, auth_url=None):
@@ -78,8 +77,10 @@ def jwt_session(client_id, private_key, username, url=None, auth_url=None):
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
     token_url = urljoin(url, "services/oauth2/token")
     response = requests.post(url=token_url, data=data, headers=headers)
-    if response.status_code == 400:
-        raise CumulusCIException(ERROR_MESSAGE_400.format(response.text))
+    if response.status_code != 200:
+        raise SalesforceCredentialsException(
+            f"Error retrieving access token: {response.text}"
+        )
 
     return safe_json_from_response(response)
 

--- a/cumulusci/oauth/tests/test_salesforce.py
+++ b/cumulusci/oauth/tests/test_salesforce.py
@@ -22,15 +22,16 @@ from cumulusci.oauth.salesforce import (
 @responses.activate
 @mock.patch("cumulusci.oauth.salesforce.jwt.encode")
 def test_jwt_session(encode):
-    # mock this as to not need to commit a sample server.key
-    encode.return_value = {"some": "stuff"}
+    # Mock the call to encode so we don't need
+    # to generate a private key that would be committed
+    error = "Yeti"
     responses.add(
         responses.POST,
         "https://login.salesforce.com/services/oauth2/token",
-        body=b"Yeti",
+        body=error,
         status=400,
     )
-    with pytest.raises(CumulusCIException, match=ERROR_MESSAGE_400.format("Yeti")):
+    with pytest.raises(CumulusCIException, match=ERROR_MESSAGE_400.format(error)):
         jwt_session("client_id", "server_key", "username")
 
 

--- a/cumulusci/oauth/tests/test_salesforce.py
+++ b/cumulusci/oauth/tests/test_salesforce.py
@@ -10,12 +10,11 @@ import urllib.request
 
 from unittest import mock
 
-from cumulusci.core.exceptions import CumulusCIException
+from cumulusci.core.exceptions import SalesforceCredentialsException
 from cumulusci.oauth.salesforce import (
     CaptureSalesforceOAuth,
     SalesforceOAuth2,
     jwt_session,
-    ERROR_MESSAGE_400,
 )
 
 
@@ -31,7 +30,9 @@ def test_jwt_session(encode):
         body=error,
         status=400,
     )
-    with pytest.raises(CumulusCIException, match=ERROR_MESSAGE_400.format(error)):
+    with pytest.raises(
+        SalesforceCredentialsException, match=f"Error retrieving access token: {error}"
+    ):
         jwt_session("client_id", "server_key", "username")
 
 
@@ -97,15 +98,15 @@ class TestCaptureSalesforceOAuth(unittest.TestCase):
 
         # mock response for SalesforceOAuth2.get_token()
         expected_response = {
-            u"access_token": u"abc123",
-            u"id_token": u"abc123",
-            u"token_type": u"Bearer",
-            u"signature": u"abc123",
-            u"issued_at": u"12345",
-            u"scope": u"{}".format(self.scope),
-            u"instance_url": u"https://na15.salesforce.com",
-            u"id": u"https://login.salesforce.com/id/abc/xyz",
-            u"refresh_token": u"abc123",
+            "access_token": "abc123",
+            "id_token": "abc123",
+            "token_type": "Bearer",
+            "signature": "abc123",
+            "issued_at": "12345",
+            "scope": "{}".format(self.scope),
+            "instance_url": "https://na15.salesforce.com",
+            "id": "https://login.salesforce.com/id/abc/xyz",
+            "refresh_token": "abc123",
         }
         responses.add(
             responses.POST,
@@ -149,15 +150,15 @@ class TestCaptureSalesforceOAuth(unittest.TestCase):
 
         # mock response for SalesforceOAuth2.get_token()
         expected_response = {
-            u"access_token": u"abc123",
-            u"id_token": u"abc123",
-            u"token_type": u"Bearer",
-            u"signature": u"abc123",
-            u"issued_at": u"12345",
-            u"scope": u"{}".format(self.scope),
-            u"instance_url": u"https://na15.salesforce.com",
-            u"id": u"https://login.salesforce.com/id/abc/xyz",
-            u"refresh_token": u"abc123",
+            "access_token": "abc123",
+            "id_token": "abc123",
+            "token_type": "Bearer",
+            "signature": "abc123",
+            "issued_at": "12345",
+            "scope": "{}".format(self.scope),
+            "instance_url": "https://na15.salesforce.com",
+            "id": "https://login.salesforce.com/id/abc/xyz",
+            "refresh_token": "abc123",
         }
         responses.add(
             responses.POST,


### PR DESCRIPTION
# Changes
* Enhanced error messaging on 400 errors encountered when acquiring a JWT session.

Thoughts on mocking `encode()`? I know, I know; bad practice to mock something that really doesn't need to be mocked. But, without an actual dummy key value (i.e. the contents of a genuine server.key file) I wasn't able to get past that method, and it didn't feel right needing to commit private key value somewhere, even if it's just a throwaway.