### PR TITLE
Remove </input> in libdoc template; added doctype and charset

### DIFF
--- a/cumulusci/tasks/robotframework/template.html
+++ b/cumulusci/tasks/robotframework/template.html
@@ -1,5 +1,7 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
+    <meta charset="utf-8" />
     <script
       src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
       integrity="sha256-3edrmyuQ0w65f8gfBsqowzjJe2iM6n0nKciPUp8y+7E="
@@ -34,7 +36,7 @@
       <!-- this is the header for the documentation as a whole -->
       <div class="header">
         <h1 class="title">{{title}}</h1>
-        <div class="filter right">filter: <input id="filter" type="filter"></input></div>
+        <div class="filter right">filter: <input id="filter" type="filter"/></div>
       </div>
 
       {% for kwfile in libraries %}


### PR DESCRIPTION
One of our teams was running `npx prettier` on the generated HTML and it flagged the closing </input> tag as a violation.
In fixing the </input> I also decided to add the doctype and lang metadata.


# Critical Changes

# Changes
* improved the output of the robot_libdoc task by removing an unnecessary closing </input> tag, added a doctype, and specified the  language and charset.

# Issues Closed
