### PR TITLE
Fix Snowfakery's Unique ID feature

### DIFF
--- a/cumulusci/tasks/bulkdata/snowfakery_utils/snowfakery_working_directory.py
+++ b/cumulusci/tasks/bulkdata/snowfakery_utils/snowfakery_working_directory.py
@@ -22,6 +22,10 @@ class SnowfakeryWorkingDirectory:
         metadata.reflect()
         return engine, metadata
 
+    @property
+    def index(self) -> str:
+        return self.path.name.rsplit("_")[0]
+
     def get_record_counts(self):
         """Get record counts generated for this portion."""
         engine, metadata = self.setup_engine()

--- a/cumulusci/tasks/bulkdata/snowfakery_utils/subtask_configurator.py
+++ b/cumulusci/tasks/bulkdata/snowfakery_utils/subtask_configurator.py
@@ -34,7 +34,7 @@ class SubtaskConfigurator:
         #
         # big_ids ensures that the pid is incorporated into the ids.
         plugin_options = {
-            "pid": parts[0],
+            "pid": str(wd.index),
             "big_ids": "True",
         }
 

--- a/cumulusci/tasks/bulkdata/snowfakery_utils/subtask_configurator.py
+++ b/cumulusci/tasks/bulkdata/snowfakery_utils/subtask_configurator.py
@@ -29,6 +29,15 @@ class SubtaskConfigurator:
         parts = name.rsplit("_", 1)
         batch_size = int(parts[-1])
 
+        # The pid is the tool that ensures that every uniqueid is
+        # unique even across different processes.
+        #
+        # big_ids ensures that the pid is incorporated into the ids.
+        plugin_options = {
+            "pid": parts[0],
+            "big_ids": "True",
+        }
+
         return {
             "generator_yaml": str(self.recipe),
             "database_url": wd.database_url,
@@ -37,6 +46,7 @@ class SubtaskConfigurator:
             "continuation_file": wd.continuation_file,
             "num_records_tablename": self.run_until.sobject_name or COUNT_REPS,
             "vars": recipe_options,
+            "plugin_options": plugin_options,
         }
 
     def data_loader_opts(self, working_dir: Path):


### PR DESCRIPTION
Snowfakery's Unique ID feature depends upon a parent process passing a uniquifying "context identifier" called a "pid" (because it is the ID for this Snowfakery process).

I dug into why the test case didn't catch the problem but the fix for the test is larger and I don't want to slow down this PR, but I'm working on a separate PR to fix that.

The old code was here:

https://github.com/SFDO-Tooling/CumulusCI/blob/f6777e673eca9978a84f70af365835d307885abb/cumulusci/tasks/bulkdata/snowfakery.py#L498