### PR TITLE
Don't use checkboxes in bug issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -47,16 +47,17 @@ body:
       attributes:
           label: Operating System
           description: Your operating system and version.
-    - type: checkboxes
+    - type: dropdown
       id: win
       attributes:
           label: Windows environment
           description: If using Windows, how are you running CumulusCI?
+          multiple: true
           options:
-              - label: Command Prompt
-              - label: PowerShell
-              - label: Bash on Windows
-              - label: WSL
+              - Bash on Windows
+              - Command Prompt
+              - PowerShell
+              - WSL
     - type: dropdown
       id: install
       attributes:


### PR DESCRIPTION
Github's form schema treats the `checkbox` type as a tasklist. Since the
intention is to allow the user to select more than one environment we should use a dropdown and give the user the _option_ to select more than one option.


# Critical Changes

# Changes

# Issues Closed
