### PR TITLE
POC: Validate model after merge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,6 @@ dev-install:
 	pip install -e .
 
 schema:
-		python -c 'from cumulusci.utils.yaml import cumulusci_yml; open("cumulusci/schema/cumulusci.jsonschema.json", "w").write(cumulusci_yml.CumulusCIRoot.schema_json(indent=4))'
+		python -c 'from cumulusci.utils.yaml import cumulusci_yml; open("cumulusci/schema/cumulusci.jsonschema.json", "w").write(cumulusci_yml.pre_merge_models.CumulusCIRoot.schema_json(indent=4))'
 		@pre-commit run prettier --files cumulusci/schema/cumulusci.jsonschema.json > /dev/null || true
 		@echo cumulusci/schema/cumulusci.jsonschema.json

--- a/cumulusci/core/config/tests/test_config.py
+++ b/cumulusci/core/config/tests/test_config.py
@@ -39,7 +39,7 @@ from cumulusci.core.exceptions import (
 from cumulusci.core.source import LocalFolderSource
 from cumulusci.tests.util import DummyKeychain
 from cumulusci.utils import temporary_dir, touch
-from cumulusci.utils.yaml.cumulusci_yml import GitHubSourceModel, LocalFolderSourceModel
+from cumulusci.utils.yaml.cumulusci_yml import cci_yml_models
 
 
 class TestBaseConfig(unittest.TestCase):
@@ -633,8 +633,12 @@ class TestBaseProjectConfig(unittest.TestCase):
         project_config = BaseProjectConfig(universal_config)
         with temporary_dir() as d:
             touch("cumulusci.yml")
-            other1 = project_config.include_source(LocalFolderSourceModel(path=d))
-            other2 = project_config.include_source(LocalFolderSourceModel(path=d))
+            other1 = project_config.include_source(
+                cci_yml_models.LocalFolderSourceModel(path=d)
+            )
+            other2 = project_config.include_source(
+                cci_yml_models.LocalFolderSourceModel(path=d)
+            )
         assert other1 is other2
 
     @mock.patch("cumulusci.core.config.project_config.GitHubSource")
@@ -643,7 +647,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         universal_config = UniversalConfig()
         project_config = BaseProjectConfig(universal_config)
         other_config = project_config.include_source(
-            GitHubSourceModel(github="foo/bar")
+            cci_yml_models.GitHubSourceModel(github="foo/bar")
         )
         assert other_config.source is expected_result
 

--- a/cumulusci/core/source/github.py
+++ b/cumulusci/core/source/github.py
@@ -11,11 +11,11 @@ from cumulusci.core.github import (
 )
 from cumulusci.utils import download_extract_github
 from cumulusci.utils.git import split_repo_url
-from cumulusci.utils.yaml.cumulusci_yml import GitHubSourceModel, GitHubSourceRelease
+from cumulusci.utils.yaml.cumulusci_yml import cci_yml_models
 
 
 class GitHubSource:
-    def __init__(self, project_config, spec: GitHubSourceModel):
+    def __init__(self, project_config, spec: cci_yml_models.GitHubSourceModel):
         self.project_config = project_config
         self.spec = spec
         self.url = spec.github
@@ -86,11 +86,11 @@ class GitHubSource:
             ref = "heads/" + self.spec.branch
         elif self.spec.release:
             release = None
-            if self.spec.release is GitHubSourceRelease.LATEST:
+            if self.spec.release is cci_yml_models.GitHubSourceRelease.LATEST:
                 release = find_latest_release(self.repo, include_beta=False)
-            elif self.spec.release is GitHubSourceRelease.LATEST_BETA:
+            elif self.spec.release is cci_yml_models.GitHubSourceRelease.LATEST_BETA:
                 release = find_latest_release(self.repo, include_beta=True)
-            elif self.spec.release is GitHubSourceRelease.PREVIOUS:
+            elif self.spec.release is cci_yml_models.GitHubSourceRelease.PREVIOUS:
                 release = find_previous_release(self.repo)
             if release is None:
                 raise DependencyResolutionError(

--- a/cumulusci/core/source/local_folder.py
+++ b/cumulusci/core/source/local_folder.py
@@ -1,10 +1,10 @@
 import os
 
-from cumulusci.utils.yaml.cumulusci_yml import LocalFolderSourceModel
+from cumulusci.utils.yaml.cumulusci_yml import cci_yml_models
 
 
 class LocalFolderSource:
-    def __init__(self, project_config, spec: LocalFolderSourceModel):
+    def __init__(self, project_config, spec: cci_yml_models.LocalFolderSourceModel):
         self.project_config = project_config
         self.spec = spec
         self.path = spec.path

--- a/cumulusci/core/tests/test_source.py
+++ b/cumulusci/core/tests/test_source.py
@@ -16,11 +16,12 @@ from cumulusci.core.exceptions import DependencyResolutionError
 from cumulusci.core.keychain import BaseProjectKeychain
 from cumulusci.tasks.release_notes.tests.utils import MockUtil
 from cumulusci.utils import temporary_dir, touch
-from cumulusci.utils.yaml.cumulusci_yml import (
-    GitHubSourceModel,
-    GitHubSourceRelease,
-    LocalFolderSourceModel,
-)
+from cumulusci.utils.yaml.cumulusci_yml import cci_yml_models
+
+GitHubSourceModel = cci_yml_models.GitHubSourceModel
+GitHubSourceRelease = cci_yml_models.GitHubSourceRelease
+LocalFolderSourceModel = cci_yml_models.LocalFolderSourceModel
+
 
 from ..source import GitHubSource, LocalFolderSource
 

--- a/cumulusci/tests/test_schema.py
+++ b/cumulusci/tests/test_schema.py
@@ -25,7 +25,7 @@ class TestSchema:
         assert validate(data, schema=schema) is None
 
     def test_schema_is_current(self, cumulusci_test_repo_root):
-        current_schema = cumulusci_yml.CumulusCIRoot.schema()
+        current_schema = cumulusci_yml.cci_yml_models.CumulusCIRoot.schema()
         schemapath = (
             cumulusci_test_repo_root / "cumulusci/schema/cumulusci.jsonschema.json"
         )

--- a/cumulusci/tests/test_schema.py
+++ b/cumulusci/tests/test_schema.py
@@ -25,7 +25,7 @@ class TestSchema:
         assert validate(data, schema=schema) is None
 
     def test_schema_is_current(self, cumulusci_test_repo_root):
-        current_schema = cumulusci_yml.cci_yml_models.CumulusCIRoot.schema()
+        current_schema = cumulusci_yml.pre_merge_models.CumulusCIRoot.schema()
         schemapath = (
             cumulusci_test_repo_root / "cumulusci/schema/cumulusci.jsonschema.json"
         )

--- a/cumulusci/utils/yaml/tests/test_cumulusci_yml.py
+++ b/cumulusci/utils/yaml/tests/test_cumulusci_yml.py
@@ -8,10 +8,10 @@ from pydantic import ValidationError
 
 from cumulusci.utils import temporary_dir
 from cumulusci.utils.yaml.cumulusci_yml import (
-    GitHubSourceModel,
     _validate_files,
     _validate_url,
     cci_safe_load,
+    cci_yml_models,
     parse_from_yaml,
 )
 
@@ -192,13 +192,17 @@ def test_mutually_exclusive_options():
 
 def test_github_source():
     with pytest.raises(ValidationError):
-        GitHubSourceModel(
+        cci_yml_models.GitHubSourceModel(
             github="https://github.com/Test/TestRepo", commit="abcdef", release="foo"
         )
 
-    GitHubSourceModel(github="https://github.com/Test/TestRepo", release="latest")
+    cci_yml_models.GitHubSourceModel(
+        github="https://github.com/Test/TestRepo", release="latest"
+    )
 
     assert (
-        GitHubSourceModel(github="https://github.com/Test/TestRepo").resolution_strategy
+        cci_yml_models.GitHubSourceModel(
+            github="https://github.com/Test/TestRepo"
+        ).resolution_strategy
         == "production"
     )


### PR DESCRIPTION
# Changes

Proof of concept: Validate presence of class_paths after merging cumulusci_yml files.

Next steps:

 * more post-merge validations
 * tests

Technique is summarized in smaller code here:

https://github.com/samuelcolvin/pydantic/issues/1549#issuecomment-942875458
