### PR TITLE
Fix regression in freezing DeployBundles task

### DIFF
--- a/cumulusci/tasks/metadeploy.py
+++ b/cumulusci/tasks/metadeploy.py
@@ -107,6 +107,7 @@ class Publish(BaseMetaDeployTask):
         # Check out the specified tag
         repo_owner = self.project_config.repo_owner
         repo_name = self.project_config.repo_name
+        repo_url = f"https://github.com/{repo_owner}/{repo_name}"
         gh = self.project_config.get_github_api()
         repo = gh.repository(repo_owner, repo_name)
         if self.tag:
@@ -126,7 +127,7 @@ class Publish(BaseMetaDeployTask):
                     "root": project_dir,
                     "owner": repo_owner,
                     "name": repo_name,
-                    "url": self.project_config.repo_url,
+                    "url": repo_url,
                     "branch": self.tag or self.commit,
                     "commit": self.commit,
                 },


### PR DESCRIPTION
Frozen DeployBundles steps were ending up with `github: None`. That was happening here because we were looking up project_config.repo_url on a project_config with no repo_root set after switching to a different working directory. I'm switching to constructing the URL from the repo_owner and repo_name so that we also avoid freezing an ssh-based github URL.

# Critical Changes

# Changes

# Issues Closed
- Fixed a regression in freezing the deploy_pre/deploy_post tasks for MetaDeploy install plans.