### PR TITLE
Handle github ssh urls even when using an alias for github.com

### DIFF
--- a/cumulusci/utils/git.py
+++ b/cumulusci/utils/git.py
@@ -57,7 +57,7 @@ def split_repo_url(url: str) -> Tuple[str, str]:
         name = name[:-4]
 
     owner = url_parts[-2]
-    if "git@github.com" in url:  # ssh url
-        owner = owner.split(":")[-1]
+    # if it's an ssh url we might need to get rid of git@github.com
+    owner = owner.split(":")[-1]
 
     return (owner, name)

--- a/cumulusci/utils/tests/test_git.py
+++ b/cumulusci/utils/tests/test_git.py
@@ -3,6 +3,7 @@ from cumulusci.utils.git import (
     is_release_branch_or_child,
     get_release_identifier,
     construct_release_branch_name,
+    split_repo_url,
 )
 
 
@@ -27,3 +28,10 @@ def test_get_release_identifier():
 
 def test_construct_release_branch_name():
     assert construct_release_branch_name("feature/", "230") == "feature/230"
+
+
+def test_split_repo_url():
+    assert split_repo_url("https://github.com/owner/repo") == ("owner", "repo")
+    assert split_repo_url("https://github.com/owner/repo.git") == ("owner", "repo")
+    assert split_repo_url("git@github.com:owner/repo") == ("owner", "repo")
+    assert split_repo_url("git@alias:owner/repo") == ("owner", "repo")


### PR DESCRIPTION
See https://trailblazers.salesforce.com/_ui/core/chatter/groups/GroupProfilePage?g=0F9300000009M9Z&fId=0D54S00000A7GWS&s1oid=00D4S0000019iJX&s1nid=0DB30000000072L&emkind=chatterCommentNotification&s1uid=0053A00000CB68z&emtm=1623793353675&fromEmail=1&s1ext=0

# Critical Changes

# Changes

# Issues Closed
- Fixed an issue where CumulusCI would not find the right GitHub repository if the project was cloned using an ssh URL including an ssh alias instead of github.com.