### PR TITLE
Feature/robot seleniumlibrary 5

### DIFF
--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  CUMULUSCI_ORG_scratch: '{"config_file": "orgs/dev.json", "scratch": true}'
+  CUMULUSCI_ORG_scratch: '{"config_file": "orgs/prerelease.json", "scratch": true}'
   CUMULUSCI_ORG_packaging: ${{ secrets.CUMULUSCI_ORG_packaging }}
   CUMULUSCI_SERVICE_github: ${{ secrets.CUMULUSCI_SERVICE_github }}
   SFDX_CLIENT_ID: ${{ secrets.SFDX_CLIENT_ID }}

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -1523,6 +1523,19 @@ class Salesforce(object):
 
         return elements
 
+    def select_window(self, locator="MAIN", timeout=None):
+        """Alias for SeleniuimLibrary 'Switch Window'
+
+        This keyword was removed from SeleniumLibrary 5.x, but some of our
+        tests still use this keyword. You can continue to use this,
+        but should replace any calls to this keyword with calls to
+        'Switch Window' instead.
+        """
+        self.builtin.log(
+            "'Select Window' is deprecated; use 'Switch Window' instead", "WARN"
+        )
+        self.selenium.switch_window(locator=locator, timeout=timeout)
+
 
 def _duration(start_date: str, end_date: str, record: dict):
     try:

--- a/cumulusci/robotframework/tests/salesforce/browsers.robot
+++ b/cumulusci/robotframework/tests/salesforce/browsers.robot
@@ -120,3 +120,23 @@ Initializing selenium speed via global variable
 
     Open test browser
     Assert keyword status  PASS  SeleniumLibrary.Set Selenium Speed  \${SELENIUM_SPEED}
+
+Select Window calls Switch Window
+    [Documentation]  Verify that 'Select Window' calls 'Switch Window'
+    ...              and also that it logs a deprecation warning
+    [Setup]          Run keywords
+    ...  Open test browser
+    ...  AND  execute javascript  window.open("about:blank", "window1")
+    [Teardown]       Close all browsers
+
+    ${main location}=  get location
+
+    Reset test listener message log
+    Select Window       window1
+    Assert robot log    'Select Window' is deprecated; use 'Switch Window' instead  WARN
+    location should be  about:blank
+
+    Reset test listener message log
+    Select Window       # defaults to the original window
+    Assert robot log    'Select Window' is deprecated; use 'Switch Window' instead  WARN
+    location should be  ${main location}

--- a/cumulusci/robotframework/tests/salesforce/browsers.robot
+++ b/cumulusci/robotframework/tests/salesforce/browsers.robot
@@ -41,7 +41,7 @@ Open Test Browser Twice
 
     Assert active browser count  0
     Open test browser
-    Open test browser
+    Open test browser  alias=browser2
     Assert active browser count  2
 
 Browser aliases

--- a/orgs/prerelease.json
+++ b/orgs/prerelease.json
@@ -4,7 +4,7 @@
   "features": [
     "Communities"
   ],
-  "instance": "cs46",
+  "release": "Preview",
   "settings": {
     "lightningExperienceSettings": {
       "enableS1DesktopEnabled": true

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -18,7 +18,7 @@ robotframework
 robotframework-lint
 robotframework-pabot
 robotframework-requests
-robotframework-seleniumlibrary<5
+robotframework-seleniumlibrary
 rst2ansi
 salesforce-bulk
 sarge

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -96,7 +96,7 @@ robotframework-pythonlibcore==2.2.1
     # via robotframework-seleniumlibrary
 robotframework-requests==0.9.1
     # via -r requirements/prod.in
-robotframework-seleniumlibrary==4.5.0
+robotframework-seleniumlibrary==5.1.3
     # via -r requirements/prod.in
 robotframework==4.0.3
     # via


### PR DESCRIPTION
This updates the SeleniumLibrary dependency to be the latest version. There are a few small backward incompatibilities which don't seem to affect very many of our tests. However, the keyword 'select window' was renamed to 'switch window' which would break several of our tests, so I added a 'select window' keyword to Salesforce.py along with our own deprecation warning.

Selenium has been warning about this deprecation for a while, but some of our tests still use the keyword. Adding the keyword back to Salesforce.py gives our teams a bit longer grace period. I'll write a blog post warning people that we will be removing the keyword in a future release.


# Critical Changes

# Changes
* upgrades the SeleniumLibrary dependency to 5.x
* adds new keyword "select window" to Salesforce library, to replace the keyword of the same name which was renamed in SeleniumLibrary 5.x to 'switch window'. We will be removing this keyword in a future release, tests should use 'switch window' instead.

# Issues Closed
