### PR TITLE
Fix `cci task list --json`

### DIFF
--- a/cumulusci/cli/task.py
+++ b/cumulusci/cli/task.py
@@ -33,7 +33,7 @@ def task_list(runtime, plain, print_json):
 
     console = Console()
     if print_json:
-        console.print(json.dumps(tasks))
+        console.print_json(json.dumps(tasks))
         return None
 
     task_groups = group_items(tasks)

--- a/cumulusci/cli/tests/test_task.py
+++ b/cumulusci/cli/tests/test_task.py
@@ -178,23 +178,7 @@ def test_task_list(cli_tbl):
     )
 
 
-@patch("json.dumps")
-def test_task_list__json(json_):
-    task_dicts = {
-        "name": "test_task",
-        "description": "Test Task",
-        "group": "Test Group",
-    }
-    runtime = Mock()
-    runtime.universal_config.cli__plain_output = None
-    runtime.get_available_tasks.return_value = [task_dicts]
-
-    run_click_command(task.task_list, runtime=runtime, plain=False, print_json=True)
-
-    json_.assert_called_with([task_dicts])
-
-
-def test_task_list__json_output(capsys):
+def test_task_list__json(capsys):
     expected_output = {
         "name": "test_task",
         "description": "This can be a really long description that might need a newline if some library is formatting it for ANSI output.",

--- a/cumulusci/cli/tests/test_task.py
+++ b/cumulusci/cli/tests/test_task.py
@@ -1,5 +1,6 @@
 import contextlib
 import io
+import json
 from unittest.mock import Mock, patch
 
 import click
@@ -178,7 +179,7 @@ def test_task_list(cli_tbl):
 
 
 @patch("json.dumps")
-def test_task_list_json(json_):
+def test_task_list__json(json_):
     task_dicts = {
         "name": "test_task",
         "description": "Test Task",
@@ -191,6 +192,23 @@ def test_task_list_json(json_):
     run_click_command(task.task_list, runtime=runtime, plain=False, print_json=True)
 
     json_.assert_called_with([task_dicts])
+
+
+def test_task_list__json_output(capsys):
+    expected_output = {
+        "name": "test_task",
+        "description": "This can be a really long description that might need a newline if some library is formatting it for ANSI output.",
+        "group": "Test Group",
+    }
+    runtime = Mock()
+    runtime.universal_config.cli__plain_output = None
+    runtime.get_available_tasks.return_value = [expected_output]
+
+    run_click_command(task.task_list, runtime=runtime, plain=False, print_json=True)
+
+    captured = capsys.readouterr()
+    parsed_output = json.loads(captured.out)[0]
+    assert parsed_output == expected_output
 
 
 @patch("cumulusci.cli.task.doc_task", return_value="docs")


### PR DESCRIPTION
# Issues Closed
* Fixed an issue where the `--json` flag was not outputting properly formatted `JSON` with the `cci task list` command.
