### PR TITLE
Added "ordering" and "testlevelsplit" options to the robot task

### DIFF
--- a/cumulusci/tasks/robotframework/tests/test_robot_parallel.py
+++ b/cumulusci/tasks/robotframework/tests/test_robot_parallel.py
@@ -1,0 +1,140 @@
+"""
+Tests for the robot task, specifically for options related to running tests in parallel
+"""
+
+from unittest import mock
+import unittest
+import sys
+from pathlib import Path
+
+from cumulusci.tasks.robotframework import Robot
+from cumulusci.tasks.salesforce.tests.util import create_task
+
+
+class TestRobotParallel(unittest.TestCase):
+    """Tests for the robot task when running tests with pabot"""
+
+    @mock.patch("cumulusci.tasks.robotframework.robotframework.robot_run")
+    @mock.patch("cumulusci.tasks.robotframework.robotframework.subprocess.run")
+    def test_process_arg_gt_zero(self, mock_subprocess_run, mock_robot_run):
+        """Verify that setting the process option to a number > 1 runs pabot"""
+        mock_subprocess_run.return_value = mock.Mock(returncode=0)
+        task = create_task(Robot, {"suites": "tests", "processes": "2"})
+        task()
+        outputdir = str(Path(".").resolve())
+        expected_cmd = [
+            sys.executable,
+            "-m",
+            "pabot.pabot",
+            "--pabotlib",
+            "--processes",
+            "2",
+            "--pythonpath",
+            task.project_config.repo_root,
+            "--variable",
+            "org:test",
+            "--outputdir",
+            outputdir,
+            "--tagstatexclude",
+            "cci_metric_elapsed_time",
+            "--tagstatexclude",
+            "cci_metric",
+            "tests",
+        ]
+        mock_robot_run.assert_not_called()
+        mock_subprocess_run.assert_called_once_with(expected_cmd)
+
+    @mock.patch("cumulusci.tasks.robotframework.robotframework.robot_run")
+    @mock.patch("cumulusci.tasks.robotframework.robotframework.subprocess.run")
+    def test_ordering_arg_processes_gt_1(self, mock_subprocess_run, mock_robot_run):
+        mock_subprocess_run.return_value = mock.Mock(returncode=0)
+        task = create_task(
+            Robot, {"suites": "tests", "processes": "2", "ordering": "robot/order.txt"}
+        )
+        task()
+        outputdir = str(Path(".").resolve())
+        expected_cmd = [
+            sys.executable,
+            "-m",
+            "pabot.pabot",
+            "--pabotlib",
+            "--processes",
+            "2",
+            # note: we are specifically testing that this comes before --pythonpath
+            "--ordering",
+            "robot/order.txt",
+            "--pythonpath",
+            task.project_config.repo_root,
+            "--variable",
+            "org:test",
+            "--outputdir",
+            outputdir,
+            "--tagstatexclude",
+            "cci_metric_elapsed_time",
+            "--tagstatexclude",
+            "cci_metric",
+            "tests",
+        ]
+        mock_robot_run.assert_not_called()
+        mock_subprocess_run.assert_called_once_with(expected_cmd)
+
+    @mock.patch("cumulusci.tasks.robotframework.robotframework.robot_run")
+    @mock.patch("cumulusci.tasks.robotframework.robotframework.subprocess.run")
+    def test_testlevelsplit_arg_processes_gt_1(
+        self, mock_subprocess_run, mock_robot_run
+    ):
+        mock_subprocess_run.return_value = mock.Mock(returncode=0)
+        task = create_task(
+            Robot, {"suites": "tests", "processes": "2", "testlevelsplit": "true"}
+        )
+        task()
+        outputdir = str(Path(".").resolve())
+        expected_cmd = [
+            sys.executable,
+            "-m",
+            "pabot.pabot",
+            "--pabotlib",
+            "--processes",
+            "2",
+            # note: we are specifically testing that this comes before --pythonpath
+            # and that the option isn't followed by a value
+            "--testlevelsplit",
+            "--pythonpath",
+            task.project_config.repo_root,
+            "--variable",
+            "org:test",
+            "--outputdir",
+            outputdir,
+            "--tagstatexclude",
+            "cci_metric_elapsed_time",
+            "--tagstatexclude",
+            "cci_metric",
+            "tests",
+        ]
+        mock_robot_run.assert_not_called()
+        mock_subprocess_run.assert_called_once_with(expected_cmd)
+
+    @mock.patch("cumulusci.tasks.robotframework.robotframework.robot_run")
+    @mock.patch("cumulusci.tasks.robotframework.robotframework.subprocess.run")
+    def test_pabot_args_process_eq_zero(self, mock_subprocess_run, mock_robot_run):
+        """Verifies that pabot-specific options are not passed on when processes=1"""
+        mock_robot_run.return_value = 0
+        task = create_task(
+            Robot,
+            {
+                "suites": "tests",
+                "processes": 1,
+                "testlevelsplit": "true",
+                "ordering": "./robot/order.txt",
+            },
+        )
+        task()
+        mock_subprocess_run.assert_not_called()
+        outputdir = str(Path(".").resolve())
+        mock_robot_run.assert_called_once_with(
+            "tests",
+            listener=[],
+            outputdir=outputdir,
+            variable=["org:test"],
+            tagstatexclude=["cci_metric_elapsed_time", "cci_metric"],
+        )


### PR DESCRIPTION
This adds two new robot task options: `ordering` and `testlevelsplit`. Both of these are options that are passed through to pabot when the `processes` option is set higher than 1.  Parallel test runs are still in the experimental stage, but this will give teams a bit more to experiment with.

We don't do anything with these options other than to pass them through, so the only tests I've added assert that the options are part of the pabot command but are ignored for the normal path through the code.

Jason and I had a brief discussion on whether these should be first class options or a layer deeper under a "parallel" or "pabot" option, and we agreed that first class options are the way to go.

test_robotframework.py is getting a bit large so I split out the parallel tests into their own separate test file.

# Critical Changes

# Changes
* Added two new options to the robot task: `ordering` and `testlevelsplit`. These only have an effect when combined with the `processes` option to run tests in parallel.

# Issues Closed
