### PR TITLE
Remove max-lines option from `cci error info`

### DIFF
--- a/cumulusci/cli/error.py
+++ b/cumulusci/cli/error.py
@@ -47,36 +47,13 @@ CCI_LOGFILE_PATH = Path.home() / ".cumulusci" / "logs" / "cci.log"
     name="info",
     help="Outputs the most recent traceback (if one exists in the most recent log)",
 )
-@click.option("--max-lines", "-m", type=int)
-def error_info(max_lines: int = 0):
+def error_info():
     if not CCI_LOGFILE_PATH.is_file():
         click.echo(f"No logfile found at: {CCI_LOGFILE_PATH}")
-    else:
-        output = lines_from_traceback(
-            CCI_LOGFILE_PATH.read_text(encoding="utf-8"), max_lines
-        )
-        click.echo(output)
+        return
 
-
-def lines_from_traceback(log_content: str, max_lines: int = 0) -> str:
-    """Returns the the last max_lines of the logfile,
-    or the whole traceback, whichever is shorter. If
-    no stacktrace is found in the logfile, the user is
-    notified.
-    """
-    stacktrace_start = "Traceback (most recent call last):"
-    if stacktrace_start not in log_content:
-        return f"\nNo stacktrace found in: {CCI_LOGFILE_PATH}\n"
-
-    stacktrace = ""
-    for i, line in enumerate(reversed(log_content.split("\n")), 1):
-        stacktrace = "\n" + line + stacktrace
-        if stacktrace_start in line:
-            break
-        if i == max_lines:
-            break
-
-    return stacktrace
+    logfile_content = CCI_LOGFILE_PATH.read_text(encoding="utf-8")
+    click.echo(logfile_content)
 
 
 @error.command(name="gist", help="Creates a GitHub gist from the latest logfile")

--- a/cumulusci/cli/tests/test_error.py
+++ b/cumulusci/cli/tests/test_error.py
@@ -41,7 +41,7 @@ class TestErrorCommands:
     def test_error_info__no_log_file(self, log_path, echo):
         log_path.is_file.return_value = False
         run_click_command(error.error_info)
-        assert "No logfile found at:" in echo.call_args_list[0].args[0]
+        assert "No logfile found at:" in echo.call_args_list[0][0][0]
 
     @mock.patch("cumulusci.cli.error.CCI_LOGFILE_PATH")
     @mock.patch("webbrowser.open")

--- a/cumulusci/cli/tests/test_error.py
+++ b/cumulusci/cli/tests/test_error.py
@@ -33,29 +33,15 @@ class TestErrorCommands:
             with mock.patch("cumulusci.cli.error.CCI_LOGFILE_PATH", logfile):
                 run_click_command(error.error_info)
         echo.assert_called_once_with(
-            "\nTraceback (most recent call last):\n1\n2\n3\n\u2603"
+            "This\nis\na\ntest\nTraceback (most recent call last):\n1\n2\n3\n☃"
         )
 
     @mock.patch("click.echo")
     @mock.patch("cumulusci.cli.error.CCI_LOGFILE_PATH")
-    def test_error_info__output_less(self, log_path, echo):
-        log_path.is_file.return_value = True
-        log_path.read_text.return_value = (
-            "This\nis\na\ntest\nTraceback (most recent call last):\n1\n2\n3\n4"
-        )
-
-        run_click_command(error.error_info, max_lines=3)
-        echo.assert_called_once_with("\n2\n3\n4")
-
-    def test_lines_from_traceback_no_traceback(self):
-        output = error.lines_from_traceback("test_content", 10)
-        assert "\nNo stacktrace found in:" in output
-
-    def test_lines_from_traceback(self):
-        traceback = "\nTraceback (most recent call last):\n1\n2\n3\n4"
-        content = "This\nis\na" + traceback
-        output = error.lines_from_traceback(content, 10)
-        assert output == traceback
+    def test_error_info__no_log_file(self, log_path, echo):
+        log_path.is_file.return_value = False
+        run_click_command(error.error_info)
+        assert "No logfile found at:" in echo.call_args_list[0].args[0]
 
     @mock.patch("cumulusci.cli.error.CCI_LOGFILE_PATH")
     @mock.patch("webbrowser.open")


### PR DESCRIPTION
This option is likely rarely used if at all. I was thinking it would be more useful than it actually is when I originally implemented the command.

# Critical Changes
- The `--max-lines` option in the `cci error info` command has been deprecated.

