### PR TITLE
Add CustomTab wildcard to admin_profile.xml

### DIFF
--- a/cumulusci/files/admin_profile.xml
+++ b/cumulusci/files/admin_profile.xml
@@ -10,6 +10,10 @@
         <name>CustomObject</name>
     </types>
     <types>
+        <members>*</members>
+        <name>CustomTab</name>
+    </types>
+    <types>
         <name>Profile</name>
     </types>
     <version>39.0</version>


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed
- We fixed an issue where CumulusCI did not grant permissions to Custom Tabs when running `update_admin_profile` without a custom `package.xml`. Projects that use a custom `package.xml` with `update_admin_profile` should update their manifest to include a `CustomTab` wildcard for the same outcome.