### PR TITLE
New flow: release_2gp_production

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -1067,6 +1067,26 @@ flows:
                     publish: True
                     tag: ^^github_release.tag_name
                     version_id: ^^upload_production.version_id
+    
+    release_2gp_production:
+        group: Release Operations
+        description: Promote the latest beta release of the project to a production release
+        steps:
+            1:
+                task: promote_package_version
+            2:
+                task: github_release
+                options:
+                    version: ^^upload_production.version_number
+                    version_id: ^^upload_production.version_id
+                    dependencies: ^^upload_production.dependencies
+            3:
+                task: github_release_notes
+                ignore_failure: True  # Attempt to generate release notes but don't fail build
+                options:
+                    publish: True
+                    tag: ^^github_release.tag_name
+                    version_id: ^^upload_production.version_id
 
     build_feature_test_package:
         group: Release Operations

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -1077,16 +1077,16 @@ flows:
             2:
                 task: github_release
                 options:
-                    version: ^^upload_production.version_number
-                    version_id: ^^upload_production.version_id
-                    dependencies: ^^upload_production.dependencies
+                    version: ^^promote_package_version.version_number
+                    version_id: ^^promote_package_version.version_id
+                    dependencies: ^^promote_package_version.dependencies
             3:
                 task: github_release_notes
                 ignore_failure: True  # Attempt to generate release notes but don't fail build
                 options:
                     publish: True
                     tag: ^^github_release.tag_name
-                    version_id: ^^upload_production.version_id
+                    version_id: ^^promote_package_version.version_id
 
     build_feature_test_package:
         group: Release Operations

--- a/cumulusci/tasks/salesforce/promote_package_version.py
+++ b/cumulusci/tasks/salesforce/promote_package_version.py
@@ -10,6 +10,7 @@ from cumulusci.core.exceptions import (
 from cumulusci.core.github import get_tag_by_name
 from cumulusci.salesforce_api.utils import get_simple_salesforce_connection
 from cumulusci.tasks.salesforce import BaseSalesforceApiTask
+from cumulusci.tasks.package_2gp import PackageVersionNumber
 
 
 class PromotePackageVersion(BaseSalesforceApiTask):
@@ -85,6 +86,11 @@ class PromotePackageVersion(BaseSalesforceApiTask):
 
         target_package_info = self._get_target_package_info(version_id)
         self._promote_package_version(target_package_info)
+        self.return_values = {
+            "dependencies": [d["spv_id"] for d in dependencies],
+            "version_id": version_id,
+            "version_number": target_package_info["package_version_number"],
+        }
 
     def _resolve_version_id(self) -> str:
         """
@@ -236,10 +242,17 @@ class PromotePackageVersion(BaseSalesforceApiTask):
         }
         """
         package_2_version = self._query_Package2Version(spv_id)
+        subscriber_pacakage_version = self._query_SubscriberPackageVersion(spv_id)
         return {
             "name": self.project_config.project__name,
             "Package2VersionId": package_2_version["Id"],
             "version_id": spv_id,
+            "package_version_number": PackageVersionNumber(
+                subscriber_pacakage_version["MajorVersion"],
+                subscriber_pacakage_version["MinorVersion"],
+                subscriber_pacakage_version["PatchVersion"],
+                subscriber_pacakage_version["BuildNumber"],
+            ),
         }
 
     def _promote_package_version(self, package_info: Dict) -> None:
@@ -289,7 +302,15 @@ class PromotePackageVersion(BaseSalesforceApiTask):
     def _query_SubscriberPackageVersion(self, spv_id: str) -> Optional[Dict]:
         """Queries for a SubscriberPackageVersion record with the given SubscriberPackageVersionId"""
         return self._query_one_tooling(
-            ["Id", "Dependencies", "ReleaseState", "SubscriberPackageId"],
+            [
+                "Id",
+                "BuildNumber",
+                "Dependencies",
+                "MajorVersion",
+                "MinorVersion",
+                "PatchVersion" "ReleaseState",
+                "SubscriberPackageId",
+            ],
             "SubscriberPackageVersion",
             where_clause=f"Id='{spv_id}'",
             raise_error=True,

--- a/cumulusci/tasks/tests/test_promote_package_version.py
+++ b/cumulusci/tasks/tests/test_promote_package_version.py
@@ -55,6 +55,30 @@ def task(project_config, devhub_config, org_config):
 class TestPromotePackageVersion(GithubApiTestMixin):
     devhub_base_url = "https://devhub.my.salesforce.com/services/data/v50.0"
 
+    def _mock_target_package_api_calls(self):
+        responses.add(  # query for main package's Package2Version info
+            "GET",
+            f"{self.devhub_base_url}/tooling/query/",
+            json={
+                "size": 1,
+                "records": [
+                    {
+                        "BuildNumber": 0,
+                        "Id": "main_package",
+                        "IsReleased": False,
+                        "MajorVersion": 1,
+                        "MinorVersion": 0,
+                        "PatchVersion": 0,
+                    }
+                ],
+                "done": True,
+            },
+        )
+        responses.add(  # Promote the Package2Version
+            "PATCH",
+            f"{self.devhub_base_url}/tooling/sobjects/Package2Version/main_package",
+        )
+
     def _mock_dependencies(
         self, total_deps: int, num_2gp: int, num_unpromoted: int
     ) -> None:
@@ -89,20 +113,6 @@ class TestPromotePackageVersion(GithubApiTestMixin):
         # mock promoted 2GP dependencies
         for i in range(num_2gp - num_unpromoted):
             self._mock_dependency(i + 1, is_two_gp=True, is_promoted=True)
-
-        responses.add(  # query for main package's Package2Version
-            "GET",
-            f"{self.devhub_base_url}/tooling/query/",
-            json={
-                "size": 1,
-                "records": [{"Id": "main_package", "IsReleased": False}],
-                "done": True,
-            },
-        )
-        responses.add(
-            "PATCH",
-            f"{self.devhub_base_url}/tooling/sobjects/Package2Version/main_package",
-        )
 
     def _mock_dependency(
         self, dependency_num: int, is_two_gp: bool = False, is_promoted: bool = False
@@ -164,6 +174,7 @@ class TestPromotePackageVersion(GithubApiTestMixin):
     def test_run_task(self, task, devhub_config):
         # 20 dependencies, 10 are 2GP, 5 of those are not yet promoted
         self._mock_dependencies(20, 10, 5)
+        self._mock_target_package_api_calls()
         with mock.patch(
             "cumulusci.tasks.salesforce.promote_package_version.get_devhub_config",
             return_value=devhub_config,
@@ -173,6 +184,7 @@ class TestPromotePackageVersion(GithubApiTestMixin):
     @responses.activate
     def test_run_task__no_dependencies(self, task, devhub_config):
         self._mock_dependencies(0, 0, 0)
+        self._mock_target_package_api_calls()
         with mock.patch(
             "cumulusci.tasks.salesforce.promote_package_version.get_devhub_config",
             return_value=devhub_config,
@@ -182,6 +194,7 @@ class TestPromotePackageVersion(GithubApiTestMixin):
     @responses.activate
     def test_run_task__promote_dependencies(self, task, devhub_config):
         self._mock_dependencies(2, 1, 1)
+        self._mock_target_package_api_calls()
         with mock.patch(
             "cumulusci.tasks.salesforce.promote_package_version.get_devhub_config",
             return_value=devhub_config,
@@ -189,9 +202,17 @@ class TestPromotePackageVersion(GithubApiTestMixin):
             task.options["promote_dependencies"] = True
             task()
 
+        assert task.return_values["version_id"] == "04t000000000000"
+        assert task.return_values["version_number"] == "1.0.0.0"
+        assert task.return_values["dependencies"] == [
+            "04t000000000001",
+            "04t000000000002",
+        ]
+
     @responses.activate
     def test_run_task__all_deps_promoted(self, task, devhub_config):
         self._mock_dependencies(4, 4, 4)
+        self._mock_target_package_api_calls()
         with mock.patch(
             "cumulusci.tasks.salesforce.promote_package_version.get_devhub_config",
             return_value=devhub_config,
@@ -234,6 +255,7 @@ class TestPromotePackageVersion(GithubApiTestMixin):
             status=200,
         )
         self._mock_dependencies(2, 1, 0)
+        self._mock_target_package_api_calls()
         with mock.patch(
             "cumulusci.tasks.salesforce.promote_package_version.get_devhub_config",
             return_value=devhub_config,
@@ -276,6 +298,7 @@ class TestPromotePackageVersion(GithubApiTestMixin):
             status=200,
         )
         self._mock_dependencies(2, 1, 0)
+        self._mock_target_package_api_calls()
         with mock.patch(
             "cumulusci.tasks.salesforce.promote_package_version.get_devhub_config",
             return_value=devhub_config,
@@ -321,6 +344,7 @@ class TestPromotePackageVersion(GithubApiTestMixin):
             status=200,
         )
         self._mock_dependencies(2, 1, 0)
+        self._mock_target_package_api_calls()
         with mock.patch(
             "cumulusci.tasks.salesforce.promote_package_version.get_devhub_config",
             return_value=devhub_config,


### PR DESCRIPTION
# Changes
* CumulusCI has a new flow for creating production releases of a 2GP managed package: `release_2gp_production`
