### PR TITLE
Snowfakery uses load files

### DIFF
--- a/cumulusci/core/utils.py
+++ b/cumulusci/core/utils.py
@@ -10,7 +10,7 @@ import glob
 import pytz
 import time
 from shutil import rmtree
-from typing import Union
+import typing as T
 import warnings
 
 from cumulusci.core.exceptions import ConfigMergeError, TaskOptionsError
@@ -35,7 +35,7 @@ def parse_datetime(dt_str, format):
     return datetime(t[0], t[1], t[2], t[3], t[4], t[5], t[6], pytz.UTC)
 
 
-def process_bool_arg(arg: Union[int, str, None]):
+def process_bool_arg(arg: T.Union[int, str, None]):
     """Determine True/False from argument.
 
     Similar to parts of the Salesforce API, there are a few true-ish and false-ish strings,
@@ -98,7 +98,7 @@ def process_glob_list_arg(arg):
     return list(dict.fromkeys(files))
 
 
-def process_list_arg(arg):
+def process_list_arg(arg) -> T.Optional[T.List[str]]:
     """ Parse a string into a list separated by commas with whitespace stripped """
     if isinstance(arg, list):
         return arg

--- a/cumulusci/core/utils.py
+++ b/cumulusci/core/utils.py
@@ -98,7 +98,7 @@ def process_glob_list_arg(arg):
     return list(dict.fromkeys(files))
 
 
-def process_list_arg(arg) -> T.Optional[T.List[str]]:
+def process_list_arg(arg):
     """ Parse a string into a list separated by commas with whitespace stripped """
     if isinstance(arg, list):
         return arg

--- a/cumulusci/robotframework/tests/cumulusci/datagen.robot
+++ b/cumulusci/robotframework/tests/cumulusci/datagen.robot
@@ -81,4 +81,4 @@ Test Snowfakery
     ...     num_records=20
     ...     num_records_tablename=Account
     ...     batch_size=5
-    ...     generator_yaml=cumulusci/tasks/bulkdata/tests/simple_snowfakery.recipe.yml
+    ...     generator_yaml=cumulusci/tasks/bulkdata/tests/snowfakery/simple_snowfakery.recipe.yml

--- a/cumulusci/tasks/bulkdata/generate_from_yaml.py
+++ b/cumulusci/tasks/bulkdata/generate_from_yaml.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 import yaml
 
 
-from cumulusci.core.utils import process_list_of_pairs_dict_arg
+from cumulusci.core.utils import process_list_of_pairs_dict_arg, process_list_arg
 
 from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.tasks.bulkdata.base_generate_data_task import BaseGenerateDataTask
@@ -15,6 +15,7 @@ from cumulusci.tasks.bulkdata.mapping_parser import parse_from_yaml
 from snowfakery.output_streams import SqlDbOutputStream
 from snowfakery.data_generator import generate, StoppingCriteria
 from snowfakery.generate_mapping_from_recipe import mapping_from_recipe_templates
+from snowfakery.cli import gather_declarations
 from snowfakery.salesforce import create_cci_record_type_tables
 
 
@@ -51,6 +52,9 @@ class GenerateDataFromYaml(BaseGenerateDataTask):
         },
         "working_directory": {
             "description": "Default path for temporary / working files"
+        },
+        "loading_rules": {
+            "description": "Path to .load.yml containing rules to use to load the file. Defaults to <recipename>.load.yml . Multiple flles can be comma separated."
         },
         "num_records": {
             "description": (
@@ -92,6 +96,8 @@ class GenerateDataFromYaml(BaseGenerateDataTask):
                 num_records_tablename, num_records
             )
         self.working_directory = self.options.get("working_directory")
+        loading_rules = process_list_arg(self.options.get("loading_rules")) or []
+        self.loading_rules = [Path(path) for path in loading_rules if path]
 
     def _generate_data(self, db_url, mapping_file_path, num_records, current_batch_num):
         """Generate all of the data"""
@@ -180,9 +186,12 @@ class GenerateDataFromYaml(BaseGenerateDataTask):
                 )
 
         if self.generate_mapping_file:
+            declarations = gather_declarations(self.yaml_file, self.loading_rules)
             with open(self.generate_mapping_file, "w+") as f:
                 yaml.safe_dump(
-                    mapping_from_recipe_templates(summary), f, sort_keys=False
+                    mapping_from_recipe_templates(summary, declarations),
+                    f,
+                    sort_keys=False,
                 )
 
         create_cci_record_type_tables(db_url)

--- a/cumulusci/tasks/bulkdata/generate_from_yaml.py
+++ b/cumulusci/tasks/bulkdata/generate_from_yaml.py
@@ -23,14 +23,13 @@ class GenerateDataFromYaml(BaseGenerateDataTask):
     """Generate sample data from a YAML template file."""
 
     task_docs = """
-    Depends on the currently un-released Snowfakery tool from SFDO. Better documentation
-    will appear here when Snowfakery is publically available.
+    Generate YAML from a Snowfakery recipe.
     """
 
     task_options = {
         **BaseGenerateDataTask.task_options,
         "generator_yaml": {
-            "description": "A generator YAML file to use",
+            "description": "A Snowfakery recipe file to use",
             "required": True,
         },
         "vars": {
@@ -54,7 +53,7 @@ class GenerateDataFromYaml(BaseGenerateDataTask):
             "description": "Default path for temporary / working files"
         },
         "loading_rules": {
-            "description": "Path to .load.yml containing rules to use to load the file. Defaults to <recipename>.load.yml . Multiple flles can be comma separated."
+            "description": "Path to .load.yml file containing rules to use to load the file. Defaults to <recipename>.load.yml . Multiple files can be comma separated."
         },
         "num_records": {
             "description": (

--- a/cumulusci/tasks/bulkdata/mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/mapping_parser.py
@@ -102,6 +102,8 @@ class MappingStep(CCIDictModel):
 
     @validator("bulk_mode", "api", "action", pre=True)
     def case_normalize(cls, val):
+        if isinstance(val, Enum):
+            return val
         return ENUM_VALUES.get(val.lower())
 
     def get_oid_as_pk(self):

--- a/cumulusci/tasks/bulkdata/tests/mapping_v2.yml
+++ b/cumulusci/tasks/bulkdata/tests/mapping_v2.yml
@@ -1,16 +1,16 @@
 Insert Households:
-    api: bulk
+    api: Bulk
     sf_object: Account
     table: households
     fields:
         Name: name
     record_type: HH_Account
 Insert Contacts:
-    api: bulk
+    api: BULK
     sf_object: Contact
     table: contacts
     filters:
-        - 'household_id is not null'
+        - "household_id is not null"
     fields:
         FirstName: first_name
         LastName: last_name

--- a/cumulusci/tasks/bulkdata/tests/simple_snowfakery.recipe.yml
+++ b/cumulusci/tasks/bulkdata/tests/simple_snowfakery.recipe.yml
@@ -1,5 +1,0 @@
-- object: Account
-  fields:
-    Name:
-      fake: name
-    ShippingCountry: Canada

--- a/cumulusci/tasks/bulkdata/tests/snowfakery/simple_snowfakery.load.yml
+++ b/cumulusci/tasks/bulkdata/tests/snowfakery/simple_snowfakery.load.yml
@@ -1,0 +1,2 @@
+- sf_object: Account
+  api: bulk

--- a/cumulusci/tasks/bulkdata/tests/snowfakery/simple_snowfakery.recipe.yml
+++ b/cumulusci/tasks/bulkdata/tests/snowfakery/simple_snowfakery.recipe.yml
@@ -1,0 +1,13 @@
+- object: Account
+  fields:
+    Name:
+      fake: name
+    ShippingCountry: Canada
+- object: Contact
+  fields:
+    FirstName:
+      fake: first_name
+    LastName:
+      fake: last_name
+    AccountId:
+      reference: Account

--- a/cumulusci/tasks/bulkdata/tests/snowfakery/simple_snowfakery_2.load.yml
+++ b/cumulusci/tasks/bulkdata/tests/snowfakery/simple_snowfakery_2.load.yml
@@ -1,0 +1,5 @@
+- sf_object: Contact
+  bulk_mode: Parallel
+
+- sf_object: Account
+  load_after: Contact

--- a/cumulusci/tasks/bulkdata/tests/test_generate_from_snowfakery_task.py
+++ b/cumulusci/tasks/bulkdata/tests/test_generate_from_snowfakery_task.py
@@ -18,6 +18,10 @@ from snowfakery import data_generator_runtime, data_generator
 
 sample_yaml = Path(__file__).parent / "snowfakery/gen_npsp_standard_objects.yml"
 simple_yaml = Path(__file__).parent / "snowfakery/include_parent.yml"
+simple_snowfakery_yaml = (
+    Path(__file__).parent / "snowfakery/simple_snowfakery.recipe.yml"
+)
+
 from cumulusci.tasks.bulkdata.generate_from_yaml import GenerateDataFromYaml
 
 vanilla_mapping_file = Path(__file__).parent / "../tests/mapping_vanilla_sf.yml"
@@ -34,6 +38,15 @@ def temporary_file_path(filename):
 def temp_sqlite_database_url():
     with temporary_file_path("test.db") as path:
         yield f"sqlite:///{str(path)}"
+
+
+@contextmanager
+def run_task(task=GenerateDataFromYaml, **options):
+    with temp_sqlite_database_url() as database_url:
+        options["database_url"] = database_url
+        task = _make_task(task, {"options": options})
+        task()
+        yield database_url
 
 
 class TestGenerateFromDataTask(unittest.TestCase):
@@ -301,5 +314,65 @@ class TestGenerateFromDataTask(unittest.TestCase):
                     },
                 )
                 task()
-            mapping = yaml.safe_load(open(temp_continuation_file))
-            assert mapping  # internals of this file are not important to MetaCI
+            continuation_file = yaml.safe_load(open(temp_continuation_file))
+            assert continuation_file  # internals of this file are not important to CumulusCI
+
+    def _get_mapping_file(self, **options):
+        with temporary_file_path("mapping.yml") as temp_mapping:
+            with temp_sqlite_database_url() as database_url:
+                task = _make_task(
+                    GenerateDataFromYaml,
+                    {
+                        "options": {
+                            "database_url": database_url,
+                            "generate_mapping_file": temp_mapping,
+                            **options,
+                        }
+                    },
+                )
+                task()
+            with open(temp_mapping) as f:
+                mapping = yaml.safe_load(f)
+        return mapping
+
+    def test_generate_mapping_file__loadfile__inferred(self):
+        mapping = self._get_mapping_file(generator_yaml=simple_snowfakery_yaml)
+
+        assert mapping["Insert Account"]["api"] == "bulk"
+        assert mapping["Insert Contact"].get("bulk_mode") is None
+        assert list(mapping.keys()) == ["Insert Account", "Insert Contact"]
+
+    def test_generate_mapping_file__loadfile__overridden(self):
+        loading_rules = str(simple_snowfakery_yaml).replace(
+            ".recipe.yml", "_2.load.yml"
+        )
+        mapping = self._get_mapping_file(
+            generator_yaml=simple_snowfakery_yaml, loading_rules=str(loading_rules)
+        )
+
+        assert mapping["Insert Account"].get("api") is None
+        assert mapping["Insert Contact"]["bulk_mode"].lower() == "parallel"
+        assert list(mapping.keys()) == ["Insert Contact", "Insert Account"]
+
+    def test_generate_mapping_file__loadfile_multiple_files(self):
+        loading_rules = (
+            str(simple_snowfakery_yaml).replace(".recipe.yml", "_2.load.yml")
+            + ","
+            + str(simple_snowfakery_yaml).replace(".recipe.yml", ".load.yml")
+        )
+        mapping = self._get_mapping_file(
+            generator_yaml=simple_snowfakery_yaml, loading_rules=str(loading_rules)
+        )
+
+        assert mapping["Insert Account"]["api"] == "bulk"
+        assert mapping["Insert Contact"]["bulk_mode"].lower() == "parallel"
+        assert list(mapping.keys()) == ["Insert Contact", "Insert Account"]
+
+    def test_generate_mapping_file__loadfile_missing(self):
+        loading_rules = str(simple_snowfakery_yaml).replace(
+            ".recipe.yml", "_3.load.yml"
+        )
+        with pytest.raises(FileNotFoundError):
+            self._get_mapping_file(
+                generator_yaml=simple_snowfakery_yaml, loading_rules=str(loading_rules)
+            )

--- a/cumulusci/tasks/bulkdata/tests/test_mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/tests/test_mapping_parser.py
@@ -1086,3 +1086,25 @@ class TestMappingLookup:
         assert mapping["Insert Accounts"].api == DataApi.REST
         assert mapping["Insert Accounts"].bulk_mode == "Serial"
         assert mapping["Insert Accounts"].batch_size == 50
+
+    @responses.activate
+    def test_case_conversions(self):
+        mapping = parse_from_yaml(
+            StringIO(
+                (
+                    """Insert Accounts:
+                        sf_object: account
+                        table: account
+                        api: ReST
+                        bulk_mode: serial
+                        action: INSerT
+                        batch_size: 50
+                        fields:
+                            - name"""
+                )
+            )
+        )
+        assert mapping["Insert Accounts"].api == DataApi.REST
+        assert mapping["Insert Accounts"].bulk_mode == "Serial"
+        assert mapping["Insert Accounts"].action.value == "insert"
+        assert mapping["Insert Accounts"].batch_size == 50

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -641,6 +641,51 @@ then when you run the command above it will run the recipe
 100 times (100*10=1000) which will generate 1000 Accounts, 500 Contacts
 and 1500 Opportunities.
 
+Controlling the Loading Process
+-------------------------------
+
+CumulusCI's data loader has many knobs and switches that you might want to
+adjust during your load. It supports a ".load.yml" file format which allows you to
+manipulate these load settings. The simplest way to use this file format is to make
+a file in the same directory as your recipe with a filename that is derived from
+the recipe's by replacing everything after the first "." with ".load.yml". For example,
+if your recipe is called "babka.recipe.yml" then your load file would be
+"babka.load.yml".
+
+Inside of that file you put a list of declarations in the following format:
+
+```yaml
+- sf_object: Account
+  api: bulk
+  bulk_mode: parallel
+```
+
+Which would specifically load accounts using the bulk API's parallel mode.
+
+The specific keys that you can associate with an object are:
+
+* api: "smart", "rest" or "bulk"
+* batch_size: a number
+* bulk_mode: "serial" or "parallel"]
+* load_after: the name of another sobject to wait for before loading
+
+For example, one could force Accounts and Opportunities to load after
+Contacts:
+
+```yaml
+- sf_object: Account
+  load_after: Contact
+
+- sf_object: Opportunity
+  load_after: Contact
+```
+
+If you wish to share a loading file between multiple recipes, you can
+refer to it with the ``--loading_rules`` option. That will override the
+default filename (``<recipename>.load.yml``). If you want both, or
+any combination of multiple files, you can do that by listing them with
+commas between the filenames.
+
 Batch Sizes
 -----------
 
@@ -698,3 +743,4 @@ at all is the fastest.
 Smaller batch sizes reduce the risk of something going wrong. You
 may need to experiment to find the best batch size for your use
 case.
+

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -666,8 +666,11 @@ The specific keys that you can associate with an object are:
 
 * api: "smart", "rest" or "bulk"
 * batch_size: a number
-* bulk_mode: "serial" or "parallel"]
+* bulk_mode: "serial" or "parallel"
 * load_after: the name of another sobject to wait for before loading
+
+"api", "batch_size" and "bulk_mode" have the same meanings that they
+do in mapping.yml as described in `API Selection`_.
 
 For example, one could force Accounts and Opportunities to load after
 Contacts:

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -116,7 +116,7 @@ six==1.15.0
     #   fs
     #   python-dateutil
     #   salesforce-bulk
-snowfakery==1.8
+snowfakery==1.8.1
     # via -r requirements/prod.in
 sqlalchemy==1.3.23
     # via

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -116,7 +116,7 @@ six==1.15.0
     #   fs
     #   python-dateutil
     #   salesforce-bulk
-snowfakery==1.7
+snowfakery==1.8
     # via -r requirements/prod.in
 sqlalchemy==1.3.23
     # via


### PR DESCRIPTION
Changes

Snowfakery can now use "load files" to drive the load process.

Mapping file params like "Serial", "rest, "bulk" are now case-insensitive.
