### PR TITLE
Fix serialization of dependencies while making a 1gp release

### DIFF
--- a/cumulusci/core/dependencies/dependencies.py
+++ b/cumulusci/core/dependencies/dependencies.py
@@ -522,16 +522,13 @@ class UnmanagedGitHubRefDependency(UnmanagedDependency):
             values.get("github"),
         ], "Must specify `repo_owner` or `github`, but not both."
 
-        # Populate the `github` and `repo_name, `repo_owner` properties if not already populated.
-        if (not values.get("repo_name") or not values.get("repo_owner")) and values.get(
-            "github"
-        ):
-            values["repo_owner"], values["repo_name"] = split_repo_url(values["github"])
-
+        # Populate the `github` property if not already populated.
         if not values.get("github") and values.get("repo_name"):
             values[
                 "github"
             ] = f"https://github.com/{values['repo_owner']}/{values['repo_name']}"
+            values.pop("repo_owner")
+            values.pop("repo_name")
 
         return values
 
@@ -582,10 +579,12 @@ def parse_dependencies(deps: Optional[List[dict]]) -> List[Dependency]:
     (as defined in `cumulusci.yml`) and parse each into a concrete Dependency subclass.
 
     Throws DependencyParseError if a dict cannot be parsed."""
-    parsed_deps = [parse_dependency(d) for d in deps or []]
-    if None in parsed_deps:
-        raise DependencyParseError("Unable to parse dependencies")
-
+    parsed_deps = []
+    for dep in deps or []:
+        parsed = parse_dependency(dep)
+        if parsed is None:
+            raise DependencyParseError(f"Unable to parse dependency: {dep}")
+        parsed_deps.append(parsed)
     return parsed_deps
 
 

--- a/cumulusci/core/dependencies/tests/test_dependencies.py
+++ b/cumulusci/core/dependencies/tests/test_dependencies.py
@@ -560,8 +560,6 @@ class TestUnmanagedGitHubRefDependency:
         u = UnmanagedGitHubRefDependency(
             github="https://github.com/Test/TestRepo", ref="aaaaaaaa"
         )
-        assert u.repo_owner == "Test"
-        assert u.repo_name == "TestRepo"
 
         u = UnmanagedGitHubRefDependency(
             repo_owner="Test", repo_name="TestRepo", ref="aaaaaaaa"

--- a/cumulusci/tasks/package_2gp.py
+++ b/cumulusci/tasks/package_2gp.py
@@ -28,6 +28,7 @@ from cumulusci.salesforce_api.utils import get_simple_salesforce_connection
 from cumulusci.tasks.salesforce.BaseSalesforceApiTask import BaseSalesforceApiTask
 from cumulusci.tasks.salesforce.org_settings import build_settings_package
 from cumulusci.utils import download_extract_github
+from cumulusci.utils.git import split_repo_url
 
 
 VERSION_RE = re.compile(
@@ -630,13 +631,12 @@ class CreatePackageVersion(BaseSalesforceApiTask):
         return dependencies
 
     def _create_unlocked_package_from_github(self, dependency, dependencies):
-        gh_for_repo = self.project_config.get_github_api(
-            dependency.repo_owner, dependency.repo_name
-        )
+        repo_owner, repo_name = split_repo_url(dependency.github)
+        gh_for_repo = self.project_config.get_github_api(repo_owner, repo_name)
         zip_src = download_extract_github(
             gh_for_repo,
-            dependency.repo_owner,
-            dependency.repo_name,
+            repo_owner,
+            repo_name,
             dependency.subfolder,
             ref=dependency.ref,
         )
@@ -648,7 +648,7 @@ class CreatePackageVersion(BaseSalesforceApiTask):
         )
 
         package_config = PackageConfig(
-            package_name=f"{dependency.repo_owner}/{dependency.repo_name} {dependency.subfolder}",
+            package_name=f"{repo_owner}/{repo_name} {dependency.subfolder}",
             version_name="Auto",
             package_type="Unlocked",
             # Ideally we'd do this without a namespace,

--- a/cumulusci/tasks/salesforce/tests/test_update_dependencies.py
+++ b/cumulusci/tasks/salesforce/tests/test_update_dependencies.py
@@ -364,8 +364,6 @@ def test_freeze(get_static_dependencies):
                         {
                             "ref": "abcdef",
                             "github": "https://github.com/SFDO-Tooling/CumulusCI-Test",
-                            "repo_name": "CumulusCI-Test",
-                            "repo_owner": "SFDO-Tooling",
                             "subfolder": "src",
                         }
                     ],


### PR DESCRIPTION
- Make UnmanagedGitHubRefDependency discard repo_owner and repo_name after converting to github (when both are present, UnmanagedGitHubRefDependency will not deserialize the dependency)
- When a dependency can't be parsed, show it in the error that is raised

# Critical Changes

# Changes

# Issues Closed
Fixes #2564 