### PR TITLE
Log errors in stderr of sfdx commands during source conversion

### DIFF
--- a/cumulusci/salesforce_api/package_zip.py
+++ b/cumulusci/salesforce_api/package_zip.py
@@ -127,7 +127,7 @@ class MetadataPackageZipBuilder(BasePackageZipBuilder):
                 sfdx(
                     "force:source:convert",
                     args=args,
-                    capture_output=False,
+                    capture_output=True,
                     check_return=True,
                 )
 


### PR DESCRIPTION
# Issues Closed
* Improved logging of errors from sfdx while converting sfdx format metadata to deploy via the Metadata API, so that they are not lost when CumulusCI is embedded in another system like MetaCI or Metecho.
