### PR TITLE
Feature/robot keyword bugfix

### DIFF
--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -118,7 +118,7 @@ class Salesforce(object):
             self.selenium.add_location_strategy(
                 "title", "Salesforce.Locate Element by Title"
             )
-            self.selenium.add_location_strategy("label", self.locate_element_by_label)
+            self.selenium.add_location_strategy("label", self._locate_element_by_label)
             self.builtin.set_suite_variable("${LOCATION STRATEGIES INITIALIZED}", True)
 
     @selenium_retry(False)
@@ -1486,7 +1486,7 @@ class Salesforce(object):
         # other element to trigger any event handlers on the last
         # element? But what should we set the focus to?
 
-    def locate_element_by_label(self, browser, locator, tag, constraints):
+    def _locate_element_by_label(self, browser, locator, tag, constraints):
         """Find a lightning component, input, or textarea based on a label
 
         If the component is inside a fieldset, the fieldset label can

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -222,6 +222,7 @@ class Salesforce(object):
             raise Exception(f"Unknown fake data request: '{fake}'")
 
     def get_latest_api_version(self):
+        """Return the API version used by the current org"""
         return self.cumulusci.org.latest_api_version
 
     def create_webdriver_with_retry(self, *args, **kwargs):

--- a/cumulusci/robotframework/tests/salesforce/locators.robot
+++ b/cumulusci/robotframework/tests/salesforce/locators.robot
@@ -13,24 +13,32 @@ Suite Teardown  Close all browsers
 Locator strategy 'text'
     [Documentation]
     ...  Test that the 'text' location strategy has been added
-
-    ...  Unfortunately, selenium doesn't provide introspection
-    ...  so we'll just try a locator that should work
-
     [Setup]  Go to setup home
 
+    # Try to use the locator strategy on an element
+    # we know should be on the page.
     Wait until page contains element     text:Mobile Publisher
 
 Locator strategy 'title'
     [Documentation]
     ...  Test that the 'title' location strategy has been added
-
-    ...  Unfortunately, selenium doesn't provide introspection
-    ...  so we'll just try a locator that should work
-
     [Setup]  Go to setup home
 
+    # Try to use the locator strategy on an element
+    # we know should be on the page.
     Wait until page contains element     title:Object Manager
+
+Locator strategy 'label'
+    [Documentation]
+    ...  Test that the 'label' location strategy has been added
+    [Setup]  Run keywords
+    ...  Go To Object Home           Contact
+    ...  AND  Click Object Button    New
+    [Teardown]  Close Modal
+
+    # Try to use the locator strategy on an element
+    # we know should be on the page.
+    Wait until page contains element    label:Phone
 
 Keyword library locators
     [Documentation]

--- a/docs/robot/Keywords.html
+++ b/docs/robot/Keywords.html
@@ -1450,61 +1450,6 @@ Input form data
                                 </td>
                             </tr>
 
-                            <tr class="kwrow" id="Salesforce.Locate Element By Label">
-                                <td class="kwname">Locate Element By Label</td>
-                                <td class="kwargs">
-                                    <i>browser</i>,
-
-                                    <i>locator</i>,
-
-                                    <i>tag</i>,
-
-                                    <i>constraints</i>
-                                </td>
-                                <td class="kwdoc">
-                                    <p>
-                                        Find a lightning component, input, or textarea
-                                        based on a label
-                                    </p>
-                                    <p>
-                                        If the component is inside a fieldset, the
-                                        fieldset label can be prefixed to the label with a
-                                        double colon in order to disambiguate the label.
-                                        (eg: Other address::First Name)
-                                    </p>
-                                    <p>
-                                        If the label is inside nested ligntning components
-                                        (eg:
-                                        <code
-                                            >&lt;lightning-input&gt;...&lt;lightning-combobox&gt;...&lt;label&gt;</code
-                                        >), the lightning component closest to the label
-                                        will be returned (in this case,
-                                        <code>lightning-combobox</code>).
-                                    </p>
-                                    <p>
-                                        If a lightning component cannot be found for the
-                                        label, an attempt will be made to find an input or
-                                        textarea associated with the label.
-                                    </p>
-                                    <p>
-                                        This is registered as a custom locator strategy
-                                        named "label"
-                                    </p>
-                                    <p>Example:</p>
-                                    <p>
-                                        The following example is for a form with a formset
-                                        named "Expected Delivery Date", and inside of that
-                                        a date input field with a label of "Date".
-                                    </p>
-                                    <p>These examples produce identical results:</p>
-                                    <pre>
-${element}=  Locate element by label    Expected Delivery Date::Date
-${element}=  Get webelement             label:Expected Delivery Date::Date
-</pre
-                                    >
-                                </td>
-                            </tr>
-
                             <tr class="kwrow" id="Salesforce.Log Browser Capabilities">
                                 <td class="kwname">Log Browser Capabilities</td>
                                 <td class="kwargs">
@@ -3224,7 +3169,7 @@ Populate form
             </div>
         </div>
         <div class="footer">
-            Generated on Tuesday December 07, 02:47 PM - cumulusci v3.48.2
+            Generated on Tuesday January 25, 03:39 PM - cumulusci v3.51.1
         </div>
     </body>
 </html>


### PR DESCRIPTION
Renamed a function so that it wouldn't be exposed as a keyword. I added a test specifically for the way this function is used. I also noticed a keyword that was missing a docstring, so I added it even though it's unrelated to this fix.  Finally, I regenerated the Keywords.html file via the robot_libdoc task.

This fixes [W-10311183](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000XtxcPYAR/view)

# Critical Changes

# Changes
* The robot keyword `Locate element by label` has been removed from the Salesforce.py library. This wasn't designed to be a keyword but was accidentally exported as one. If you want to find an input or textarea element by its label you can use a locator of the form "label:<text>" (eg: "label:First Name")

# Issues Closed
