### PR TITLE
Bulk Test Cleanups - Part 2

### DIFF
--- a/cumulusci/tasks/bulkdata/tests/Contact.json
+++ b/cumulusci/tasks/bulkdata/tests/Contact.json
@@ -1038,9 +1038,7 @@
             "precision": 0,
             "queryByDistance": false,
             "referenceTargetField": null,
-            "referenceTo": [
-                "Contact"
-            ],
+            "referenceTo": ["Contact"],
             "relationshipName": "MasterRecord",
             "relationshipOrder": null,
             "restrictedDelete": false,
@@ -1099,9 +1097,7 @@
             "precision": 0,
             "queryByDistance": false,
             "referenceTargetField": null,
-            "referenceTo": [
-                "Account"
-            ],
+            "referenceTo": ["Account"],
             "relationshipName": "Account",
             "relationshipOrder": null,
             "restrictedDelete": false,
@@ -3004,9 +3000,7 @@
             "precision": 0,
             "queryByDistance": false,
             "referenceTargetField": null,
-            "referenceTo": [
-                "Contact"
-            ],
+            "referenceTo": ["Contact"],
             "relationshipName": "ReportsTo",
             "relationshipOrder": null,
             "restrictedDelete": false,
@@ -3514,9 +3508,7 @@
             "precision": 0,
             "queryByDistance": false,
             "referenceTargetField": null,
-            "referenceTo": [
-                "User"
-            ],
+            "referenceTo": ["User"],
             "relationshipName": "Owner",
             "relationshipOrder": null,
             "restrictedDelete": false,
@@ -3634,9 +3626,7 @@
             "precision": 0,
             "queryByDistance": false,
             "referenceTargetField": null,
-            "referenceTo": [
-                "User"
-            ],
+            "referenceTo": ["User"],
             "relationshipName": "CreatedBy",
             "relationshipOrder": null,
             "restrictedDelete": false,
@@ -3754,9 +3744,7 @@
             "precision": 0,
             "queryByDistance": false,
             "referenceTargetField": null,
-            "referenceTo": [
-                "User"
-            ],
+            "referenceTo": ["User"],
             "relationshipName": "LastModifiedBy",
             "relationshipOrder": null,
             "restrictedDelete": false,
@@ -4639,9 +4627,7 @@
             "precision": 0,
             "queryByDistance": false,
             "referenceTargetField": null,
-            "referenceTo": [
-                "Individual"
-            ],
+            "referenceTo": ["Individual"],
             "relationshipName": "Individual",
             "relationshipOrder": null,
             "restrictedDelete": false,

--- a/cumulusci/tasks/bulkdata/tests/test_step.py
+++ b/cumulusci/tasks/bulkdata/tests/test_step.py
@@ -24,7 +24,7 @@ from cumulusci.tasks.bulkdata.step import (
     get_query_operation,
 )
 from cumulusci.tasks.bulkdata.tests.utils import _make_task
-from cumulusci.tests.util import mock_describe_calls
+from cumulusci.tests.util import CURRENT_SF_API_VERSION, mock_describe_calls
 
 BULK_BATCH_RESPONSE = """<root xmlns="http://ns">
 <batch>
@@ -737,12 +737,12 @@ class TestRestApiDmlOperation:
                 }
             },
         )
-        task.project_config.project__package__api_version = "48.0"
+        task.project_config.project__package__api_version = CURRENT_SF_API_VERSION
         task._init_task()
 
         responses.add(
             responses.POST,
-            url="https://example.com/services/data/v48.0/composite/sobjects",
+            url=f"https://example.com/services/data/v{CURRENT_SF_API_VERSION}/composite/sobjects",
             json=[
                 {"id": "003000000000001", "success": True},
                 {"id": "003000000000002", "success": True},
@@ -751,7 +751,7 @@ class TestRestApiDmlOperation:
         )
         responses.add(
             responses.POST,
-            url="https://example.com/services/data/v48.0/composite/sobjects",
+            url=f"https://example.com/services/data/v{CURRENT_SF_API_VERSION}/composite/sobjects",
             json=[{"id": "003000000000003", "success": True}],
             status=200,
         )
@@ -791,12 +791,12 @@ class TestRestApiDmlOperation:
                 }
             },
         )
-        task.project_config.project__package__api_version = "48.0"
+        task.project_config.project__package__api_version = CURRENT_SF_API_VERSION
         task._init_task()
 
         responses.add(
             responses.POST,
-            url="https://example.com/services/data/v48.0/composite/sobjects",
+            url=f"https://example.com/services/data/v{CURRENT_SF_API_VERSION}/composite/sobjects",
             json=[
                 {"id": "003000000000001", "success": True},
                 {"id": "003000000000002", "success": True},
@@ -805,7 +805,7 @@ class TestRestApiDmlOperation:
         )
         responses.add(
             responses.POST,
-            url="https://example.com/services/data/v48.0/composite/sobjects",
+            url=f"https://example.com/services/data/v{CURRENT_SF_API_VERSION}/composite/sobjects",
             json=[{"id": "003000000000003", "success": True}],
             status=200,
         )
@@ -909,12 +909,12 @@ class TestRestApiDmlOperation:
                 }
             },
         )
-        task.project_config.project__package__api_version = "48.0"
+        task.project_config.project__package__api_version = CURRENT_SF_API_VERSION
         task._init_task()
 
         responses.add(
             responses.POST,
-            url="https://example.com/services/data/v48.0/composite/sobjects",
+            url=f"https://example.com/services/data/v{CURRENT_SF_API_VERSION}/composite/sobjects",
             json=[
                 {"id": "003000000000001", "success": True},
                 {"id": "003000000000002", "success": True},
@@ -923,7 +923,7 @@ class TestRestApiDmlOperation:
         )
         responses.add(
             responses.POST,
-            url="https://example.com/services/data/v48.0/composite/sobjects",
+            url=f"https://example.com/services/data/v{CURRENT_SF_API_VERSION}/composite/sobjects",
             json=[{"id": "003000000000003", "success": True}],
             status=200,
         )
@@ -957,12 +957,12 @@ class TestRestApiDmlOperation:
                 }
             },
         )
-        task.project_config.project__package__api_version = "48.0"
+        task.project_config.project__package__api_version = CURRENT_SF_API_VERSION
         task._init_task()
 
         responses.add(
             responses.POST,
-            url="https://example.com/services/data/v48.0/composite/sobjects",
+            url=f"https://example.com/services/data/v{CURRENT_SF_API_VERSION}/composite/sobjects",
             json=[
                 {"id": "003000000000001", "success": True},
                 {"id": "003000000000002", "success": True},
@@ -971,7 +971,7 @@ class TestRestApiDmlOperation:
         )
         responses.add(
             responses.POST,
-            url="https://example.com/services/data/v48.0/composite/sobjects",
+            url=f"https://example.com/services/data/v{CURRENT_SF_API_VERSION}/composite/sobjects",
             json=[
                 {
                     "id": "003000000000003",
@@ -1025,12 +1025,12 @@ class TestRestApiDmlOperation:
                 }
             },
         )
-        task.project_config.project__package__api_version = "48.0"
+        task.project_config.project__package__api_version = CURRENT_SF_API_VERSION
         task._init_task()
 
         responses.add(
             responses.DELETE,
-            url="https://example.com/services/data/v48.0/composite/sobjects?ids=003000000000001,003000000000002",
+            url=f"https://example.com/services/data/v{CURRENT_SF_API_VERSION}/composite/sobjects?ids=003000000000001,003000000000002",
             json=[
                 {"id": "003000000000001", "success": True},
                 {"id": "003000000000002", "success": True},
@@ -1039,7 +1039,7 @@ class TestRestApiDmlOperation:
         )
         responses.add(
             responses.DELETE,
-            url="https://example.com/services/data/v48.0/composite/sobjects?ids=003000000000003",
+            url=f"https://example.com/services/data/v{CURRENT_SF_API_VERSION}/composite/sobjects?ids=003000000000003",
             json=[{"id": "003000000000003", "success": True}],
             status=200,
         )
@@ -1079,12 +1079,12 @@ class TestRestApiDmlOperation:
                 }
             },
         )
-        task.project_config.project__package__api_version = "48.0"
+        task.project_config.project__package__api_version = CURRENT_SF_API_VERSION
         task._init_task()
 
         responses.add(
             responses.POST,
-            url="https://example.com/services/data/v48.0/composite/sobjects",
+            url=f"https://example.com/services/data/v{CURRENT_SF_API_VERSION}/composite/sobjects",
             json=[{"id": "003000000000001", "success": True}],
             status=200,
         )

--- a/cumulusci/tasks/bulkdata/tests/test_utils.py
+++ b/cumulusci/tasks/bulkdata/tests/test_utils.py
@@ -1,4 +1,3 @@
-import json
 import os
 import unittest
 from unittest import mock
@@ -29,44 +28,6 @@ def create_db_memory():
     metadata = MetaData()
     metadata.bind = engine
     return engine, metadata
-
-
-def mock_describe_calls():
-    def read_mock(name: str):
-        base_path = os.path.dirname(__file__)
-
-        with open(os.path.join(base_path, f"{name}.json"), "r") as f:
-            return f.read()
-
-    def mock_sobject_describe(name: str):
-        responses.add(
-            method="GET",
-            url=f"https://example.com/services/data/v48.0/sobjects/{name}/describe",
-            body=read_mock(name),
-            status=200,
-        )
-
-    responses.add(
-        method="GET",
-        url="https://example.com/services/data",
-        body=json.dumps([{"version": "40.0"}, {"version": "48.0"}]),
-        status=200,
-    )
-    responses.add(
-        method="GET",
-        url="https://example.com/services/data/v48.0/sobjects",
-        body=read_mock("global_describe"),
-        status=200,
-    )
-
-    for sobject in [
-        "Account",
-        "Contact",
-        "Opportunity",
-        "OpportunityContactRole",
-        "Case",
-    ]:
-        mock_sobject_describe(sobject)
 
 
 class TestSqlAlchemyMixin(unittest.TestCase):

--- a/cumulusci/tasks/bulkdata/tests/utils.py
+++ b/cumulusci/tasks/bulkdata/tests/utils.py
@@ -7,8 +7,6 @@ from cumulusci.tasks.bulkdata.step import (
 )
 from cumulusci.tests import util as cci_test_utils
 
-CURRENT_SF_API_VERSION = "48.0"
-
 
 def _make_task(task_class, task_config):
     task_config = TaskConfig(task_config)
@@ -17,7 +15,9 @@ def _make_task(task_class, task_config):
         universal_config,
         config={
             "noyaml": True,
-            "project": {"package": {"api_version": CURRENT_SF_API_VERSION}},
+            "project": {
+                "package": {"api_version": cci_test_utils.CURRENT_SF_API_VERSION}
+            },
         },
     )
     keychain = BaseProjectKeychain(project_config, "")
@@ -36,9 +36,7 @@ class FakeBulkAPI:
 
     next_job_id = 0
     next_batch_id = 0
-    endpoint = (
-        f"https://example.my.salesforce.com/services/async/{CURRENT_SF_API_VERSION}"
-    )
+    endpoint = f"https://example.my.salesforce.com/services/async/{cci_test_utils.CURRENT_SF_API_VERSION}"
 
     @classmethod
     def create_job(cls, *args, **kwargs):

--- a/cumulusci/tests/pytest_plugins/pytest_sf_orgconnect.py
+++ b/cumulusci/tests/pytest_plugins/pytest_sf_orgconnect.py
@@ -10,7 +10,7 @@ from cumulusci.cli.runtime import CliRuntime
 from cumulusci.core.config import OrgConfig, TaskConfig
 from cumulusci.core.exceptions import OrgNotFound
 from cumulusci.salesforce_api.utils import get_simple_salesforce_connection
-from cumulusci.tests.util import unmock_env
+from cumulusci.tests.util import CURRENT_SF_API_VERSION, unmock_env
 
 
 def pytest_addoption(parser, pluginmanager):
@@ -114,9 +114,9 @@ def org_config(request, current_org_shape, cli_org_config, fallback_org_config):
     # fast running test suites it might return a hardcoded
     # org and for integration test suites it might return
     # a specific default org or throw an exception.
-    with mock.patch.object(OrgConfig, "latest_api_version", "48.0"), mock.patch.object(
-        OrgConfig, "refresh_oauth_token"
-    ):
+    with mock.patch.object(
+        OrgConfig, "latest_api_version", CURRENT_SF_API_VERSION
+    ), mock.patch.object(OrgConfig, "refresh_oauth_token"):
         yield org_config
 
 


### PR DESCRIPTION
Nothing for Release Notes.

Contact.json was prettied.

CURRENT_SF_API_VERSION was moved from one file to another.

CURRENT_SF_API_VERSION was used in more places than before.

An unused, second copy of `mock_describe_calls` was deleted.

`mock_describe_calls` is now versionable.

