### PR TITLE
Made the test for 'Switch Window' more robust

### DIFF
--- a/cumulusci/robotframework/tests/salesforce/browsers.robot
+++ b/cumulusci/robotframework/tests/salesforce/browsers.robot
@@ -126,10 +126,10 @@ Select Window calls Switch Window
     ...              and also that it logs a deprecation warning
     [Setup]          Run keywords
     ...  Open test browser
+    ...  AND  go to setup home
     ...  AND  execute javascript  window.open("about:blank", "window1")
     [Teardown]       Close all browsers
 
-    ${main location}=  get location
 
     Reset test listener message log
     Select Window       window1
@@ -139,4 +139,5 @@ Select Window calls Switch Window
     Reset test listener message log
     Select Window       # defaults to the original window
     Assert robot log    'Select Window' is deprecated; use 'Switch Window' instead  WARN
-    location should be  ${main location}
+    # let's make sure we actually are at the main window's location
+    Wait until location contains  /lightning/setup/SetupOneHome/home


### PR DESCRIPTION
The problem was that we were capturing the location before salesforce was ready, and we weren't capturing the final location. The fix is to explicitly go to a known page and then later wait until we are on that known page.


# Critical Changes

# Changes

# Issues Closed
