### PR TITLE
Remove bugged task option validation in `push_list`

### DIFF
--- a/cumulusci/tasks/push/tasks.py
+++ b/cumulusci/tasks/push/tasks.py
@@ -260,6 +260,10 @@ class SchedulePushOrgList(BaseSalesforcePushTask):
         # already set
         if "namespace" not in self.options:
             self.options["namespace"] = self.project_config.project__package__namespace
+        if "metadata_package_id" not in self.options:
+            self.options[
+                "metadata_package_id"
+            ] = self.project_config.project__package__metadata_package_id
         if "batch_size" not in self.options:
             self.options["batch_size"] = 200
         if "csv" not in self.options and "csv_field_name" in self.options:
@@ -282,10 +286,6 @@ class SchedulePushOrgList(BaseSalesforcePushTask):
         package_id = self.options.get("metadata_package_id")
         version_id = self.options.get("version_id")
         namespace_opt = self.options.get("namespace")
-        if package_id is not None and namespace_opt is not None:
-            raise TaskOptionsError(
-                "'metadata_package_id' and 'namespace' options cannot both be set."
-            )
 
         package = self._get_package(
             metadata_package_id=package_id,

--- a/cumulusci/utils/yaml/cumulusci_yml.py
+++ b/cumulusci/utils/yaml/cumulusci_yml.py
@@ -66,6 +66,7 @@ class Package(CCIDictModel):
     install_class: str = None
     uninstall_class: str = None
     api_version: str = None
+    metadata_package_id: str = None
 
 
 class Test(CCIDictModel):


### PR DESCRIPTION
The modification PR #2837 to allow 2GP push upgrades via `push_list` included validation, this introduced a bug because the init options method was already setting `namespace` as default. The validation is not needed because when `metadata_package_id` is present is takes precedence over `namespace`. 

Also added `metadata_package_id` as an available option in project config


# Critical Changes

# Changes
- We fixed a regression in the `push_list` task that affected 2GP push upgrades

# Issues Closed
