### PR TITLE
Don't require service name for `cci service connect`

### DIFF
--- a/cumulusci/cli/service.py
+++ b/cumulusci/cli/service.py
@@ -125,7 +125,13 @@ class ConnectServiceCommand(click.MultiCommand):
         params.extend(self._get_default_options(runtime))
 
         def callback(*args, **kwargs):
-            service_name = kwargs["service_name"]
+            service_name = kwargs.get("service_name")
+            if not service_name:
+                click.echo(
+                    "No service name specified. Using 'default' as the service name."
+                )
+                service_name = "default"
+
             configured_services = runtime.keychain.list_services()
             if (
                 service_type in configured_services
@@ -176,7 +182,7 @@ class ConnectServiceCommand(click.MultiCommand):
                     f"Service {service_type}:{service_name} is now the default for project '{project_name}'"
                 )
 
-        params.append(click.Argument(["service_name"]))
+        params.append(click.Argument(["service_name"], required=False))
         return click.Command(service_type, params=params, callback=callback)
 
 


### PR DESCRIPTION
# Changes
* `cci service connect` now assigns a service name of "default" if a name is not specified. 