### PR TITLE
Fix GitHub authentication for Homebrew releases

### DIFF
--- a/utility/push-homebrew.py
+++ b/utility/push-homebrew.py
@@ -20,7 +20,7 @@ def get_github_user():
         CliRuntime().project_config, CliRuntime().get_keychain_key()
     )
     github_config = keychain.get_service("github")
-    return github_config.username, github_config.password
+    return github_config.username, (github_config.password or github_config.token)
 
 
 def get_repo():

--- a/utility/push-homebrew.py
+++ b/utility/push-homebrew.py
@@ -20,7 +20,7 @@ def get_github_user():
         CliRuntime().project_config, CliRuntime().get_keychain_key()
     )
     github_config = keychain.get_service("github")
-    return github_config.username, (github_config.password or github_config.token)
+    return github_config.username, github_config.token
 
 
 def get_repo():


### PR DESCRIPTION
`make release-homebrew` wasn't working due to an issue in the `push-homebrew` script.

# Critical Changes

# Changes

# Issues Closed
