### PR TITLE
Update homebrew formula to install using pip

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,6 +5,7 @@ coverage[toml]==5.4
 coveralls==3.0.0
 flake8==3.8.4
 furo==2020.10.15b13
+pip-tools==5.5.0
 pre-commit==2.10.1
 pytest==6.2.2
 pytest-random-order==1.0.4

--- a/utility/build-homebrew.sh
+++ b/utility/build-homebrew.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 OUT_FILE="$1"
 
 ENV_DIR="$(mktemp -d)"
-RES_FILE="$(mktemp)" 
+REQS_IN_FILE="$(mktemp)"
+REQS_FILE="$(mktemp)"
 PYPI_JSON="$(mktemp)" 
 
 echo " "
@@ -17,17 +18,10 @@ PACKAGE_SHA="$(cat "$PYPI_JSON" | jq '.urls[1].digests.sha256')"
 PACKAGE_VERSION="$(cat cumulusci/version.txt)"
 
 echo " "
-echo "=> Creating a temporary virtualenv and installing CumulusCI..."
+echo "=> Compiling pip requirements including hashes..."
 echo " "
-python3.8 -m venv "$ENV_DIR" 
-source "$ENV_DIR/bin/activate" 
-pip install -U pip
-pip install --no-cache-dir cumulusci==$PACKAGE_VERSION homebrew-pypi-poet 
-
-echo " "
-echo "=> Collecting dependencies and generating resource stanzas..."
-echo " "
-poet cumulusci | awk '/resource "cumulusci"/{c=5} !(c&&c--)' > "$RES_FILE"
+echo "cumulusci==$PACKAGE_VERSION" > "$REQS_IN_FILE"
+pip-compile "$REQS_IN_FILE" -o "$REQS_FILE" --generate-hashes
 
 echo " "
 echo "=> Writing Homebrew Formula to ${OUT_FILE}..."
@@ -44,21 +38,17 @@ class Cumulusci < Formula
 
   depends_on "python@3.8"
 
-$(cat "$RES_FILE")
-
   def install
     xy = Language::Python.major_minor_version "python3"
     site_packages = libexec/"lib/python#{xy}/site-packages"
     ENV.prepend_create_path "PYTHONPATH", site_packages
 
-    system "python3", *Language::Python.setup_install_args(libexec)
+    reqs = <<-REQS
+$(cat "$REQS_FILE")
+REQS
 
-    deps = resources.map(&:name).to_set
-    deps.each do |r|
-      resource(r).stage do
-        system "python3", *Language::Python.setup_install_args(libexec)
-      end
-    end
+    File.write("requirements.txt", reqs)
+    system "python3", "-m", "pip", "install", "-r", "requirements.txt", "--require-hashes", "--no-deps", "--prefix", libexec
 
     bin.install Dir["#{libexec}/bin/cci"]
     bin.install Dir["#{libexec}/bin/snowfakery"]


### PR DESCRIPTION
This updates our script for generating a Homebrew formula to install using pip rather than setup.py install. This brings us more in line with how Python packages are typically installed and makes it possible to take advantage of binary wheels (which will be the easiest way to install the newest versions of cryptography).

The script uses the pip-compile tool from pip-tools to build a pip requirements file for cumulusci and its dependencies which includes the sha256 hashes from PyPI. This is embedded in a heredoc in the formula and written out to a requirements.txt file during installation before running pip install.

# Critical Changes

# Changes

# Issues Closed
