### PR TITLE
Better backwards compatible behaviour for some places it is called.

### DIFF
--- a/cumulusci/core/utils.py
+++ b/cumulusci/core/utils.py
@@ -108,6 +108,9 @@ def process_list_arg(arg):
         for part in arg.split(","):
             args.append(part.strip())
         return args
+    elif arg is None:
+        # backwards compatible behaviour.
+        return None
     else:
         getLogger(__file__).warn(
             f"Unknown option type `{type(arg)}` for value `{arg}`."


### PR DESCRIPTION
(nothing for Release notes in this PR)

A recent change to `process_list_arg` will probably output annoying warnings that the user does not have control over, if the person who wrote the task wrote:

process_list_arg(self.options.get("FOO"))

instead of

process_list_arg(self.options.get("FOO", []))

This skips the warning message in the former case.

Some might argue that process_list_arg should always return a list or throw an exception, but that behaviour would not be backwards compatible, so this is better.
