### PR TITLE
Add dry_run option to uninstall_packaged_incremental

### DIFF
--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  CUMULUSCI_ORG_scratch: '{"config_file": "orgs/prerelease.json", "scratch": true}'
+  CUMULUSCI_ORG_scratch: '{"config_file": "orgs/dev.json", "scratch": true}'
   CUMULUSCI_ORG_packaging: ${{ secrets.CUMULUSCI_ORG_packaging }}
   CUMULUSCI_SERVICE_github: ${{ secrets.CUMULUSCI_SERVICE_github }}
   SFDX_CLIENT_ID: ${{ secrets.SFDX_CLIENT_ID }}

--- a/cumulusci/tasks/salesforce/BaseUninstallMetadata.py
+++ b/cumulusci/tasks/salesforce/BaseUninstallMetadata.py
@@ -7,6 +7,9 @@ uninstall_task_options = Deploy.task_options.copy()
 uninstall_task_options["purge_on_delete"] = {
     "description": "Sets the purgeOnDelete option for the deployment. Defaults to True"
 }
+uninstall_task_options["dry_run"] = {
+    "description": "Perform a dry run of the operation without actually deleting any components, and display the components that would be deleted."
+}
 
 
 class BaseUninstallMetadata(Deploy):
@@ -17,11 +20,19 @@ class BaseUninstallMetadata(Deploy):
         self.options["purge_on_delete"] = process_bool_arg(
             self.options.get("purge_on_delete", True)
         )
+        self.options["dry_run"] = process_bool_arg(self.options.get("dry_run", False))
 
     def _get_api(self, path=None):
         destructive_changes = self._get_destructive_changes(path=path)
         if not destructive_changes:
             return
+        if self.options["dry_run"]:
+            self.logger.info(
+                "Performing uninstall dry run. This destructive deployment was created:"
+            )
+            self.logger.info(destructive_changes)
+            return
+
         package_zip = DestructiveChangesZipBuilder(
             destructive_changes, self.project_config.project__package__api_version
         )

--- a/cumulusci/tasks/salesforce/UninstallPackaged.py
+++ b/cumulusci/tasks/salesforce/UninstallPackaged.py
@@ -16,15 +16,15 @@ class UninstallPackaged(UninstallLocal):
             "description": "Sets the purgeOnDelete option for the deployment.  Defaults to True",
             "required": True,
         },
+        "dry_run": {
+            "description": "Perform a dry run of the operation without actually deleting any components, and display the components that would be deleted."
+        },
     }
 
     def _init_options(self, kwargs):
         super(UninstallPackaged, self)._init_options(kwargs)
         if "package" not in self.options:
             self.options["package"] = self.project_config.project__package__name
-        self.options["purge_on_delete"] = process_bool_arg(
-            self.options.get("purge_on_delete", True)
-        )
 
     def _retrieve_packaged(self):
         retrieve_api = ApiRetrievePackaged(

--- a/cumulusci/tasks/salesforce/UninstallPackagedIncremental.py
+++ b/cumulusci/tasks/salesforce/UninstallPackagedIncremental.py
@@ -31,15 +31,15 @@ class UninstallPackagedIncremental(UninstallPackaged):
         "ignore_types": {
             "description": f"List of component types to ignore in the org and not try to delete. Defaults to {DEFAULT_IGNORE_TYPES}"
         },
+        "dry_run": {
+            "description": "Perform a dry run of the operation without actually deleting any components, and display the components that would be deleted."
+        },
     }
 
     def _init_options(self, kwargs):
         super(UninstallPackagedIncremental, self)._init_options(kwargs)
         if "path" not in self.options:
             self.options["path"] = "src"
-        self.options["purge_on_delete"] = process_bool_arg(
-            self.options.get("purge_on_delete", True)
-        )
         self.options["ignore"] = self.options.get("ignore", {})
         self.options["ignore_types"] = self.options.get(
             "ignore_types", DEFAULT_IGNORE_TYPES

--- a/cumulusci/tasks/salesforce/tests/test_UninstallPackagedIncremental.py
+++ b/cumulusci/tasks/salesforce/tests/test_UninstallPackagedIncremental.py
@@ -92,3 +92,19 @@ class TestUninstallPackagedIncremental(unittest.TestCase):
 </Package>""",
                 result,
             )
+
+    def test_dry_run(self):
+        project_config = create_project_config()
+        task = create_task(
+            UninstallPackagedIncremental,
+            {"dry_run": True},
+            project_config,
+        )
+        task._get_destructive_changes = mock.Mock(return_value="foo")
+        task.api_class = mock.Mock()
+        task.logger = mock.Mock()
+
+        task()
+        assert task._get_api() is None
+        task.logger.info.assert_has_calls([mock.call("foo")])
+        task.api_class.assert_not_called()


### PR DESCRIPTION
# Critical Changes

# Changes

- The `uninstall_packaged_incremental` and `uninstall_packaged` tasks now support a `dry_run` option, which outputs the destructiveChanges package manifest to the log instead of executing it.

# Issues Closed
