### PR TITLE
Un-pin Snowfakery

### DIFF
--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -26,7 +26,7 @@ salesforce-bulk
 sarge
 selenium
 simple-salesforce
-snowfakery==2.0.dev1
+snowfakery
 SQLAlchemy
 terminaltables
 xmltodict

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -136,7 +136,7 @@ six==1.16.0
     #   jwcrypto
     #   python-dateutil
     #   salesforce-bulk
-snowfakery==2.0.dev0
+snowfakery==2.0
     # via -r requirements/prod.in
 sqlalchemy==1.4.19
     # via


### PR DESCRIPTION
Snowfakery 2 is the newest version on PyPI, so we don't need to pin anymore.