### PR TITLE
Add version check

### DIFF
--- a/cumulusci/cli/tests/test_utils.py
+++ b/cumulusci/cli/tests/test_utils.py
@@ -1,4 +1,5 @@
 import json
+import sys
 import time
 from unittest import mock
 
@@ -48,8 +49,10 @@ def test_check_latest_version(click, get_latest_final_version, get_installed_ver
     get_installed_version.return_value = pkg_resources.parse_version("1")
 
     utils.check_latest_version()
-
-    click.echo.assert_called_once()
+    if sys.version_info > utils.LOWEST_SUPPORTED_VERSION:
+        click.echo.assert_called_once()
+    else:
+        click.echo.assert_called()
 
 
 @mock.patch("cumulusci.cli.utils.get_latest_final_version")

--- a/cumulusci/cli/utils.py
+++ b/cumulusci/cli/utils.py
@@ -1,6 +1,7 @@
 import contextlib
 import os
 import re
+import sys
 import time
 from collections import defaultdict
 
@@ -12,6 +13,8 @@ from cumulusci import __version__
 from cumulusci.core.config import UniversalConfig
 from cumulusci.utils import get_cci_upgrade_command
 from cumulusci.utils.http.requests_utils import safe_json_from_response
+
+LOWEST_SUPPORTED_VERSION = (3, 8, 0)
 
 
 def group_items(items):
@@ -90,6 +93,12 @@ def check_latest_version():
         if result:
             click.echo(
                 f"""An update to CumulusCI is available. To install the update, run this command: {get_cci_upgrade_command()}""",
+                err=True,
+            )
+
+        if sys.version_info < LOWEST_SUPPORTED_VERSION:
+            click.echo(
+                "Sorry! Your Python version is not supported. Please upgrade to Python 3.9.",
                 err=True,
             )
 


### PR DESCRIPTION
# Changes

Python versions less than 3.8 now give a warning.

"Sorry! Your Python version is not supported. Please upgrade to Python 3.9."
