### PR TITLE
Use Python > 3.7  for readthedoc builds

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -10,18 +10,15 @@ build:
     os: ubuntu-20.04
     tools:
         python: "3.9"
-        # You can also specify other tool versions:
-        # nodejs: "16"
-        # rust: "1.55"
-        # golang: "1.17"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
     configuration: docs/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
-# formats:
-#    - pdf
+formats:
+    - pdf
+    - epub
 
 # Optionally declare the Python requirements required to build your docs
 python:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,29 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+    os: ubuntu-20.04
+    tools:
+        python: "3.9"
+        # You can also specify other tool versions:
+        # nodejs: "16"
+        # rust: "1.55"
+        # golang: "1.17"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+    configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+    install:
+        - requirements: requirements_dev.txt


### PR DESCRIPTION
# Dev Changes
* The CumulusCI repo now includes a `readthedocs.yml` file for configuring builds in readthedocs.