### PR TITLE
remove nonfunctional --skip option for cci flow run

### DIFF
--- a/cumulusci/cli/flow.py
+++ b/cumulusci/cli/flow.py
@@ -123,17 +123,12 @@ def flow_info(runtime, flow_name):
     help="Pass task specific options for the task as '-o taskname__option value'.  You can specify more than one option by using -o more than once.",
 )
 @click.option(
-    "--skip",
-    multiple=True,
-    help="Specify task names that should be skipped in the flow.  Specify multiple by repeating the --skip option",
-)
-@click.option(
     "--no-prompt",
     is_flag=True,
     help="Disables all prompts.  Set for non-interactive mode use such as calling from scripts or CI systems",
 )
 @pass_runtime(require_keychain=True)
-def flow_run(runtime, flow_name, org, delete_org, debug, o, skip, no_prompt):
+def flow_run(runtime, flow_name, org, delete_org, debug, o, no_prompt):
 
     # Get necessary configs
     org, org_config = runtime.get_org(org)

--- a/cumulusci/cli/tests/test_flow.py
+++ b/cumulusci/cli/tests/test_flow.py
@@ -158,7 +158,6 @@ def test_flow_run():
         delete_org=True,
         debug=False,
         o=[("test_task__color", "blue")],
-        skip=(),
         no_prompt=True,
     )
 
@@ -196,7 +195,6 @@ def test_flow_run__delete_org_when_error_occurs_in_flow():
             delete_org=True,
             debug=False,
             o=[("test_task__color", "blue")],
-            skip=(),
             no_prompt=True,
         )
 
@@ -220,7 +218,6 @@ def test_flow_run__option_error():
             delete_org=True,
             debug=False,
             o=[("test_task", "blue")],
-            skip=(),
             no_prompt=True,
         )
 
@@ -239,7 +236,6 @@ def test_flow_run__delete_non_scratch():
             delete_org=True,
             debug=False,
             o=None,
-            skip=(),
             no_prompt=True,
         )
 
@@ -273,7 +269,6 @@ def test_flow_run__org_delete_error(echo):
         "debug": False,
         "no_prompt": True,
         "o": (("test_task__color", "blue"),),
-        "skip": (),
     }
 
     run_click_command(flow.flow_run, **kwargs)


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed
- Removed the `--skip` option for the `cci flow run` command, which was not actually doing anything