### PR TITLE
Named service fixes

### DIFF
--- a/cumulusci/cli/service.py
+++ b/cumulusci/cli/service.py
@@ -126,7 +126,11 @@ class ConnectServiceCommand(click.MultiCommand):
 
         def callback(*args, **kwargs):
             service_name = kwargs["service_name"]
-            if service_name in runtime.keychain.list_services()[service_type]:
+            configured_services = runtime.keychain.list_services()
+            if (
+                service_type in configured_services
+                and service_name in configured_services[service_type]
+            ):
                 click.confirm(
                     f"There is already a {service_type}:{service_name} service. Do you want to overwrite it?",
                     abort=True,
@@ -263,10 +267,9 @@ def service_rename(runtime, service_type, current_name, new_name):
 @pass_runtime(require_project=False, require_keychain=True)
 def service_remove(runtime, service_type, service_name):
     new_default = None
-    if (
-        len(runtime.keychain.services[service_type].keys()) > 2
-        and service_name == runtime.keychain._default_services[service_type]
-    ):
+    if len(
+        runtime.keychain.services.get(service_type, {}).keys()
+    ) > 2 and service_name == runtime.keychain._default_services.get(service_type):
         click.echo(
             f"The service you would like to remove is currently the default for {service_type} services."
         )

--- a/cumulusci/core/keychain/encrypted_file_project_keychain.py
+++ b/cumulusci/core/keychain/encrypted_file_project_keychain.py
@@ -352,10 +352,9 @@ class EncryptedFileProjectKeychain(BaseEncryptedProjectKeychain):
 
         @param default_services_file path to a DEFAULT_SERVICES.json file
         """
-        if default_services_file.is_file():
-            default_services = self._read_default_services(default_services_file)
-            for s_type, alias in default_services.items():
-                self._default_services[s_type] = alias
+        default_services = self._read_default_services(default_services_file)
+        for s_type, alias in default_services.items():
+            self._default_services[s_type] = alias
 
     def _save_default_service(
         self, service_type: str, alias: str, project: bool = False
@@ -504,12 +503,9 @@ class EncryptedFileProjectKeychain(BaseEncryptedProjectKeychain):
         @raises CumulusCIException if the file does not exist
         """
         if not file_path.is_file() or file_path.name != DEFAULT_SERVICES_FILENAME:
-            raise CumulusCIException(
-                f"No {DEFAULT_SERVICES_FILENAME} file found at: {file_path}"
-            )
-
-        with open(file_path, "r") as f:
-            return json.loads(f.read())
+            return {}
+        else:
+            return json.loads(file_path.read_text(encoding="utf-8"))
 
     def _write_default_services(
         self, file_path: Path, default_services: T.Dict[str, str]
@@ -525,7 +521,7 @@ class EncryptedFileProjectKeychain(BaseEncryptedProjectKeychain):
                 f"No {DEFAULT_SERVICES_FILENAME} file found at: {file_path}"
             )
 
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             f.write(json.dumps(default_services))
 
     def _iter_local_project_dirs(self):

--- a/cumulusci/core/keychain/tests/test_encrypted_file_project_keychain.py
+++ b/cumulusci/core/keychain/tests/test_encrypted_file_project_keychain.py
@@ -610,8 +610,7 @@ class TestEncryptedFileProjectKeychain:
         assert actual_defaults == expected_defaults
 
     def test_read_default_services__file_does_not_exist(self, keychain):
-        with pytest.raises(CumulusCIException):
-            keychain._read_default_services(Path("not-a-valid-filepath"))
+        assert keychain._read_default_services(Path("not-a-valid-filepath")) == {}
 
     def test_write_default_services(self, keychain):
         expected_defaults = {


### PR DESCRIPTION
- Fix `cci service connect` when service isn't configured yet
- Make _read_default_services return an empty dict instead of raising an exception if the default services file doesn't exist yet

# Critical Changes

# Changes

# Issues Closed
