### PR TITLE
Add backwards-compatible files and warnings for OrgConfig rename

### DIFF
--- a/cumulusci/core/config/BaseConfig.py
+++ b/cumulusci/core/config/BaseConfig.py
@@ -1,0 +1,5 @@
+from warnings import warn
+
+from .base_config import *  # noqa
+
+warn("Deprecation warning: Please import from .base_config rather than .BaseConfig")

--- a/cumulusci/core/config/BaseTaskFlowConfig.py
+++ b/cumulusci/core/config/BaseTaskFlowConfig.py
@@ -1,0 +1,7 @@
+from warnings import warn
+
+from .base_task_flow_config import *  # noqa
+
+warn(
+    "Deprecation warning: Please import from .base_task_flow_config rather than .BaseTaskFlowConfig"
+)

--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -1,0 +1,5 @@
+from warnings import warn
+
+from .org_config import *  # noqa
+
+warn("Deprecation warning: Please import from .org_config rather than .OrgConfig")

--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -1,0 +1,7 @@
+from warnings import warn
+
+from .scratch_org_config import *  # noqa
+
+warn(
+    "Deprecation warning: Please import from .scratch_org_config rather than .ScratchOrgConfig"
+)

--- a/cumulusci/core/config/tests/_test_config_backwards_compatibility.py
+++ b/cumulusci/core/config/tests/_test_config_backwards_compatibility.py
@@ -1,0 +1,24 @@
+import pytest
+
+
+class TestConfigBackwardsCompatibility:
+    def test_temporary_backwards_compatiblity_hacks(self):
+        with pytest.warns(UserWarning):
+            from cumulusci.core.config.OrgConfig import OrgConfig
+
+            assert isinstance(OrgConfig, type)
+
+        with pytest.warns(UserWarning):
+            from cumulusci.core.config.ScratchOrgConfig import ScratchOrgConfig  # noqa
+
+            assert isinstance(ScratchOrgConfig, type)
+
+        with pytest.warns(UserWarning):
+            from cumulusci.core.config.BaseConfig import BaseConfig
+
+            assert isinstance(BaseConfig, type)
+
+        with pytest.warns(UserWarning):
+            from cumulusci.core.config.BaseTaskFlowConfig import BaseTaskFlowConfig
+
+            assert isinstance(BaseTaskFlowConfig, type)

--- a/cumulusci/core/config/tests/test_config_expensive.py
+++ b/cumulusci/core/config/tests/test_config_expensive.py
@@ -795,3 +795,9 @@ class TestScratchOrgConfigPytest:
             args = config._build_org_create_args()
 
         assert "adminEmail=test@example.com" not in args
+
+    def test_temporary_backwards_compatiblity_hacks(self):
+        filename = Path(__file__).parent / "_test_config_backwards_compatibility.py"
+        # run this in a separate process to not confuse
+        # the module table
+        assert os.system(f"pytest {filename}") == 0


### PR DESCRIPTION
Nothing for release notes:

Make backwards compatible shims for OrgConfig stuff.