### PR TITLE
Feature/case insensitive record types

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -4,6 +4,13 @@ project:
         name: CumulusCI
 
 tasks:
+    update_admin_profile:
+        options:
+            record_types:
+                - record_type: Account.HH_Account
+                  default: True
+                - record_type: Account.Organization
+
     robot:
         options:
             suites: cumulusci/robotframework/tests

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from unittest.mock import MagicMock
 
+from requests.structures import CaseInsensitiveDict
 from sqlalchemy import Column, MetaData, Table, Unicode, create_engine, func, text
 from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.orm import Session, aliased
@@ -276,7 +277,7 @@ class LoadData(SqlAlchemyMixin, BaseSalesforceApiTask):
             columns.append(lookup.aliased_table.columns.sf_id)
 
         if "RecordTypeId" in mapping.fields:
-            rt_dest_table = self.metadata.tables[
+            rt_dest_table = CaseInsensitiveDict(self.metadata.tables)[
                 mapping.get_destination_record_type_table()
             ]
             columns.append(rt_dest_table.columns.record_type_id)
@@ -292,7 +293,7 @@ class LoadData(SqlAlchemyMixin, BaseSalesforceApiTask):
 
         if "RecordTypeId" in mapping.fields:
             try:
-                rt_source_table = self.metadata.tables[
+                rt_source_table = CaseInsensitiveDict(self.metadata.tables)[
                     mapping.get_source_record_type_table()
                 ]
             except KeyError as e:

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -315,13 +315,13 @@ class LoadData(SqlAlchemyMixin, BaseSalesforceApiTask):
             ]
             query = query.outerjoin(
                 rt_source_table,
-                rt_source_table.columns.record_type_id
-                == getattr(model, mapping.fields["RecordTypeId"]),
+                func.lower(rt_source_table.columns.record_type_id)
+                == func.lower(getattr(model, mapping.fields["RecordTypeId"])),
             )
             query = query.outerjoin(
                 rt_dest_table,
-                rt_dest_table.columns.developer_name
-                == rt_source_table.columns.developer_name,
+                func.lower(rt_dest_table.columns.developer_name)
+                == func.lower(rt_source_table.columns.developer_name),
             )
 
         for sf_field, lookup in lookups.items():

--- a/cumulusci/tasks/bulkdata/snowfakery.py
+++ b/cumulusci/tasks/bulkdata/snowfakery.py
@@ -227,6 +227,10 @@ class Snowfakery(BaseSalesforceApiTask):
                 portions,
             )
             self.finish(upload_status, self.data_gen_q, self.load_data_q)
+            sobject_counts = {
+                name: value.as_dict() for name, value in self.sobject_counts.items()
+            }
+            self.return_values = {"sobject_counts": sobject_counts}
 
     def configure_queues(self, working_directory):
         """Configure two ParallelWorkerQueues for datagen and dataload"""
@@ -750,3 +754,6 @@ class RunningTotals:
 
     def __repr__(self):
         return f"<{self.__class__.__name__} {self.__dict__}>"
+
+    def as_dict(self):
+        return self.__dict__.copy()

--- a/cumulusci/tasks/bulkdata/tests/snowfakery/record_types.recipe.yml
+++ b/cumulusci/tasks/bulkdata/tests/snowfakery/record_types.recipe.yml
@@ -1,0 +1,5 @@
+# contact based on a user
+- object: ACCOUNT
+  fields:
+      name: Name
+      RecordType: hh_Account2

--- a/cumulusci/tasks/bulkdata/tests/snowfakery/record_types.recipe.yml
+++ b/cumulusci/tasks/bulkdata/tests/snowfakery/record_types.recipe.yml
@@ -1,5 +1,4 @@
-# contact based on a user
 - object: ACCOUNT
   fields:
       name: Name
-      RecordType: hh_Account2
+      RecordType: Organization

--- a/cumulusci/tasks/bulkdata/tests/test_load.py
+++ b/cumulusci/tasks/bulkdata/tests/test_load.py
@@ -1476,10 +1476,10 @@ class TestLoadData(unittest.TestCase):
 
         # Validate that we asked for the right joins on the record type tables
         task.session.query.return_value.outerjoin.assert_called_once_with(
-            task.metadata.tables["Account_rt_mapping"], False
+            task.metadata.tables["Account_rt_mapping"], mock.ANY
         )
         task.session.query.return_value.outerjoin.return_value.outerjoin.assert_called_once_with(
-            task.metadata.tables["Account_rt_target_mapping"], False
+            task.metadata.tables["Account_rt_target_mapping"], mock.ANY
         )
 
     @mock.patch("cumulusci.tasks.bulkdata.load.automap_base")

--- a/cumulusci/tasks/bulkdata/tests/test_snowfakery.py
+++ b/cumulusci/tasks/bulkdata/tests/test_snowfakery.py
@@ -566,13 +566,22 @@ class TestSnowfakery:
     @pytest.mark.needs_org()
     @pytest.mark.slow()
     @pytest.mark.org_shape("qa", "qa_org")
-    def test_record_types(self, snowfakery):
+    def test_record_types(self, snowfakery, sf):
+        data = sf.query(
+            "SELECT Name,RecordType.Name from Account where RecordTypeId != NULL"
+        )["records"]
+        assert not data, data
         record_type_recipe = samples_dir / "record_types.recipe.yml"
         task = snowfakery(recipe=record_type_recipe)
         task()
         account_info = task.return_values["sobject_counts"]["Account"]
         assert account_info["successes"] == 1
         assert account_info["errors"] == 0
+        data = sf.query(
+            "SELECT Name,RecordType.Name from Account where RecordTypeId != NULL"
+        )["records"]
+        assert len(data) == 1
+        assert data[0]["RecordType"]["Name"] == "Organization"
 
     # def test_generate_mapping_file(self):
     #     with temporary_file_path("mapping.yml") as temp_mapping:

--- a/unpackaged/README.md
+++ b/unpackaged/README.md
@@ -1,0 +1,4 @@
+## Unpackaged test configuration
+
+Used to test Snowfakery's generation of record type references,
+especially case insensitivity of object names.

--- a/unpackaged/config.json
+++ b/unpackaged/config.json
@@ -2,7 +2,7 @@
     "pre": [
         {
             "bundle": "Account Record Types",
-            "description": "Creates the Household Account record types",
+            "description": "Creates the Household and Organization Account record types",
             "path": "pre/account_record_types"
         }
     ],

--- a/unpackaged/config.json
+++ b/unpackaged/config.json
@@ -1,0 +1,10 @@
+{
+    "pre": [
+        {
+            "bundle": "Account Record Types",
+            "description": "Creates the Household Account record types",
+            "path": "pre/account_record_types"
+        }
+    ],
+    "post": []
+}

--- a/unpackaged/pre/account_record_types/objects/Account.object
+++ b/unpackaged/pre/account_record_types/objects/Account.object
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <recordTypes>
+        <fullName>HH_Account</fullName>
+        <active>true</active>
+        <description>An Account representing a Household containing one or more individuals</description>
+        <label>Household Account</label>
+    </recordTypes>
+    <recordTypes>
+        <fullName>Organization</fullName>
+        <active>true</active>
+        <description>An Account representing an organization</description>
+        <label>Organization</label>
+    </recordTypes>
+</CustomObject>

--- a/unpackaged/pre/account_record_types/package.xml
+++ b/unpackaged/pre/account_record_types/package.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <types>
+    <members>*</members>
+    <name>CustomObject</name>
+  </types>
+  <version>48.0</version>
+</Package>


### PR DESCRIPTION
SObject names are generally case insensitive in Salesforce and Snowfakery. Because Snowfakery does not know the "real" names of sobjects, it may generate synthetic record type tables which do not have the same case as the real SObjects. This PR fixes a crash that happens when sobject names use the 'wrong' case.