### PR TITLE
Add token expiry to service info when present

### DIFF
--- a/cumulusci/core/github.py
+++ b/cumulusci/core/github.py
@@ -123,6 +123,12 @@ def validate_service(options: dict) -> dict:
         if unauthorized_orgs:
             options["SSO Disabled"] = ", ".join([k for k in unauthorized_orgs.values()])
 
+        expiration_date = repo_response.headers.get(
+            "GitHub-Authentication-Token-Expiration"
+        )
+        if expiration_date:
+            options["expires"] = expiration_date
+
     return options
 
 

--- a/cumulusci/core/tests/test_github.py
+++ b/cumulusci/core/tests/test_github.py
@@ -531,7 +531,10 @@ class TestGithub(GithubApiTestMixin):
             responses.GET,
             "https://api.github.com/user/repos",
             json=[],
-            headers={"X-OAuth-Scopes": "gist, repo"},
+            headers={
+                "GitHub-Authentication-Token-Expiration": "2021-10-07 19:07:53 UTC",
+                "X-OAuth-Scopes": "gist, repo",
+            },
         )
         updated_dict = validate_service(service_dict)
         expected_dict = {
@@ -540,6 +543,7 @@ class TestGithub(GithubApiTestMixin):
             "email": "testerson@test.com",
             "Organizations": "",
             "scopes": {"gist", "repo"},
+            "expires": "2021-10-07 19:07:53 UTC",
         }
         assert expected_dict == updated_dict
 


### PR DESCRIPTION
GH added this in July. See [blog](https://github.blog/changelog/2021-07-26-expiration-options-for-personal-access-tokens/). 

-------

# Critical Changes

# Changes
- The GitHub service now displays expiration dates for personal access tokens, if set.
# Issues Closed