### PR TITLE
Support for JSON Schema for driving IDEs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,3 +116,8 @@ dev-install:
 	pip install --upgrade pip-tools
 	pip-sync requirements/*.txt
 	pip install -e .
+
+schema:
+		python -c 'from cumulusci.utils.yaml import cumulusci_yml; open("cumulusci/schema/cumulusci.jsonschema.json", "w").write(cumulusci_yml.CumulusCIRoot.schema_json(indent=4))'
+		pre-commit run prettier --files cumulusci/schema/cumulusci.jsonschema.json || true
+	

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=cumulusci/schema/cumulusci.jsonschema.json
 project:
     name: CumulusCI
     package:

--- a/cumulusci/schema/cumulusci.jsonschema.json
+++ b/cumulusci/schema/cumulusci.jsonschema.json
@@ -1,0 +1,611 @@
+{
+    "title": "CumulusCIRoot",
+    "type": "object",
+    "properties": {
+        "tasks": {
+            "title": "Tasks",
+            "default": {},
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/Task"
+            }
+        },
+        "flows": {
+            "title": "Flows",
+            "default": {},
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/Flow"
+            }
+        },
+        "project": {
+            "title": "Project",
+            "default": {},
+            "allOf": [
+                {
+                    "$ref": "#/definitions/Project"
+                }
+            ]
+        },
+        "orgs": {
+            "title": "Orgs",
+            "default": {},
+            "allOf": [
+                {
+                    "$ref": "#/definitions/Orgs"
+                }
+            ]
+        },
+        "services": {
+            "title": "Services",
+            "default": {},
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/Service"
+            }
+        },
+        "cumulusci": {
+            "$ref": "#/definitions/CumulusCIConfig"
+        },
+        "plans": {
+            "title": "Plans",
+            "default": {},
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/Plan"
+            }
+        },
+        "minimum_cumulusci_version": {
+            "title": "Minimum Cumulusci Version",
+            "type": "string"
+        },
+        "sources": {
+            "title": "Sources",
+            "default": {},
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    {
+                        "$ref": "#/definitions/LocalFolderSourceModel"
+                    },
+                    {
+                        "$ref": "#/definitions/GitHubSourceModel"
+                    }
+                ]
+            }
+        },
+        "cli": {
+            "$ref": "#/definitions/CumulusCLIConfig"
+        }
+    },
+    "additionalProperties": false,
+    "definitions": {
+        "Task": {
+            "title": "Task",
+            "type": "object",
+            "properties": {
+                "class_path": {
+                    "title": "Class Path",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "options": {
+                    "title": "Options",
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "group": {
+                    "title": "Group",
+                    "type": "string"
+                },
+                "ui_options": {
+                    "title": "Ui Options",
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "PreflightCheck": {
+            "title": "PreflightCheck",
+            "type": "object",
+            "properties": {
+                "when": {
+                    "title": "When",
+                    "type": "string"
+                },
+                "action": {
+                    "title": "Action",
+                    "type": "string"
+                },
+                "message": {
+                    "title": "Message",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "Step": {
+            "title": "Step",
+            "type": "object",
+            "properties": {
+                "task": {
+                    "title": "Task",
+                    "type": "string"
+                },
+                "flow": {
+                    "title": "Flow",
+                    "type": "string"
+                },
+                "options": {
+                    "title": "Options",
+                    "default": {},
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "ignore_failure": {
+                    "title": "Ignore Failure",
+                    "default": false,
+                    "type": "boolean"
+                },
+                "when": {
+                    "title": "When",
+                    "type": "string"
+                },
+                "ui_options": {
+                    "title": "Ui Options",
+                    "default": {},
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "checks": {
+                    "title": "Checks",
+                    "default": [],
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/PreflightCheck"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "Flow": {
+            "title": "Flow",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "steps": {
+                    "title": "Steps",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/Step"
+                    }
+                },
+                "group": {
+                    "title": "Group",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "Package": {
+            "title": "Package",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "name_managed": {
+                    "title": "Name Managed",
+                    "type": "string"
+                },
+                "namespace": {
+                    "title": "Namespace",
+                    "type": "string"
+                },
+                "install_class": {
+                    "title": "Install Class",
+                    "type": "string"
+                },
+                "uninstall_class": {
+                    "title": "Uninstall Class",
+                    "type": "string"
+                },
+                "api_version": {
+                    "title": "Api Version",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "Test": {
+            "title": "Test",
+            "type": "object",
+            "properties": {
+                "name_match": {
+                    "title": "Name Match",
+                    "type": "string"
+                }
+            },
+            "required": ["name_match"],
+            "additionalProperties": false
+        },
+        "ReleaseNotesParser": {
+            "title": "ReleaseNotesParser",
+            "type": "object",
+            "properties": {
+                "class_path": {
+                    "title": "Class Path",
+                    "type": "string"
+                },
+                "title": {
+                    "title": "Title",
+                    "type": "string"
+                }
+            },
+            "required": ["class_path", "title"],
+            "additionalProperties": false
+        },
+        "ReleaseNotes": {
+            "title": "ReleaseNotes",
+            "type": "object",
+            "properties": {
+                "parsers": {
+                    "title": "Parsers",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ReleaseNotesParser"
+                    }
+                }
+            },
+            "required": ["parsers"],
+            "additionalProperties": false
+        },
+        "Git": {
+            "title": "Git",
+            "type": "object",
+            "properties": {
+                "repo_url": {
+                    "title": "Repo Url",
+                    "type": "string"
+                },
+                "default_branch": {
+                    "title": "Default Branch",
+                    "type": "string"
+                },
+                "prefix_feature": {
+                    "title": "Prefix Feature",
+                    "type": "string"
+                },
+                "prefix_beta": {
+                    "title": "Prefix Beta",
+                    "type": "string"
+                },
+                "prefix_release": {
+                    "title": "Prefix Release",
+                    "type": "string"
+                },
+                "push_prefix_sandbox": {
+                    "title": "Push Prefix Sandbox",
+                    "type": "string"
+                },
+                "push_prefix_production": {
+                    "title": "Push Prefix Production",
+                    "type": "string"
+                },
+                "release_notes": {
+                    "$ref": "#/definitions/ReleaseNotes"
+                },
+                "2gp_context": {
+                    "title": "2Gp Context",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "DependencyResolutions": {
+            "title": "DependencyResolutions",
+            "type": "object",
+            "properties": {
+                "production": {
+                    "title": "Production",
+                    "type": "string"
+                },
+                "preproduction": {
+                    "title": "Preproduction",
+                    "type": "string"
+                },
+                "resolution_strategies": {
+                    "title": "Resolution Strategies",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "Project": {
+            "title": "Project",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "package": {
+                    "$ref": "#/definitions/Package"
+                },
+                "test": {
+                    "$ref": "#/definitions/Test"
+                },
+                "git": {
+                    "$ref": "#/definitions/Git"
+                },
+                "dependencies": {
+                    "title": "Dependencies",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "dependency_resolutions": {
+                    "$ref": "#/definitions/DependencyResolutions"
+                },
+                "source_format": {
+                    "title": "Source Format",
+                    "default": "mdapi",
+                    "enum": ["sfdx", "mdapi"],
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "ScratchOrg": {
+            "title": "ScratchOrg",
+            "type": "object",
+            "properties": {
+                "config_file": {
+                    "title": "Config File",
+                    "type": "string",
+                    "format": "path"
+                },
+                "days": {
+                    "title": "Days",
+                    "type": "integer"
+                },
+                "namespaced": {
+                    "title": "Namespaced",
+                    "type": "string"
+                },
+                "setup_flow": {
+                    "title": "Setup Flow",
+                    "type": "string"
+                },
+                "noancestors": {
+                    "title": "Noancestors",
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
+        },
+        "Orgs": {
+            "title": "Orgs",
+            "type": "object",
+            "properties": {
+                "scratch": {
+                    "title": "Scratch",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ScratchOrg"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "ServiceAttribute": {
+            "title": "ServiceAttribute",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "required": {
+                    "title": "Required",
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
+        },
+        "Service": {
+            "title": "Service",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "class_path": {
+                    "title": "Class Path",
+                    "type": "string"
+                },
+                "attributes": {
+                    "title": "Attributes",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ServiceAttribute"
+                    }
+                },
+                "validator": {
+                    "title": "Validator",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "CumulusCIConfig": {
+            "title": "CumulusCIConfig",
+            "type": "object",
+            "properties": {
+                "keychain": {
+                    "title": "Keychain",
+                    "type": "string"
+                }
+            },
+            "required": ["keychain"],
+            "additionalProperties": false
+        },
+        "Plan": {
+            "title": "Plan",
+            "type": "object",
+            "properties": {
+                "title": {
+                    "title": "Title",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "tier": {
+                    "title": "Tier",
+                    "enum": ["primary", "secondary", "additional"],
+                    "type": "string"
+                },
+                "slug": {
+                    "title": "Slug",
+                    "type": "string"
+                },
+                "is_listed": {
+                    "title": "Is Listed",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "steps": {
+                    "title": "Steps",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/Step"
+                    }
+                },
+                "checks": {
+                    "title": "Checks",
+                    "default": [],
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/PreflightCheck"
+                    }
+                },
+                "group": {
+                    "title": "Group",
+                    "type": "string"
+                },
+                "error_message": {
+                    "title": "Error Message",
+                    "type": "string"
+                },
+                "post_install_message": {
+                    "title": "Post Install Message",
+                    "type": "string"
+                },
+                "preflight_message": {
+                    "title": "Preflight Message",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "LocalFolderSourceModel": {
+            "title": "LocalFolderSourceModel",
+            "type": "object",
+            "properties": {
+                "path": {
+                    "title": "Path",
+                    "format": "directory-path",
+                    "type": "string"
+                }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+        },
+        "GitHubSourceRelease": {
+            "title": "GitHubSourceRelease",
+            "description": "An enumeration.",
+            "enum": ["latest", "previous", "latest_beta"],
+            "type": "string"
+        },
+        "GitHubSourceModel": {
+            "title": "GitHubSourceModel",
+            "type": "object",
+            "properties": {
+                "github": {
+                    "title": "Github",
+                    "type": "string"
+                },
+                "resolution_strategy": {
+                    "title": "Resolution Strategy",
+                    "type": "string"
+                },
+                "commit": {
+                    "title": "Commit",
+                    "type": "string"
+                },
+                "ref": {
+                    "title": "Ref",
+                    "type": "string"
+                },
+                "branch": {
+                    "title": "Branch",
+                    "type": "string"
+                },
+                "tag": {
+                    "title": "Tag",
+                    "type": "string"
+                },
+                "release": {
+                    "$ref": "#/definitions/GitHubSourceRelease"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                }
+            },
+            "required": ["github"],
+            "additionalProperties": false
+        },
+        "CumulusCLIConfig": {
+            "title": "CumulusCLIConfig",
+            "type": "object",
+            "properties": {
+                "show_stacktraces": {
+                    "title": "Show Stacktraces",
+                    "default": false,
+                    "type": "boolean"
+                },
+                "plain_output": {
+                    "title": "Plain Output",
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
+        }
+    }
+}

--- a/cumulusci/tests/test_schema.py
+++ b/cumulusci/tests/test_schema.py
@@ -1,0 +1,29 @@
+import json
+
+import yaml
+from jsonschema import validate
+
+from cumulusci.utils.yaml import cumulusci_yml
+
+
+class TestSchema:
+    def test_schema_validates(self, cumulusci_test_repo_root):
+        schemapath = (
+            cumulusci_test_repo_root / "cumulusci/schema/cumulusci.jsonschema.json"
+        )
+        with open(schemapath) as f:
+            schema = json.load(f)
+        with open(cumulusci_test_repo_root / "cumulusci.yml") as f:
+            data = yaml.load(f)
+
+        assert validate(data, schema=schema) is None
+
+    def test_schema_is_current(self, cumulusci_test_repo_root):
+        current_schema = cumulusci_yml.CumulusCIRoot.schema()
+        schemapath = (
+            cumulusci_test_repo_root / "cumulusci/schema/cumulusci.jsonschema.json"
+        )
+        with open(schemapath) as f:
+            saved_schema = json.load(f)
+
+        assert current_schema == saved_schema, (current_schema, saved_schema)

--- a/cumulusci/utils/fileutils.py
+++ b/cumulusci/utils/fileutils.py
@@ -68,7 +68,7 @@ def load_from_source(source: DataInput) -> ContextManager[Tuple[IO[Text], Text]]
     ...     print(file.readline().strip())
     ...
     cumulusci.yml
-    project:
+    # yaml-language-server: $schema=cumulusci/schema/cumulusci.jsonschema.json
     """
     if (
         hasattr(source, "read") and hasattr(source, "readable") and source.readable()
@@ -261,7 +261,7 @@ class FSResource:
         >>> with open_fs_resource("cumulusci.yml") as cumulusci_yml:
         ...      with cumulusci_yml.open() as c:
         ...          print(c.read(5))
-        proje
+        # yam
 
         """
         resource = FSResource.new(resource_url_or_path, filesystem)

--- a/cumulusci/utils/yaml/cumulusci_yml.py
+++ b/cumulusci/utils/yaml/cumulusci_yml.py
@@ -209,6 +209,18 @@ class CumulusCIRoot(CCIDictModel):
     sources: Dict[str, Union[LocalFolderSourceModel, GitHubSourceModel]] = {}
     cli: CumulusCLIConfig = None
 
+    @classmethod
+    def schema(cls, *args, **kwargs):
+        json = super().schema(*args, **kwargs)
+        # Workaround VSCode-YAML vs pydantic.schema quirks
+        task_model = json["definitions"]["Task"]["properties"]
+        task_model["options"]["additionalProperties"] = True
+        task_model["ui_options"]["additionalProperties"] = True
+        step_model = json["definitions"]["Step"]["properties"]
+        step_model["options"]["additionalProperties"] = True
+        step_model["ui_options"]["additionalProperties"] = True
+        return json
+
 
 class CumulusCIFile(CCIDictModel):
     __root__: Union[CumulusCIRoot, None]
@@ -231,7 +243,7 @@ def validate_data(
 
     https://pydantic-docs.helpmanual.io/usage/models/#error-handling
     """
-    return CumulusCIFile.validate_data(data, context=context, on_error=on_error)
+    return CumulusCIRoot.validate_data(data, context=context, on_error=on_error)
 
 
 class ErrorDict(TypedDict):

--- a/cumulusci/utils/yaml/model_parser.py
+++ b/cumulusci/utils/yaml/model_parser.py
@@ -8,7 +8,7 @@ from cumulusci.utils.yaml.safer_loader import load_from_source, load_yaml_data
 
 
 class CCIModel(BaseModel):
-    """Base class for CumulusCI's Pydantic models"""
+    # Base class for CumulusCI's Pydantic models
 
     _magic_fields = ["fields"]
 
@@ -96,8 +96,8 @@ class CCIModel(BaseModel):
 
 
 class CCIDictModel(CCIModel):
-    """A base class that acts as both a model and a dict. For transitioning from
-    one to the other."""
+    # A base class that acts as both a model and a dict. For transitioning from
+    # one to the other.
 
     def __getitem__(self, name):
         """Pretend to a do my_dict[name]"""
@@ -147,8 +147,8 @@ def _add_filenames(e: ValidationError, filename):
 
 
 class HashableBaseModel(CCIModel):
-    """Base Pydantic model class that has a functional `hash()` method.
-    Requires that model can be converted to JSON."""
+    # Base Pydantic model class that has a functional `hash()` method.
+    # Requires that model can be converted to JSON.
 
     # See https://github.com/samuelcolvin/pydantic/issues/1303
     def __hash__(self):


### PR DESCRIPTION
# Changes

CumulusCi now has a schema published at https://github.com/SFDO-Tooling/CumulusCI/tree/main/cumulusci/schema/cumulusci.jsonschema.json

This is primarily intended to be use for enabling linting in VS Code, but could be used for any schema-aware editor or any validation purpose.

# Issues Closed
