### PR TITLE
Misc adjustments for oauth2 services

### DIFF
--- a/cumulusci/cli/org.py
+++ b/cumulusci/cli/org.py
@@ -11,7 +11,7 @@ from cumulusci.cli.ui import CliTable, CROSSMARK, SimpleSalesforceUIHelpers
 from cumulusci.core.config import OrgConfig, ScratchOrgConfig
 from cumulusci.core.exceptions import OrgNotFound
 from cumulusci.core.utils import cleanup_org_cache_dirs
-from cumulusci.oauth.client import OAuth2Client
+from cumulusci.oauth.client import OAuth2Client, OAuth2ClientConfig
 from cumulusci.salesforce_api.utils import get_simple_salesforce_connection
 from cumulusci.utils import parse_api_datetime
 from .runtime import pass_runtime
@@ -146,16 +146,16 @@ def org_connect(runtime, org_name, sandbox, login_url, default, global_org):
     auth_uri = base_uri + "/services/oauth2/authorize"
     token_uri = base_uri + "/services/oauth2/token"
 
-    sf_client_config = {
-        "client_id": connected_app.client_id,
-        "client_secret": connected_app.client_secret,
-        "auth_uri": auth_uri,
-        "token_uri": token_uri,
-        "scope": "web full refresh_token",
-        "prompt": "login",
-    }
+    sf_client_config = OAuth2ClientConfig(
+        client_id=connected_app.client_id,
+        client_secret=connected_app.client_secret,
+        redirect_uri=connected_app.callback_url,
+        auth_uri=auth_uri,
+        token_uri=token_uri,
+        scope="web full refresh_token",
+    )
     sf_client = OAuth2Client(sf_client_config)
-    oauth_dict = sf_client.auth_code_flow()
+    oauth_dict = sf_client.auth_code_flow(prompt="login")
 
     global_org = global_org or runtime.project_config is None
     org_config = OrgConfig(oauth_dict, org_name, runtime.keychain, global_org)

--- a/cumulusci/cli/tests/test_org.py
+++ b/cumulusci/cli/tests/test_org.py
@@ -104,6 +104,7 @@ class TestOrgCommands:
         runtime.keychain.get_service.return_value = mock.Mock(
             client_id="asdfasdf",
             client_secret="asdfasdf",
+            callback_url="http://localhost:8080/callback",
         )
         responses.add(
             method="GET",
@@ -154,6 +155,7 @@ class TestOrgCommands:
         runtime.keychain.get_service.return_value = mock.Mock(
             client_id="asdfasdf",
             client_secret="asdfasdf",
+            callback_url="http://localhost:8080/callback",
         )
         responses.add(
             method="GET",

--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -5,7 +5,7 @@ import requests
 from contextlib import contextmanager
 from collections import defaultdict
 from collections import namedtuple
-from cumulusci.oauth.client import OAuth2Client
+from cumulusci.oauth.client import OAuth2Client, OAuth2ClientConfig
 from distutils.version import StrictVersion
 from simple_salesforce import Salesforce
 from simple_salesforce.exceptions import SalesforceError, SalesforceResourceNotFound
@@ -95,13 +95,13 @@ class OrgConfig(BaseConfig):
             client_id = connected_app.client_id
             client_secret = connected_app.client_secret
 
-        sf_oauth_config = {
-            "client_id": client_id,
-            "client_secret": client_secret,
-            "auth_uri": f"{self.instance_url}/services/oauth2/authorize",
-            "token_uri": f"{self.instance_url}/services/oauth2/token",
-            "scope": "web full refresh_token",
-        }
+        sf_oauth_config = OAuth2ClientConfig(
+            client_id=client_id,
+            client_secret=client_secret,
+            auth_uri=f"{self.instance_url}/services/oauth2/authorize",
+            token_uri=f"{self.instance_url}/services/oauth2/token",
+            scope="web full refresh_token",
+        )
         sf_oauth = self.OAuth2Client(sf_oauth_config)
         return sf_oauth.refresh_token(self.refresh_token)
 

--- a/cumulusci/core/config/__init__.py
+++ b/cumulusci/core/config/__init__.py
@@ -24,9 +24,8 @@ from cumulusci.core.config.OrgConfig import OrgConfig
 
 
 class ServiceConfig(BaseConfig):
-    def __init__(self, config, name, keychain):
-        """Services need access to a keychain and the alias of their service."""
-        self.name = name
+    def __init__(self, config, name=None, keychain=None):
+        """Services may need access to a keychain and the alias of their service."""
         super().__init__(config, keychain)
 
 

--- a/cumulusci/core/config/oauth2_service_config.py
+++ b/cumulusci/core/config/oauth2_service_config.py
@@ -1,15 +1,15 @@
 from abc import ABC
-from abc import abstractmethod
+from abc import abstractclassmethod
 from typing import Dict
 
 from cumulusci.core.config import ServiceConfig
 
 
 class OAuth2ServiceConfig(ServiceConfig, ABC):
-    """Base class for services that require and OAuth2 Client
+    """Base class for services that require an OAuth2 Client
     for establishing a connection."""
 
-    @abstractmethod
+    @abstractclassmethod
     def connect(self) -> Dict:
         """This method is called when the service is first connected
         via `cci service connect`. This method should perform the necessary

--- a/cumulusci/oauth/client.py
+++ b/cumulusci/oauth/client.py
@@ -1,3 +1,4 @@
+from typing import Dict, Optional, Union
 import http.client
 import logging
 import os
@@ -20,7 +21,7 @@ from datetime import timedelta
 from http.server import BaseHTTPRequestHandler
 from http.server import HTTPServer
 from pathlib import Path
-from typing import Dict
+from pydantic import BaseModel
 from urllib.parse import parse_qs
 from urllib.parse import quote
 from urllib.parse import urlparse
@@ -75,24 +76,34 @@ def create_key_and_self_signed_cert():
         )
 
 
+class OAuth2ClientConfig(BaseModel):
+    client_id: str
+    client_secret: Optional[str] = None
+    auth_uri: str
+    token_uri: str
+    redirect_uri: Optional[str] = None
+    scope: Optional[str] = None
+
+
 class OAuth2Client(object):
     """Represents an OAuth2 client with the ability to
     execute different grant types.
-    Currenntly supported grant types include:
+    Currently supported grant types include:
         (1) Authorization Code - via auth_code_flow()
-
-    To instantiate, just provide an instance or subclass
-    of OAuth2ClientInfo to the contructor.
+        (2) Refresh Token - via refresh_token()
     """
 
-    def __init__(self, client_config: Dict):
-        # the config for and oauth2_client service
+    response: Optional[requests.Response]
+
+    def __init__(self, client_config: Union[OAuth2ClientConfig, Dict]):
+        if isinstance(client_config, dict):
+            client_config = OAuth2ClientConfig(**client_config)
         self.client_config = client_config
         self.response = None
         self.httpd = None
         self.httpd_timeout = 300
 
-    def auth_code_flow(self) -> None:
+    def auth_code_flow(self, **kwargs) -> dict:
         """Completes the flow for the OAuth2 auth code grant type.
         For more info on the auth code flow see:
         https://www.oauth.com/oauth2-servers/server-side-apps/authorization-code/
@@ -101,21 +112,22 @@ class OAuth2Client(object):
         @returns a dict of values returned from the auth server.
         It will be similar in shape to:
         {
-            "access_token":"<acces_token>",
+            "access_token":"<access_token>",
             "token_type":"bearer",
             "expires_in":3600,
             "refresh_token":"<refresh_token>",
             "scope":"create"
         }
         """
-        auth_uri_with_params = self._get_auth_uri()
+        assert self.client_config.redirect_uri
+        auth_uri_with_params = self._get_auth_uri(**kwargs)
         # Open a browser and direct the user to login
         webbrowser.open(auth_uri_with_params, new=1)
         # Open up an http daemon to listen for the
         # callback from the auth server
         self.httpd = self._create_httpd()
         logger.info(
-            f"Spawning HTTP server at {self.client_config['callback_url']}"
+            f"Spawning HTTP server at {self.client_config.redirect_uri}"
             f" with timeout of {self.httpd.timeout} seconds.\n"
             "If you are unable to log in to Salesforce you can"
             " press <Ctrl+C> to kill the server and return to the command line."
@@ -130,16 +142,16 @@ class OAuth2Client(object):
         # 1. Get a callback from Salesforce.
         # 2. Timeout
 
+        # for some reason this is required for Safari (checked Feb 2021)
+        # https://github.com/SFDO-Tooling/CumulusCI/pull/2373
+        old_timeout = socket.getdefaulttimeout()
         try:
-            # for some reason this is required for Safari (checked Feb 2021)
-            # https://github.com/SFDO-Tooling/CumulusCI/pull/2373
-            old_timeout = socket.getdefaulttimeout()
             socket.setdefaulttimeout(3)
             self.httpd.serve_forever()
         finally:
             socket.setdefaulttimeout(old_timeout)
 
-        if self.client_config["callback_url"].startswith("https:"):
+        if self.client_config.redirect_uri.startswith("https:"):
             Path("key.pem").unlink()
             Path("localhost.pem").unlink()
 
@@ -148,21 +160,21 @@ class OAuth2Client(object):
         self.validate_response(self.response)
         return safe_json_from_response(self.response)
 
-    def _get_auth_uri(self):
-        url = self.client_config["auth_uri"]
+    def _get_auth_uri(self, **kwargs: Dict[str, str]):
+        url = self.client_config.auth_uri
         url += "?response_type=code"
-        url += f"&client_id={self.client_config['client_id']}"
-        url += f"&redirect_uri={self.client_config['callback_url']}"
-        if "scope" in self.client_config:
-            url += f"&scope={quote(self.client_config['scope'])}"
-        if "prompt" in self.client_config:
-            url += f"&prompt={quote(self.client_config['prompt'])}"
+        url += f"&client_id={self.client_config.client_id}"
+        url += f"&redirect_uri={self.client_config.redirect_uri}"
+        if self.client_config.scope:
+            url += f"&scope={quote(self.client_config.scope)}"
+        for k, v in kwargs:
+            url += f"&{k}={quote(v)}"
         return url
 
     def _create_httpd(self):
         """Create an http daemon process to listen
         for the callback from the auth server"""
-        url_parts = urlparse(self.client_config["callback_url"])
+        url_parts = urlparse(self.client_config.redirect_uri)
         use_https = url_parts.scheme == "https"
         server_address = (url_parts.hostname, url_parts.port)
         OAuthCallbackHandler.parent = self
@@ -185,25 +197,25 @@ class OAuth2Client(object):
     def auth_code_grant(self, auth_code):
         """Exchange an auth code for an access token"""
         data = {
-            "client_id": self.client_config["client_id"],
-            "client_secret": self.client_config["client_secret"],
+            "client_id": self.client_config.client_id,
+            "client_secret": self.client_config.client_secret,
             "grant_type": "authorization_code",
-            "redirect_uri": self.client_config["callback_url"],
+            "redirect_uri": self.client_config.redirect_uri,
             "code": auth_code,
         }
         return requests.post(
-            self.client_config["token_uri"], headers=HTTP_HEADERS, data=data
+            self.client_config.token_uri, headers=HTTP_HEADERS, data=data
         )
 
     def refresh_token(self, refresh_token):
         data = {
-            "client_id": self.client_config["client_id"],
-            "client_secret": self.client_config["client_secret"],
+            "client_id": self.client_config.client_id,
+            "client_secret": self.client_config.client_secret,
             "grant_type": "refresh_token",
             "refresh_token": refresh_token,
         }
         response = requests.post(
-            self.client_config["token_uri"], headers=HTTP_HEADERS, data=data
+            self.client_config.token_uri, headers=HTTP_HEADERS, data=data
         )
         self.validate_response(response)
         return safe_json_from_response(response)
@@ -249,7 +261,7 @@ class HTTPDTimeout(threading.Thread):
 
 
 class OAuthCallbackHandler(BaseHTTPRequestHandler):
-    parent = None
+    parent: Optional[OAuth2Client] = None
 
     def do_GET(self):
         args = parse_qs(urlparse(self.path).query, keep_blank_values=True)


### PR DESCRIPTION
- I was sad to lose the oauth2 client pydantic model entirely, because of the type checking, so I re-added it but made it so that OAuth2Client accepts either the pydantic model or a dict.
- Renamed callback_url to redirect_uri to better match what it's called in the OAuth2 RFCs.
- Pass `prompt` as an option to the auth_code_flow method, rather than a property of the oauth2 client
- Keep `name` as an optional parameter for the base ServiceConfig. Making it required was breaking too many tests.
- OAuth2ServiceConfig.connect is a classmethod
- Renamed OAuth2ServiceConfig._save to `save` to match OrgConfig.
- A few typo and type hint fixes.

# Critical Changes

# Changes

# Issues Closed
