### PR TITLE
Fix: `release_2gp_beta` flow

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -1050,6 +1050,7 @@ flows:
           version_id: ^^create_package_version.subscriber_package_version_id
           dependencies: ^^create_package_version.dependencies
           package_type: 2GP
+          tag_prefix: $project_config.project__git__prefix_beta
       3:
         task: github_release_notes
         ignore_failure: True # Attempt to generate release notes but don't fail build

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -1042,7 +1042,7 @@ flows:
           ancestor_id: latest_github_release
           version_base: latest_github_release
           version_type: minor
-          tag_prefix: $project_config.project__git__prefix_beta
+          force_upload: True
       2:
         task: github_release
         options:


### PR DESCRIPTION
# Changes
* The `release_2gp_beta` flow now sets the `force_upload` option to `True`. This means that a new package version will be created _even if_ there are no changes to the package contents.

# Issues Closed
* Fixed an issue where the `tag_prefix` option was being used on the wrong task in the `release_2gp_beta` flow.