### PR TITLE
fix reporting of oauth errors

### DIFF
--- a/cumulusci/oauth/client.py
+++ b/cumulusci/oauth/client.py
@@ -221,7 +221,7 @@ class OAuth2Client(object):
 
     def validate_response(self, response):
         """Subclasses can implement custom response validation"""
-        if not response:
+        if response is None:
             raise CumulusCIUsageError("Authentication timed out or otherwise failed.")
         elif response.status_code == http.client.OK:
             return

--- a/cumulusci/oauth/tests/test_client.py
+++ b/cumulusci/oauth/tests/test_client.py
@@ -9,6 +9,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
+from requests.models import Response
 from unittest import mock
 
 from cumulusci.core.exceptions import SalesforceCredentialsException
@@ -206,7 +207,8 @@ class TestOAuth2Client:
             with pytest.raises(urllib.error.HTTPError):
                 urllib.request.urlopen(client.client_config.redirect_uri + "?code=123")
 
-    def test_validate_resposne__raises_error(self, client):
-        response = mock.Mock(status_code=503)
+    def test_validate_response__raises_error(self, client):
+        response = Response()
+        response.status_code = 400
         with pytest.raises(OAuth2Error):
             client.validate_response(response)


### PR DESCRIPTION
Response objects from `requests` evaluate to False in a boolean context if the status code is >= 400. (Who knew?!) So let's be sure to check if the response is None instead of whether it is falsy -- and update the test to use a real response object since the mock didn't behave the same.

# Critical Changes

# Changes

# Issues Closed
- Fixed a bug where OAuth errors were not reported in detail.
