### PR TITLE
Get commit sha when in detached HEAD

### DIFF
--- a/cumulusci/core/config/project_config.py
+++ b/cumulusci/core/config/project_config.py
@@ -323,7 +323,6 @@ class BaseProjectConfig(BaseTaskFlowConfig):
             return
 
         branch = self.repo_branch
-        commit_file_path = pathlib.Path(self.repo_root) / ".git" / "HEAD"
         if branch:
             commit_file_path = pathlib.Path(self.repo_root) / ".git" / "refs" / "heads"
             commit_file_path = commit_file_path.joinpath(*branch.split("/"))

--- a/cumulusci/core/config/project_config.py
+++ b/cumulusci/core/config/project_config.py
@@ -333,16 +333,20 @@ class BaseProjectConfig(BaseTaskFlowConfig):
         if commit_file_path.exists() and commit_file_path.is_file():
             return commit_file_path.read_text().strip()
         else:
-            packed_refs_path = os.path.join(self.repo_root, ".git", "packed-refs")
-            with open(packed_refs_path, "r") as f:
-                for line in f:
-                    parts = line.split(" ")
-                    if len(parts) == 1:
-                        # Skip lines showing the commit sha of a tag on the
-                        # preceeding line
-                        continue
-                    if parts[1].replace("refs/remotes/origin/", "").strip() == branch:
-                        return parts[0]
+            if branch:
+                packed_refs_path = os.path.join(self.repo_root, ".git", "packed-refs")
+                with open(packed_refs_path, "r") as f:
+                    for line in f:
+                        parts = line.split(" ")
+                        if len(parts) == 1:
+                            # Skip lines showing the commit sha of a tag on the
+                            # preceeding line
+                            continue
+                        if (
+                            parts[1].replace("refs/remotes/origin/", "").strip()
+                            == branch
+                        ):
+                            return parts[0]
 
     def get_github_api(self, owner=None, repo=None):
         return get_github_api_for_repo(

--- a/cumulusci/core/config/project_config.py
+++ b/cumulusci/core/config/project_config.py
@@ -1,5 +1,6 @@
 import json
 import os
+import pathlib
 import re
 from configparser import ConfigParser
 from contextlib import contextmanager
@@ -322,17 +323,16 @@ class BaseProjectConfig(BaseTaskFlowConfig):
             return
 
         branch = self.repo_branch
-        if not branch:
-            return
+        commit_file_path = pathlib.Path(self.repo_root) / ".git" / "HEAD"
+        if branch:
+            commit_file_path = pathlib.Path(self.repo_root) / ".git" / "refs" / "heads"
+            commit_file_path = commit_file_path.joinpath(*branch.split("/"))
+        else:
+            # We're in detached HEAD mode; .git/HEAD contains the SHA
+            commit_file_path = pathlib.Path(self.repo_root) / ".git" / "HEAD"
 
-        join_args = [self.repo_root, ".git", "refs", "heads"]
-        join_args.extend(branch.split("/"))
-        commit_file = os.path.join(*join_args)
-
-        commit_sha = None
-        if os.path.isfile(commit_file):
-            with open(commit_file, "r") as f:
-                commit_sha = f.read().strip()
+        if commit_file_path.exists() and commit_file_path.is_file():
+            return commit_file_path.read_text().strip()
         else:
             packed_refs_path = os.path.join(self.repo_root, ".git", "packed-refs")
             with open(packed_refs_path, "r") as f:
@@ -343,10 +343,7 @@ class BaseProjectConfig(BaseTaskFlowConfig):
                         # preceeding line
                         continue
                     if parts[1].replace("refs/remotes/origin/", "").strip() == branch:
-                        commit_sha = parts[0]
-                        break
-
-        return commit_sha
+                        return parts[0]
 
     def get_github_api(self, owner=None, repo=None):
         return get_github_api_for_repo(

--- a/cumulusci/core/config/tests/test_config.py
+++ b/cumulusci/core/config/tests/test_config.py
@@ -403,7 +403,7 @@ class TestBaseProjectConfig(unittest.TestCase):
             with open(os.path.join(d, ".git", "HEAD"), "w") as f:
                 f.write("abcdef")
 
-            self.assertIsNone(config.repo_commit)
+            assert config.repo_commit == "abcdef"
 
     def test_repo_commit_packed_refs(self):
         config = BaseProjectConfig(UniversalConfig())


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed

- We fixed an issue causing 2GP commit-status builds to fail when the local Git repository has a detached HEAD (fixes #2801).
