### PR TITLE
Code cleanups: remove org_config in MP and sf_version

### DIFF
--- a/cumulusci/tasks/bulkdata/extract.py
+++ b/cumulusci/tasks/bulkdata/extract.py
@@ -110,7 +110,7 @@ class ExtractData(SqlAlchemyMixin, BaseSalesforceApiTask):
 
         validate_and_inject_mapping(
             mapping=self.mapping,
-            org_config=self.org_config,
+            sf=self.sf,
             namespace=self.project_config.project__package__namespace,
             data_operation=DataOperationType.QUERY,
             inject_namespaces=self.options["inject_namespaces"],
@@ -180,7 +180,7 @@ class ExtractData(SqlAlchemyMixin, BaseSalesforceApiTask):
         # Convert relative dates to stable dates.
         if mapping.anchor_date:
             date_context = mapping.get_relative_date_context(
-                list(field_map.keys()), self.org_config
+                list(field_map.keys()), self.sf
             )
             if date_context[0] or date_context[1]:
                 record_iterator = (

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -202,7 +202,7 @@ class LoadData(SqlAlchemyMixin, BaseSalesforceApiTask):
 
         if mapping.anchor_date:
             date_context = mapping.get_relative_date_context(
-                mapping.get_load_field_list(), self.org_config
+                mapping.get_load_field_list(), self.sf
             )
         # Clamping the yield from the query ensures we do not
         # create more Bulk API batches than expected, regardless
@@ -498,7 +498,7 @@ class LoadData(SqlAlchemyMixin, BaseSalesforceApiTask):
 
         validate_and_inject_mapping(
             mapping=self.mapping,
-            org_config=self.org_config,
+            sf=self.sf,
             namespace=self.project_config.project__package__namespace,
             data_operation=DataOperationType.INSERT,
             inject_namespaces=self.options["inject_namespaces"],

--- a/cumulusci/tasks/bulkdata/tests/test_extract.py
+++ b/cumulusci/tasks/bulkdata/tests/test_extract.py
@@ -386,6 +386,7 @@ class TestExtractData:
         step = mock.Mock()
         step.get_results.return_value = [[1], [2]]
         task.session = mock.Mock()
+        task._init_task()
         task._init_mapping()
         task.mapping["Opportunity"] = mapping
         with task._init_db():
@@ -414,6 +415,7 @@ class TestExtractData:
         )
         task.session = mock.Mock()
         task._sql_bulk_insert_from_records = mock.Mock()
+        task._init_task()
         task._import_results(mapping, step)
 
         task.session.connection.assert_called_once_with()
@@ -524,6 +526,7 @@ class TestExtractData:
         task._convert_lookups_to_id = mock.Mock()
         task.metadata = mock.MagicMock()
 
+        task._init_task()
         task._init_mapping()
         task._map_autopks()
 
@@ -740,6 +743,7 @@ class TestExtractData:
         )
         task.org_config._is_person_accounts_enabled = False
 
+        task._init_task()
         task._init_mapping()
         assert "Insert Households" in task.mapping
 
@@ -757,6 +761,7 @@ class TestExtractData:
         )
         task.org_config._is_person_accounts_enabled = True
 
+        task._init_task()
         task._init_mapping()
         assert "Insert Households" in task.mapping
 
@@ -780,11 +785,12 @@ class TestExtractData:
         )
         t.org_config._is_person_accounts_enabled = True
 
+        t._init_task()
         t._init_mapping()
 
         validate_and_inject_mapping.assert_called_once_with(
             mapping=t.mapping,
-            org_config=t.org_config,
+            sf=t.sf,
             namespace=t.project_config.project__package__namespace,
             data_operation=DataOperationType.QUERY,
             inject_namespaces=True,

--- a/cumulusci/tasks/bulkdata/tests/test_load.py
+++ b/cumulusci/tasks/bulkdata/tests/test_load.py
@@ -31,8 +31,8 @@ from cumulusci.tasks.bulkdata.tests.utils import (
     _make_task,
 )
 from cumulusci.tests.util import (
+    CURRENT_SF_API_VERSION,
     assert_max_memory_usage,
-    current_sf_version,
     mock_describe_calls,
 )
 from cumulusci.utils import temporary_dir
@@ -46,7 +46,7 @@ class TestLoadData(unittest.TestCase):
     def test_run(self, dml_mock):
         responses.add(
             method="GET",
-            url=f"https://example.com/services/data/v{current_sf_version}/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
+            url=f"https://example.com/services/data/v{CURRENT_SF_API_VERSION}/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
             body=json.dumps({"records": [{"Id": "1"}]}),
             status=200,
         )
@@ -190,7 +190,7 @@ class TestLoadData(unittest.TestCase):
     def test_run__sql(self, dml_mock):
         responses.add(
             method="GET",
-            url=f"https://example.com/services/data/v{current_sf_version}/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
+            url=f"https://example.com/services/data/v{CURRENT_SF_API_VERSION}/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
             body=json.dumps({"records": [{"Id": "1"}]}),
             status=200,
         )
@@ -1538,7 +1538,7 @@ class TestLoadData(unittest.TestCase):
     def test_run__autopk(self, dml_mock):
         responses.add(
             method="GET",
-            url=f"https://example.com/services/data/v{current_sf_version}/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
+            url=f"https://example.com/services/data/v{CURRENT_SF_API_VERSION}/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
             body=json.dumps({"records": [{"Id": "1"}]}),
             status=200,
         )
@@ -2194,7 +2194,7 @@ class TestLoadData(unittest.TestCase):
     def test_load_memory_usage(self):
         responses.add(
             method="GET",
-            url=f"https://example.com/services/data/v{current_sf_version}/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
+            url=f"https://example.com/services/data/v{CURRENT_SF_API_VERSION}/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
             body=json.dumps({"records": [{"Id": "1"}]}),
             status=200,
         )

--- a/cumulusci/tasks/bulkdata/tests/test_load.py
+++ b/cumulusci/tasks/bulkdata/tests/test_load.py
@@ -30,7 +30,11 @@ from cumulusci.tasks.bulkdata.tests.utils import (
     FakeBulkAPIDmlOperation,
     _make_task,
 )
-from cumulusci.tests.util import assert_max_memory_usage, mock_describe_calls
+from cumulusci.tests.util import (
+    assert_max_memory_usage,
+    current_sf_version,
+    mock_describe_calls,
+)
 from cumulusci.utils import temporary_dir
 
 
@@ -42,7 +46,7 @@ class TestLoadData(unittest.TestCase):
     def test_run(self, dml_mock):
         responses.add(
             method="GET",
-            url="https://example.com/services/data/v46.0/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
+            url=f"https://example.com/services/data/v{current_sf_version}/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
             body=json.dumps({"records": [{"Id": "1"}]}),
             status=200,
         )
@@ -186,7 +190,7 @@ class TestLoadData(unittest.TestCase):
     def test_run__sql(self, dml_mock):
         responses.add(
             method="GET",
-            url="https://example.com/services/data/v46.0/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
+            url=f"https://example.com/services/data/v{current_sf_version}/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
             body=json.dumps({"records": [{"Id": "1"}]}),
             status=200,
         )
@@ -291,11 +295,12 @@ class TestLoadData(unittest.TestCase):
             },
         )
 
+        t._init_task()
         t._init_mapping()
 
         validate_and_inject_mapping.assert_called_once_with(
             mapping=t.mapping,
-            org_config=t.org_config,
+            sf=t.sf,
             namespace=t.project_config.project__package__namespace,
             data_operation=DataOperationType.INSERT,
             inject_namespaces=True,
@@ -312,6 +317,7 @@ class TestLoadData(unittest.TestCase):
         )
 
         mock_describe_calls()
+        task._init_task()
         task._init_mapping()
 
         model = mock.Mock()
@@ -429,8 +435,7 @@ class TestLoadData(unittest.TestCase):
         task = _make_task(
             LoadData, {"options": {"database_url": "sqlite://", "mapping": "test.yml"}}
         )
-        task.sf = mock.Mock()
-
+        task._init_task()
         mapping = MappingStep(
             sf_object="Contact",
             action="insert",
@@ -1503,6 +1508,7 @@ class TestLoadData(unittest.TestCase):
         )
         mock_describe_calls()
 
+        task._init_task()
         task._init_mapping()
         task.mapping["Insert Households"]["fields"]["RecordTypeId"] = "RecordTypeId"
         with task._init_db():
@@ -1532,7 +1538,7 @@ class TestLoadData(unittest.TestCase):
     def test_run__autopk(self, dml_mock):
         responses.add(
             method="GET",
-            url="https://example.com/services/data/v46.0/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
+            url=f"https://example.com/services/data/v{current_sf_version}/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
             body=json.dumps({"records": [{"Id": "1"}]}),
             status=200,
         )
@@ -1595,6 +1601,7 @@ class TestLoadData(unittest.TestCase):
             {"options": {"database_url": "sqlite://", "mapping": mapping_path}},
         )
         mock_describe_calls()
+        task._init_task()
         task._init_mapping()
         assert (
             task.mapping["Insert Accounts"]["lookups"]["ParentId"]["after"]
@@ -1623,6 +1630,7 @@ class TestLoadData(unittest.TestCase):
             {"options": {"database_url": "sqlite://", "mapping": mapping_path}},
         )
         mock_describe_calls()
+        task._init_task()
         task._init_mapping()
 
         class FakeModel:
@@ -1645,6 +1653,7 @@ class TestLoadData(unittest.TestCase):
             {"options": {"database_url": "sqlite://", "mapping": mapping_path}},
         )
         mock_describe_calls()
+        task._init_task()
         task._init_mapping()
 
         class FakeModel:
@@ -2185,7 +2194,7 @@ class TestLoadData(unittest.TestCase):
     def test_load_memory_usage(self):
         responses.add(
             method="GET",
-            url="https://example.com/services/data/v46.0/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
+            url=f"https://example.com/services/data/v{current_sf_version}/query/?q=SELECT+Id+FROM+RecordType+WHERE+SObjectType%3D%27Account%27AND+DeveloperName+%3D+%27HH_Account%27+LIMIT+1",
             body=json.dumps({"records": [{"Id": "1"}]}),
             status=200,
         )

--- a/cumulusci/tasks/bulkdata/tests/test_mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/tests/test_mapping_parser.py
@@ -176,8 +176,8 @@ class TestMappingParser:
             anchor_date="2020-07-01",
         )
 
-        org_config = mock.Mock()
-        org_config.salesforce_client.Account.describe.return_value = {
+        salesforce_client = mock.Mock()
+        salesforce_client.Account.describe.return_value = {
             "fields": [
                 {"name": "Some_Date__c", "type": "date"},
                 {"name": "Some_Datetime__c", "type": "datetime"},
@@ -186,14 +186,14 @@ class TestMappingParser:
         }
 
         assert mapping.get_relative_date_context(
-            mapping.get_load_field_list(), org_config
+            mapping.get_load_field_list(), salesforce_client
         ) == ([0], [1], date.today())
 
     def test_get_relative_date_e2e(self):
         base_path = Path(__file__).parent / "mapping_v1.yml"
         mapping = parse_from_yaml(base_path)
-        org_config = mock.Mock()
-        org_config.salesforce_client.Contact.describe.return_value = {
+        salesforce_client = mock.Mock()
+        salesforce_client.Contact.describe.return_value = {
             "fields": [
                 {"name": "Some_Date__c", "type": "date"},
                 {"name": "Some_Datetime__c", "type": "datetime"},
@@ -205,7 +205,7 @@ class TestMappingParser:
             {"Some_Date__c": "Some_Date__c", "Some_Datetime__c": "Some_Datetime__c"}
         )
         assert contacts_mapping.get_relative_date_context(
-            contacts_mapping.get_load_field_list(), org_config
+            contacts_mapping.get_load_field_list(), salesforce_client
         ) == (
             [3],
             [4],
@@ -441,16 +441,16 @@ class TestMappingParser:
             )
         )["Insert Accounts"]
 
-        org_config = mock.Mock()
-        org_config.salesforce_client.describe.return_value = {
+        salesforce_client = mock.Mock()
+        salesforce_client.describe.return_value = {
             "sobjects": [{"name": "Account", "createable": True}]
         }
-        org_config.salesforce_client.Account.describe.return_value = {
+        salesforce_client.Account.describe.return_value = {
             "fields": [{"name": "ns__Test__c", "createable": True}]
         }
 
         assert ms.validate_and_inject_namespace(
-            org_config, "ns", DataOperationType.INSERT, inject_namespaces=True
+            salesforce_client, "ns", DataOperationType.INSERT, inject_namespaces=True
         )
 
         ms._validate_sobject.assert_called_once_with(
@@ -507,11 +507,11 @@ class TestMappingParser:
             )
         )["Insert Accounts"]
 
-        org_config = mock.Mock()
-        org_config.salesforce_client.describe.return_value = {
+        salesforce_client = mock.Mock()
+        salesforce_client.describe.return_value = {
             "sobjects": [{"name": "Account", "createable": True}]
         }
-        org_config.salesforce_client.Account.describe.return_value = {
+        salesforce_client.Account.describe.return_value = {
             "fields": [
                 {"name": "Name", "createable": True},
                 {"name": "ns__Lookup__c", "updateable": False, "createable": True},
@@ -519,7 +519,7 @@ class TestMappingParser:
         }
 
         assert ms.validate_and_inject_namespace(
-            org_config, "ns", DataOperationType.INSERT, inject_namespaces=True
+            salesforce_client, "ns", DataOperationType.INSERT, inject_namespaces=True
         )
 
         ms._validate_sobject.assert_called_once_with(
@@ -577,15 +577,15 @@ class TestMappingParser:
             sf_object="Test__c", fields=["Field__c"], action=DataOperationType.INSERT
         )
 
-        org_config = mock.Mock()
-        org_config.salesforce_client.describe.return_value = {
+        salesforce_client = mock.Mock()
+        salesforce_client.describe.return_value = {
             "sobjects": [{"name": "Test__c", "createable": True}]
         }
-        org_config.salesforce_client.Test__c.describe.return_value = {
+        salesforce_client.Test__c.describe.return_value = {
             "fields": [{"name": "Field__c", "createable": True}]
         }
         assert ms.validate_and_inject_namespace(
-            org_config, "ns", DataOperationType.INSERT
+            salesforce_client, "ns", DataOperationType.INSERT
         )
 
         ms._validate_sobject.assert_called_once_with(
@@ -631,15 +631,15 @@ class TestMappingParser:
             sf_object="Test__c", fields=["Name"], action=DataOperationType.INSERT
         )
 
-        org_config = mock.Mock()
-        org_config.salesforce_client.describe.return_value = {
+        salesforce_client = mock.Mock()
+        salesforce_client.describe.return_value = {
             "sobjects": [{"name": "Test__c", "createable": False}]
         }
-        org_config.salesforce_client.Test__c.describe.return_value = {
+        salesforce_client.Test__c.describe.return_value = {
             "fields": [{"name": "Name", "createable": True}]
         }
         assert not ms.validate_and_inject_namespace(
-            org_config, "ns", DataOperationType.INSERT
+            salesforce_client, "ns", DataOperationType.INSERT
         )
 
         ms._validate_sobject.assert_called_once_with(
@@ -666,15 +666,15 @@ class TestMappingParser:
             sf_object="Test__c", fields=["Name"], action=DataOperationType.INSERT
         )
 
-        org_config = mock.Mock()
-        org_config.salesforce_client.describe.return_value = {
+        salesforce_client = mock.Mock()
+        salesforce_client.describe.return_value = {
             "sobjects": [{"name": "Test__c", "createable": True}]
         }
-        org_config.salesforce_client.Test__c.describe.return_value = {
+        salesforce_client.Test__c.describe.return_value = {
             "fields": [{"name": "Name", "createable": False}]
         }
         assert not ms.validate_and_inject_namespace(
-            org_config, "ns", DataOperationType.INSERT
+            salesforce_client, "ns", DataOperationType.INSERT
         )
 
         ms._validate_sobject.assert_called_once_with(
@@ -721,18 +721,18 @@ class TestMappingParser:
             )
         )["Insert Accounts"]
 
-        org_config = mock.Mock()
-        org_config.salesforce_client.describe.return_value = {
+        salesforce_client = mock.Mock()
+        salesforce_client.describe.return_value = {
             "sobjects": [{"name": "Account", "createable": True}]
         }
-        org_config.salesforce_client.Account.describe.return_value = {
+        salesforce_client.Account.describe.return_value = {
             "fields": [
                 {"name": "Name", "createable": True},
                 {"name": "Lookup__c", "updateable": True, "createable": False},
             ]
         }
         assert not ms.validate_and_inject_namespace(
-            org_config, "ns", DataOperationType.INSERT
+            salesforce_client, "ns", DataOperationType.INSERT
         )
 
         ms._validate_sobject.assert_called_once_with(
@@ -802,18 +802,18 @@ class TestMappingParser:
             )
         )["Insert Accounts"]
 
-        org_config = mock.Mock()
-        org_config.salesforce_client.describe.return_value = {
+        salesforce_client = mock.Mock()
+        salesforce_client.describe.return_value = {
             "sobjects": [{"name": "Account", "createable": True}]
         }
-        org_config.salesforce_client.Account.describe.return_value = {
+        salesforce_client.Account.describe.return_value = {
             "fields": [
                 {"name": "Name", "createable": True},
                 {"name": "Lookup__c", "updateable": False, "createable": True},
             ]
         }
         assert not ms.validate_and_inject_namespace(
-            org_config, "ns", DataOperationType.INSERT
+            salesforce_client, "ns", DataOperationType.INSERT
         )
 
         ms._validate_sobject.assert_called_once_with(
@@ -875,7 +875,7 @@ class TestMappingParser:
         with pytest.raises(BulkDataException):
             validate_and_inject_mapping(
                 mapping=mapping,
-                org_config=org_config,
+                sf=org_config.salesforce_client,
                 namespace=None,
                 data_operation=DataOperationType.INSERT,
                 inject_namespaces=False,
@@ -896,7 +896,7 @@ class TestMappingParser:
 
         validate_and_inject_mapping(
             mapping=mapping,
-            org_config=org_config,
+            sf=org_config.salesforce_client,
             namespace=None,
             data_operation=DataOperationType.INSERT,
             inject_namespaces=False,
@@ -922,7 +922,7 @@ class TestMappingParser:
 
         validate_and_inject_mapping(
             mapping=mapping,
-            org_config=org_config,
+            sf=org_config.salesforce_client,
             namespace=None,
             data_operation=DataOperationType.INSERT,
             inject_namespaces=False,
@@ -955,7 +955,7 @@ class TestMappingParser:
         with pytest.raises(BulkDataException):
             validate_and_inject_mapping(
                 mapping=mapping,
-                org_config=org_config,
+                sf=org_config.salesforce_client,
                 namespace=None,
                 data_operation=DataOperationType.INSERT,
                 inject_namespaces=False,
@@ -980,7 +980,10 @@ class TestMappingParser:
         )
 
         assert ms.validate_and_inject_namespace(
-            org_config, "ns", DataOperationType.INSERT, inject_namespaces=True
+            org_config.salesforce_client,
+            "ns",
+            DataOperationType.INSERT,
+            inject_namespaces=True,
         )
 
         assert list(ms.fields.keys()) == ["ns__Description__c"]
@@ -1003,7 +1006,10 @@ class TestMappingParser:
         )
 
         assert ms.validate_and_inject_namespace(
-            org_config, "ns", DataOperationType.INSERT, inject_namespaces=True
+            org_config.salesforce_client,
+            "ns",
+            DataOperationType.INSERT,
+            inject_namespaces=True,
         )
 
         assert list(ms.fields.keys()) == ["History__c"]
@@ -1025,7 +1031,7 @@ class TestMappingParser:
 
         validate_and_inject_mapping(
             mapping=mapping,
-            org_config=org_config,
+            sf=org_config.salesforce_client,
             namespace=None,
             data_operation=DataOperationType.QUERY,
             inject_namespaces=False,
@@ -1099,7 +1105,7 @@ class TestMappingLookup:
 
         validate_and_inject_mapping(
             mapping=mapping,
-            org_config=org_config,
+            sf=org_config.salesforce_client,
             namespace=None,
             data_operation=DataOperationType.INSERT,
             inject_namespaces=False,

--- a/cumulusci/tasks/bulkdata/tests/utils.py
+++ b/cumulusci/tasks/bulkdata/tests/utils.py
@@ -7,13 +7,18 @@ from cumulusci.tasks.bulkdata.step import (
 )
 from cumulusci.tests import util as cci_test_utils
 
+current_sf_version = "48.0"
+
 
 def _make_task(task_class, task_config):
     task_config = TaskConfig(task_config)
     universal_config = UniversalConfig()
     project_config = BaseProjectConfig(
         universal_config,
-        config={"noyaml": True, "project": {"package": {"api_version": "46.0"}}},
+        config={
+            "noyaml": True,
+            "project": {"package": {"api_version": current_sf_version}},
+        },
     )
     keychain = BaseProjectKeychain(project_config, "")
     project_config.set_keychain(keychain)
@@ -31,6 +36,7 @@ class FakeBulkAPI:
 
     next_job_id = 0
     next_batch_id = 0
+    endpoint = f"https://example.my.salesforce.com/services/async/{current_sf_version}"
 
     @classmethod
     def create_job(cls, *args, **kwargs):

--- a/cumulusci/tasks/bulkdata/tests/utils.py
+++ b/cumulusci/tasks/bulkdata/tests/utils.py
@@ -7,7 +7,7 @@ from cumulusci.tasks.bulkdata.step import (
 )
 from cumulusci.tests import util as cci_test_utils
 
-current_sf_version = "48.0"
+CURRENT_SF_API_VERSION = "48.0"
 
 
 def _make_task(task_class, task_config):
@@ -17,7 +17,7 @@ def _make_task(task_class, task_config):
         universal_config,
         config={
             "noyaml": True,
-            "project": {"package": {"api_version": current_sf_version}},
+            "project": {"package": {"api_version": CURRENT_SF_API_VERSION}},
         },
     )
     keychain = BaseProjectKeychain(project_config, "")
@@ -36,7 +36,9 @@ class FakeBulkAPI:
 
     next_job_id = 0
     next_batch_id = 0
-    endpoint = f"https://example.my.salesforce.com/services/async/{current_sf_version}"
+    endpoint = (
+        f"https://example.my.salesforce.com/services/async/{CURRENT_SF_API_VERSION}"
+    )
 
     @classmethod
     def create_job(cls, *args, **kwargs):

--- a/cumulusci/tests/util.py
+++ b/cumulusci/tests/util.py
@@ -19,7 +19,7 @@ from cumulusci.core.config import (
     UniversalConfig,
 )
 from cumulusci.core.keychain import BaseProjectKeychain
-from cumulusci.tasks.bulkdata.tests.utils import FakeBulkAPI, current_sf_version
+from cumulusci.tasks.bulkdata.tests.utils import CURRENT_SF_API_VERSION, FakeBulkAPI
 
 
 def random_sha():
@@ -308,4 +308,7 @@ class FakeUnreliableRequestHandler:
     def real_reliable_request_callback(self, request):
         return self.response
 
-current_sf_version = current_sf_version # quiet linter and export to other modules
+
+CURRENT_SF_API_VERSION = (
+    CURRENT_SF_API_VERSION  # quiet linter and export to other modules
+)


### PR DESCRIPTION
1. Don't pass org_config to mapping_parser functions. Pass salesforce_client instead. The only reason they need an org_config is for the salesforce_client, and passing in an existing one is cleaner, more performant and easier to mock.

2. Start the process of centralizing the "preferred" Salesforce version for test cases in a single place.

Nothing relevant to release notes.