### PR TITLE
Fix some doc and move rather than copy

### DIFF
--- a/cumulusci/core/utils.py
+++ b/cumulusci/core/utils.py
@@ -1,8 +1,4 @@
-""" Utilities for CumulusCI Core
-
-import_global: task class defn import helper
-process_bool_arg: determine true/false for a commandline arg
-decode_to_unicode: get unicode string from sf api """
+""" Utilities for CumulusCI Core"""
 
 from datetime import datetime, timedelta
 import copy

--- a/cumulusci/tasks/bulkdata/generate_from_yaml.py
+++ b/cumulusci/tasks/bulkdata/generate_from_yaml.py
@@ -161,11 +161,11 @@ class GenerateDataFromYaml(BaseGenerateDataTask):
                 should_create_cci_record_type_tables=True,
             )
 
-            if (
-                new_continuation_file
-                and Path(new_continuation_file.name).exists()
-                and self.working_directory
-            ):
-                shutil.copyfile(
-                    new_continuation_file.name, self.default_continuation_file_path()
-                )
+        if (
+            new_continuation_file
+            and Path(new_continuation_file.name).exists()
+            and self.working_directory
+        ):
+            shutil.move(
+                new_continuation_file.name, self.default_continuation_file_path()
+            )


### PR DESCRIPTION
One module had a comment that is irrelevant now. Deleted.

The other module copied a file from one place to another which left a vestigial file behind. David Glick asked about it in a code review. Instead I move it now and there is no file left behind.

I changed the indentation to make sure that the file was closed before I tried to move it. (probably should not have copied it while it was open!).

