### PR TITLE
Fix test_record_count test method by using queue.Queue instead of multiprocessing.Queue

### DIFF
--- a/cumulusci/tasks/bulkdata/snowfakery.py
+++ b/cumulusci/tasks/bulkdata/snowfakery.py
@@ -403,7 +403,7 @@ class Snowfakery(BaseSalesforceApiTask):
                 results = self.queue_manager.get_results_report()
             except Empty:
                 break
-            if "results" in results:
+            if "results" in results and "step_results" in results["results"]:
                 self.update_running_totals_from_load_step_results(results["results"])
             elif "error" in results:
                 self.logger.warning(f"Error in load: {results}")

--- a/cumulusci/tasks/bulkdata/snowfakery_utils/queue_manager.py
+++ b/cumulusci/tasks/bulkdata/snowfakery_utils/queue_manager.py
@@ -1,3 +1,4 @@
+import queue
 import random
 import shutil
 import time
@@ -44,7 +45,12 @@ class SnowfakeryChannelManager:
         project_config,
         logger,
     ):
-        self.results_reporter = WorkerQueue.context.Queue()
+        # be careful to use a Queue class appropriate to
+        # the spawn type (thread, process) you're using.
+        #
+        # Snowfakery runs its loader in threads, so queue.Queue()
+        # works.
+        self.results_reporter = queue.Queue()
         self.channels = []
         self.project_config = project_config
         self.logger = logger

--- a/cumulusci/tasks/bulkdata/tests/test_snowfakery.py
+++ b/cumulusci/tasks/bulkdata/tests/test_snowfakery.py
@@ -474,7 +474,8 @@ class TestSnowfakery:
             task()
         assert "Using 11 workers" in str(logger.mock_calls)
 
-    def test_record_count(self, snowfakery, mock_load_data):
+    @pytest.mark.parametrize("execution_number", range(100))
+    def test_record_count(self, snowfakery, mock_load_data, execution_number):
         task = snowfakery(recipe="datasets/recipe.yml", run_until_recipe_repeated="4")
         with mock.patch.object(task, "logger") as logger, mock.patch.object(
             task.project_config, "keychain", DummyKeychain()

--- a/cumulusci/utils/parallel/task_worker_queues/parallel_worker.py
+++ b/cumulusci/utils/parallel/task_worker_queues/parallel_worker.py
@@ -135,20 +135,22 @@ class TaskWorker:
                 self.subtask()
                 logger.info(str(self.subtask.return_values))
                 logger.info("SubTask Success!")
-                self.results_reporter.put(
-                    {
-                        "status": "success",
-                        "results": self.subtask.return_values,
-                        "directory": str(self.working_dir),
-                    }
-                )
+                if self.results_reporter:
+                    self.results_reporter.put(
+                        {
+                            "status": "success",
+                            "results": self.subtask.return_values,
+                            "directory": str(self.working_dir),
+                        }
+                    )
             except BaseException as e:
                 logger.info(f"Failure detected: {e}")
                 self.save_exception(e)
                 self.failures_dir.mkdir(exist_ok=True)
                 logfile.close()
                 shutil.move(str(self.working_dir), str(self.failures_dir))
-                self.results_reporter.put({"status": "error", "error": str(e)})
+                if self.results_reporter:
+                    self.results_reporter.put({"status": "error", "error": str(e)})
                 raise
 
         try:

--- a/cumulusci/utils/parallel/task_worker_queues/parallel_worker_queue.py
+++ b/cumulusci/utils/parallel/task_worker_queues/parallel_worker_queue.py
@@ -2,12 +2,12 @@
    that represent the same "step" in a pipeline.
    """
 
-
 import logging
 import shutil
 import typing as T
-from multiprocessing import Queue, get_context
+from multiprocessing import get_context
 from pathlib import Path
+from queue import Queue
 from tempfile import gettempdir
 from threading import Thread
 
@@ -64,13 +64,17 @@ class WorkerQueue:
     def __init__(
         self,
         queue_config: WorkerQueueConfig,
+        # be careful to pass a Queue compatible with your spawn_type
+        # also, be VERY careful of race conditions.
+        # multiprocessing.Queue seems prone to delays that cause
+        # race conditions
         results_reporter: Queue = None,
     ):
         self.config = queue_config
         # convenience access to names
         self._create_dirs()
         self.workers = []
-        self.results_reporter = results_reporter or self.context.Queue()
+        self.results_reporter = results_reporter
 
     def __getattr__(self, name):
         """Convenience proxy for config values


### PR DESCRIPTION
# Changes for Release Notes:

None.

Fix test_record_count test method by using queue.Queue instead of multiprocessing.Queue

Attached file shows strange behaviours of multiprocessing.Queue. The downside of queue.Queue is that it only works for threads, not processes. Luckily Snowfakery currently only needs results reported "in realtime" from threads, so queue.Queue will work for our current needs.

[testqueues.py.txt](https://github.com/SFDO-Tooling/CumulusCI/files/8065064/testqueues.py.txt)
