### PR TITLE
feat: adds the noancestors option to scratch org def

### DIFF
--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -73,6 +73,7 @@ class ScratchOrgConfig(SfdxOrgConfig):
             "config_file": self.config_file,
             "devhub": f" --targetdevhubusername {devhub}" if devhub else "",
             "namespaced": " -n" if not self.namespaced else "",
+            "noancestors": " --noancestors" if self.noancestors else "",
             "days": f" --durationdays {self.days}" if self.days else "",
             "wait": " -w 120",
             "alias": sarge.shell_format(' -a "{0!s}"', self.sfdx_alias)
@@ -88,7 +89,7 @@ class ScratchOrgConfig(SfdxOrgConfig):
 
         # This feels a little dirty, but the use cases for extra args would mostly
         # work best with env vars
-        command = "force:org:create -f {config_file}{devhub}{namespaced}{days}{alias}{default}{wait}{email}{instance} {extraargs}".format(
+        command = "force:org:create -f {config_file}{devhub}{namespaced}{noancestors}{days}{alias}{default}{wait}{email}{instance} {extraargs}".format(
             **options
         )
         p = sfdx(command, username=None, log_note="Creating scratch org")

--- a/cumulusci/core/keychain/base_project_keychain.py
+++ b/cumulusci/core/keychain/base_project_keychain.py
@@ -94,6 +94,7 @@ class BaseProjectKeychain(BaseConfig):
         scratch_config["set_password"] = bool(set_password)
         scratch_config["scratch"] = True
         scratch_config.setdefault("namespaced", False)
+        scratch_config.setdefault("noancestors", False)
         scratch_config["config_name"] = config_name
         scratch_config[
             "sfdx_alias"

--- a/cumulusci/core/tests/test_keychain.py
+++ b/cumulusci/core/tests/test_keychain.py
@@ -219,6 +219,7 @@ class TestBaseProjectKeychain(ProjectKeychainTestMixin):
         keychain.create_scratch_org("test", "dev", days=3)
         org_config = keychain.set_org.call_args[0][0]
         self.assertEqual(3, org_config.days)
+        self.assertEqual(False, org_config.noancestors)
 
     @mock.patch("cumulusci.core.keychain.base_project_keychain.cleanup_org_cache_dirs")
     def test_remove_org(self, cleanup_org_cache_dirs):


### PR DESCRIPTION
# Critical Changes

# Changes

Adds a new option for scratch org definitions to specify the `noancestors` flag.

A note for the reviewers: I tried to find a unit test to verify that the flag is properly built and passed to dx. Ultimately, using a builder pattern could be handy to build the sfdx command string.

# Issues Closed
Closes #2441 
