### PR TITLE
Fix tag prefix and name inconsistencies

### DIFF
--- a/cumulusci/core/config/project_config.py
+++ b/cumulusci/core/config/project_config.py
@@ -446,18 +446,12 @@ class BaseProjectConfig(BaseTaskFlowConfig):
             config = json.load(f)
         return config
 
-    def get_tag_for_version(self, version, prefix=None):
-        """Given a version, returns the appropriate tag name to use.
-        If a prefix is not specified, we infer beta vs. release based
-        on 1GP beta version naming conventions."""
-        if prefix:
-            tag_name = prefix + version
-        elif "(Beta" in version:
-            tag_version = version.replace(" (", "-").replace(")", "").replace(" ", "_")
-            tag_name = self.project__git__prefix_beta + tag_version
-        else:
-            tag_name = self.project__git__prefix_release + version
-        return tag_name
+    def get_tag_for_version(self, prefix, version):
+        """Given a prefix and version, returns the appropriate tag name to use."""
+        if "(Beta" in version:
+            version = version.replace(" (", "-").replace(")", "").replace(" ", "_")
+
+        return f"{prefix}{version}"
 
     def get_version_for_tag(self, tag, prefix_beta=None, prefix_release=None):
         if prefix_beta is None:

--- a/cumulusci/core/config/tests/test_config.py
+++ b/cumulusci/core/config/tests/test_config.py
@@ -547,7 +547,10 @@ class TestBaseProjectConfig(unittest.TestCase):
         config = BaseProjectConfig(
             UniversalConfig(), {"project": {"git": {"prefix_release": "release/"}}}
         )
-        self.assertEqual("release/1.0", config.get_tag_for_version("1.0"))
+        self.assertEqual("beta/1.0", config.get_tag_for_version("beta/", "1.0"))
+        self.assertEqual(
+            "beta/1.117-Beta_5", config.get_tag_for_version("beta/", "1.117 (Beta 5)")
+        )
 
     def test_get_tag_for_version__1gp_beta(self):
         config = BaseProjectConfig(

--- a/cumulusci/core/config/tests/test_config.py
+++ b/cumulusci/core/config/tests/test_config.py
@@ -548,21 +548,20 @@ class TestBaseProjectConfig(unittest.TestCase):
             UniversalConfig(), {"project": {"git": {"prefix_release": "release/"}}}
         )
         self.assertEqual("beta/1.0", config.get_tag_for_version("beta/", "1.0"))
-        self.assertEqual(
-            "beta/1.117-Beta_5", config.get_tag_for_version("beta/", "1.117 (Beta 5)")
-        )
 
     def test_get_tag_for_version__1gp_beta(self):
         config = BaseProjectConfig(
             UniversalConfig(), {"project": {"git": {"prefix_beta": "beta/"}}}
         )
-        self.assertEqual("beta/1.0-Beta_1", config.get_tag_for_version("1.0 (Beta 1)"))
+        self.assertEqual(
+            "beta/1.0-Beta_1", config.get_tag_for_version("beta/", "1.0 (Beta 1)")
+        )
 
     def test_get_tag_for_version__with_tag_prefix_option(self):
         config = BaseProjectConfig(UniversalConfig(), {})
         self.assertEqual(
             "custom/1.0",
-            config.get_tag_for_version("1.0", prefix="custom/"),
+            config.get_tag_for_version("custom/", "1.0"),
         )
 
     def test_get_version_for_tag(self):

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -1131,6 +1131,7 @@ flows:
           version_id: ^^upload_beta.version_id
           dependencies: ^^upload_beta.dependencies
           package_type: 1GP
+          tag_prefix: $project_config.project__git__prefix_beta
       3:
         task: github_release_notes
         ignore_failure: True # Attempt to generate release notes but don't fail build
@@ -1156,6 +1157,7 @@ flows:
           version_id: ^^upload_production.version_id
           dependencies: ^^upload_production.dependencies
           package_type: 1GP
+          tag_prefix: $project_config.project__git__prefix_release
       3:
         task: github_release_notes
         ignore_failure: True # Attempt to generate release notes but don't fail build
@@ -1177,6 +1179,7 @@ flows:
           version_id: ^^promote_package_version.version_id
           dependencies: ^^promote_package_version.dependencies
           package_type: 2GP
+          tag_prefix: $project_config.project__git__prefix_release
       3:
         task: github_release_notes
         ignore_failure: True # Attempt to generate release notes but don't fail build
@@ -1198,6 +1201,7 @@ flows:
           version_id: ^^promote_package_version.version_id
           dependencies: ^^promote_package_version.dependencies
           package_type: 2GP
+          tag_prefix: $project_config.project__git__prefix_release
       3:
         task: github_release_notes
         ignore_failure: True # Attempt to generate release notes but don't fail build

--- a/cumulusci/tasks/github/publish.py
+++ b/cumulusci/tasks/github/publish.py
@@ -24,16 +24,17 @@ class PublishSubtree(BaseGithubTask):
             "required": True,
         },
         "version": {
-            "description": "(Deprecated) Only the values of 'latest' and 'latest_beta' are acceptable. "
-            "Required if 'ref' is not set. This will override any"
+            "description": "(Deprecated >= 3.42.0) Only the values of 'latest' and 'latest_beta' are acceptable. "
+            "Required if 'ref' or 'tag_name' is not set. This will override tag_name if it is provided."
         },
         "tag_name": {
             "description": "The name of the tag that should be associated with this release. "
             "Values of 'latest' and 'latest_beta' are also allowed. "
-            "Required if 'ref' is not set."
+            "Required if 'ref' or 'version' is not set."
         },
         "ref": {
-            "description": "The git reference to publish.  Takes precedence over 'version'."
+            "description": "The git reference to publish.  Takes precedence over 'version' and 'tag_name'. "
+            "Required if 'tag_name' is not set."
         },
         "include": {
             "description": "A list of paths from repo root to include. Directories must end with a trailing slash."
@@ -200,7 +201,7 @@ class PublishSubtree(BaseGithubTask):
         committer = CommitDir(self.target_repo, logger=self.logger)
         message = f"Published content from ref {self.ref}"
         if "tag_name" in self.options:
-            message += f'\n\nTag {self.options["tag_name"]}'
+            message += f"\n\nTag {self.tag_name}"
         return committer(
             path,
             self.options["branch"],

--- a/cumulusci/tasks/github/release.py
+++ b/cumulusci/tasks/github/release.py
@@ -39,7 +39,8 @@ class CreateRelease(BaseGithubTask):
             "required": True,
         },
         "tag_prefix": {
-            "description": "The prefix to use for the release tag created in github."
+            "description": "The prefix to use for the release tag created in github.",
+            "required": True,
         },
     }
 
@@ -58,7 +59,7 @@ class CreateRelease(BaseGithubTask):
         repo = self.get_repo()
         version = self.options["version"]
         tag_prefix = self.options.get("tag_prefix")
-        tag_name = self.project_config.get_tag_for_version(version, prefix=tag_prefix)
+        tag_name = self.project_config.get_tag_for_version(tag_prefix, version)
 
         # Make sure release doesn't already exist
         try:

--- a/cumulusci/tasks/github/tests/test_publish.py
+++ b/cumulusci/tasks/github/tests/test_publish.py
@@ -41,9 +41,25 @@ class TestPublishSubtree(unittest.TestCase, GithubApiTestMixin):
             ),
         )
 
+    def test_run_task__invalid_version_option_value(self):
+        task_config = TaskConfig(
+            {
+                "options": {
+                    "branch": "main",
+                    "version": "invalue_value",
+                    "create_release": True,
+                    "repo_url": self.public_repo_url,
+                    "includes": ["tasks/foo.py", "unpackaged/pre/foo/package.xml"],
+                }
+            }
+        )
+
+        with pytest.raises(TaskOptionsError):
+            PublishSubtree(self.project_config, task_config)
+
     @mock.patch("cumulusci.tasks.github.publish.download_extract_github_from_repo")
     @mock.patch("cumulusci.tasks.github.publish.CommitDir")
-    def test_run_task_tag_name(self, commit_dir, extract_github):
+    def test_run_task_tag_name__explicit_tag_name(self, commit_dir, extract_github):
         with responses.RequestsMock() as rsps:
             rsps.add(
                 method=responses.GET,
@@ -116,6 +132,178 @@ class TestPublishSubtree(unittest.TestCase, GithubApiTestMixin):
                 }
             )
             create_release_call = rsps.calls[7]
+            assert create_release_call.request.url == self.public_repo_url + "/releases"
+            assert create_release_call.request.method == responses.POST
+            assert create_release_call.request.body == expected_release_body
+
+    @mock.patch("cumulusci.tasks.github.publish.download_extract_github_from_repo")
+    @mock.patch("cumulusci.tasks.github.publish.CommitDir")
+    def test_run_task_tag_name__latest(self, commit_dir, extract_github):
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                method=responses.GET,
+                url=self.repo_api_url,
+                json=self._get_expected_repo(
+                    owner=self.repo_owner, name=self.repo_name
+                ),
+            )
+            rsps.add(
+                method=responses.GET,
+                url=self.public_repo_url,
+                json=self._get_expected_repo(
+                    owner=self.public_owner, name=self.public_name
+                ),
+            )
+            rsps.add(
+                method=responses.GET,
+                url=self.repo_api_url + "/releases/latest",
+                status=200,
+                json=self._get_expected_release("release/1.0"),
+            )
+            rsps.add(
+                method=responses.GET,
+                url=self.repo_api_url + "/git/refs/tags/release/1.0",
+                status=200,
+                json=self._get_expected_tag_ref("release/1.0", "SHA"),
+            )
+            rsps.add(
+                method=responses.GET,
+                url=self.repo_api_url + "/git/tags/SHA",
+                json=self._get_expected_tag("release/1.0", "SHA"),
+                status=200,
+            )
+            rsps.add(
+                responses.GET,
+                self.repo_api_url + "/releases/tags/release/1.0",
+                json=self._get_expected_release("release/1.0"),
+            )
+            rsps.add(
+                responses.GET,
+                self.public_repo_url + "/git/refs/tags/release/1.0",
+                status=404,
+            )
+            rsps.add(
+                responses.POST,
+                self.public_repo_url + "/releases",
+                json=self._get_expected_release("release"),
+            )
+            task_config = TaskConfig(
+                {
+                    "options": {
+                        "branch": "main",
+                        "tag_name": "latest",
+                        "create_release": True,
+                        "repo_url": self.public_repo_url,
+                        "includes": ["tasks/foo.py", "unpackaged/pre/foo/package.xml"],
+                    }
+                }
+            )
+            extract_github.return_value.namelist.return_value = [
+                "tasks/foo.py",
+                "unpackaged/pre/foo/package.xml",
+                "force-app",
+            ]
+
+            task = PublishSubtree(self.project_config, task_config)
+            task()
+
+            expected_release_body = json.dumps(
+                {
+                    "tag_name": "release/1.0",
+                    "name": "1.0",
+                    "body": "",
+                    "draft": False,
+                    "prerelease": False,
+                }
+            )
+            create_release_call = rsps.calls[9]
+            assert create_release_call.request.url == self.public_repo_url + "/releases"
+            assert create_release_call.request.method == responses.POST
+            assert create_release_call.request.body == expected_release_body
+
+    @mock.patch("cumulusci.tasks.github.publish.download_extract_github_from_repo")
+    @mock.patch("cumulusci.tasks.github.publish.CommitDir")
+    def test_run_task_version(self, commit_dir, extract_github):
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                method=responses.GET,
+                url=self.repo_api_url,
+                json=self._get_expected_repo(
+                    owner=self.repo_owner, name=self.repo_name
+                ),
+            )
+            rsps.add(
+                method=responses.GET,
+                url=self.public_repo_url,
+                json=self._get_expected_repo(
+                    owner=self.public_owner, name=self.public_name
+                ),
+            )
+            rsps.add(
+                method=responses.GET,
+                url=self.repo_api_url + "/releases",
+                status=200,
+                json=self._get_expected_releases(
+                    "TestOwner", "TestRepo", ["beta/1.0-Beta_1"]
+                ),
+            )
+            rsps.add(
+                method=responses.GET,
+                url=self.repo_api_url + "/git/refs/tags/beta/1.0-Beta_1",
+                status=200,
+                json=self._get_expected_tag_ref("release/1.0", "SHA"),
+            )
+            rsps.add(
+                method=responses.GET,
+                url=self.repo_api_url + "/git/tags/SHA",
+                json=self._get_expected_tag("release/1.0", "SHA"),
+                status=200,
+            )
+            rsps.add(
+                responses.GET,
+                self.repo_api_url + "/releases/tags/beta/1.0-Beta_1",
+                json=self._get_expected_release("release/1.0"),
+            )
+            rsps.add(
+                responses.GET,
+                self.public_repo_url + "/git/refs/tags/beta/1.0-Beta_1",
+                status=404,
+            )
+            rsps.add(
+                responses.POST,
+                self.public_repo_url + "/releases",
+                json=self._get_expected_release("beta/1.0-Beta_1"),
+            )
+            task_config = TaskConfig(
+                {
+                    "options": {
+                        "branch": "main",
+                        "version": "latest_beta",
+                        "create_release": True,
+                        "repo_url": self.public_repo_url,
+                        "includes": ["tasks/foo.py", "unpackaged/pre/foo/package.xml"],
+                    }
+                }
+            )
+            extract_github.return_value.namelist.return_value = [
+                "tasks/foo.py",
+                "unpackaged/pre/foo/package.xml",
+                "force-app",
+            ]
+
+            task = PublishSubtree(self.project_config, task_config)
+            task()
+
+            expected_release_body = json.dumps(
+                {
+                    "tag_name": "beta/1.0-Beta_1",
+                    "name": "1.0 (Beta 1)",
+                    "body": "",
+                    "draft": False,
+                    "prerelease": False,
+                }
+            )
+            create_release_call = rsps.calls[9]
             assert create_release_call.request.url == self.public_repo_url + "/releases"
             assert create_release_call.request.method == responses.POST
             assert create_release_call.request.body == expected_release_body
@@ -362,7 +550,7 @@ class TestPublishSubtree(unittest.TestCase, GithubApiTestMixin):
         )
         with pytest.raises(TaskOptionsError) as exc:
             PublishSubtree(self.project_config, task_config)
-        assert "Either `ref` or `tag_name` option is required" == str(exc.value)
+        assert "Either `ref` or `tag_name` option is required." == str(exc.value)
 
     def test_renames_not_list_error(self):
         task_config = TaskConfig(

--- a/cumulusci/tasks/github/tests/test_publish.py
+++ b/cumulusci/tasks/github/tests/test_publish.py
@@ -43,7 +43,7 @@ class TestPublishSubtree(unittest.TestCase, GithubApiTestMixin):
 
     @mock.patch("cumulusci.tasks.github.publish.download_extract_github_from_repo")
     @mock.patch("cumulusci.tasks.github.publish.CommitDir")
-    def test_run_task_version(self, commit_dir, extract_github):
+    def test_run_task_tag_name(self, commit_dir, extract_github):
         with responses.RequestsMock() as rsps:
             rsps.add(
                 method=responses.GET,
@@ -51,11 +51,6 @@ class TestPublishSubtree(unittest.TestCase, GithubApiTestMixin):
                 json=self._get_expected_repo(
                     owner=self.repo_owner, name=self.repo_name
                 ),
-            )
-            rsps.add(
-                responses.GET,
-                self.repo_api_url + "/releases/latest",
-                json=self._get_expected_release("release/1.0"),
             )
             rsps.add(
                 method=responses.GET,
@@ -95,7 +90,7 @@ class TestPublishSubtree(unittest.TestCase, GithubApiTestMixin):
                 {
                     "options": {
                         "branch": "main",
-                        "version": "latest",
+                        "tag_name": "release/1.0",
                         "create_release": True,
                         "repo_url": self.public_repo_url,
                         "includes": ["tasks/foo.py", "unpackaged/pre/foo/package.xml"],
@@ -120,43 +115,10 @@ class TestPublishSubtree(unittest.TestCase, GithubApiTestMixin):
                     "prerelease": False,
                 }
             )
-            create_release_call = rsps.calls[9]
+            create_release_call = rsps.calls[7]
             assert create_release_call.request.url == self.public_repo_url + "/releases"
             assert create_release_call.request.method == responses.POST
             assert create_release_call.request.body == expected_release_body
-
-    @responses.activate
-    @mock.patch("cumulusci.core.config.project_config.BaseProjectConfig.get_latest_tag")
-    @mock.patch("cumulusci.tasks.github.publish.download_extract_github_from_repo")
-    @mock.patch("cumulusci.tasks.github.publish.CommitDir.__call__")
-    def test_run_task_latest_beta(self, commit_dir, download, get_tag):
-        responses.add(
-            method=responses.GET,
-            url=self.repo_api_url,
-            json=self._get_expected_repo(owner=self.repo_owner, name=self.repo_name),
-        )
-        responses.add(
-            method=responses.GET,
-            url=self.public_repo_url,
-            json=self._get_expected_repo(
-                owner=self.public_owner, name=self.public_name
-            ),
-        )
-        task_config = TaskConfig(
-            {
-                "options": {
-                    "branch": "main",
-                    "version": "latest_beta",
-                    "repo_url": self.public_repo_url,
-                    "includes": ["tasks/foo.py", "unpackaged/pre/foo/package.xml"],
-                }
-            }
-        )
-        get_tag.return_value = "beta/1.0_Beta_1"
-        commit_dir.return_value = None
-        task = PublishSubtree(self.project_config, task_config)
-        task()
-        get_tag.assert_called_once_with(True)
 
     @responses.activate
     @mock.patch("cumulusci.tasks.github.publish.download_extract_github_from_repo")
@@ -188,7 +150,7 @@ class TestPublishSubtree(unittest.TestCase, GithubApiTestMixin):
             {
                 "options": {
                     "branch": "main",
-                    "version": "latest",
+                    "tag_name": "release/1.0",
                     "create_release": True,
                     "repo_url": self.public_repo_url,
                     "includes": ["tasks/foo.py", "unpackaged/pre/foo/package.xml"],
@@ -244,7 +206,7 @@ class TestPublishSubtree(unittest.TestCase, GithubApiTestMixin):
             {
                 "options": {
                     "branch": "main",
-                    "version": "latest",
+                    "tag_name": "release/1.0",
                     "create_release": True,
                     "repo_url": self.public_repo_url,
                     "includes": ["tasks/foo.py", "unpackaged/pre/foo/package.xml"],
@@ -301,7 +263,7 @@ class TestPublishSubtree(unittest.TestCase, GithubApiTestMixin):
             {
                 "options": {
                     "branch": "master",
-                    "version": "latest",
+                    "tag_name": "release/1.0",
                     "create_release": True,
                     "repo_url": self.public_repo_url,
                     "includes": ["tasks/foo.py", "unpackaged/pre/foo/package.xml"],
@@ -371,7 +333,7 @@ class TestPublishSubtree(unittest.TestCase, GithubApiTestMixin):
             {
                 "options": {
                     "branch": "master",
-                    "version": "latest",
+                    "tag_name": "release/1.0",
                     "create_release": True,
                     "repo_url": self.public_repo_url,
                     "includes": ["tasks/foo.py", "unpackaged/pre/foo/package.xml"],
@@ -388,7 +350,7 @@ class TestPublishSubtree(unittest.TestCase, GithubApiTestMixin):
             task()
         assert "Ref for tag release/1.0 already exists in target repo" == str(exc.value)
 
-    def test_ref_nor_version_error(self):
+    def test_ref_nor_tag_name_error(self):
         task_config = TaskConfig(
             {
                 "options": {
@@ -400,7 +362,7 @@ class TestPublishSubtree(unittest.TestCase, GithubApiTestMixin):
         )
         with pytest.raises(TaskOptionsError) as exc:
             PublishSubtree(self.project_config, task_config)
-        assert "Either `ref` or `version` option is required" == str(exc.value)
+        assert "Either `ref` or `tag_name` option is required" == str(exc.value)
 
     def test_renames_not_list_error(self):
         task_config = TaskConfig(

--- a/cumulusci/tasks/github/tests/test_release.py
+++ b/cumulusci/tasks/github/tests/test_release.py
@@ -83,6 +83,7 @@ class TestCreateRelease(unittest.TestCase, GithubApiTestMixin):
                         "version_id": "04t000000000000",
                         "dependencies": [{"namespace": "foo", "version": "1.0"}],
                         "package_type": "1GP",
+                        "tag_prefix": "release/",
                     }
                 }
             ),
@@ -124,6 +125,7 @@ class TestCreateRelease(unittest.TestCase, GithubApiTestMixin):
                         "version": "1.0",
                         "version_id": "04t000000000000",
                         "package_type": "1GP",
+                        "tag_prefix": "release/",
                     }
                 }
             ),
@@ -279,6 +281,7 @@ class TestCreateRelease(unittest.TestCase, GithubApiTestMixin):
                         "version": "1.0 (Beta 1)",
                         "version_id": "04t000000000000",
                         "package_type": "1GP",
+                        "tag_prefix": "beta/",
                     }
                 }
             ),


### PR DESCRIPTION
# Critical Changes
* The `github_release` task now requires the `tag_prefix` option to be passed.
* The `github_copy_subtree` task now requires a `tag_name` option to be passed, and the `version` option has been deprecated.

# Issues Closed
* Fixed an issue where GitHub tags for 2GP package would always include the "release" prefix (even for Beta packages).

## Dev Notes
* @jstvz - We're reworking the `project_config.get_tag_for_version()` method to require both a `tag_prefix` and a `version`. The `PublishSubtree` class is the only other place where this method is referenced but is currently not passing a prefix.  I don't know too much about this task; is there a way we can derive which tag prefix to use—either `beta/` or `release/`—based on the the value of the `create_release` option? If not, is there another way we can infer what prefix is desired? Looks like we do set the `prerelease` value for the release based on `release.prerelease`, but we only have access to that release object after the tag has been created.
