### PR TITLE
Fix lint workflow

### DIFF
--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -1,9 +1,11 @@
 name: Feature Test
 
 on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened] # Default
   push:
     branches:
-      - feature/**
       - main
 
 env:
@@ -13,28 +15,47 @@ env:
 jobs:
   lint:
     name: Lint
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: "Checkout"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
       - name: Set up Python 3.8
+        id: py
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - name: pip cache
+        id: pip_cache
         uses: actions/cache@v1
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
+      - name: pre-commit cache
+        id: pc_cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ steps.py.outputs.python-version }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ steps.py.outputs.python-version }}-pre-commit-
       - name: Install dependencies
         run: |
           python -m pip install -U pip
           pip install pre-commit
+      - name: Install pre-commit
+        if: steps.pc_cache.outputs.cache-hit != 'true'
+        run: |
+          pre-commit install --install-hooks
       - name: Run pre-commit on changed files
         run: |
-          git fetch --depth=1 origin main
-          pre-commit run --files $(git diff --diff-filter=d --name-only origin/main...HEAD)
+          git fetch --depth=1 --no-tags origin $GITHUB_BASE_REF:$GITHUB_BASE_REF
+          git fetch --depth=1 --no-tags origin $GITHUB_HEAD_REF:$GITHUB_HEAD_REF
+          pre-commit run --files $(git diff --diff-filter=d --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)
 
   unit_tests:
     name: "Unit tests: Python ${{ matrix.python-version }}"


### PR DESCRIPTION
Previously, the `lint` job compared HEAD against origin/main on every push, but that didn't necessarily match the context; you could, for example, be in a child branch. Ultimately, it made the most sense for this to be triggered by the pull_request event instead.

This PR also changes the events triggering the feature test workflow to one of the following:

1. Manual runs:
    gh workflow run feature_test.yml
2. Pull requests
3. Commits to `main`

Failing workflow [here](https://github.com/SFDO-Tooling/CumulusCI/pull/2772/checks?check_run_id=3225142344).

---

# Critical Changes

# Changes

# Issues Closed