### PR TITLE
Fix two bugs in Data Dictionary

### DIFF
--- a/cumulusci/tasks/datadictionary.py
+++ b/cumulusci/tasks/datadictionary.py
@@ -430,14 +430,17 @@ class GenerateDataDictionary(BaseGithubTask):
         if self._should_process_object(
             version.package.namespace, sobject_name, element
         ):
+            if description_elem and description_elem.text:
+                description = description_elem.text
+            else:
+                description = ""
+
             self.sobjects[sobject_name].append(
                 SObjectDetail(
                     version=version,
                     api_name=sobject_name,
                     label=element.label.text,
-                    description=description_elem.text
-                    if description_elem is not None
-                    else "",
+                    description=description,
                 )
             )
 
@@ -464,13 +467,13 @@ class GenerateDataDictionary(BaseGithubTask):
         # `element` may be either a `fields` element (in MDAPI)
         # or a `CustomField` (SFDX)
         # If this is a custom field, register its presence in this version
-        field_name = f"{version.package.namespace}{field.fullName.text}"
-        # get field help text value
-        help_text_elem = field.find("inlineHelpText")
-        # get field description text value
-        description_text_elem = field.find("description")
+        if "__" in field.fullName.text:
+            field_name = f"{version.package.namespace}{field.fullName.text}"
+            # get field help text value
+            help_text_elem = field.find("inlineHelpText")
+            # get field description text value
+            description_text_elem = field.find("description")
 
-        if "__" in field_name:
             field_type = field.type.text
             valid_values = ""
 
@@ -526,14 +529,24 @@ class GenerateDataDictionary(BaseGithubTask):
                 field_type = f"Master-Detail Relationship to {target_sobject}"
                 # Note: polymorphic custom fields are not allowed.
 
+            if help_text_elem and help_text_elem.text:
+                help_text = help_text_elem.text
+            else:
+                help_text = ""
+
+            if description_text_elem and description_text_elem.text:
+                description = description_text_elem.text
+            else:
+                description = ""
+
             fd = FieldDetail(
                 version=version,
                 sobject=sobject,
                 api_name=field_name,
                 label=field.label.text,
                 type=f"{field_type}{length}",
-                help_text=help_text_elem.text if help_text_elem else "",
-                description=description_text_elem.text if description_text_elem else "",
+                help_text=help_text,
+                description=description,
                 valid_values=valid_values,
             )
             fully_qualified_name = f"{sobject}.{fd.api_name}"

--- a/cumulusci/tasks/tests/test_datadictionary.py
+++ b/cumulusci/tasks/tests/test_datadictionary.py
@@ -408,7 +408,6 @@ class test_GenerateDataDictionary(unittest.TestCase):
             )
         ]
 
-    # FIXME: why did this test not fail?
     def test_process_field_element__standard(self):
         xml_source = """<?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">

--- a/cumulusci/tasks/tests/test_datadictionary.py
+++ b/cumulusci/tasks/tests/test_datadictionary.py
@@ -372,6 +372,43 @@ class test_GenerateDataDictionary(unittest.TestCase):
             )
         ]
 
+    def test_process_field_element__blank_elements(self):
+        xml_source = """<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Lookup__c</fullName>
+    <label>Test</label>
+    <description></description>
+    <inlineHelpText></inlineHelpText>
+    <type>MasterDetail</type>
+    <referenceTo>Test__c</referenceTo>
+</CustomField>
+"""
+        task = create_task(GenerateDataDictionary, {})
+        p = Package(
+            repo=None, package_name="Test", namespace="test__", prefix_release="rel/"
+        )
+        v = PackageVersion(package=p, version=StrictVersion("1.1"))
+
+        task._init_schema()
+        task._process_field_element(
+            "test__Test__c", metadata_tree.fromstring(xml_source.encode("utf-8")), v
+        )
+
+        assert "test__Test__c.test__Lookup__c" in task.fields
+        assert task.fields["test__Test__c.test__Lookup__c"] == [
+            FieldDetail(
+                version=v,
+                sobject="test__Test__c",
+                api_name="test__Lookup__c",
+                label="Test",
+                type="Master-Detail Relationship to test__Test__c",
+                description="",
+                help_text="",
+                valid_values="",
+            )
+        ]
+
+    # FIXME: why did this test not fail?
     def test_process_field_element__standard(self):
         xml_source = """<?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
@@ -393,7 +430,7 @@ class test_GenerateDataDictionary(unittest.TestCase):
             "test__Test__c", metadata_tree.fromstring(xml_source.encode("utf-8")), v
         )
 
-        assert "test__Test__c.Account" not in task.fields
+        assert len(task.fields) == 0
 
     def test_process_field_element__updated(self):
         xml_source = """<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed

- We fixed issues in the `generate_data_dictionary` task that resulted in failures when processing fields with blank Help Text or processing standard fields.