### PR TITLE
Allow release_notes to process PRs with empty body

### DIFF
--- a/cumulusci/tasks/release_notes/task.py
+++ b/cumulusci/tasks/release_notes/task.py
@@ -266,6 +266,7 @@ class ParentPullRequestNotes(BaseGithubTask):
 
     def _add_header(self, pull_request):
         """Appends the header to the pull_request.body if not already present"""
+        pull_request.body = "" if pull_request.body is None else pull_request.body
         if self.UNAGGREGATED_PR_HEADER not in pull_request.body:
             pull_request.body += self.UNAGGREGATED_PR_HEADER
 

--- a/cumulusci/tasks/release_notes/tests/test_task.py
+++ b/cumulusci/tasks/release_notes/tests/test_task.py
@@ -381,6 +381,19 @@ class TestParentPullRequestNotes(GithubApiTestMixin):
         task._add_header(pull_request)  # header shouldn't be added again
         assert pull_request.body.count(task.UNAGGREGATED_PR_HEADER) == 1
 
+    def test_empty_body(self, task_factory, gh_api, project_config):
+        self.init_github()
+        self.project_config = project_config
+        task = task_factory(self.PARENT_BRANCH_OPTIONS)
+        pull_request = ShortPullRequest(self._get_expected_pull_request(1, 1), gh_api)
+        pull_request.body = None
+
+        task._add_header(pull_request)
+        assert task.UNAGGREGATED_PR_HEADER in pull_request.body
+
+        task._add_header(pull_request)  # header shouldn't be added again
+        assert pull_request.body.count(task.UNAGGREGATED_PR_HEADER) == 1
+
     @mock.patch("cumulusci.tasks.release_notes.task.markdown_link_to_pr")
     def test_add_link_to_pr(self, link_to_pr, task_factory, gh_api, project_config):
         self.init_github()


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed
- The `github_parent_pr_notes` now handles child PRs with an empty `body`.