### PR TITLE
Fix documentation for skipping unpackaged metadata

### DIFF
--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -337,7 +337,8 @@ If the referenced repository has unpackaged metadata under ``unpackaged/pre`` or
     project:
         dependencies:
             - github: https://github.com/SalesforceFoundation/EDA
-              skip: unpackaged/post/course_connection_record_types
+              skip: 
+                - unpackaged/post/course_connection_record_types
 
 
 


### PR DESCRIPTION
# Critical Changes

# Changes
Fix documentation for skipping unpackaged metadata. CumulusCI expects a list, documentation shows a single string value

# Issues Closed
