### PR TITLE
init_logger cleans up after itself

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -228,21 +228,21 @@ def main(args=None):
 
         should_show_stacktraces = RUNTIME.universal_config.cli__show_stacktraces
 
-        init_logger(log_requests=debug)
-        # Hand CLI processing over to click, but handle exceptions
-        try:
-            cli(args[1:], standalone_mode=False)
-        except click.Abort:  # Keyboard interrupt
-            show_debug_info() if debug else click.echo("\nAborted!", err=True)
-            sys.exit(1)
-        except Exception as e:
-            if debug:
-                show_debug_info()
-            else:
-                handle_exception(
-                    e, is_error_command, tempfile_path, should_show_stacktraces
-                )
-            sys.exit(1)
+        with init_logger(log_requests=debug):
+            # Hand CLI processing over to click, but handle exceptions
+            try:
+                cli(args[1:], standalone_mode=False)
+            except click.Abort:  # Keyboard interrupt
+                show_debug_info() if debug else click.echo("\nAborted!", err=True)
+                sys.exit(1)
+            except Exception as e:
+                if debug:
+                    show_debug_info()
+                else:
+                    handle_exception(
+                        e, is_error_command, tempfile_path, should_show_stacktraces
+                    )
+                sys.exit(1)
 
 
 def handle_exception(error, is_error_cmd, logfile_path, should_show_stacktraces=False):

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -232,12 +232,9 @@ class TestCCI(unittest.TestCase):
 
     @mock.patch("cumulusci.cli.cci.tee_stdout_stderr")
     @mock.patch("cumulusci.cli.cci.get_tempfile_logger")
-    @mock.patch("cumulusci.cli.cci.init_logger")
     @mock.patch("cumulusci.cli.cci.cli")
     @mock.patch("sys.exit")
-    def test_main__abort(
-        self, sys_exit, cli, init_logger, get_tempfile_logger, tee_stdout_stderr
-    ):
+    def test_main__abort(self, sys_exit, cli, get_tempfile_logger, tee_stdout_stderr):
         get_tempfile_logger.return_value = (mock.Mock(), "tempfile.log")
         cli.side_effect = click.Abort
         cci.main(["cci"])
@@ -305,13 +302,12 @@ class TestCCI(unittest.TestCase):
         tempfile = Path("tempfile.log")
         tempfile.unlink()
 
-    @mock.patch("cumulusci.cli.cci.init_logger")  # side effects break other tests
     @mock.patch("cumulusci.cli.cci.get_tempfile_logger")
     @mock.patch("cumulusci.cli.cci.tee_stdout_stderr")
     @mock.patch("sys.exit")
     @mock.patch("cumulusci.cli.cci.CliRuntime")
     def test_handle_org_name(
-        self, CliRuntime, exit, tee_stdout_stderr, get_tempfile_logger, init_logger
+        self, CliRuntime, exit, tee_stdout_stderr, get_tempfile_logger
     ):
 
         # get_tempfile_logger doesn't clean up after itself which breaks other tests
@@ -338,13 +334,12 @@ class TestCCI(unittest.TestCase):
             "Please specify ORGNAME or --org ORGNAME" in stderr.getvalue()
         ), stderr.getvalue()
 
-    @mock.patch("cumulusci.cli.cci.init_logger")  # side effects break other tests
     @mock.patch("cumulusci.cli.cci.get_tempfile_logger")
     @mock.patch("cumulusci.cli.cci.tee_stdout_stderr")
     @mock.patch("sys.exit")
     @mock.patch("cumulusci.cli.cci.CliRuntime")
     def test_cci_org_default__no_orgname(
-        self, CliRuntime, exit, tee_stdout_stderr, get_tempfile_logger, init_logger
+        self, CliRuntime, exit, tee_stdout_stderr, get_tempfile_logger
     ):
         # get_tempfile_logger doesn't clean up after itself which breaks other tests
         get_tempfile_logger.return_value = mock.Mock(), ""

--- a/cumulusci/cli/tests/test_logger.py
+++ b/cumulusci/cli/tests/test_logger.py
@@ -9,7 +9,8 @@ class TestLogger:
     @patch("cumulusci.cli.logger.requests")
     @patch("cumulusci.cli.logger.logging")
     def test_init_logger(self, logging, requests):
-        init_logger(log_requests=True)
+        with init_logger(log_requests=True):
+            pass
         requests.packages.urllib3.add_stderr_logger.assert_called_once()
 
     def test_get_tempfile_logger(self):


### PR DESCRIPTION
Reduce mocking by letting init_logger clean up after itself.