### PR TITLE
Better error message for org import

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1042,6 +1042,11 @@ def org_import(runtime, username_or_alias, org_name):
     scratch_org_config.config["created"] = True
 
     info = scratch_org_config.sfdx_info
+    if not info.get("created_date"):
+        raise click.UsageError(
+            "cci org import only works for locally created "
+            "scratch orgs.\nUse `cci org connect` for other orgs."
+        )
     scratch_org_config.config["days"] = calculate_org_days(info)
     scratch_org_config.config["date_created"] = parse_api_datetime(info["created_date"])
 

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -1175,6 +1175,33 @@ Environment Info: Rossian / x68_46
             "Imported scratch org: access, username: test@test.org" in "".join(out)
         )
 
+    @mock.patch("sarge.Command")
+    def test_org_import__persistent_org(self, cmd):
+        runtime = mock.Mock()
+        result = b"""{
+            "result": {
+                "createdDate": null,
+                "instanceUrl": "url",
+                "accessToken": "access!token",
+                "username": "test@test.org",
+                "password": "password"
+            }
+        }"""
+        cmd.return_value = mock.Mock(
+            stderr=io.BytesIO(b""), stdout=io.BytesIO(result), returncode=0
+        )
+
+        out = []
+        with mock.patch("click.echo", out.append), pytest.raises(
+            click.UsageError, match="cci org connect"
+        ):
+            run_click_command(
+                cci.org_import,
+                username_or_alias="test@test.org",
+                org_name="test",
+                runtime=runtime,
+            )
+
     def test_calculate_org_days(self):
         info_1 = {
             "created_date": "1970-01-01T12:34:56.789Z",


### PR DESCRIPTION
# Issues Closed

- The `cci org import` command now shows a clearer error message if you try to import an org that is not a locally created scratch org.