### PR TITLE
use python naming conventions

### DIFF
--- a/cumulusci/cli/org.py
+++ b/cumulusci/cli/org.py
@@ -325,12 +325,12 @@ def org_list(runtime, json_flag, plain):
             )
             scratch_data.append(row)
             json_data[org] = {
-                "isDefault": is_org_default,
+                "is_default": is_org_default,
                 "days": org_days,
                 "expired": not org_config.active,
                 "config": org_config.config_name,
                 "domain": domain,
-                "isScratch": True,
+                "is_scratch": True,
             }
         else:
             username = org_config.config.get(
@@ -339,7 +339,7 @@ def org_list(runtime, json_flag, plain):
             row.append(username)
             row.append(org_config.expires or "Unknown")
             persistent_data.append(row)
-            json_data[org] = {"isDefault": is_org_default, "isScratch": False}
+            json_data[org] = {"is_default": is_org_default, "is_scratch": False}
 
     if json_flag:
         click.echo(json.dumps(json_data))

--- a/cumulusci/cli/tests/test_org.py
+++ b/cumulusci/cli/tests/test_org.py
@@ -563,22 +563,22 @@ class TestOrgCommands:
         run_click_command(org.org_list, runtime=runtime, json_flag=True, plain=False)
         expected = {
             "test0": {
-                "isDefault": True,
+                "is_default": True,
                 "days": "7",
                 "expired": True,
                 "config": "dev",
                 "domain": "",
-                "isScratch": True,
+                "is_scratch": True,
             },
             "test1": {
-                "isDefault": False,
+                "is_default": False,
                 "days": "1/7",
                 "expired": False,
                 "config": "dev",
                 "domain": "sneaky-master-2330-dev-ed.cs22",
-                "isScratch": True,
+                "is_scratch": True,
             },
-            "test2": {"isDefault": False, "isScratch": False},
+            "test2": {"is_default": False, "is_scratch": False},
         }
         echo.assert_called_once_with(json.dumps(expected))
 


### PR DESCRIPTION
@davisagli - Apologies for closing that PR early. Here are the edits you noted.