### PR TITLE
Marketing Cloud: Get User Info Task

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -205,6 +205,10 @@ tasks:
         class_path: cumulusci.tasks.marketing_cloud.api.CreateUser
         description: Creates a new User via the Marketing Cloud SOAP API.
         group: Marketing Cloud
+    marketing_cloud_get_user_info:
+        class_path: cumulusci.tasks.marketing_cloud.get_user_info.GetUserInfoTask
+        description: Return user info retrieved from the /userinfo endpoint of the Marketing Cloud REST API.
+        group: Marketing Cloud
     marketing_cloud_update_user_role:
         class_path: cumulusci.tasks.marketing_cloud.api.UpdateUserRole
         description: Assigns a Role to an existing User via the Marketing Cloud SOAP API.

--- a/cumulusci/tasks/marketing_cloud/get_user_info.py
+++ b/cumulusci/tasks/marketing_cloud/get_user_info.py
@@ -1,3 +1,5 @@
+import json
+
 import requests
 
 from cumulusci.utils.http.requests_utils import safe_json_from_response
@@ -27,7 +29,7 @@ class GetUserInfoTask(BaseMarketingCloudTask):
         payload = self._sanitize_payload(payload)
 
         self.logger.info("Successfully fetched user info.")
-        self.logger.info(payload)
+        self.logger.info(json.dumps(payload, indent=4))
 
         self.return_values = payload
 

--- a/cumulusci/tasks/marketing_cloud/get_user_info.py
+++ b/cumulusci/tasks/marketing_cloud/get_user_info.py
@@ -1,5 +1,3 @@
-from logging import getLogger
-
 import requests
 
 from cumulusci.utils.http.requests_utils import safe_json_from_response
@@ -11,8 +9,6 @@ from .mc_constants import MC_API_VERSION
 class GetUserInfoTask(BaseMarketingCloudTask):
     """Retrieves user info of pertaining to the currently logged in user.
     Sanitizes and returns the payload in self.return_values."""
-
-    logger = getLogger(__name__)
 
     def _run_task(self):
         endpoint = f"https://{self.mc_config.tssd}.auth.marketingcloudapis.com/{MC_API_VERSION}/userinfo"
@@ -27,9 +23,13 @@ class GetUserInfoTask(BaseMarketingCloudTask):
             self.logger.error(f"Exception occurred fetching user info: {response.text}")
             raise
 
-        self.logger.info("Successfully fetched user info")
         payload = safe_json_from_response(response)
-        self.return_values = self._sanitize_payload(payload)
+        payload = self._sanitize_payload(payload)
+
+        self.logger.info("Successfully fetched user info.")
+        self.logger.info(payload)
+
+        self.return_values = payload
 
     def _sanitize_payload(self, payload: dict) -> dict:
         """Removes any sensitive or non-pertinent informaiton from the payload.

--- a/cumulusci/tasks/marketing_cloud/get_user_info.py
+++ b/cumulusci/tasks/marketing_cloud/get_user_info.py
@@ -38,10 +38,12 @@ class GetUserInfoTask(BaseMarketingCloudTask):
         This currently includes the following top-level portions of the response:
         (1) rest
         (2) application
+        (3) permissions
 
         See the following for a comprehensive response example:
         https://developer.salesforce.com/docs/marketing/marketing-cloud/guide/getUserInfo.html
         """
         del payload["rest"]
         del payload["application"]
+        del payload["permissions"]
         return payload

--- a/cumulusci/tasks/marketing_cloud/get_user_info.py
+++ b/cumulusci/tasks/marketing_cloud/get_user_info.py
@@ -21,8 +21,9 @@ class GetUserInfoTask(BaseMarketingCloudTask):
         }
         try:
             response = requests.get(endpoint, headers=headers)
-        except requests.exceptions.HTTPError as e:
-            self.logger.error(f"Error fetching user info: {e}")
+            response.raise_for_status()
+        except requests.exceptions.HTTPError:
+            self.logger.error(f"Exception occurred fetching user info: {response.text}")
             raise
 
         payload = json.loads(response.text)

--- a/cumulusci/tasks/marketing_cloud/get_user_info.py
+++ b/cumulusci/tasks/marketing_cloud/get_user_info.py
@@ -1,7 +1,8 @@
-import json
 from logging import getLogger
 
 import requests
+
+from cumulusci.utils.http.requests_utils import safe_json_from_response
 
 from .base import BaseMarketingCloudTask
 from .mc_constants import MC_API_VERSION
@@ -26,7 +27,8 @@ class GetUserInfoTask(BaseMarketingCloudTask):
             self.logger.error(f"Exception occurred fetching user info: {response.text}")
             raise
 
-        payload = json.loads(response.text)
+        self.logger.info("Successfully fetched user info")
+        payload = safe_json_from_response(response)
         self.return_values = self._sanitize_payload(payload)
 
     def _sanitize_payload(self, payload: dict) -> dict:

--- a/cumulusci/tasks/marketing_cloud/get_user_info.py
+++ b/cumulusci/tasks/marketing_cloud/get_user_info.py
@@ -1,0 +1,42 @@
+import json
+from logging import getLogger
+
+import requests
+
+from .base import BaseMarketingCloudTask
+from .mc_constants import MC_API_VERSION
+
+
+class GetUserInfoTask(BaseMarketingCloudTask):
+    """Retrieves user info of pertaining to the currently logged in user.
+    Sanitizes and returns the payload in self.return_values."""
+
+    logger = getLogger(__name__)
+
+    def _run_task(self):
+        endpoint = f"https://{self.mc_config.tssd}.auth.marketingcloudapis.com/{MC_API_VERSION}/userinfo"
+        headers = {
+            "Authorization": f"Bearer {self.mc_config.access_token}",
+            "Content-Type": "application/json",
+        }
+        try:
+            response = requests.get(endpoint, headers=headers)
+        except requests.exceptions.HTTPError as e:
+            self.logger.error(f"Error fetching user info: {e}")
+            raise
+
+        payload = json.loads(response.text)
+        self.return_values = self._sanitize_payload(payload)
+
+    def _sanitize_payload(self, payload: dict) -> dict:
+        """Removes any sensitive or non-pertinent informaiton from the payload.
+        This currently includes the following top-level portions of the response:
+        (1) rest
+        (2) application
+
+        See the following for a comprehensive response example:
+        https://developer.salesforce.com/docs/marketing/marketing-cloud/guide/getUserInfo.html
+        """
+        del payload["rest"]
+        del payload["application"]
+        return payload

--- a/cumulusci/tasks/marketing_cloud/mc_constants.py
+++ b/cumulusci/tasks/marketing_cloud/mc_constants.py
@@ -1,0 +1,1 @@
+MC_API_VERSION = "v2"

--- a/cumulusci/tasks/marketing_cloud/tests/conftest.py
+++ b/cumulusci/tasks/marketing_cloud/tests/conftest.py
@@ -1,0 +1,46 @@
+import pytest
+
+from cumulusci.core.config import ServiceConfig
+from cumulusci.core.config.marketing_cloud_service_config import (
+    MarketingCloudServiceConfig,
+)
+from cumulusci.tests.util import create_project_config
+
+from ..mc_constants import MC_API_VERSION
+
+
+@pytest.fixture
+def mc_project_config():
+    project_config = create_project_config()
+    project_config.keychain.set_service(
+        "oauth2_client",
+        "test",
+        ServiceConfig(
+            {
+                "client_id": "MC_CLIENT_ID",
+                "client_secret": "BOGUS",
+                "auth_uri": f"https://TSSD.auth.marketingcloudapis.com/{MC_API_VERSION}/authorize",
+                "token_uri": f"https://TSSD.auth.marketingcloudapis.com/{MC_API_VERSION}/token",
+                "callback_url": "https://127.0.0.1:8080/",
+            },
+            "test",
+            project_config.keychain,
+        ),
+        False,
+    )
+    project_config.keychain.set_service(
+        "marketing_cloud",
+        "test",
+        MarketingCloudServiceConfig(
+            {
+                "oauth2_client": "test",
+                "refresh_token": "REFRESH",
+                "rest_instance_url": "https://TSSD.auth.marketingcloudapis.com/",
+                "soap_instance_url": "https://TSSD.soap.marketingcloudapis.com/",
+            },
+            "test",
+            project_config.keychain,
+        ),
+        False,
+    )
+    return project_config

--- a/cumulusci/tasks/marketing_cloud/tests/test_api.py
+++ b/cumulusci/tasks/marketing_cloud/tests/test_api.py
@@ -1,57 +1,18 @@
-import pytest
 import responses
 
-from cumulusci.core.config import ServiceConfig
-from cumulusci.core.config.marketing_cloud_service_config import (
-    MarketingCloudServiceConfig,
-)
 from cumulusci.tasks.marketing_cloud.tests import test_api_soap_envelopes as envelopes
-from cumulusci.tests.util import create_project_config
 
 from ..api import CreateSubscriberAttribute, CreateUser, UpdateUserRole
-
-
-@pytest.fixture
-def project_config():
-    project_config = create_project_config()
-    project_config.keychain.set_service(
-        "oauth2_client",
-        "test",
-        ServiceConfig(
-            {
-                "client_id": "MC_CLIENT_ID",
-                "client_secret": "BOGUS",
-                "auth_uri": "https://TSSD.auth.marketingcloudapis.com/v2/authorize",
-                "token_uri": "https://TSSD.auth.marketingcloudapis.com/v2/token",
-                "callback_url": "https://127.0.0.1:8080/",
-            },
-            "test",
-            project_config.keychain,
-        ),
-        False,
-    )
-    project_config.keychain.set_service(
-        "marketing_cloud",
-        "test",
-        MarketingCloudServiceConfig(
-            {
-                "oauth2_client": "test",
-                "refresh_token": "REFRESH",
-                "soap_instance_url": "https://TSSD.soap.marketingcloudapis.com/",
-            },
-            "test",
-            project_config.keychain,
-        ),
-        False,
-    )
-    return project_config
+from ..mc_constants import MC_API_VERSION
 
 
 @responses.activate
-def test_marketing_cloud_create_subscriber_attribute_task(create_task, project_config):
+def test_marketing_cloud_create_subscriber_attribute_task(
+    create_task, mc_project_config
+):
     responses.add(
         "POST",
-        "https://tssd.auth.marketingcloudapis.com/v2/token",
+        f"https://tssd.auth.marketingcloudapis.com/{MC_API_VERSION}/token",
         json={"access_token": "ACCESS_TOKEN"},
     )
     responses.add(
@@ -65,17 +26,17 @@ def test_marketing_cloud_create_subscriber_attribute_task(create_task, project_c
         {
             "attribute_name": "Test Subscriber Attribute",
         },
-        project_config=project_config,
+        project_config=mc_project_config,
     )
     task()
     assert task.return_values == {"success": True}
 
 
 @responses.activate
-def test_marketing_cloud_create_user_task(create_task, project_config):
+def test_marketing_cloud_create_user_task(create_task, mc_project_config):
     responses.add(
         "POST",
-        "https://tssd.auth.marketingcloudapis.com/v2/token",
+        f"https://tssd.auth.marketingcloudapis.com/{MC_API_VERSION}/token",
         json={"access_token": "ACCESS_TOKEN"},
     )
     responses.add(
@@ -96,17 +57,17 @@ def test_marketing_cloud_create_user_task(create_task, project_config):
             "user_username": "sterling-don",
             "role_id": "31",
         },
-        project_config=project_config,
+        project_config=mc_project_config,
     )
     task()
     assert task.return_values == {"success": True}
 
 
 @responses.activate
-def test_marketing_cloud_update_user_role_task(create_task, project_config):
+def test_marketing_cloud_update_user_role_task(create_task, mc_project_config):
     responses.add(
         "POST",
-        "https://tssd.auth.marketingcloudapis.com/v2/token",
+        f"https://tssd.auth.marketingcloudapis.com/{MC_API_VERSION}/token",
         json={"access_token": "ACCESS_TOKEN"},
     )
     responses.add(
@@ -125,7 +86,7 @@ def test_marketing_cloud_update_user_role_task(create_task, project_config):
             "user_password": "SterlingCooperDraperPryce1!",
             "role_id": "31",
         },
-        project_config=project_config,
+        project_config=mc_project_config,
     )
     task()
     assert task.return_values == {"success": True}

--- a/cumulusci/tasks/marketing_cloud/tests/test_get_user_info.py
+++ b/cumulusci/tasks/marketing_cloud/tests/test_get_user_info.py
@@ -97,6 +97,7 @@ def test_get_user_info__success(get_user_info_task, user_info_payload):
     expected_payload = user_info_payload
     del expected_payload["rest"]
     del expected_payload["application"]
+    del expected_payload["permissions"]
 
     assert get_user_info_task.return_values == expected_payload
 
@@ -129,10 +130,12 @@ def test_sanitize_payload(get_user_info_task):
         "bar": "bar-stuff",
         "rest": "rest-stuff",
         "application": "application-stuff",
+        "permissions": "permission-stuff",
     }
     start_num_keys = len(payload.keys())
     sanitized_payload = get_user_info_task._sanitize_payload(payload)
 
-    assert start_num_keys - 2 == len(sanitized_payload.keys())
+    assert start_num_keys - 3 == len(sanitized_payload.keys())
     assert "rest" not in sanitized_payload
     assert "appliation" not in sanitized_payload
+    assert "permissions" not in sanitized_payload

--- a/cumulusci/tasks/marketing_cloud/tests/test_get_user_info.py
+++ b/cumulusci/tasks/marketing_cloud/tests/test_get_user_info.py
@@ -1,0 +1,130 @@
+import pytest
+import requests
+import responses
+
+from cumulusci.tasks.marketing_cloud.get_user_info import GetUserInfoTask
+from cumulusci.tasks.marketing_cloud.mc_constants import MC_API_VERSION
+
+
+@pytest.fixture
+def get_user_info_task(create_task, mc_project_config):
+    return create_task(GetUserInfoTask, {}, project_config=mc_project_config)
+
+
+@pytest.fixture
+def user_info_payload():
+    return {
+        "exp": 1527771992,
+        "iss": "https://mc.exacttarget.com",
+        "user": {
+            "sub": "10654321",
+            "name": "Auth_user_name",
+            "preferred_username": "Auth_user_preferred_username",
+            "email": "example@example.com",
+            "locale": "en-GB",
+            "zoneinfo": "Europe/London",
+            "timezone": {
+                "longName": "(GMT) Dublin, Edinburgh, Lisbon, London *",
+                "shortName": "GMT+0",
+                "offset": 0,
+                "dst": True,
+            },
+        },
+        "organization": {
+            "member_id": 10123456,
+            "enterprise_id": 10123456,
+            "enterprise_name": "Auth_enterprise_name",
+            "account_type": "enterprise",
+            "stack_key": "S1",
+            "region": "NA1",
+            "locale": "en-US",
+            "zoneinfo": "America/Los_Angeles",
+            "timezone": {
+                "longName": "(GMT-08:00) Pacific Time (US & Canada) *",
+                "shortName": "GMT-8",
+                "offset": -8,
+                "dst": True,
+            },
+        },
+        "rest": {
+            "rest_instance_url": "https://mc563885gzs27c5t9-63k636ttgm.rest.marketingcloudapis.com",
+            "soap_instance_url": "https://mc563885gzs27c5t9-63k636ttgm.soap.marketingcloudapis.com",
+        },
+        "application": {
+            "id": "1a23b4cd-5e66-789f-0g1h-2i3a6efb6d80",
+            "name": "auth_application_name",
+            "redirectUrl": [
+                "https://example.example.com*",
+                "https://example.com/oauth-authorize",
+                "https://example.example.com/***********",
+            ],
+            "appScopes": [
+                "openid",
+                "offline",
+                "email_read",
+                "email_send",
+                "email_write",
+            ],
+        },
+        "permissions": [
+            {
+                "objectTypeName": "Email",
+                "operationName": "Update",
+                "name": "Update",
+                "id": 123,
+            }
+        ],
+    }
+
+
+@responses.activate
+def test_get_user_info__success(get_user_info_task, user_info_payload):
+    responses.add(
+        "POST",
+        "https://tssd.auth.marketingcloudapis.com/v2/token",
+        json={"access_token": "ACCESS_TOKEN"},
+    )
+    responses.add(
+        "GET",
+        f"https://TSSD.auth.marketingcloudapis.com/{MC_API_VERSION}/userinfo",
+        json=user_info_payload,
+    )
+
+    get_user_info_task()
+
+    expected_payload = user_info_payload
+    del expected_payload["rest"]
+    del expected_payload["application"]
+
+    assert get_user_info_task.return_values == expected_payload
+
+
+@responses.activate
+def test_get_user_info__HTTPError(get_user_info_task, user_info_payload):
+    responses.add(
+        "POST",
+        "https://tssd.auth.marketingcloudapis.com/v2/token",
+        json={"access_token": "ACCESS_TOKEN"},
+    )
+    responses.add(
+        "GET",
+        f"https://TSSD.auth.marketingcloudapis.com/{MC_API_VERSION}/userinfo",
+        body=requests.exceptions.HTTPError("bad request"),
+    )
+    with pytest.raises(requests.exceptions.HTTPError, match="bad request"):
+        get_user_info_task()
+
+
+def test_sanitize_payload(get_user_info_task):
+    payload = {
+        "foo": "foo-stuff",
+        "bar": "bar-stuff",
+        "rest": "rest-stuff",
+        "application": "application-stuff",
+    }
+    start_num_keys = len(payload.keys())
+    sanitized_payload = get_user_info_task._sanitize_payload(payload)
+
+    assert start_num_keys - 2 == len(sanitized_payload.keys())
+    assert "rest" not in sanitized_payload
+    assert "appliation" not in sanitized_payload

--- a/cumulusci/tasks/marketing_cloud/tests/test_get_user_info.py
+++ b/cumulusci/tasks/marketing_cloud/tests/test_get_user_info.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 import requests
 import responses
@@ -109,9 +111,15 @@ def test_get_user_info__HTTPError(get_user_info_task, user_info_payload):
     responses.add(
         "GET",
         f"https://TSSD.auth.marketingcloudapis.com/{MC_API_VERSION}/userinfo",
-        body=requests.exceptions.HTTPError("bad request"),
+        status=400,
+        body="bad request",
     )
-    with pytest.raises(requests.exceptions.HTTPError, match="bad request"):
+    with pytest.raises(
+        requests.exceptions.HTTPError,
+        match=re.escape(
+            "400 Client Error: Bad Request for url: https://tssd.auth.marketingcloudapis.com/v2/userinfo"
+        ),
+    ):
         get_user_info_task()
 
 


### PR DESCRIPTION
# Changes
* A new task is available for getting user information from the Marketing Cloud REST API `/userinfo` endpoint: `marketing_cloud_get_user_info`.

# Dev Changes
* Created a new `mc_constants.py` file for shared constants across MC files.
* Refactored a couple of pytest fixtures into a mc specific `conftest.py`.
