### PR TITLE
Fix race condition in test framework

### DIFF
--- a/cumulusci/tasks/bulkdata/tests/test_snowfakery.py
+++ b/cumulusci/tasks/bulkdata/tests/test_snowfakery.py
@@ -78,17 +78,16 @@ def call_closure():
     """Simulate a cycle of load results without doing a real load."""
     return_values = cycle(iter(FAKE_LOAD_RESULTS))
 
+    # Manipulating "self" from a mock side-effect is a challenge.
+    # So we need a "real function"
     def __call__(self, *args, **kwargs):
         """Like the __call__ of _run_task, but also capture calls
         in a normal mock_values structure."""
 
-        # Manipulating "self" from a mock side-effect is a challenge.
-        # So we need a "real function"
         self.return_values = {"step_results": next(return_values)}
-        rc = __call__.mock(*args, **kwargs)
-        # remember the values that would have been loaded for later inspection in tests
         values_loaded = db_values_from_db_url(self.options["database_url"])
-        __call__.mock.mock_calls[-1].values_loaded = values_loaded
+        kwargs = {**kwargs, "values_loaded": values_loaded}
+        rc = __call__.mock(*args, **kwargs)
         return rc
 
     __call__.mock = mock.Mock()
@@ -502,7 +501,7 @@ class TestSnowfakery:
         class LoadDataSucceedsOnceThenFails:
             count = 0
 
-            def __call__(self):
+            def __call__(self, *args, **kwargs):
                 self.count += 1
                 if self.count > 1:
                     raise AssertionError("XYZZY")
@@ -591,8 +590,11 @@ class TestSnowfakery:
         )
         task()
 
+        def rows_from_mock_call(call):
+            return call.kwargs["values_loaded"]["blah"]
+
         all_rows = chain(
-            *(call.values_loaded["blah"] for call in mock_load_data.mock_calls)
+            *(rows_from_mock_call(call) for call in mock_load_data.mock_calls)
         )
         unique_values = [row.value for row in all_rows]
         assert len(unique_values) == len(set(unique_values))


### PR DESCRIPTION
Fix a race condition in test framework

The old code mutated the "last" mock call. If two threads create mock calls at the same time, the data got attached to the wrong call.

```
        self.return_values = {"step_results": next(return_values)}
        rc = __call__.mock(*args, **kwargs)
        # remember the values that would have been loaded for later inspection in tests
        values_loaded = db_values_from_db_url(self.options["database_url"])
        __call__.mock.mock_calls[-1].values_loaded = values_loaded
```

The new code is more "functional" style: no mutations or dependence on shared variables.

```
        values_loaded = db_values_from_db_url(self.options["database_url"])
        kwargs = {**kwargs, "values_loaded": values_loaded}
        rc = __call__.mock(*args, **kwargs)
```

The other changes are side effects of this change.

