### PR TITLE
LeadStatus Picklist Support

### DIFF
--- a/cumulusci/tasks/metadata_etl/value_sets.py
+++ b/cumulusci/tasks/metadata_etl/value_sets.py
@@ -2,6 +2,16 @@ from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.tasks.metadata_etl import MetadataSingleEntityTransformTask
 from cumulusci.utils.xml.metadata_tree import MetadataElement
 
+CASE_STATUS_ERR = "CaseStatus standard value set entries require the key 'closed'"
+LEAD_STATUS_ERR = "LeadStatus standard value set entries require the key 'converted'"
+FULL_NAME_AND_LABEL_ERR = (
+    "Standard value set entries must contain the 'fullName' and 'label' keys."
+)
+OPP_STAGE_ERR = (
+    "OpportunityStage standard value set entries require the keys "
+    "'closed', 'forecastCategory', 'probability', and 'won'"
+)
+
 
 class AddValueSetEntries(MetadataSingleEntityTransformTask):
     entity = "StandardValueSet"
@@ -12,12 +22,12 @@ class AddValueSetEntries(MetadataSingleEntityTransformTask):
             "Each standardValue should contain the keys 'fullName', the API name of the entry, "
             "and 'label', the user-facing label. OpportunityStage entries require the additional "
             "keys 'closed', 'won', 'forecastCategory', and 'probability'; CaseStatus entries "
-            "require 'closed'.",
+            "require 'closed'; LeadStatus entries require 'converted'.",
             "required": True,
         },
         "api_names": {
             "description": "List of API names of StandardValueSets to affect, "
-            "such as 'OpportunityStage', 'AccountType', 'CaseStatus'",
+            "such as 'OpportunityStage', 'AccountType', 'CaseStatus', 'LeadStatus'",
             "required": True,
         },
     }
@@ -25,11 +35,9 @@ class AddValueSetEntries(MetadataSingleEntityTransformTask):
     def _transform_entity(self, metadata: MetadataElement, api_name: str):
         for entry in self.options.get("entries", []):
             if "fullName" not in entry or "label" not in entry:
-                raise TaskOptionsError(
-                    "Standard value set entries must contain the 'fullName' and 'label' keys."
-                )
+                raise TaskOptionsError(FULL_NAME_AND_LABEL_ERR)
 
-            # Check for extra metadata on CaseStatus and OpportunityStage
+            # Check for extra metadata on CaseStatus, OpportunityStage and LeadStatus
             if api_name == "OpportunityStage":
                 if not all(
                     [
@@ -39,15 +47,13 @@ class AddValueSetEntries(MetadataSingleEntityTransformTask):
                         "won" in entry,
                     ]
                 ):
-                    raise TaskOptionsError(
-                        "OpportunityStage standard value set entries require the keys "
-                        "'closed', 'forecastCategory', 'probability', and 'won'"
-                    )
+                    raise TaskOptionsError(OPP_STAGE_ERR)
             if api_name == "CaseStatus":
                 if "closed" not in entry:
-                    raise TaskOptionsError(
-                        "CaseStatus standard value set entries require the key 'closed'"
-                    )
+                    raise TaskOptionsError(CASE_STATUS_ERR)
+            if api_name == "LeadStatus":
+                if "converted" not in entry:
+                    raise TaskOptionsError(LEAD_STATUS_ERR)
 
             existing_entry = metadata.findall(
                 "standardValue", fullName=entry["fullName"]
@@ -69,5 +75,8 @@ class AddValueSetEntries(MetadataSingleEntityTransformTask):
                     elem.append("won", str(entry["won"]).lower())
                     elem.append("probability", str(entry["probability"]))
                     elem.append("forecastCategory", entry["forecastCategory"])
+
+                if api_name == "LeadStatus":
+                    elem.append("converted", str(entry["converted"]).lower())
 
         return metadata


### PR DESCRIPTION
# Changes
* The `add_standard_value_set_entries` task now supports value sets for `LeadStatus`.

These changes came from [PR 2695](https://github.com/SFDO-Tooling/CumulusCI/pull/2695).