### PR TITLE
Add add_page_layout_fields Metadata ETL task

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -11,6 +11,12 @@ tasks:
         class_path: cumulusci.tasks.metadata_etl.AddRelatedLists
         options:
             namespace_inject: $project_config.project__package__namespace
+    add_page_layout_fields:
+        group: Metadata Transformations
+        description: Adds specified Fields to one Page Layout.
+        class_path: cumulusci.tasks.metadata_etl.AddFields
+        options:
+            namespace_inject: $project_config.project__package__namespace
     add_standard_value_set_entries:
         group: Metadata Transformations
         description: Adds specified picklist entries to a Standard Value Set.

--- a/cumulusci/tasks/metadata_etl/layouts.py
+++ b/cumulusci/tasks/metadata_etl/layouts.py
@@ -68,3 +68,70 @@ class AddRelatedLists(MetadataSingleEntityTransformTask):
             elem.append("customButtons", button)
 
         elem.append("relatedList", text=related_list)
+
+
+class AddFields(MetadataSingleEntityTransformTask):
+    entity = "Layout"
+    task_options = {
+        "layout_section": {
+            "description": "Which layout section the fields should be added to, default is Information",
+            "required": False,
+        },
+        "fields": {
+            "description": "Array of field API names to append to specified layout section",
+            "required": True,
+        },
+        **MetadataSingleEntityTransformTask.task_options,
+    }
+
+    def _transform_entity(
+        self, metadata: MetadataElement, api_name: str
+    ) -> Optional[MetadataElement]:
+
+        # Set layout section and default to "Information" section if not passed in
+        layout_section = self._inject_namespace(self.options.get("layout_section") or "Information")
+
+        # Set fields to be added to layout section
+        adding_fields = [
+            self._inject_namespace(field)
+            for field in process_list_arg(self.options.get("fields", []))
+        ]
+
+        self._remove_existing_fields(metadata, api_name, adding_fields)
+
+        self._set_adding_fields(metadata, api_name, layout_section, adding_fields)
+
+        return metadata
+
+    ## If fields passed in that already exist in the Page Layout, remove from current sections
+    def _remove_existing_fields(self, metadata, api_name, adding_fields):
+
+        ## Need to traverse all layoutSections->layoutColumns->layoutItems->fields to find if item/field already exists
+        layout_sections = metadata.findall("layoutSections")
+        for section in layout_sections:
+            layout_columns = section.findall("layoutColumns")
+            for col in layout_columns:
+                layout_items = col.findall("layoutItems")
+                for item in layout_items:
+                    if item.field.text in adding_fields:
+                        # remove that item from existing layout to be re-added
+                        col.remove(item)
+
+    def _set_adding_fields(self, metadata, api_name, layout_section_name, adding_fields):
+        ## If no fields are passed in, do nothing
+        if len(adding_fields) == 0:
+            return
+
+        # Find specified layout sections to add fields to
+        layout_section_element = metadata.find("layoutSections", label=layout_section_name)
+        
+        # If layout section doesn't exist, exit gracefully with appropriate message
+        if layout_section_element is None:
+            raise CumulusCIException("Layout section doesn't exist, task failed")
+
+        layout_columns_element = layout_section_element.find("layoutColumns")
+
+        for f in adding_fields:
+            layout_items_element = layout_columns_element.append("layoutItems")
+            layout_items_element.append("behavior", "Edit")
+            layout_items_element.append("field", f)

--- a/docs/metadata_etl.rst
+++ b/docs/metadata_etl.rst
@@ -59,6 +59,7 @@ CumulusCI includes several out-of-the-box Metadata ETL tasks:
 
  - ``activate_flow`` activates Flows (or Processes).
  - ``add_page_layout_related_lists`` adds Related Lists, with given fields, to Page Layouts.
+ - ``add_page_layout_fields`` adds or moves fields to a given Page Layout section.
  - ``add_permission_set_perms`` adds FLS and Apex class access entries to Permission Sets.
  - ``add_picklist_entries`` adds picklist entries to a custom picklist field.
  - ``add_standard_value_set_entries`` adds entries to a Standard Value Set.


### PR DESCRIPTION
# Critical Changes

# Changes
Added new metadata etl feature to layouts.py that enables user to add or move fields to a specified Page Layout section.  Note - if a field is labeled as Required or Read-Only in Section A, and user runs task to move to Section B, it will lose those field properties.

# Issues Closed
