### PR TITLE
Built-in connected_app should be the default if no others are present

### DIFF
--- a/cumulusci/core/keychain/environment_project_keychain.py
+++ b/cumulusci/core/keychain/environment_project_keychain.py
@@ -59,7 +59,7 @@ class EnvironmentProjectKeychain(BaseProjectKeychain):
         # then set the built-in connected_app as the default.
         # The built-in is always loaded, so 2 or more would indicate
         # the presence of a user-provided connected app.
-        if len(self.config["services"]["connected_app"].keys()) == 1:
+        if len(self.config["services"]["connected_app"]) == 1:
             self._default_services["connected_app"] = DEFAULT_CONNECTED_APP_NAME
 
     def cleanup_org_cache_dirs(self):

--- a/cumulusci/core/keychain/environment_project_keychain.py
+++ b/cumulusci/core/keychain/environment_project_keychain.py
@@ -56,7 +56,7 @@ class EnvironmentProjectKeychain(BaseProjectKeychain):
             self._default_services[service_type] = "env"
 
         # If there are no connected_app services loaded
-        # then set the built-in connecteid_app as the default.
+        # then set the built-in connected_app as the default.
         # The built-in is always loaded, so 2 or more would indicate
         # the presence of a user-provided connected app.
         if len(self.config["services"]["connected_app"].keys()) == 1:

--- a/cumulusci/core/keychain/environment_project_keychain.py
+++ b/cumulusci/core/keychain/environment_project_keychain.py
@@ -3,6 +3,7 @@ import os
 
 from cumulusci.core.config import OrgConfig, ScratchOrgConfig, ServiceConfig
 from cumulusci.core.keychain import BaseProjectKeychain
+from cumulusci.core.keychain.base_project_keychain import DEFAULT_CONNECTED_APP_NAME
 from cumulusci.core.utils import import_global
 
 scratch_org_class = os.environ.get("CUMULUSCI_SCRATCH_ORG_CLASS")
@@ -53,6 +54,13 @@ class EnvironmentProjectKeychain(BaseProjectKeychain):
     def _load_default_services(self):
         for service_type in self.services:
             self._default_services[service_type] = "env"
+
+        # If there are no connected_app services loaded
+        # then set the built-in connecteid_app as the default.
+        # The built-in is always loaded, so 2 or more would indicate
+        # the presence of a user-provided connected app.
+        if len(self.config["services"]["connected_app"].keys()) == 1:
+            self._default_services["connected_app"] = DEFAULT_CONNECTED_APP_NAME
 
     def cleanup_org_cache_dirs(self):
         pass

--- a/cumulusci/core/keychain/tests/test_environment_project_keychain.py
+++ b/cumulusci/core/keychain/tests/test_environment_project_keychain.py
@@ -9,6 +9,7 @@ from cumulusci.core.config import ScratchOrgConfig
 from cumulusci.core.config import ServiceConfig
 from cumulusci.core.keychain import BaseProjectKeychain
 from cumulusci.core.keychain import EnvironmentProjectKeychain
+from cumulusci.core.keychain.base_project_keychain import DEFAULT_CONNECTED_APP
 from cumulusci.core.exceptions import OrgNotFound
 from cumulusci.core.tests.utils import EnvironmentVarGuard
 
@@ -184,3 +185,16 @@ class TestEnvironmentProjectKeychain(ProjectKeychainTestMixin):
     def test_set_and_get_scratch_org(self):
         self._clean_env(self.env)
         super(TestEnvironmentProjectKeychain, self).test_set_and_get_scratch_org()
+
+    def test_load_built_in_connected_app(self):
+        keychain = self.keychain_class(self.project_config, self.key)
+        # clear out any connected apps that are present
+        keychain.config["services"]["connected_app"] = {}
+        # clear out any default services
+        keychain._default_services = {}
+
+        keychain._load_default_connected_app()
+        keychain._load_default_services()
+
+        connected_app = keychain.get_service("connected_app")
+        assert connected_app is DEFAULT_CONNECTED_APP


### PR DESCRIPTION
# Issues Closed
* Fixed an issue where the the built-in connected app was not accessible when running CumulusCI in a headless environment. (Fixes #2737)