### PR TITLE
Support objectSettings in create_package_version and change default behavior to not create unlocked packages

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -121,7 +121,7 @@ Note that some formatting, such as reStructuredText links, need to be converted 
 
 .. note::
 
-    If pandoc is installed on macOS, you can run ``pbpaste | pandoc -f rst -t gfm | pbcopy`` to convert from RST to GitHub Flavored Markdown.
+    If pandoc is installed on macOS, you can run ``pbpaste | pandoc -f rst -t gfm --wrap none | pbcopy`` to convert from RST to GitHub Flavored Markdown. Chatter handles DOCX input best, so you can run ``pbpaste | pandoc -f gfm -t docx -o /tmp/f.docx && open /tmp/f.docx``
 
 You can then create a pull request to update the `Homebrew Tap`_ by running this locally (note, it's important to do this as soon as possible after the release is published on PyPI, because PyPI is the source CumulusCI checks to see if a new version is available)::
 

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -1053,6 +1053,7 @@ flows:
           version_base: latest_github_release
           version_type: minor
           force_upload: True
+          create_unlocked_dependency_packages: False
       2:
         task: github_release
         options:

--- a/cumulusci/tasks/salesforce/org_settings.py
+++ b/cumulusci/tasks/salesforce/org_settings.py
@@ -1,7 +1,6 @@
 import contextlib
 from cumulusci.tasks.metadata.package import PackageXmlGenerator
 import json
-import os
 import pathlib
 import textwrap
 from typing import Optional
@@ -74,7 +73,7 @@ def build_settings_package(
 ):
     with temporary_dir() as path:
         if settings:
-            os.mkdir("settings")
+            pathlib.Path("settings").mkdir()
             for section, section_settings in settings.items():
                 settings_name = capitalize(section)
                 if section == "orgPreferenceSettings":
@@ -98,7 +97,7 @@ def build_settings_package(
                     )
 
         if object_settings:
-            os.mkdir("objects")
+            pathlib.Path("objects").mkdir()
             for obj_lower_name, this_obj_settings in object_settings.items():
                 object_name = capitalize(obj_lower_name)
                 file_content = _get_object_file(object_name, this_obj_settings)

--- a/cumulusci/tasks/salesforce/org_settings.py
+++ b/cumulusci/tasks/salesforce/org_settings.py
@@ -1,7 +1,10 @@
 import contextlib
+from cumulusci.tasks.metadata.package import PackageXmlGenerator
 import json
 import os
+import pathlib
 import textwrap
+from typing import Optional
 
 from cumulusci.tasks.salesforce import Deploy
 from cumulusci.utils import temporary_dir
@@ -16,14 +19,6 @@ ORGPREF = """<preferences>
     <settingName>{name}</settingName>
     <settingValue>{value}</settingValue>
 </preferences>"""
-PACKAGE_XML = """<?xml version="1.0" encoding="UTF-8"?>
-<Package xmlns="http://soap.sforce.com/2006/04/metadata">
-    <types>
-        <members>*</members>
-        <name>Settings</name>
-    </types>
-    <version>{api_version}</version>
-</Package>"""
 
 
 class DeployOrgSettings(Deploy):
@@ -59,7 +54,7 @@ class DeployOrgSettings(Deploy):
         api_version = (
             self.options.get("api_version") or self.org_config.latest_api_version
         )
-        with build_settings_package(settings, api_version) as path:
+        with build_settings_package(settings, None, api_version) as path:
             self.options["path"] = path
             return super()._run_task()
 
@@ -74,31 +69,104 @@ def capitalize(s):
 
 
 @contextlib.contextmanager
-def build_settings_package(settings: dict, api_version: str):
+def build_settings_package(
+    settings: Optional[dict], object_settings: Optional[dict], api_version: str
+):
     with temporary_dir() as path:
-        os.mkdir("settings")
-        for section, section_settings in settings.items():
-            settings_name = capitalize(section)
-            if section == "orgPreferenceSettings":
-                values = "    " + "\n    ".join(
-                    line
-                    for line in "\n".join(
-                        ORGPREF.format(name=capitalize(k), value=v)
-                        for k, v in section_settings.items()
-                    ).splitlines()
+        if settings:
+            os.mkdir("settings")
+            for section, section_settings in settings.items():
+                settings_name = capitalize(section)
+                if section == "orgPreferenceSettings":
+                    values = "    " + "\n    ".join(
+                        line
+                        for line in "\n".join(
+                            ORGPREF.format(name=capitalize(k), value=v)
+                            for k, v in section_settings.items()
+                        ).splitlines()
+                    )
+                else:
+                    values = textwrap.indent(_dict_to_xml(section_settings), "    ")
+                # e.g. AccountSettings -> settings/Account.settings
+                settings_file = (
+                    pathlib.Path("settings")
+                    / f"{settings_name[: -len('Settings')]}.settings"
                 )
-            else:
-                values = textwrap.indent(_dict_to_xml(section_settings), "    ")
-            # e.g. AccountSettings -> settings/Account.settings
-            settings_file = os.path.join(
-                "settings", settings_name[: -len("Settings")] + ".settings"
-            )
-            with open(settings_file, "w") as f:
-                f.write(SETTINGS_XML.format(settingsName=settings_name, values=values))
+                with open(settings_file, "w", encoding="utf-8") as f:
+                    f.write(
+                        SETTINGS_XML.format(settingsName=settings_name, values=values)
+                    )
+
+        if object_settings:
+            os.mkdir("objects")
+            for obj_lower_name, this_obj_settings in object_settings.items():
+                object_name = capitalize(obj_lower_name)
+                file_content = _get_object_file(object_name, this_obj_settings)
+                with open(
+                    pathlib.Path("objects") / f"{object_name}.object",
+                    "w",
+                    encoding="utf-8",
+                ) as f:
+                    f.write(file_content)
+
+        package_generator = PackageXmlGenerator(path, api_version)
         with open("package.xml", "w") as f:
-            f.write(PACKAGE_XML.format(api_version=api_version))
+            f.write(package_generator())
 
         yield path
+
+
+def _get_object_file(object_name: str, settings: dict) -> str:
+    sharing_model = ""
+    if "sharingModel" in settings:
+        sharing_model = (
+            f"    <sharingModel>{capitalize(settings['sharingModel'])}</sharingModel>"
+        )
+
+    record_type = ""
+    business_process = ""
+    if "defaultRecordType" in settings:
+        # Use the same default picklist values as SFDX to generate a Business Process,
+        # if this object requires one.
+        picklist_value = {
+            "Case": "New",
+            "Lead": "New - Not Contacted",
+            "Opportunity": "Prospecting",
+            "Solution": "Draft",
+        }.get(object_name, "")
+        default_status = (
+            "<default>true</default>" if object_name == "Opportunity" else ""
+        )
+
+        business_process_reference = ""
+        if picklist_value:
+            # We need to add a Business Process
+            business_process_reference = (
+                f"<businessProcess>Default{object_name}</businessProcess>"
+            )
+            default_status = ""
+            business_process = f"""    <businessProcesses>
+        <fullName>Default{object_name}</fullName>
+        <isActive>true</isActive>
+        <values>
+            <fullName>{picklist_value}</fullName>
+            {default_status}
+        </values>
+    </businessProcesses>"""
+        record_type = f"""    <recordTypes>
+        <fullName>{capitalize(settings['defaultRecordType'])}</fullName>
+        <label>{capitalize(settings['defaultRecordType'])}</label>
+        <active>true</active>
+        {business_process_reference}
+    </recordTypes>
+        """
+
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<Object xmlns="http://soap.sforce.com/2006/04/metadata">
+{sharing_model}
+{record_type}
+{business_process}
+</Object>"""
 
 
 def _dict_to_xml(d: dict) -> str:

--- a/cumulusci/tasks/tests/test_create_package_version.py
+++ b/cumulusci/tasks/tests/test_create_package_version.py
@@ -106,6 +106,7 @@ def task(project_config, devhub_config, org_config):
                     "package_name": "Test Package",
                     "static_resource_path": "static-resources",
                     "ancestor_id": "04t000000000000",
+                    "create_unlocked_dependency_packages": True
                 }
             }
         ),
@@ -579,8 +580,22 @@ class TestCreatePackageVersion:
         with pytest.raises(DependencyLookupError):
             task._convert_project_dependencies([{"foo": "bar"}])
 
+    def test_convert_project_dependencies__no_unlocked_packages(self, task):
+        task.options["create_unlocked_dependency_packages"] = False
+        assert task._convert_project_dependencies(
+            [
+                PackageVersionIdDependency(version_id="04t000000000000"), 
+                UnmanagedGitHubRefDependency(github="https://github.com/test/test", ref="abcdef")
+            ]
+        ) == [{"subscriberPackageVersionId": "04t000000000000"}]
+
     def test_unpackaged_pre_dependencies__none(self, task):
         shutil.rmtree(str(pathlib.Path(task.project_config.repo_root, "unpackaged")))
+
+        assert task._get_unpackaged_pre_dependencies([]) == []
+
+    def test_unpackaged_pre_dependencies__no_unlocked_packages(self, task):
+        task.options["create_unlocked_dependency_packages"] = False
 
         assert task._get_unpackaged_pre_dependencies([]) == []
 


### PR DESCRIPTION
# Critical Changes

- The `create_package_version` task no longer creates Unlocked Packages from the `unpackaged/pre` and `unpackaged/post` directories of dependencies, or local `unpackaged/pre` directories by default. This behavior is now opt-in via the `create_unlocked_dependency_packages` option, which defaults to False. Projects using the old default behavior must explicitly set this option. We believe the new behavior is a more sane default for most 2GP projects.

# Changes

- The `create_package_version` task now supports `objectSettings` in the org definition file.

# Issues Closed
