### PR TITLE
fix 2gp beta tags

### DIFF
--- a/cumulusci/core/config/project_config.py
+++ b/cumulusci/core/config/project_config.py
@@ -451,10 +451,12 @@ class BaseProjectConfig(BaseTaskFlowConfig):
             config = json.load(f)
         return config
 
-    def get_tag_for_version(self, version):
+    def get_tag_for_version(self, version, is_beta=False):
         if "(Beta" in version:
             tag_version = version.replace(" (", "-").replace(")", "").replace(" ", "_")
             tag_name = self.project__git__prefix_beta + tag_version
+        elif is_beta:
+            tag_name = self.project__git__prefix_beta + version
         else:
             tag_name = self.project__git__prefix_release + version
         return tag_name

--- a/cumulusci/core/config/tests/test_config.py
+++ b/cumulusci/core/config/tests/test_config.py
@@ -546,11 +546,17 @@ class TestBaseProjectConfig(unittest.TestCase):
         )
         self.assertEqual("release/1.0", config.get_tag_for_version("1.0"))
 
-    def test_get_tag_for_version_beta(self):
+    def test_get_tag_for_version__1gp_beta(self):
         config = BaseProjectConfig(
             UniversalConfig(), {"project": {"git": {"prefix_beta": "beta/"}}}
         )
         self.assertEqual("beta/1.0-Beta_1", config.get_tag_for_version("1.0 (Beta 1)"))
+
+    def test_get_tag_for_version__explicit_beta(self):
+        config = BaseProjectConfig(
+            UniversalConfig(), {"project": {"git": {"prefix_beta": "beta/"}}}
+        )
+        self.assertEqual("beta/1.0", config.get_tag_for_version("1.0", is_beta=True))
 
     def test_get_version_for_tag(self):
         config = BaseProjectConfig(

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -1049,6 +1049,7 @@ flows:
           version_id: ^^create_package_version.subscriber_package_version_id
           dependencies: ^^create_package_version.dependencies
           package_type: 2GP
+          is_beta: True
       3:
         task: github_release_notes
         ignore_failure: True # Attempt to generate release notes but don't fail build
@@ -1076,6 +1077,7 @@ flows:
           version_id: ^^upload_beta.version_id
           dependencies: ^^upload_beta.dependencies
           package_type: 1GP
+          is_beta: True
       3:
         task: github_release_notes
         ignore_failure: True # Attempt to generate release notes but don't fail build
@@ -1101,6 +1103,7 @@ flows:
           version_id: ^^upload_production.version_id
           dependencies: ^^upload_production.dependencies
           package_type: 1GP
+          is_beta: False
       3:
         task: github_release_notes
         ignore_failure: True # Attempt to generate release notes but don't fail build
@@ -1122,6 +1125,7 @@ flows:
           version_id: ^^promote_package_version.version_id
           dependencies: ^^promote_package_version.dependencies
           package_type: 2GP
+          is_beta: False
       3:
         task: github_release_notes
         ignore_failure: True # Attempt to generate release notes but don't fail build

--- a/cumulusci/tasks/github/release.py
+++ b/cumulusci/tasks/github/release.py
@@ -39,6 +39,10 @@ class CreateRelease(BaseGithubTask):
             "description": "The package type of the project (either 1GP or 2GP)",
             "required": True,
         },
+        "is_beta": {
+            "description": "Indicates if the release is for a beta version. Defaults to True.",
+            "required": False,
+        },
     }
 
     def _init_options(self, kwargs):
@@ -56,7 +60,8 @@ class CreateRelease(BaseGithubTask):
         repo = self.get_repo()
 
         version = self.options["version"]
-        tag_name = self.project_config.get_tag_for_version(version)
+        is_beta = self.options.get("is_beta", True)
+        tag_name = self.project_config.get_tag_for_version(version, is_beta=is_beta)
 
         # Make sure release doesn't already exist
         try:


### PR DESCRIPTION
# Changes
* The `github_release` task now has an `is_beta` option which indicates whether the release is associated with a beta package version.  

# Issues Closed
* Fixed a bug where beta tags created for 2GP packages were not receiving the proper tag prefix.

Should I just make the option required outright? As is, the option is required for a production release (which I don't think is necessarily bad as a precaution). Would the option be better if it were named `is_production` instead?