### PR TITLE
Remove global RUNTIME

### DIFF
--- a/cumulusci/cli/runtime.py
+++ b/cumulusci/cli/runtime.py
@@ -17,6 +17,16 @@ from cumulusci.utils import random_alphanumeric_underscore
 
 
 class CliRuntime(BaseCumulusCI):
+    _instance = None
+
+    @classmethod
+    def get_instance(cls, load_keychain=False):
+        """Public method that provides access to one
+        instance of the CliRuntime object"""
+        if not cls._instance:
+            cls._instance = CliRuntime(load_keychain=load_keychain)
+        return cls._instance
+
     def __init__(self, *args, **kwargs):
         try:
             super(CliRuntime, self).__init__(*args, **kwargs)

--- a/cumulusci/cli/tests/utils.py
+++ b/cumulusci/cli/tests/utils.py
@@ -7,8 +7,10 @@ from cumulusci.core.tasks import BaseTask
 
 def run_click_command(cmd, *args, **kw):
     """Run a click command with a mock context and injected CCI runtime object."""
-    runtime = kw.pop("runtime", mock.Mock())
-    with mock.patch("cumulusci.cli.cci.RUNTIME", runtime):
+    runtime_instance = kw.pop("runtime", mock.Mock())
+    runtime = mock.Mock()
+    runtime.get_instance.return_value = runtime_instance
+    with mock.patch("cumulusci.cli.cci.CliRuntime", runtime):
         with click.Context(command=mock.Mock()):
             return cmd.callback(*args, **kw)
 


### PR DESCRIPTION
# Changes
* We now have a new method for accessing a single instance of `CliRuntime` class: `CliRuntime.get_instance()`.

This is the first piece of work needed in order to refactor the commands contained in `cci.py` into their own (separate) files.