### PR TITLE
Handle, and warn about, package versions specified as numbers

### DIFF
--- a/cumulusci/tasks/salesforce/install_package_version.py
+++ b/cumulusci/tasks/salesforce/install_package_version.py
@@ -104,6 +104,12 @@ class InstallPackageVersion(BaseSalesforceApiTask):
                 self.project_config,
                 get_resolver_stack(self.project_config, "production"),
             )
+        elif isinstance(version, (float, int)):
+            self.logger.warning(
+                f"The `version` option is specified as a number ({version}). "
+                "Please specify as a quoted string to avoid ambiguous results."
+            )
+            self.options["version"] = str(version)
 
         if dependency:
             if dependency.managed_dependency:

--- a/cumulusci/tasks/salesforce/tests/test_install_package_version.py
+++ b/cumulusci/tasks/salesforce/tests/test_install_package_version.py
@@ -84,6 +84,27 @@ def test_init_options():
     )
 
 
+def test_init_options__float_version():
+    project_config = create_project_config()
+    project_config.config["project"]["package"]["namespace"] = "ns"
+    task = create_task(
+        InstallPackageVersion,
+        {
+            "version": 1.0,
+            "retries": 20,
+            "retry_interval": 50,
+            "retry_interval_add": 100,
+            "password": "foo",
+            "activateRSS": True,
+            "name": "bar",
+            "security_type": "PUSH",
+        },
+        project_config=project_config,
+    )
+
+    assert task.options["version"] == "1.0"
+
+
 @mock.patch(
     "cumulusci.tasks.salesforce.install_package_version.GitHubDynamicDependency"
 )


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed
- We fixed an issue where CumulusCI did not correctly convert a package version specified as a number in YAML to a string. This now raises a warning.