### PR TITLE
Allow `SOQL Query` keyword to accept queries that span multiple lines

### DIFF
--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -1068,28 +1068,36 @@ class Salesforce(object):
         obj_class = getattr(self.cumulusci.sf, obj_name)
         return obj_class.update(obj_id, kwargs)
 
-    def soql_query(self, query):
-        """Runs a simple SOQL query and returns the dict results
+    def soql_query(self, query, *args):
+        """Runs a SOQL query and returns the result as a dictionary.
 
-        The _query_ parameter must be a properly quoted SOQL query statement. The
-        return value is a dictionary. The dictionary contains the keys
-        as documented for the raw API call. The most useful key is ``records``,
-        which contains a list of records which were matched by the query.
+        The _query_ parameter must be a properly quoted SOQL query
+        statement or statement fragment. Additional arguments will be
+        joined to the query with spaces, allowing for a query to span
+        multiple lines.
 
-        Example
+        This keyword will return a dictionary. The dictionary contains
+        the keys as documented for the raw API call. The most useful
+        keys are ``records`` and ``totalSize``, which contains a list
+        of records that were matched by the query and the number of
+        records that were returned.
+
+        Example:
 
         The following example searches for all Contacts with a first
-        name of "Eleanor" and a last name of "Rigby", and then prints
-        the name of the first record found.
+        name of "Eleanor" and a last name of "Rigby", and then logs
+        the Id of the first record found.
 
         | ${result}=  SOQL Query
-        | ...  SELECT Name, Id FROM Contact WHERE FirstName='Eleanor' AND LastName='Rigby'
-        | Run keyword if  len($result['records']) == 0  Fail  No records found
+        | ...  SELECT Name, Id
+        | ...  FROM   Contact
+        | ...  WHERE  FirstName='Eleanor' AND LastName='Rigby'
         |
         | ${contact}=  Get from list  ${result['records']}  0
-        | Should be equal  ${contact['Name']}  Eleanor Rigby
+        | log  Contact Id: ${contact['Id']}
 
         """
+        query = " ".join((query,) + args)
         self.builtin.log("Running SOQL Query: {}".format(query))
         return self.cumulusci.sf.query_all(query)
 

--- a/cumulusci/robotframework/tests/salesforce/api.robot
+++ b/cumulusci/robotframework/tests/salesforce/api.robot
@@ -91,7 +91,7 @@ Salesforce Query Where Limit Order
     Should Be Equal As Numbers   ${cnt}  2
 
 
-SOQL Query
+SOQL Query - single line
     &{new_contact} =  Create Contact
     &{result} =  Soql Query  Select Id, FirstName, LastName from Contact WHERE Id = '${new_contact}[Id]'
     @{records} =  Get From Dictionary  ${result}  records
@@ -99,6 +99,19 @@ SOQL Query
     Should Be Equal  ${result}[totalSize]  ${1}
     Should Be Equal  ${contact}[FirstName]  ${new_contact}[FirstName]
     Should Be Equal  ${contact}[LastName]  ${new_contact}[LastName]
+
+SOQL Query - multiline
+    [Documentation]  Verify that a SOQL query can span multiple lines
+    [Tags]  W-10244357
+    &{contact1} =  Create Contact
+    &{contact2} =  Create Contact
+
+    &{result}=  SOQL Query
+    ...  SELECT Id, FirstName, LastName
+    ...  FROM   Contact
+    ...  WHERE  Id = '${contact1}[Id]'  OR  Id = '${contact2}[Id]'
+
+    Should Be Equal as numbers  ${result}[totalSize]  2
 
 Salesforce Delete Session Records
     [Documentation]
@@ -163,4 +176,3 @@ Collection API Errors Test
 Get Version
     ${version} =   Get Latest Api Version
     Should Be True     ${version} > 46
-

--- a/docs/robot/Keywords.html
+++ b/docs/robot/Keywords.html
@@ -2089,35 +2089,46 @@ Set Test Metric    Max_CPU_Percent    30
                             <tr class="kwrow" id="Salesforce.Soql Query">
                                 <td class="kwname">Soql Query</td>
                                 <td class="kwargs">
-                                    <i>query</i>
+                                    <i>query</i>,
+
+                                    <i>*args</i>
                                 </td>
                                 <td class="kwdoc">
                                     <p>
-                                        Runs a simple SOQL query and returns the dict
-                                        results
+                                        Runs a SOQL query and returns the result as a
+                                        dictionary.
                                     </p>
                                     <p>
                                         The <i>query</i> parameter must be a properly
-                                        quoted SOQL query statement. The return value is a
-                                        dictionary. The dictionary contains the keys as
-                                        documented for the raw API call. The most useful
-                                        key is <code>records</code>, which contains a list
-                                        of records which were matched by the query.
+                                        quoted SOQL query statement or statement fragment.
+                                        Additional arguments will be joined to the query
+                                        with spaces, allowing for a query to span multiple
+                                        lines.
                                     </p>
-                                    <p>Example</p>
+                                    <p>
+                                        This keyword will return a dictionary. The
+                                        dictionary contains the keys as documented for the
+                                        raw API call. The most useful keys are
+                                        <code>records</code> and <code>totalSize</code>,
+                                        which contains a list of records that were matched
+                                        by the query and the number of records that were
+                                        returned.
+                                    </p>
+                                    <p>Example:</p>
                                     <p>
                                         The following example searches for all Contacts
                                         with a first name of "Eleanor" and a last name of
-                                        "Rigby", and then prints the name of the first
-                                        record found.
+                                        "Rigby", and then logs the Id of the first record
+                                        found.
                                     </p>
                                     <pre>
 ${result}=  SOQL Query
-...  SELECT Name, Id FROM Contact WHERE FirstName='Eleanor' AND LastName='Rigby'
-Run keyword if  len($result['records']) == 0  Fail  No records found
+...  SELECT Name, Id
+...  FROM   Contact
+...  WHERE  FirstName='Eleanor' AND LastName='Rigby'
 
 ${contact}=  Get from list  ${result['records']}  0
-Should be equal  ${contact['Name']}  Eleanor Rigby
+log  Contact Id: ${contact['Id']}
 </pre
                                     >
                                 </td>
@@ -3213,7 +3224,7 @@ Populate form
             </div>
         </div>
         <div class="footer">
-            Generated on Wednesday November 17, 10:09 PM - cumulusci v3.48.1
+            Generated on Tuesday December 07, 02:47 PM - cumulusci v3.48.2
         </div>
     </body>
 </html>


### PR DESCRIPTION
This lets you spread a SOQL query across multiple rows in the `SOQL Query` keyword. 
Fixes W-10244357


# Critical Changes

# Changes
* queries passed to the `SOQL Query` keyword can now span multiple lines. 

# Issues Closed
