### PR TITLE
Feature/robot run task cross project

### DIFF
--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  CUMULUSCI_ORG_scratch: '{"config_file": "orgs/prerelease.json", "scratch": true}'
+  CUMULUSCI_ORG_scratch: '{"config_file": "orgs/dev.json", "scratch": true}'
   CUMULUSCI_ORG_packaging: ${{ secrets.CUMULUSCI_ORG_packaging }}
   CUMULUSCI_SERVICE_github: ${{ secrets.CUMULUSCI_SERVICE_github }}
   SFDX_CLIENT_ID: ${{ secrets.SFDX_CLIENT_ID }}

--- a/cumulusci/robotframework/CumulusCI.py
+++ b/cumulusci/robotframework/CumulusCI.py
@@ -178,16 +178,20 @@ class CumulusCI(object):
         """Runs a named CumulusCI task for the current project with optional
         support for overriding task options via kwargs.
 
+        Note: task_name can be prefixed with the name of another project,
+        just the same as when running the task from the command line. The other
+        project needs to have been defined in the 'sources' section of cumulusci.yml.
+
         Examples:
         | =Keyword= | =task_name= | =task_options=             | =comment=                        |
         | Run Task  | deploy      |                            | Run deploy with standard options |
         | Run Task  | deploy      | path=path/to/some/metadata | Run deploy with custom path      |
+        | Run task  | npsp:deploy_rd2_config  |                | Run the deploy_rd2_config task from the NPSP project |
         """
         task_config = self.project_config.get_task(task_name)
         class_path = task_config.class_path
-        logger.console("\n")
-        task_class, task_config = self._init_task(class_path, options, task_config)
-        return self._run_task(task_class, task_config)
+        task = self._init_task(class_path, options, task_config)
+        return self._run_task(task)
 
     def run_task_class(self, class_path, **options):
         """Runs a CumulusCI task class with task options via kwargs.
@@ -202,9 +206,8 @@ class CumulusCI(object):
         | =Keyword=      | =task_class=                     | =task_options=                            |
         | Run Task Class | cumulusci.task.utils.DownloadZip | url=http://test.com/test.zip dir=test_zip |
         """
-        logger.console("\n")
-        task_class, task_config = self._init_task(class_path, options, TaskConfig())
-        return self._run_task(task_class, task_config)
+        task = self._init_task(class_path, options, TaskConfig())
+        return self._run_task(task)
 
     def _init_api(self, base_url=None):
         client = get_simple_salesforce_connection(self.project_config, self.org)
@@ -215,7 +218,13 @@ class CumulusCI(object):
     def _init_task(self, class_path, options, task_config):
         task_class = import_global(class_path)
         task_config = self._parse_task_options(options, task_class, task_config)
-        return task_class, task_config
+        task = task_class(
+            task_config.project_config or self.project_config,
+            task_config,
+            org_config=self.org,
+        )
+
+        return task
 
     def _parse_task_options(self, options, task_class, task_config):
         if "options" not in task_config.config:
@@ -236,9 +245,10 @@ class CumulusCI(object):
 
         return task_config
 
-    def _run_task(self, task_class, task_config):
-        task = task_class(self.project_config, task_config, org_config=self.org)
-
+    def _run_task(self, task):
+        # add newline so first line of task output is not appended
+        # to the current line
+        logger.console("\n")
         task()
         return task.return_values
 

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -243,6 +243,19 @@ class Salesforce(object):
         self.wait_until_modal_is_open()
 
     @capture_screenshot_on_error
+    def scroll_element_into_view(self, locator):
+        """Scroll the element identified by 'locator'
+
+        This is a replacement for the keyword of the same name in
+        SeleniumLibrary. With firefox, that uses a low level function
+        which prevents it from working reliably.
+
+        For more info see https://stackoverflow.com/a/52045231/7432
+        """
+        element = self.selenium.get_webelement(locator)
+        self.selenium.driver.execute_script("arguments[0].scrollIntoView()", element)
+
+    @capture_screenshot_on_error
     def load_related_list(self, heading, tries=10):
         """Scrolls down until the specified related list loads.
 

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -247,8 +247,9 @@ class Salesforce(object):
         """Scroll the element identified by 'locator'
 
         This is a replacement for the keyword of the same name in
-        SeleniumLibrary. With firefox, that uses a low level function
-        which prevents it from working reliably.
+        SeleniumLibrary. The SeleniumLibrary implementation uses
+        an unreliable method on Firefox. This keyword uses
+        a more reliable technique.
 
         For more info see https://stackoverflow.com/a/52045231/7432
         """

--- a/cumulusci/robotframework/pageobjects/ObjectManagerPageObject.py
+++ b/cumulusci/robotframework/pageobjects/ObjectManagerPageObject.py
@@ -144,7 +144,7 @@ class ObjectManagerPage(BasePage):
         self.selenium.wait_until_page_contains_element(next_button, 60)
         self.selenium.click_element(next_button)
         self.selenium.wait_until_page_contains_element(related, 60)
-        self.selenium.scroll_element_into_view(related)
+        self.salesforce.scroll_element_into_view(related)
         self.selenium.get_webelement(related).click()
         self.selenium.click_element(option)
         self.selenium.wait_until_page_contains_element(next_button, 60)
@@ -167,30 +167,47 @@ class ObjectManagerPage(BasePage):
     def is_field_present(self, field_name):
         """Searches for the field name (field_name) and asserts the field got created """
         self.selenium.wait_until_page_contains_element(search_button)
-        self.selenium.get_webelement(search_button).clear()
-        self.selenium.get_webelement(search_button).send_keys(field_name)
-        self.selenium.get_webelement(search_button).send_keys(Keys.ENTER)
+        self.selenium.clear_element_text(search_button)
+        self.selenium.press_keys(search_button, field_name, "ENTER")
+        self.selenium.wait_until_element_is_not_visible("sf:spinner")
         search_results = object_manager["search_result"].format(field_name)
         self.selenium.wait_until_page_contains_element(search_results)
-        # I hate adding a hard-coded sleep, but I can't figure out what else to
-        # wait on. It appears that part of the page will eventually refresh
-        # but I don't know what triggers it.
-        self.builtin.sleep("500ms")
 
     @capture_screenshot_on_error
     def delete_custom_field(self, field_name):
         """Searches for the custom field and performs the delete action from the actions menu next to the field"""
         action_menu_button = actions_menu.format(field_name)
         self.is_field_present(field_name)
-        self.selenium.wait_until_page_contains_element(action_menu_button)
-        self.selenium.scroll_element_into_view(action_menu_button)
 
-        self.salesforce._jsclick(action_menu_button)
-        self.selenium.wait_until_element_is_visible(action_item_delete)
-        self.selenium.click_element(action_item_delete, action_chain=True)
-        self.selenium.wait_until_element_is_visible(confirm_delete)
-        self.selenium.click_element(confirm_delete, action_chain=True)
-        self.selenium.wait_until_location_contains("/view", timeout=90)
+        self.selenium.wait_until_page_contains_element(action_menu_button)
+        self.salesforce.scroll_element_into_view(action_menu_button)
+
+        # I don't know why, but sometimes clicking the action menu just
+        # doesn't work. The menu doesn't appear, or clicking the item on
+        # the menu does nothing. So, we'll try and handful of times.
+        # Yes, this feels icky.
+        for tries in range(5):
+            try:
+                self.selenium.wait_until_element_is_visible(action_menu_button)
+                self.selenium.click_element(action_menu_button)
+                self.selenium.wait_until_element_is_visible(
+                    action_item_delete, timeout="5 seconds"
+                )
+                self.selenium.click_element(action_item_delete, action_chain=True)
+                self.selenium.wait_until_element_is_visible(
+                    confirm_delete, timeout="5 seconds"
+                )
+                self.selenium.click_element(confirm_delete, action_chain=True)
+                self.selenium.wait_until_location_contains("/view", timeout=90)
+                return
+
+            except Exception as e:
+                self.builtin.log(
+                    f"on try #{tries+1} we caught this error: {e}", "DEBUG"
+                )
+                self.builtin.sleep("1 second")
+                last_error = e
+        raise (last_error)
 
     @capture_screenshot_on_error
     def create_custom_field(self, **kwargs):

--- a/cumulusci/robotframework/tests/test_cumulusci_library.py
+++ b/cumulusci/robotframework/tests/test_cumulusci_library.py
@@ -65,11 +65,13 @@ class TestCumulusCILibrary(MockLoggerMixin, unittest.TestCase):
 
             with mock.patch.object(self.cumulusci, "_run_task"):
                 self.cumulusci.run_task("example:whatever")
-                task = self.cumulusci._run_task.mock_calls[0].args[0]
+
+                args, kwargs = self.cumulusci._run_task.call_args
+                self.assertEqual(len(args), 1)
 
                 # make sure it's not using the current project config
                 # for the task, and that the config it _is_ using is
                 # rooted in the directory we created
+                task = args[0]
                 self.assertNotEqual(task.project_config, self.cumulusci.project_config)
                 self.assertEqual(tmpdir, Path(task.project_config.repo_root))
-                print("bruh")

--- a/cumulusci/robotframework/tests/test_cumulusci_library.py
+++ b/cumulusci/robotframework/tests/test_cumulusci_library.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+from unittest import mock
+import unittest
+from cumulusci.robotframework.CumulusCI import CumulusCI
+from cumulusci.core.config import UniversalConfig, BaseProjectConfig
+from cumulusci.core.tests.utils import MockLoggerMixin
+from cumulusci.core.exceptions import TaskNotFoundError
+from cumulusci.utils import temporary_dir
+
+
+class TestCumulusCILibrary(MockLoggerMixin, unittest.TestCase):
+    def setUp(self):
+        self.universal_config = UniversalConfig()
+        self.project_config = BaseProjectConfig(
+            self.universal_config,
+            {
+                "project": {"name": "Test"},
+                "tasks": {
+                    "get_pwd": {
+                        "class_path": "cumulusci.tasks.command.Command",
+                        "options": {
+                            "command": "pwd",
+                        },
+                    },
+                },
+                "sources": {
+                    "example": {"path": "/tmp"},
+                },
+            },
+        )
+        self.cumulusci = CumulusCI()
+        self.cumulusci._project_config = self.project_config
+        self.cumulusci._org = mock.Mock()
+
+        self._task_log_handler.reset()
+        self.task_log = self._task_log_handler.messages
+
+    def test_run_task(self):
+        """Smoke test; can we run the command task?"""
+        self.cumulusci.run_task("get_pwd")
+        self.assertIn("Running command: pwd", self.task_log["info"])
+
+    def test_run_unknown_task(self):
+        with self.assertRaises(TaskNotFoundError):
+            self.cumulusci.run_task("bogus")
+
+    def test_cross_project_task(self):
+        """Verify that the cross-project task runs with the project config of the task
+        See W-8891667
+        """
+        with temporary_dir() as tmpdir:
+            tmpdir = Path(tmpdir).resolve()
+            cumulusci_yml_path = tmpdir / "cumulusci.yml"
+            with open(cumulusci_yml_path, "w+") as cumulusci_yml:
+                self.project_config.sources["example"] = {"path": tmpdir}
+                cumulusci_yml.write(
+                    """
+                    tasks:
+                        whatever:
+                            class_path: cumulusci.tasks.command.Command
+                            options:
+                                command: pwd
+                    """
+                )
+
+            with mock.patch.object(self.cumulusci, "_run_task"):
+                self.cumulusci.run_task("example:whatever")
+                task = self.cumulusci._run_task.mock_calls[0].args[0]
+
+                # make sure it's not using the current project config
+                # for the task, and that the config it _is_ using is
+                # rooted in the directory we created
+                self.assertNotEqual(task.project_config, self.cumulusci.project_config)
+                self.assertEqual(tmpdir, Path(task.project_config.repo_root))
+                print("bruh")

--- a/docs/robot/Keywords.html
+++ b/docs/robot/Keywords.html
@@ -279,6 +279,7 @@ ${login url}=  Login URL  alias=dadvisor
                   
                 </td>
                 <td class="kwdoc"><p>Runs a named CumulusCI task for the current project with optional support for overriding task options via kwargs.</p>
+<p>Note: task_name can be prefixed with the name of another project, just the same as when running the task from the command line. The other project needs to have been defined in the 'sources' section of cumulusci.yml.</p>
 <p>Examples:</p>
 <table border="1">
 <tr>
@@ -298,6 +299,12 @@ ${login url}=  Login URL  alias=dadvisor
 <td>deploy</td>
 <td>path=path/to/some/metadata</td>
 <td>Run deploy with custom path</td>
+</tr>
+<tr>
+<td>Run task</td>
+<td>npsp:deploy_rd2_config</td>
+<td></td>
+<td>Run the deploy_rd2_config task from the NPSP project</td>
 </tr>
 </table></td>
               </tr>
@@ -2219,7 +2226,7 @@ Populate form
       
     </div>
     <div class="footer">
-      Generated on Tuesday January 12, 04:27 PM - cumulusci v3.26.0
+      Generated on Monday February 15, 05:53 PM - cumulusci v3.28.0
     </div>
   </body>
 </html>

--- a/docs/robot/Keywords.html
+++ b/docs/robot/Keywords.html
@@ -1309,6 +1309,20 @@ Should be equal as numbers ${result}  204
 </pre></td>
               </tr>
               
+              <tr class="kwrow" id="Salesforce.Scroll Element Into View">
+                <td class="kwname">
+                  Scroll Element Into View
+                </td>
+                <td class="kwargs">
+                  
+                  <i>locator</i>
+                  
+                </td>
+                <td class="kwdoc"><p>Scroll the element identified by 'locator'</p>
+<p>This is a replacement for the keyword of the same name in SeleniumLibrary. The SeleniumLibrary implementation uses an unreliable method on Firefox. This keyword uses a more reliable technique.</p>
+<p>For more info see <a href="https://stackoverflow.com/a/52045231/7432">https://stackoverflow.com/a/52045231/7432</a></p></td>
+              </tr>
+              
               <tr class="kwrow" id="Salesforce.Select App Launcher App">
                 <td class="kwname">
                   Select App Launcher App
@@ -2226,7 +2240,7 @@ Populate form
       
     </div>
     <div class="footer">
-      Generated on Monday February 15, 05:53 PM - cumulusci v3.28.0
+      Generated on Wednesday February 17, 11:00 PM - cumulusci v3.28.0
     </div>
   </body>
 </html>


### PR DESCRIPTION
This fixes the `Run Task` keyword to initialize the task with the proper project config (the project config of the task if it has one, otherwise the current project config)

This includes some pytest tests. However, I'm not super confident they are the best way to write these tests. I could definitely use some advice on how to write pytests that need to set up a repository or define a task.

I put this new pytest under the robotframework folder, which is _not_ where a similar pytest for the salesforce library lives. The pytest for the salesforce library is under the core folder but I don't think that's the right place. I wanted to keep this PR focused on the problem at hand. If you, the kind reviewer, agrees that this is the right place for these new tests, I'll move the salesforce tests out of the core folder to live alongside this new test file for consistency.

# Critical Changes

# Changes
* Run Tasks robot keyword now uses the task-specific project config when running a cross-project task
* SalesforceLibrary has a new keyword, `Scroll Element Into View`, which is more reliable on Firefox than the keyword of the same name in SeleniumLibrary
* ObjectManagerPageObject has been made more stable

# Issues Closed
