### PR TITLE
Skip one test temporarily and clean-up a warning.

### DIFF
--- a/cumulusci/tasks/bulkdata/tests/test_snowfakery.py
+++ b/cumulusci/tasks/bulkdata/tests/test_snowfakery.py
@@ -875,6 +875,7 @@ class TestSnowfakery:
             keychain.get_org = mock.Mock(wraps=get_org)
             task()
 
+    @pytest.mark.skip()  # TODO: make handling of errors more predictable and re-enable
     @mock.patch("cumulusci.tasks.bulkdata.snowfakery.MIN_PORTION_SIZE", 2)
     def test_error_handling_in_channels(self, mock_load_data, create_task):
         task = create_task(
@@ -883,7 +884,6 @@ class TestSnowfakery:
                 "recipe": Path(__file__).parent
                 / "snowfakery/simple_snowfakery.recipe.yml",
                 "run_until_recipe_repeated": 15,
-                "recipe_options": {"xyzzy": "Nothing happens", "some_number": 42},
                 "loading_rules": Path(__file__).parent
                 / "snowfakery/simple_snowfakery_channels.load.yml",
             },

--- a/cumulusci/utils/tests/test_org_schema.py
+++ b/cumulusci/utils/tests/test_org_schema.py
@@ -201,7 +201,7 @@ class TestDescribeOrg:
                 path = schema.path
             assert not caplog.text
             with open(path, "wb") as p:
-                with gzip.GzipFile(fileobj=p) as gzipped:
+                with gzip.GzipFile(fileobj=p, mode="w") as gzipped:
                     gzipped.write(b"xxx")
 
             with get_org_schema(FakeSF(), org_config) as schema:


### PR DESCRIPTION
Skip one test temporarily and clean-up a warning in another. Not for release notes.