### PR TITLE
Fix create package version dependency output

### DIFF
--- a/cumulusci/tasks/create_package_version.py
+++ b/cumulusci/tasks/create_package_version.py
@@ -287,12 +287,9 @@ class CreatePackageVersion(BaseSalesforceApiTask):
             "SELECT Dependencies FROM SubscriberPackageVersion "
             f"WHERE Id='{package2_version['SubscriberPackageVersionId']}'"
         )
-        if res["records"][0]["Dependencies"]:
-            self.return_values["dependencies"] = self._prepare_cci_dependencies(
-                res["records"][0]["Dependencies"]
-            )
-        else:
-            self.return_values["dependencies"] = []
+        self.return_values["dependencies"] = self._prepare_cci_dependencies(
+            res["records"][0]["Dependencies"]
+        )
 
         self.logger.info("Created package version:")
         self.logger.info(f"  Package2 Id: {self.package_id}")
@@ -740,9 +737,12 @@ class CreatePackageVersion(BaseSalesforceApiTask):
         # for the new package back into `update_dependencies`-compatible
         # format for persistence into the GitHub release.
 
-        return [
-            PackageVersionIdDependency(
-                version_id=v["subscriberPackageVersionId"]
-            ).dict()
-            for v in deps["ids"]
-        ]
+        if deps:
+            return [
+                PackageVersionIdDependency(
+                    version_id=v["subscriberPackageVersionId"]
+                ).dict(exclude_unset=True)
+                for v in deps["ids"]
+            ]
+
+        return []

--- a/cumulusci/tasks/create_package_version.py
+++ b/cumulusci/tasks/create_package_version.py
@@ -741,7 +741,7 @@ class CreatePackageVersion(BaseSalesforceApiTask):
             return [
                 PackageVersionIdDependency(
                     version_id=v["subscriberPackageVersionId"]
-                ).dict(exclude_unset=True)
+                ).dict(exclude_none=True)
                 for v in deps["ids"]
             ]
 

--- a/cumulusci/tasks/create_package_version.py
+++ b/cumulusci/tasks/create_package_version.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import List, Optional, Union
 import base64
 import enum
 import io
@@ -11,7 +11,10 @@ from pydantic import BaseModel, validator
 from simple_salesforce.exceptions import SalesforceMalformedRequest
 
 from cumulusci.core.config.util import get_devhub_config
-from cumulusci.core.dependencies.dependencies import PackageNamespaceVersionDependency
+from cumulusci.core.dependencies.dependencies import (
+    PackageNamespaceVersionDependency,
+    StaticDependency,
+)
 from cumulusci.core.dependencies.dependencies import PackageVersionIdDependency
 from cumulusci.core.dependencies.dependencies import UnmanagedGitHubRefDependency
 from cumulusci.core.dependencies.resolvers import get_static_dependencies
@@ -284,7 +287,12 @@ class CreatePackageVersion(BaseSalesforceApiTask):
             "SELECT Dependencies FROM SubscriberPackageVersion "
             f"WHERE Id='{package2_version['SubscriberPackageVersionId']}'"
         )
-        self.return_values["dependencies"] = res["records"][0]["Dependencies"]
+        if res["records"][0]["Dependencies"]:
+            self.return_values["dependencies"] = self._prepare_cci_dependencies(
+                res["records"][0]["Dependencies"]
+            )
+        else:
+            self.return_values["dependencies"] = []
 
         self.logger.info("Created package version:")
         self.logger.info(f"  Package2 Id: {self.package_id}")
@@ -726,3 +734,15 @@ class CreatePackageVersion(BaseSalesforceApiTask):
             raise PackageUploadFailure("\n".join(errors))
         else:
             self.logger.info(f"[{request['Status']}]")
+
+    def _prepare_cci_dependencies(self, deps) -> List[dict]:
+        # Convert the dependencies returned by the Tooling API
+        # for the new package back into `update_dependencies`-compatible
+        # format for persistence into the GitHub release.
+
+        return [
+            PackageVersionIdDependency(
+                version_id=v["subscriberPackageVersionId"]
+            ).dict()
+            for v in deps["ids"]
+        ]


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed

- We fixed an issue causing `release_2gp_beta` to fail to create a GitHub release with a dependency-parsing error.