### PR TITLE
remove max-lines option

### DIFF
--- a/cumulusci/cli/error.py
+++ b/cumulusci/cli/error.py
@@ -47,23 +47,17 @@ CCI_LOGFILE_PATH = Path.home() / ".cumulusci" / "logs" / "cci.log"
     name="info",
     help="Outputs the most recent traceback (if one exists in the most recent log)",
 )
-@click.option("--max-lines", "-m", type=int)
-def error_info(max_lines: int = 0):
+def error_info():
     if not CCI_LOGFILE_PATH.is_file():
         click.echo(f"No logfile found at: {CCI_LOGFILE_PATH}")
-    else:
-        output = lines_from_traceback(
-            CCI_LOGFILE_PATH.read_text(encoding="utf-8"), max_lines
-        )
-        click.echo(output)
+        return
+
+    traceback = get_traceback(CCI_LOGFILE_PATH.read_text(encoding="utf-8"))
+    click.echo(traceback)
 
 
-def lines_from_traceback(log_content: str, max_lines: int = 0) -> str:
-    """Returns the the last max_lines of the logfile,
-    or the whole traceback, whichever is shorter. If
-    no stacktrace is found in the logfile, the user is
-    notified.
-    """
+def get_traceback(log_content: str) -> str:
+    """Returns the the traceback in a logfile if it exists."""
     stacktrace_start = "Traceback (most recent call last):"
     if stacktrace_start not in log_content:
         return f"\nNo stacktrace found in: {CCI_LOGFILE_PATH}\n"
@@ -72,8 +66,6 @@ def lines_from_traceback(log_content: str, max_lines: int = 0) -> str:
     for i, line in enumerate(reversed(log_content.split("\n")), 1):
         stacktrace = "\n" + line + stacktrace
         if stacktrace_start in line:
-            break
-        if i == max_lines:
             break
 
     return stacktrace

--- a/cumulusci/cli/tests/test_error.py
+++ b/cumulusci/cli/tests/test_error.py
@@ -6,6 +6,7 @@ import github3
 import pytest
 
 import cumulusci
+from cumulusci.cli.error import get_traceback
 from cumulusci.core.exceptions import CumulusCIException
 from cumulusci.utils import temporary_dir
 
@@ -36,25 +37,14 @@ class TestErrorCommands:
             "\nTraceback (most recent call last):\n1\n2\n3\n\u2603"
         )
 
-    @mock.patch("click.echo")
-    @mock.patch("cumulusci.cli.error.CCI_LOGFILE_PATH")
-    def test_error_info__output_less(self, log_path, echo):
-        log_path.is_file.return_value = True
-        log_path.read_text.return_value = (
-            "This\nis\na\ntest\nTraceback (most recent call last):\n1\n2\n3\n4"
-        )
-
-        run_click_command(error.error_info, max_lines=3)
-        echo.assert_called_once_with("\n2\n3\n4")
-
-    def test_lines_from_traceback_no_traceback(self):
-        output = error.lines_from_traceback("test_content", 10)
+    def test_get_traceback__no_traceback(self):
+        output = get_traceback("test_content")
         assert "\nNo stacktrace found in:" in output
 
-    def test_lines_from_traceback(self):
+    def test_get_traceback(self):
         traceback = "\nTraceback (most recent call last):\n1\n2\n3\n4"
         content = "This\nis\na" + traceback
-        output = error.lines_from_traceback(content, 10)
+        output = get_traceback(content)
         assert output == traceback
 
     @mock.patch("cumulusci.cli.error.CCI_LOGFILE_PATH")


### PR DESCRIPTION
# Critical Changes
* The `--max-lines` option on the `cci error info` command has been deprecated.
