### PR TITLE
Trigger reviews for md/rst files

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,11 @@ name: Call SFDO-Tooling Docs Review Workflow
 
 on:
     pull_request:
-        types:
-            - labeled
+        paths:
+            - "**.md"
+            - "**.rst"
+    pull_request_review:
+        types: [submitted]
 
 jobs:
     shared-docs:


### PR DESCRIPTION
Updated to allow a more traditional PR review process for docs. Now the workflow is triggered:
- on PR creation iff:
  - docs reviewer has not been requested, and
  - PR is unlabeled
- on review submission if:
  - docs reviewer approves
  - removes label if present

The shared workflow is updated in SFDO-Tooling/.github#3


# Critical Changes

# Changes

# Issues Closed
