### PR TITLE
Default to not creating unlocked packages for unmanaged deps

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -1053,6 +1053,7 @@ flows:
           version_base: latest_github_release
           version_type: minor
           force_upload: True
+          create_unlocked_dependency_packages: False
       2:
         task: github_release
         options:

--- a/cumulusci/tasks/tests/test_create_package_version.py
+++ b/cumulusci/tasks/tests/test_create_package_version.py
@@ -106,6 +106,7 @@ def task(project_config, devhub_config, org_config):
                     "package_name": "Test Package",
                     "static_resource_path": "static-resources",
                     "ancestor_id": "04t000000000000",
+                    "create_unlocked_dependency_packages": True
                 }
             }
         ),
@@ -579,8 +580,22 @@ class TestCreatePackageVersion:
         with pytest.raises(DependencyLookupError):
             task._convert_project_dependencies([{"foo": "bar"}])
 
+    def test_convert_project_dependencies__no_unlocked_packages(self, task):
+        task.options["create_unlocked_dependency_packages"] = False
+        assert task._convert_project_dependencies(
+            [
+                PackageVersionIdDependency(version_id="04t000000000000"), 
+                UnmanagedGitHubRefDependency(github="https://github.com/test/test", ref="abcdef")
+            ]
+        ) == [{"subscriberPackageVersionId": "04t000000000000"}]
+
     def test_unpackaged_pre_dependencies__none(self, task):
         shutil.rmtree(str(pathlib.Path(task.project_config.repo_root, "unpackaged")))
+
+        assert task._get_unpackaged_pre_dependencies([]) == []
+
+    def test_unpackaged_pre_dependencies__no_unlocked_packages(self, task):
+        task.options["create_unlocked_dependency_packages"] = False
 
         assert task._get_unpackaged_pre_dependencies([]) == []
 


### PR DESCRIPTION
# Critical Changes

- The `create_package_version` task no longer creates Unlocked Packages from the `unpackaged/pre` and `unpackaged/post` directories of dependencies, or local `unpackaged/pre` directories by default. This behavior is now opt-in via the `create_unlocked_dependency_packages` option, which defaults to False. Projects using the old default behavior must explicitly set this option. We believe the new behavior is a more sane default for most 2GP projects.

# Changes

# Issues Closed
