### PR TITLE
Raise UsageError if project default set outside project directory

### DIFF
--- a/cumulusci/cli/service.py
+++ b/cumulusci/cli/service.py
@@ -286,6 +286,10 @@ def service_info(runtime, service_type, service_name, plain):
 )
 @pass_runtime(require_project=False, require_keychain=True)
 def service_default(runtime, service_type, service_name, project):
+    if not runtime.project_config and project:
+        raise click.UsageError(
+            "The --project flag must be used while in a CumulusCI project directory."
+        )
     try:
         runtime.keychain.set_default_service(service_type, service_name, project)
     except ServiceNotConfigured as e:

--- a/cumulusci/cli/tests/test_service.py
+++ b/cumulusci/cli/tests/test_service.py
@@ -439,6 +439,21 @@ def test_service_default__project(echo):
     )
 
 
+def test_service_connect__project_default_no_project():
+    runtime = mock.Mock()
+    runtime.project_config = None
+    runtime.keychain.project_local_dir = "test"
+
+    with pytest.raises(click.UsageError):
+        run_click_command(
+            service.service_default,
+            runtime=runtime,
+            service_type="test",
+            service_name="test-alias",
+            project=True,
+        )
+
+
 @mock.patch("click.echo")
 def test_service_default__exception(echo):
     runtime = mock.Mock()


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed
- `cci service default --project` presents a better error message when called outside of a project.
