### PR TITLE
Handle 2GP lookup errors more cleanly

### DIFF
--- a/cumulusci/core/github.py
+++ b/cumulusci/core/github.py
@@ -192,7 +192,8 @@ VERSION_ID_RE = re.compile(r"version_id: (\S+)")
 def get_version_id_from_commit(repo, commit_sha, context):
     try:
         commit = repo.commit(commit_sha)
-    except github3.exceptions.NotFoundError:
+    except (github3.exceptions.NotFoundError, github3.exceptions.UnprocessableEntity):
+        # GitHub returns 422 for nonexistent commits in at least some circumstances.
         raise DependencyLookupError(f"Could not find commit {commit_sha} on GitHub")
 
     for status in commit.status().statuses:

--- a/cumulusci/tasks/github/tests/test_commit_status.py
+++ b/cumulusci/tasks/github/tests/test_commit_status.py
@@ -91,7 +91,7 @@ class TestGetPackageDataFromCommitStatus(GithubApiTestMixin):
             json=self._get_expected_repo("TestOwner", "TestRepo"),
         )
         responses.add(
-            method=responses.GET, url=f"{self.repo_api_url}/commits/abcdef", status=404
+            method=responses.GET, url=f"{self.repo_api_url}/commits/abcdef", status=422
         )
 
         project_config = create_project_config(repo_commit="abcdef")
@@ -113,7 +113,8 @@ class TestGetPackageDataFromCommitStatus(GithubApiTestMixin):
         task = GetPackageDataFromCommitStatus(project_config, task_config, org_config)
         task._init_task()
         with pytest.raises(
-            DependencyLookupError, match="Could not find commit abcdef on GitHub"
+            DependencyLookupError,
+            match="Could not find package version id in '2gp' commit status for commit abcdef.",
         ):
             task._run_task()
 


### PR DESCRIPTION
# Critical Changes

# Changes

- Builds that install feature-test 2GP packages now present a cleaner error message when the current commit is not found on GitHub.

# Issues Closed
