### PR TITLE
New Services: `oauth-client` & `marketing-cloud`

### DIFF
--- a/cumulusci/cli/org.py
+++ b/cumulusci/cli/org.py
@@ -11,7 +11,8 @@ from cumulusci.cli.ui import CliTable, CROSSMARK, SimpleSalesforceUIHelpers
 from cumulusci.core.config import OrgConfig, ScratchOrgConfig
 from cumulusci.core.exceptions import OrgNotFound
 from cumulusci.core.utils import cleanup_org_cache_dirs
-from cumulusci.oauth.client import OAuth2Client, SalesforceOAuthClientInfo
+from cumulusci.oauth.client import OAuth2Client
+from cumulusci.oauth.client_info import OAuthClientInfo
 from cumulusci.salesforce_api.utils import get_simple_salesforce_connection
 from cumulusci.utils import parse_api_datetime
 from .runtime import pass_runtime
@@ -141,9 +142,18 @@ def org_connect(runtime, org_name, sandbox, login_url, default, global_org):
         )
 
     connected_app = runtime.keychain.get_service("connected_app")
+    base_uri = "https://{}.salesforce.com"
+    base_uri = base_uri.format("test" if sandbox else "login")
+    auth_uri = base_uri + "/services/oauth2/authorize"
+    token_uri = base_uri + "/services/oauth2/token"
+    revoke_uri = base_uri + "/services/oauth2/revoke"
 
-    sf_client_info = SalesforceOAuthClientInfo(
-        scope="web full refresh_token", is_sandbox=sandbox, **connected_app.config
+    sf_client_info = OAuthClientInfo(
+        **connected_app.config,  # client_id, client_secret
+        auth_uri=auth_uri,
+        token_uri=token_uri,
+        revoke_uri=revoke_uri,
+        scope="web full refresh_token",
     )
     sf_client = OAuth2Client(sf_client_info)
     oauth_dict = sf_client.auth_code_flow()

--- a/cumulusci/cli/tests/test_org.py
+++ b/cumulusci/cli/tests/test_org.py
@@ -89,17 +89,23 @@ class TestOrgCommands:
         click_echo.assert_called_once_with(start_url)
         org_config.save.assert_called_once_with()
 
-    @mock.patch("cumulusci.cli.org.CaptureSalesforceOAuth")
+    @mock.patch("cumulusci.cli.org.OAuth2Client")
     @responses.activate
-    def test_org_connect(self, oauth):
-        oauth.return_value = mock.Mock(
-            return_value={
-                "instance_url": "https://instance",
-                "access_token": "BOGUS",
-                "id": "OODxxxxxxxxxxxx/user",
+    def test_org_connect(self, oauth2client):
+        client_instance = mock.Mock()
+        client_instance.auth_code_flow.return_value = {
+            "instance_url": "https://instance",
+            "access_token": "BOGUS",
+            "id": "OODxxxxxxxxxxxx/user",
+        }
+        oauth2client.return_value = client_instance
+        runtime = mock.Mock()
+        runtime.keychain.get_service.return_value = mock.Mock(
+            config={
+                "client_id": "asdfasdf",
+                "client_secret": "asdfasdf",
             }
         )
-        runtime = mock.Mock()
         responses.add(
             method="GET",
             url="https://instance/services/oauth2/userinfo",
@@ -135,17 +141,23 @@ class TestOrgCommands:
         assert org_config.expires == "Persistent"
         runtime.keychain.set_default_org.assert_called_once_with("test")
 
-    @mock.patch("cumulusci.cli.org.CaptureSalesforceOAuth")
+    @mock.patch("cumulusci.cli.org.OAuth2Client")
     @responses.activate
-    def test_org_connect_expires(self, oauth):
-        oauth.return_value = mock.Mock(
-            return_value={
-                "instance_url": "https://instance",
-                "access_token": "BOGUS",
-                "id": "OODxxxxxxxxxxxx/user",
+    def test_org_connect_expires(self, oauth2client):
+        client_instance = mock.Mock()
+        client_instance.auth_code_flow.return_value = {
+            "instance_url": "https://instance",
+            "access_token": "BOGUS",
+            "id": "OODxxxxxxxxxxxx/user",
+        }
+        oauth2client.return_value = client_instance
+        runtime = mock.Mock()
+        runtime.keychain.get_service.return_value = mock.Mock(
+            config={
+                "client_id": "asdfasdf",
+                "client_secret": "asdfasdf",
             }
         )
-        runtime = mock.Mock()
         responses.add(
             method="GET",
             url="https://instance/services/oauth2/userinfo",

--- a/cumulusci/core/config/__init__.py
+++ b/cumulusci/core/config/__init__.py
@@ -27,6 +27,11 @@ class ServiceConfig(BaseConfig):
     pass
 
 
+from cumulusci.core.config.marketing_cloud_service_config import (
+    MarketingCloudServiceConfig,
+)
+
+
 class TaskConfig(BaseConfig):
     """ A task with its configuration merged """
 
@@ -56,6 +61,7 @@ __all__ = (
     "FlowConfig",
     "OrgConfig",
     "ServiceConfig",
+    "MarketingCloudServiceConfig",
     "TaskConfig",
     "BaseTaskFlowConfig",
     "BaseProjectConfig",

--- a/cumulusci/core/config/marketing_cloud_service_config.py
+++ b/cumulusci/core/config/marketing_cloud_service_config.py
@@ -1,0 +1,17 @@
+from cumulusci.core.config import ServiceConfig
+
+
+class MarketingCloudServiceConfig(ServiceConfig):
+    def __init__(self, oauth_client_name, config):
+        self.access_token = None
+        self.refresh_token = None
+        self.oauth_client_service_name = oauth_client_name
+        super().__init__(config=config)
+
+    def connect():
+        """Uses the access token to connect to a MC instance"""
+        pass
+
+    def refresh_token():
+        """TODO: Is there a refresh flow for MC?"""
+        pass

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -1187,6 +1187,13 @@ services:
         description: The email address to used by Github tasks when an operation requires an email address.
         required: True
     validator: cumulusci.core.github.validate_service
+  marketing_cloud:
+    description: Configure a connection to a Marketing Cloud instance
+    class_path: cumulusci.core.config.MarketingCloudServiceConfig
+    attributes:
+      oauth_client:
+        description: The oauth client service with which to establish a connection to marketing cloud
+        required: False
   metaci:
     description: Connect with a MetaCI site to run builds of projects from this repository
     attributes:
@@ -1207,6 +1214,21 @@ services:
         required: True
       token:
         description: Your API token to the MetaDeploy site (get from SITE_URL/admin/authtoken/token)
+        required: True
+  oauth_client:
+    description:
+    attributes:
+      client_id:
+        description: The client Id
+        required: True
+      client_secret:
+        description: The client secret
+        required: True
+      auth_uri:
+        description: The URI for where user's are directed to login
+        required: True
+      token_uri:
+        description: The URI for where we request an access token
         required: True
 
 project:

--- a/cumulusci/oauth/client.py
+++ b/cumulusci/oauth/client.py
@@ -1,0 +1,169 @@
+import http.client
+import logging
+import requests
+import random
+import socket
+import threading
+import time
+import webbrowser
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
+from http.server import BaseHTTPRequestHandler
+from http.server import HTTPServer
+
+from cumulusci.oauth.client_info import OAuthClientInfo
+from cumulusci.utils.http.requests_utils import safe_json_from_response
+
+logger = logging.getLogger(__name__)
+
+HTTP_HEADERS = {"Content-Type": "application/x-www-form-urlencoded"}
+
+
+class OAuth2Client(object):
+    """Represents an OAuth2Client with the ability to execute different grant types.
+    Supported grant types include:
+        (1) Authorization Code - via auth_code_flow()
+        ...
+    """
+
+    def __init__(self, client_info: OAuthClientInfo):
+        self.client_info = client_info
+        self.response = None
+        self.httpd = None
+        self.httpd_timeout = 300
+
+    def auth_code_flow(self) -> None:
+        """Given an OAuth Client config, complete the OAuth2 auth code flow.
+        For more info on the auth code flow see:
+        https://www.oauth.com/oauth2-servers/server-side-apps/authorization-code/
+
+        @param auth_info instanace of OAuthInfo to use in the flow
+        @returns a dict of values returned from the auth server.
+        It will be similar in shape to:
+        {
+            "access_token":"<acces_token_here>",
+            "token_type":"bearer",
+            "expires_in":3600,
+            "refresh_token":"<refresh_token_here>",
+            "scope":"create"
+        }
+        """
+        # Open a browser and direct the user to login
+        webbrowser.open(self.client_info.get_auth_uri(), new=1)
+        # Open up an http deamon to listen for the
+        # callback from the auth server
+        self._create_httpd()
+        logger.info(
+            f"Spawning HTTP server at {self.client_info.callback_url} with timeout of {self.httpd.timeout} seconds.\n"
+            + "If you are unable to log in to Salesforce you can "
+            + "press <Ctrl+C> to kill the server and return to the command line."
+        )
+        # Implement the 300 second timeout
+        timeout_thread = HTTPDTimeout(self.httpd, self.httpd_timeout)
+        timeout_thread.start()
+        # use serve_forever because it is smarter about polling for Ctrl-C
+        # on Windows.
+        #
+        # There are two ways it can be shutdown.
+        # 1. Get a callback from Salesforce.
+        # 2. Timeout
+
+        try:
+            # for some reason this is required for Safari (checked Feb 2021)
+            # https://github.com/SFDO-Tooling/CumulusCI/pull/2373
+            old_timeout = socket.getdefaulttimeout()
+            socket.setdefaulttimeout(3)
+            self.httpd.serve_forever()
+        finally:
+            socket.setdefaulttimeout(old_timeout)
+
+        # timeout thread can stop polling and just finish
+        timeout_thread.quit()
+        self.client_info.validate_response(self.response)
+        return safe_json_from_response(self.response)
+
+    def _create_httpd(self):
+        """Create an http deamon process to listen
+        for the callback from the auth server"""
+        url_parts = urlparse(self.client_info.callback_url)
+        server_address = (url_parts.hostname, url_parts.port)
+        OAuthCallbackHandler.parent = self
+        self.httpd = HTTPServer(server_address, OAuthCallbackHandler)
+        self.httpd.timeout = self.httpd_timeout
+
+    def get_access_token(self, auth_code):
+        """Exchange an auth code for an access token"""
+        data = {
+            "client_id": self.client_info.client_id,
+            "client_secret": self.client_info.client_secret,
+            "grant_type": "authorization_code",
+            "redirect_uri": self.client_info.callback_url,
+            "code": auth_code,
+        }
+        return requests.post(
+            self.client_info.get_token_uri(), headers=HTTP_HEADERS, data=data
+        )
+
+
+class HTTPDTimeout(threading.Thread):
+    """Establishes a timeout for a SimpleHTTPServer"""
+
+    # allow the process to quit even if the
+    # timeout thread is still alive
+    daemon = True
+
+    def __init__(self, httpd, timeout):
+        self.httpd = httpd
+        self.timeout = timeout
+        super().__init__()
+
+    def run(self):
+        """Check every second for HTTPD or quit after timeout"""
+        target_time = time.time() + self.timeout
+        while time.time() < target_time:
+            time.sleep(1)
+            if not self.httpd:
+                break
+
+        if self.httpd:  # extremely minor race condition
+            self.httpd.shutdown()
+
+    def quit(self):
+        """Quit before timeout"""
+        self.httpd = None
+
+
+class OAuthCallbackHandler(BaseHTTPRequestHandler):
+    parent = None
+
+    def do_GET(self):
+        args = parse_qs(urlparse(self.path).query, keep_blank_values=True)
+
+        if "error" in args:
+            http_status = http.client.BAD_REQUEST
+            http_body = f"error: {args['error'][0]}\nerror description: {args['error_description'][0]}"
+        else:
+            http_status = http.client.OK
+            emoji = random.choice(["🎉", "👍", "👍🏿", "🥳", "🎈"])
+            http_body = f"""<html>
+            <h1 style="font-size: large">{emoji}</h1>
+            <p>Congratulations! Your authentication succeeded.</p>"""
+            auth_code = args["code"]
+            self.parent.response = self.parent.get_access_token(auth_code)
+            if self.parent.response.status_code >= http.client.BAD_REQUEST:
+                http_status = self.parent.response.status_code
+                http_body = self.parent.response.text
+        self.send_response(http_status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+
+        self.end_headers()
+        self.wfile.write(http_body.encode("utf-8"))
+        if self.parent.response is None:
+            response = requests.Response()
+            response.status_code = http_status
+            response._content = http_body
+            self.parent.response = response
+
+        #  https://docs.python.org/3/library/socketserver.html#socketserver.BaseServer.shutdown
+        # shutdown() must be called while serve_forever() is running in a different thread otherwise it will deadlock.
+        threading.Thread(target=self.server.shutdown).start()

--- a/cumulusci/oauth/client_info.py
+++ b/cumulusci/oauth/client_info.py
@@ -1,11 +1,6 @@
-import http
 from pydantic import BaseModel
 from pydantic import AnyUrl
 from typing import Optional
-from urllib.parse import quote
-
-from cumulusci.core.exceptions import CumulusCIUsageError
-from cumulusci.oauth.exceptions import OAuthError
 
 
 class OAuthClientInfo(BaseModel):
@@ -15,50 +10,8 @@ class OAuthClientInfo(BaseModel):
     client_secret: Optional[str]
     auth_uri: AnyUrl
     token_uri: AnyUrl
+    revoke_uri: AnyUrl
     callback_url: AnyUrl = "http://localhost:8080/callback"
     scope: str
+    prompt: Optional[str]  # required for SF
     state: Optional[str]
-
-    def get_auth_uri(self):
-        """Returns the auth_url _plus_ all expected url parameters"""
-        return self.auth_uri
-
-    def get_token_uri(self):
-        return self.token_uri
-
-    def validate_response(self, response):
-        """Subclasses can implement custom response validation"""
-        if not response:
-            raise CumulusCIUsageError("Authentication timed out or otherwise failed.")
-        elif response.status_code == http.client.OK:
-            return
-        raise OAuthError(
-            f"OAuth failed\nstatus_code: {response.status_code}\ncontent: {response.content}"
-        )
-
-
-class SalesforceOAuthClientInfo(OAuthClientInfo):
-    """Information about a SalesforceOAuth client."""
-
-    is_sandbox: bool
-    prompt: str = "login"
-    scope: str = "web full refresh_token"
-    auth_uri: str = "https://{}.salesforce.com/services/oauth2/authorize"
-    token_uri: str = "https://{}.salesforce.com/services/oauth2/token"
-
-    def get_auth_uri(self):
-        """Returns the auth_url plus all expected url parameters"""
-        url = self.auth_uri.format("test" if self.is_sandbox else "login")
-        url += "?response_type=code"
-        url += f"&client_id={self.client_id}"
-        url += f"&redirect_uri={self.callback_url}"
-        url += f"&scope={quote(self.scope)}"
-        url += f"&prompt={quote(self.prompt)}"
-        return url
-
-    def get_token_uri(self):
-        return self.token_uri.format("test" if self.is_sandbox else "login")
-
-
-class MarketingCloudOAuthConfig(OAuthClientInfo):
-    pass

--- a/cumulusci/oauth/client_info.py
+++ b/cumulusci/oauth/client_info.py
@@ -1,0 +1,64 @@
+import http
+from pydantic import BaseModel
+from pydantic import AnyUrl
+from typing import Optional
+from urllib.parse import quote
+
+from cumulusci.core.exceptions import CumulusCIUsageError
+from cumulusci.oauth.exceptions import OAuthError
+
+
+class OAuthClientInfo(BaseModel):
+    """Holds info for an OAuth client"""
+
+    client_id: str
+    client_secret: Optional[str]
+    auth_uri: AnyUrl
+    token_uri: AnyUrl
+    callback_url: AnyUrl = "http://localhost:8080/callback"
+    scope: str
+    state: Optional[str]
+
+    def get_auth_uri(self):
+        """Returns the auth_url _plus_ all expected url parameters"""
+        return self.auth_uri
+
+    def get_token_uri(self):
+        return self.token_uri
+
+    def validate_response(self, response):
+        """Subclasses can implement custom response validation"""
+        if not response:
+            raise CumulusCIUsageError("Authentication timed out or otherwise failed.")
+        elif response.status_code == http.client.OK:
+            return
+        raise OAuthError(
+            f"OAuth failed\nstatus_code: {response.status_code}\ncontent: {response.content}"
+        )
+
+
+class SalesforceOAuthClientInfo(OAuthClientInfo):
+    """Information about a SalesforceOAuth client."""
+
+    is_sandbox: bool
+    prompt: str = "login"
+    scope: str = "web full refresh_token"
+    auth_uri: str = "https://{}.salesforce.com/services/oauth2/authorize"
+    token_uri: str = "https://{}.salesforce.com/services/oauth2/token"
+
+    def get_auth_uri(self):
+        """Returns the auth_url plus all expected url parameters"""
+        url = self.auth_uri.format("test" if self.is_sandbox else "login")
+        url += "?response_type=code"
+        url += f"&client_id={self.client_id}"
+        url += f"&redirect_uri={self.callback_url}"
+        url += f"&scope={quote(self.scope)}"
+        url += f"&prompt={quote(self.prompt)}"
+        return url
+
+    def get_token_uri(self):
+        return self.token_uri.format("test" if self.is_sandbox else "login")
+
+
+class MarketingCloudOAuthConfig(OAuthClientInfo):
+    pass

--- a/cumulusci/oauth/exceptions.py
+++ b/cumulusci/oauth/exceptions.py
@@ -1,5 +1,9 @@
 from cumulusci.core.exceptions import CumulusCIException
 
 
+class OAuthError(CumulusCIException):
+    pass
+
+
 class SalesforceOAuthError(CumulusCIException):
     pass


### PR DESCRIPTION
# Changes
* CumulusCI has new service types: `oauth-client` & `marketing-cloud`
* The `marketing-cloud` service allows users to connect to a marketing cloud tenant via OAuth so that future tasks that work with Marketing cloud can make API calls on the user's behalf.
* The `oauth-client` service allows users to input information for an individual oauth-client if you don't want to use default client. This currently applies only to the `marketing-cloud` service. To setup a marketing cloud service with a custom oauth-client use: `cci service connect marketing-cloud <name-of-service> --oauth_client <name-of-oauth-client>`.

## Dev Notes
* There is a new `BaseMarketingCloudTask` that has an `access_token` property. When accessed,  this property executes the Refresh Token grant type to acquire a fresh access token for the task.

## Questions Still Outstanding
- [ ] What are we using for the "default" MC client credentials?
