### PR TITLE
handle old filename_token and namespace_token options gracefully

### DIFF
--- a/cumulusci/core/dependencies/dependencies.py
+++ b/cumulusci/core/dependencies/dependencies.py
@@ -594,6 +594,10 @@ class UnmanagedGitHubRefDependency(UnmanagedDependency):
     # and
     ref: str
 
+    # for backwards compatibility only; currently unused
+    filename_token: Optional[str] = None
+    namespace_token: Optional[str] = None
+
     @pydantic.root_validator
     def validate(cls, values):
         return _validate_github_parameters(values)

--- a/cumulusci/core/dependencies/tests/test_dependencies.py
+++ b/cumulusci/core/dependencies/tests/test_dependencies.py
@@ -591,7 +591,10 @@ class TestUnmanagedGitHubRefDependency:
             UnmanagedGitHubRefDependency(github="http://github.com")
 
         u = UnmanagedGitHubRefDependency(
-            github="https://github.com/Test/TestRepo", ref="aaaaaaaa"
+            github="https://github.com/Test/TestRepo",
+            ref="aaaaaaaa",
+            namespace_token="obsolete but accepted",
+            filename_token="obsolete but accepted",
         )
 
         u = UnmanagedGitHubRefDependency(


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed
- Fixed an issue where MetaDeploy steps using the old filename_token and namespace_token options could not be used.