### PR TITLE
Filter for `cci task list`

### DIFF
--- a/cumulusci/cli/ui.py
+++ b/cumulusci/cli/ui.py
@@ -54,6 +54,9 @@ class CliTable:
             stringified_row.append(cell)
         return stringified_row
 
+    def __rich__(self) -> str:
+        return self._table
+
     def echo(self, plain=False, box_style: box.Box = None):
         """Print this table's data using click.echo()."""
         orig_box = self._table.box


### PR DESCRIPTION
# Changes
- You can now filter the `cci task list` command to see only relevant results with the `--filter` (`-f`) option.
- `cci task list` has a new `--rainbow` option, because why not 🤷  🌈 