### PR TITLE
Handle directories missing a trailing slash

### DIFF
--- a/cumulusci/tasks/github/publish.py
+++ b/cumulusci/tasks/github/publish.py
@@ -134,9 +134,28 @@ class PublishSubtree(BaseGithubTask):
         zf.extractall(path=path, members=included_members)
 
     def _filter_namelist(self, includes, namelist):
-        dirs = tuple(name for name in includes if name.endswith("/"))
+        """
+        Filter a zipfile namelist, handling any included directory filenames missing
+        a trailing slash.
+        """
+        included_dirs = []
+        zip_dirs = [
+            filename.rstrip("/") for filename in namelist if filename.endswith("/")
+        ]
+
+        for name in includes:
+            if name.endswith("/"):
+                included_dirs.append(name)
+            elif name in zip_dirs:
+                # append a trailing slash to avoid partial matches
+                included_dirs.append(name + "/")
+
         return list(
-            {name for name in namelist if name.startswith(dirs) or name in includes}
+            {
+                name
+                for name in namelist
+                if name.startswith(tuple(included_dirs)) or name in includes
+            }
         )
 
     def _rename_files(self, zip_dir):

--- a/cumulusci/tasks/github/tests/test_publish.py
+++ b/cumulusci/tasks/github/tests/test_publish.py
@@ -569,3 +569,56 @@ class TestPublishSubtree(unittest.TestCase, GithubApiTestMixin):
             commit_dir.assert_called_once()
             expected_commit_message = "Published content from ref feature/publish"
             assert commit_dir.call_args[1]["commit_message"] == expected_commit_message
+
+    def test_included_dirs_match(self):
+        test_includes = [
+            "orgs/",
+            "public/public_readme.md",
+            "scripts/anon.cls",
+            "scripts/public",
+            "tasks/move_me.py",
+        ]
+        test_namelist = [
+            "orgs/",
+            "orgs/dev.json",
+            "orgs/feature.json",
+            "orgs/prerelease.json",
+            "orgs/release.json",
+            "orgs/trial.json",
+            "public/public_readme.md",
+            "scripts/",
+            "scripts/anon.cls",
+            "scripts/more_anon.cls",
+            "scripts/public/",
+            "scripts/public/anon.cls",
+            "scripts/public_to_global.cls",
+            "tasks/",
+            "tasks/move_me.py",
+            "tasks/unmoved.py",
+        ]
+        task_config = TaskConfig(
+            {
+                "options": {
+                    "branch": "master",
+                    "ref": "some-branch-name",
+                    "repo_url": self.public_repo_url,
+                    "include": test_includes,
+                }
+            }
+        )
+        task = PublishSubtree(self.project_config, task_config)
+        expected_namelist = [
+            "orgs/",
+            "orgs/dev.json",
+            "orgs/feature.json",
+            "orgs/prerelease.json",
+            "orgs/release.json",
+            "orgs/trial.json",
+            "public/public_readme.md",
+            "scripts/anon.cls",
+            "scripts/public/",
+            "scripts/public/anon.cls",
+            "tasks/move_me.py",
+        ]
+        actual_namelist = task._filter_namelist(test_includes, test_namelist)
+        assert sorted(expected_namelist) == sorted(actual_namelist)


### PR DESCRIPTION
This PR tweaks how `github_copy_subtree` filters filenames based on an an include list. Previously, this task would silently generate incorrect/truncated commits when a directory was included in `self.options.includes` without a trailing slash. Now, it checks the zipfile namelist's directories (filenames ending with a slash) for includes that are missing a slash and appends it.

-------

# Critical Changes

# Changes

# Issues Closed