### PR TITLE
Handle no default devhub service

### DIFF
--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -6,6 +6,7 @@ import re
 from cumulusci.core.sfdx import sfdx
 from cumulusci.core.config import FAILED_TO_CREATE_SCRATCH_ORG
 from cumulusci.core.config import SfdxOrgConfig
+from cumulusci.core.exceptions import CumulusCIException
 from cumulusci.core.exceptions import ScratchOrgException
 from cumulusci.core.exceptions import ServiceNotConfigured
 
@@ -133,7 +134,7 @@ class ScratchOrgConfig(SfdxOrgConfig):
             # Otherwise see if one is configured via the "devhub" service
             try:
                 devhub_service = self.keychain.get_service("devhub")
-            except ServiceNotConfigured:
+            except (ServiceNotConfigured, CumulusCIException):
                 pass
             else:
                 devhub = devhub_service.username

--- a/cumulusci/core/config/util.py
+++ b/cumulusci/core/config/util.py
@@ -1,5 +1,5 @@
 from cumulusci.core.config import BaseProjectConfig
-from cumulusci.core.exceptions import ServiceNotConfigured
+from cumulusci.core.exceptions import CumulusCIException, ServiceNotConfigured
 from cumulusci.core.config.sfdx_org_config import SfdxOrgConfig
 from cumulusci.core.sfdx import get_default_devhub_username
 
@@ -11,7 +11,7 @@ def get_devhub_config(project_config: BaseProjectConfig) -> SfdxOrgConfig:
     """
     try:
         devhub_service = project_config.keychain.get_service("devhub")
-    except ServiceNotConfigured:
+    except (ServiceNotConfigured, CumulusCIException):
         devhub_username = get_default_devhub_username()
     else:
         devhub_username = devhub_service.username


### PR DESCRIPTION
I'm not clear on how this situation arises yet, but we can handle it more gracefully anyway.


# Critical Changes

# Changes

# Issues Closed
- Fixed a regression with creating a scratch org if the devhub service was configured but not set as the default.