### PR TITLE
Delete org when error occurs running flow

### DIFF
--- a/cumulusci/cli/flow.py
+++ b/cumulusci/cli/flow.py
@@ -158,20 +158,15 @@ def flow_run(runtime, flow_name, org, delete_org, debug, o, skip, no_prompt):
         coordinator.run(org_config)
         duration = datetime.now() - start_time
         click.echo(f"Ran {flow_name} in {format_duration(duration)}")
-    except Exception as e:
-        click.echo(
-            click.style(f"An error occurred while running the flow: {e}", fg="red"),
-            err=True,
-        )
-    else:
+    finally:
         runtime.alert(f"Flow Complete: {flow_name}")
 
-    # Delete the scratch org if --delete-org was set
-    if delete_org:
-        try:
-            org_config.delete_org()
-        except Exception as e:
-            click.echo(
-                "Scratch org deletion failed.  Ignoring the error below to complete the flow:"
-            )
-            click.echo(str(e))
+        # Delete the scratch org if --delete-org was set
+        if delete_org:
+            try:
+                org_config.delete_org()
+            except Exception as e:
+                click.echo(
+                    "Scratch org deletion failed.  Ignoring the error below to complete the flow:"
+                )
+                click.echo(str(e))

--- a/cumulusci/cli/flow.py
+++ b/cumulusci/cli/flow.py
@@ -159,8 +159,6 @@ def flow_run(runtime, flow_name, org, delete_org, debug, o, skip, no_prompt):
         duration = datetime.now() - start_time
         click.echo(f"Ran {flow_name} in {format_duration(duration)}")
     finally:
-        runtime.alert(f"Flow Complete: {flow_name}")
-
         # Delete the scratch org if --delete-org was set
         if delete_org:
             try:
@@ -170,3 +168,5 @@ def flow_run(runtime, flow_name, org, delete_org, debug, o, skip, no_prompt):
                     "Scratch org deletion failed.  Ignoring the error below to complete the flow:"
                 )
                 click.echo(str(e))
+
+    runtime.alert(f"Flow Complete: {flow_name}")

--- a/cumulusci/cli/flow.py
+++ b/cumulusci/cli/flow.py
@@ -158,8 +158,12 @@ def flow_run(runtime, flow_name, org, delete_org, debug, o, skip, no_prompt):
         coordinator.run(org_config)
         duration = datetime.now() - start_time
         click.echo(f"Ran {flow_name} in {format_duration(duration)}")
-
-    finally:
+    except Exception as e:
+        click.echo(
+            click.style(f"An error occurred while running the flow: {e}", fg="red"),
+            err=True,
+        )
+    else:
         runtime.alert(f"Flow Complete: {flow_name}")
 
     # Delete the scratch org if --delete-org was set

--- a/cumulusci/cli/flow.py
+++ b/cumulusci/cli/flow.py
@@ -158,6 +158,9 @@ def flow_run(runtime, flow_name, org, delete_org, debug, o, skip, no_prompt):
         coordinator.run(org_config)
         duration = datetime.now() - start_time
         click.echo(f"Ran {flow_name} in {format_duration(duration)}")
+    except Exception:
+        runtime.alert(f"Flow error: {flow_name}")
+        raise
     finally:
         # Delete the scratch org if --delete-org was set
         if delete_org:

--- a/cumulusci/cli/tests/test_flow.py
+++ b/cumulusci/cli/tests/test_flow.py
@@ -166,17 +166,18 @@ def test_flow_run__delete_org_when_error_occurs_in_flow():
     coordinator.run.side_effect = CumulusCIException
     runtime.get_flow = mock.Mock(return_value=coordinator)
 
-    run_click_command(
-        flow.flow_run,
-        runtime=runtime,
-        flow_name="test",
-        org="test",
-        delete_org=True,
-        debug=False,
-        o=[("test_task__color", "blue")],
-        skip=(),
-        no_prompt=True,
-    )
+    with pytest.raises(CumulusCIException):
+        run_click_command(
+            flow.flow_run,
+            runtime=runtime,
+            flow_name="test",
+            org="test",
+            delete_org=True,
+            debug=False,
+            o=[("test_task__color", "blue")],
+            skip=(),
+            no_prompt=True,
+        )
 
     runtime.get_flow.assert_called_once_with(
         "test", options={"test_task": {"color": "blue"}}

--- a/cumulusci/cli/tests/test_flow.py
+++ b/cumulusci/cli/tests/test_flow.py
@@ -5,7 +5,7 @@ import pytest
 
 from cumulusci.cli.runtime import CliRuntime
 from cumulusci.core.config import FlowConfig
-from cumulusci.core.exceptions import FlowNotFoundError
+from cumulusci.core.exceptions import CumulusCIException, FlowNotFoundError
 from cumulusci.core.flowrunner import FlowCoordinator
 
 from .. import flow
@@ -147,7 +147,44 @@ def test_flow_run():
     org_config.delete_org.assert_called_once()
 
 
-def test_flow_run_o_error():
+def test_flow_run__delete_org_when_error_occurs_in_flow():
+    org_config = mock.Mock(scratch=True, config={})
+    runtime = CliRuntime(
+        config={
+            "flows": {"test": {"steps": {1: {"task": "test_task"}}}},
+            "tasks": {
+                "test_task": {
+                    "class_path": "cumulusci.cli.tests.test_flow.DummyTask",
+                    "description": "Test Task",
+                }
+            },
+        },
+        load_keychain=False,
+    )
+    runtime.get_org = mock.Mock(return_value=("test", org_config))
+    coordinator = mock.Mock()
+    coordinator.run.side_effect = CumulusCIException
+    runtime.get_flow = mock.Mock(return_value=coordinator)
+
+    run_click_command(
+        flow.flow_run,
+        runtime=runtime,
+        flow_name="test",
+        org="test",
+        delete_org=True,
+        debug=False,
+        o=[("test_task__color", "blue")],
+        skip=(),
+        no_prompt=True,
+    )
+
+    runtime.get_flow.assert_called_once_with(
+        "test", options={"test_task": {"color": "blue"}}
+    )
+    org_config.delete_org.assert_called_once()
+
+
+def test_flow_run__option_error():
     org_config = mock.Mock(scratch=True, config={})
     runtime = CliRuntime(config={"noop": {}}, load_keychain=False)
     runtime.get_org = mock.Mock(return_value=("test", org_config))
@@ -166,7 +203,7 @@ def test_flow_run_o_error():
         )
 
 
-def test_flow_run_delete_non_scratch():
+def test_flow_run__delete_non_scratch():
     org_config = mock.Mock(scratch=False)
     runtime = mock.Mock()
     runtime.get_org.return_value = ("test", org_config)
@@ -186,7 +223,7 @@ def test_flow_run_delete_non_scratch():
 
 
 @mock.patch("click.echo")
-def test_flow_run_org_delete_error(echo):
+def test_flow_run__org_delete_error(echo):
     org_config = mock.Mock(scratch=True, config={})
     org_config.delete_org.side_effect = Exception
     org_config.save_if_changed.return_value.__enter__ = lambda *args: ...


### PR DESCRIPTION
# Issues Closed
* CumulusCI will now remove orgs when the `--delete-org` option is passed to `cci flow run`, even if an error occurs while running the flow.

## Dev Notes
I may be missing something here so let me know if I'm way off base. Not sure if there's a good reason we had just a `try/finally` block without an `except` clause in there. It looks like we would always display the "flow complete" message even when a flow encountered an error.