### PR TITLE
Improvements to cumulusci.yml warnings

### DIFF
--- a/cumulusci/core/dependencies/github.py
+++ b/cumulusci/core/dependencies/github.py
@@ -1,3 +1,4 @@
+import functools
 import io
 
 from github3.repos.repo import Repository
@@ -22,9 +23,12 @@ def get_repo(github: str, context: BaseProjectConfig) -> Repository:
     return repo
 
 
+@functools.lru_cache(50)
 def get_remote_project_config(repo: Repository, ref: str) -> BaseConfig:
     contents = repo.file_contents("cumulusci.yml", ref=ref)
-    return BaseConfig(cci_safe_load(io.StringIO(contents.decoded.decode("utf-8"))))
+    contents_io = io.StringIO(contents.decoded.decode("utf-8"))
+    contents_io.url = f"cumulusci.yml from {repo.owner}/{repo.name}"  # for logging
+    return BaseConfig(cci_safe_load(contents_io))
 
 
 def get_package_data(config: BaseConfig):

--- a/cumulusci/utils/yaml/cumulusci_yml.py
+++ b/cumulusci/utils/yaml/cumulusci_yml.py
@@ -204,20 +204,26 @@ class ErrorDict(TypedDict):
     type: str
 
 
+has_shown_yaml_error_message = False
+
+
 def _log_yaml_errors(logger, errors: List[ErrorDict]):
     "Format and log a Pydantic-style error dictionary"
+    global has_shown_yaml_error_message
     plural = "" if len(errors) <= 1 else "s"
     logger.warning(f"CumulusCI Configuration Warning{plural}:")
     for error in errors:
         loc = " -> ".join(repr(x) for x in error["loc"] if x != "__root__")
         logger.warning("  %s\n    %s", loc, error["msg"])
-    logger.error(
-        "NOTE: These warnings may become errors in future versions of CumulusCI."
-    )
-    logger.error(
-        "If you think your YAML has no error, please report the bug to the CumulusCI team."
-    )
-    logger.error("https://github.com/SFDO-Tooling/CumulusCI/issues/\n")
+    if not has_shown_yaml_error_message:
+        logger.error(
+            "NOTE: These warnings may become errors in future versions of CumulusCI."
+        )
+        logger.error(
+            "If you think your YAML has no error, please report the bug to the CumulusCI team."
+        )
+        logger.error("https://github.com/SFDO-Tooling/CumulusCI/issues/\n")
+        has_shown_yaml_error_message = True
 
 
 def cci_safe_load(


### PR DESCRIPTION
- When parsing cumulusci.yml from a github repo, log the repo it came from instead of `<stream>`
- Only show the explanation of cumulusci.yml warnings once even if multiple files have warnings.
- Cache result of get_remote_project_config in an lru_cache so we don't fetch the same file from github multiple times.

# Critical Changes

# Changes
- Improved logging of cumulusci.yml warnings from dependencies.

# Issues Closed
