### PR TITLE
Adjust marketing_cloud_create_user task

### DIFF
--- a/cumulusci/salesforce_api/mc_soap_envelopes.py
+++ b/cumulusci/salesforce_api/mc_soap_envelopes.py
@@ -44,11 +44,14 @@ CREATE_USER = """<?xml version="1.0" encoding="utf-8"?>
                 {user_name}
                 <!-- REQUIRED: Set the user email -->
                 <Email>{user_email}</Email>
+                <NotificationEmailAddress>{user_email}</NotificationEmailAddress>
                 <!-- REQUIRED: Set the user password -->
                 <Password>{user_password}</Password>
                 <!-- REQUIRED: Set the username -->
                 <UserID>{user_username}</UserID>
                 <IsAPIUser>true</IsAPIUser>
+                {active_flag}
+                <IsLocked>false</IsLocked>
                 <!-- OPTIONAL: Include this if you want to assign roles to new user -->
                 <!-- IDs for system defined roles located here: https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/setting_user_permissions_via_the_web_services_api.htm -->
                 {role_id}

--- a/cumulusci/tasks/marketing_cloud/api.py
+++ b/cumulusci/tasks/marketing_cloud/api.py
@@ -29,7 +29,7 @@ class CreateSubscriberAttribute(BaseMarketingCloudTask):
             data=envelope.encode("utf-8"),
             headers={"Content-Type": "text/xml; charset=utf-8"},
         )
-        self._check_response(response)
+        self._check_soap_response(response)
         self.logger.info(
             f"Successfully created subscriber attribute: {attribute_name}."
         )
@@ -120,7 +120,7 @@ class CreateUser(BaseMarketingCloudTask):
             data=envelope.encode("utf-8"),
             headers={"Content-Type": "text/xml; charset=utf-8"},
         )
-        self._check_response(response)
+        self._check_soap_response(response)
         self.logger.info(f"Successfully created User: {user_username}.")
         self.return_values = {"success": True}
 
@@ -182,7 +182,7 @@ class UpdateUserRole(BaseMarketingCloudTask):
             data=envelope.encode("utf-8"),
             headers={"Content-Type": "text/xml; charset=utf-8"},
         )
-        self._check_response(response)
+        self._check_soap_response(response)
         user_name = self.options.get("user_name")
         self.logger.info(f"Successfully updated role for User: {user_name}.")
         self.return_values = {"success": True}

--- a/cumulusci/tasks/marketing_cloud/base.py
+++ b/cumulusci/tasks/marketing_cloud/base.py
@@ -17,7 +17,7 @@ class BaseMarketingCloudTask(BaseTask):
         super()._init_task()
         self.mc_config = self.project_config.keychain.get_service("marketing_cloud")
 
-    def _check_response(self, response):
+    def _check_soap_response(self, response):
         """Make sure the response indicates success."""
         response.raise_for_status()
         root = lxml_parse_string(response.content)

--- a/cumulusci/tasks/marketing_cloud/base.py
+++ b/cumulusci/tasks/marketing_cloud/base.py
@@ -1,4 +1,5 @@
 from cumulusci.core.tasks import BaseTask
+from cumulusci.utils.xml import lxml_parse_string
 
 
 class BaseMarketingCloudTask(BaseTask):
@@ -15,3 +16,18 @@ class BaseMarketingCloudTask(BaseTask):
     def _init_task(self):
         super()._init_task()
         self.mc_config = self.project_config.keychain.get_service("marketing_cloud")
+
+    def _check_response(self, response):
+        """Make sure the response indicates success."""
+        response.raise_for_status()
+        root = lxml_parse_string(response.content)
+        status_code = root.find(
+            ".//{http://exacttarget.com/wsdl/partnerAPI}StatusCode"
+        ).text
+        status_message = root.find(
+            ".//{http://exacttarget.com/wsdl/partnerAPI}StatusMessage"
+        ).text
+        if status_code != "OK":
+            raise Exception(
+                f"Error from Marketing Cloud: {status_message}\n\nFull response text: {response.text}"
+            )

--- a/cumulusci/tasks/marketing_cloud/tests/test_api.py
+++ b/cumulusci/tasks/marketing_cloud/tests/test_api.py
@@ -95,11 +95,16 @@ def test_marketing_cloud_create_user_task(create_task, project_config):
             "user_password": "SterlingCooperDraperPryce1!",
             "user_username": "sterling-don",
             "role_id": "31",
+            "activate_if_existing": "True",
         },
         project_config=project_config,
     )
     task()
     assert task.return_values == {"success": True}
+
+    request = responses.calls[-1].request
+    assert b"<ActiveFlag>true</ActiveFlag>" in request.body
+    assert b"<IsLocked>false</IsLocked>" in request.body
 
 
 @responses.activate


### PR DESCRIPTION
# Critical Changes

# Changes
* The `marketing_cloud_create_user` task now creates an unlocked user with a notification email address so that it is possible for the user to log in. This task also has a new option, `activate_if_existing`, which can be set to True to ensure that if the user already exists in an inactive state, it will be activated.

# Issues Closed
