### PR TITLE
Fix `--sandbox` flag in `cci org connect`

### DIFF
--- a/cumulusci/cli/org.py
+++ b/cumulusci/cli/org.py
@@ -118,7 +118,6 @@ def org_browser(runtime, org_name, path, url_only):
 @click.option(
     "--login-url",
     help="If set, login to this hostname.",
-    default="https://login.salesforce.com",
 )
 @click.option(
     "--default",
@@ -134,7 +133,7 @@ def org_browser(runtime, org_name, path, url_only):
 def org_connect(runtime, org_name, sandbox, login_url, default, global_org):
     runtime.check_org_overwrite(org_name)
 
-    if "lightning.force.com" in login_url:
+    if login_url and "lightning.force.com" in login_url:
         raise click.UsageError(
             "Connecting an org with a lightning.force.com URL does not work. "
             "Use the my.salesforce.com version instead"

--- a/cumulusci/cli/tests/test_org.py
+++ b/cumulusci/cli/tests/test_org.py
@@ -132,7 +132,7 @@ class TestOrgCommands:
             runtime=runtime,
             org_name="test",
             sandbox=False,
-            login_url="https://login.salesforce.com",
+            login_url=None,
             default=True,
             global_org=False,
         )
@@ -184,7 +184,7 @@ class TestOrgCommands:
             runtime=runtime,
             org_name="test",
             sandbox=True,
-            login_url="https://test.salesforce.com",
+            login_url=None,
             default=True,
             global_org=False,
         )
@@ -205,7 +205,7 @@ class TestOrgCommands:
                 runtime=runtime,
                 org_name="test",
                 sandbox=True,
-                login_url="https://login.salesforce.com",
+                login_url=None,
                 default=True,
                 global_org=False,
             )

--- a/cumulusci/cli/tests/test_org.py
+++ b/cumulusci/cli/tests/test_org.py
@@ -10,10 +10,12 @@ from datetime import timedelta
 from pathlib import Path
 from unittest import mock
 
-from cumulusci.core.config import OrgConfig, ScratchOrgConfig
+from cumulusci.core.config import OrgConfig
+from cumulusci.core.config import ScratchOrgConfig
 from cumulusci.core.exceptions import OrgNotFound
 from cumulusci.core.exceptions import ServiceNotConfigured
 from cumulusci.core.exceptions import ScratchOrgException
+from cumulusci.oauth.client import OAuth2ClientConfig
 
 from .. import org
 from .utils import run_click_command
@@ -221,6 +223,61 @@ class TestOrgCommands:
                 default=True,
                 global_org=False,
             )
+
+    @mock.patch("cumulusci.cli.org.OAuth2Client")
+    @responses.activate
+    def test_org_connect__sandbox_option_gives_correct_uris(self, oauth2client):
+        client_instance = mock.Mock()
+        client_instance.auth_code_flow.return_value = {
+            "instance_url": "https://instance",
+            "access_token": "BOGUS",
+            "id": "OODxxxxxxxxxxxx/user",
+        }
+        oauth2client.return_value = client_instance
+        runtime = mock.Mock()
+        runtime.keychain.get_service.return_value = mock.Mock(
+            client_id="asdfasdf",
+            client_secret="asdfasdf",
+            callback_url="http://localhost:8080/callback",
+        )
+        responses.add(
+            method="GET",
+            url="https://instance/services/oauth2/userinfo",
+            body=b"{}",
+            status=200,
+        )
+        responses.add(
+            method="GET",
+            url="https://instance/services/data/v45.0/sobjects/Organization/OODxxxxxxxxxxxx",
+            json={
+                "TrialExpirationDate": None,
+                "OrganizationType": "Developer Edition",
+                "IsSandbox": False,
+                "InstanceName": "CS420",
+                "NamespacePrefix": None,
+            },
+            status=200,
+        )
+        responses.add("GET", "https://instance/services/data", json=[{"version": 45.0}])
+        run_click_command(
+            org.org_connect,
+            runtime=runtime,
+            org_name="test",
+            sandbox=True,  # Test we get correct auth uri when this is set
+            login_url=None,
+            default=True,
+            global_org=False,
+        )
+
+        client_config = OAuth2ClientConfig(
+            client_id="asdfasdf",
+            client_secret="asdfasdf",
+            redirect_uri="http://localhost:8080/callback",
+            auth_uri="https://test.salesforce.com/services/oauth2/authorize",
+            token_uri="https://test.salesforce.com/services/oauth2/token",
+            scope="web full refresh_token",
+        )
+        oauth2client.assert_called_once_with(client_config)
 
     def test_org_default(self):
         runtime = mock.Mock()


### PR DESCRIPTION
# Issues Closed
* Fixed a bug in `cci org connect` where the `--sandbox` flag was directing users to login at `login.salesforce.com` instead of `test.salesforce.com`.

## Dev Notes
I removed the default value on the `--login-url` option so that it will default to None. This will ensure that the auth and token uris are set to the proper values.