### PR TITLE
Fix bug when passing robot logger as the task logger

### DIFF
--- a/cumulusci/robotframework/CumulusCI.py
+++ b/cumulusci/robotframework/CumulusCI.py
@@ -221,6 +221,12 @@ class CumulusCI(object):
     def _init_task(self, class_path, options, task_config):
         task_class = import_global(class_path)
         task_config = self._parse_task_options(options, task_class, task_config)
+        # Python deprecated the logger method "warn" in favor of
+        # "warning". Robot didn't get the memo and only has a "warn"
+        # method. Some tasks use "warning", so this makes sure the
+        # robot logger can handle that.
+        if not hasattr(robot.api.logger, "warning"):
+            robot.api.logger.warning = robot.api.logger.warn
         task = task_class(
             task_config.project_config or self.project_config,
             task_config,

--- a/cumulusci/robotframework/tests/test_cumulusci_library.py
+++ b/cumulusci/robotframework/tests/test_cumulusci_library.py
@@ -49,6 +49,24 @@ class TestCumulusCILibrary(MockLoggerMixin, unittest.TestCase):
             task = args[0]
             self.assertEqual(task.logger, robot.api.logger)
 
+    def test_robot_logger_supports_warning(self):
+        """Verify that 'run task' uses a logger that supports .warning()
+
+        Python deprecated the logger method "warn" in favor of
+        "warning". Robot didn't get the memo and has "warn" instead of
+        "warning".  Since our tasks use "warning", this verifies that
+        we've patched the robot logger before passing it to the task
+        constructor.
+
+        """
+        with mock.patch.object(self.cumulusci, "_run_task"):
+            self.cumulusci.run_task("get_pwd")
+            args, kwargs = self.cumulusci._run_task.call_args
+            task = args[0]
+            assert hasattr(
+                task.logger, "warning"
+            ), "robot logger should have a warning method but doesn't"
+
     def test_run_task_class_robot_logger(self):
         """Verify that 'run task class' uses the robot logger"""
         with mock.patch.object(self.cumulusci, "_run_task"):


### PR DESCRIPTION
The robot logger uses .warn but our tasks use .warning. This fix patches the robot logger to have .warning before passing it to the task.


# Critical Changes

# Changes

# Issues Closed
