### PR TITLE
fix support for dependency skip as a string

### DIFF
--- a/cumulusci/core/dependencies/dependencies.py
+++ b/cumulusci/core/dependencies/dependencies.py
@@ -221,6 +221,12 @@ class GitHubDynamicDependency(BaseGitHubDependency):
     def is_unmanaged(self):
         return self.unmanaged
 
+    @pydantic.validator("skip", pre=True)
+    def listify_skip(cls, v):
+        if v and not isinstance(v, list):
+            v = [v]
+        return v
+
     @pydantic.root_validator
     def check_unmanaged_values(cls, values):
         if not values.get("unmanaged") and (

--- a/cumulusci/core/dependencies/tests/test_dependencies.py
+++ b/cumulusci/core/dependencies/tests/test_dependencies.py
@@ -259,7 +259,7 @@ class TestGitHubDynamicDependency:
     def test_flatten__skip(self, project_config):
         gh = GitHubDynamicDependency(
             github="https://github.com/SFDO-Tooling/RootRepo",
-            skip=["unpackaged/pre/first"],
+            skip="unpackaged/pre/first",
         )
         gh.ref = "aaaaa"
         gh.managed_dependency = PackageNamespaceVersionDependency(


### PR DESCRIPTION
#2628 made me realize that we regressed in handling the `skip` key for dependencies specified as a single string rather than a list. The restores the previous support.

# Critical Changes

# Changes

# Issues Closed
- Fixed a regression where the `skip` key for a dependency could no longer be specified as a single string instead of a list.