### PR TITLE
Feature/robot custom locators bugfix

### DIFF
--- a/cumulusci/robotframework/locator_manager.py
+++ b/cumulusci/robotframework/locator_manager.py
@@ -97,16 +97,16 @@ def locate_element(prefix, parent, locator, tag, constraints):
     logger.info(f"locator: '{prefix}:{locator}' => '{loc}'")
 
     try:
-        element = selenium.get_webelement(loc)
+        elements = selenium.get_webelements(loc)
     except Exception as e:
-        # the SeleniumLibrary documentation doesn't say, but I'm
-        # pretty sure we should return None rather than throwing an error
-        # in this case. If we throw an error, that prevents the custom
-        # locators from being used negatively (eg: Page should not
-        # contain element  custom:whatever).
+        # The SeleniumLibrary documentation doesn't say, but I'm
+        # pretty sure we should return an empty list rather than
+        # throwing an error in this case. If we throw an error, that
+        # prevents the custom locators from being used negatively (eg:
+        # Page should not contain element custom:whatever).
         logger.debug(f"caught exception in locate_element: {e}")
-        return None
-    return element
+        elements = []
+    return elements
 
 
 def translate_locator(prefix, locator):

--- a/cumulusci/robotframework/tests/salesforce/locators.robot
+++ b/cumulusci/robotframework/tests/salesforce/locators.robot
@@ -89,3 +89,49 @@ Page should not contain custom locator
     # give an error
 
     Page should not contain element  B:appname:Sorry Charlie
+
+
+Get Webelement (singlular)
+    [Documentation]
+    ...  A smoke test to verify that we can get an element with a custom locator
+    [Setup]  Go to setup home
+
+    ${element}=        Get webelement  A:breadcrumb:Home
+    Should be true  $element.__class__.__name__=="WebElement"
+
+
+Get Webelements (plural) - no matching elements
+
+    [tags]   W-10187485
+
+    # this is a locator which shouldn't match anything on the page
+    ${locator}=   Get Locator  modal.button  Bogus
+    ${elements}=  Get webelements  ${locator}
+
+    # same locator, but using the custom locator strategy
+    ${elements_via_locator_manager}=  Get webelements  sf:modal.button:Bogus
+
+    # the two lists of elements should be identical. The bug reported
+    # in W-10187485 caused the locator strategy to return [None]
+    # instead of []. This verifies that we fixed that bug.
+    Should be equal  ${elements}  ${elements via locator manager}
+
+    # In addition to getting an empty list when trying to fetch
+    # non-existing elements, this verifies that we can use the
+    # locator in a negative test.
+    Page should not contain  sf:modal.button:Bogus
+
+Get Webelements (plural) with custom locator
+    [Setup]  Run keywords
+    ...  Go to object home  Contact
+    ...  AND  Click object button  New
+
+    # Get the web element with the xpath directly, then verify
+    # that Get Webelements returns a list with just that element
+    # when using the custom locator
+    ${element}=  Get webelement  //div[contains(@class,'uiModal')]//button[.='Save & New']
+    @{expected elements}=  Create list  ${element}
+
+    ${actual elements}=  Get webelements  sf:modal.button:Save & New
+
+    Should be equal  ${actual elements}  ${expected elements}

--- a/cumulusci/robotframework/tests/test_locator_manager.py
+++ b/cumulusci/robotframework/tests/test_locator_manager.py
@@ -115,7 +115,7 @@ class TestLocateElement(unittest.TestCase):
             side_effect=mock_get_library_instance,
         ):
             locate_element("test", parent, locator, tag, constraints)
-            mock_libs["SeleniumLibrary"].get_webelement.assert_called_with(
+            mock_libs["SeleniumLibrary"].get_webelements.assert_called_with(
                 "//span[text()='Hello, world']"
             )
 


### PR DESCRIPTION
This fixes the bug described in W-10187485, which caused SeleniumLibrary's `get webelements` keyword  to return a
list with a single `None` element rather than an empty list when no elements were found.

Although the SeleniumLibrary documentation says that a custom locator keyword should return a single web element, on close inspection of the code it appears that it should instead return a list. I contacted the developers of SeleniumLibrary and they agreed with me that the documentation seemed to be incorrect.

# Critical Changes

# Changes
* fixed a bug that prevented `Get webelements` from returning an empty list if the locator was a custom locator created via  the `register_locators` function of `cumulusci.robotframework.locator_manager`

# Issues Closed
