### PR TITLE
Allow references in upserts

### DIFF
--- a/datasets/upsert/upsert_before_data.sql
+++ b/datasets/upsert/upsert_before_data.sql
@@ -1,3 +1,4 @@
+-- Data to be loaded before an upsert as the "base data"
 BEGIN TRANSACTION;
 CREATE TABLE "Account" (
 	id INTEGER NOT NULL, 
@@ -29,3 +30,13 @@ INSERT INTO "Contact" VALUES(14,'Kaitlyn','Rubio','Kaitlyn.Rubio@example.com');
 INSERT INTO "Contact" VALUES(15,'Jerry','Eaton','Jerry.Eaton@example.com');
 INSERT INTO "Contact" VALUES(16,'Gabrielle','Vargas','Gabrielle.Vargas@example.com');
 COMMIT;
+CREATE TABLE "Opportunity" (
+	id INTEGER NOT NULL,
+	"Name" VARCHAR(255),
+	"CloseDate" VARCHAR(255),
+	"Amount" VARCHAR(255),
+	"StageName" VARCHAR(255),
+	"AccountId" VARCHAR(255),
+	"ContactId" VARCHAR(255),
+	PRIMARY KEY (id)
+);

--- a/datasets/upsert/upsert_example_2.sql
+++ b/datasets/upsert/upsert_example_2.sql
@@ -14,4 +14,41 @@ CREATE TABLE "Contact" (
 INSERT INTO "Contact" VALUES(1,'Nichael','Bluth','Michael.Bluth@example.com');
 INSERT INTO "Contact" VALUES(2,'George Oscar','Bluth','GOB.Bluth@example.com');
 INSERT INTO "Contact" VALUES(3,'Lindsay','Bluth','lindsay.bluth@example.com');
+INSERT INTO "Contact" VALUES(4,'Annyong','Bluth','annyong.bluth@example.com');
 COMMIT;
+
+CREATE TABLE "Opportunity" (
+	id INTEGER NOT NULL,
+	"Name" VARCHAR(255),
+	"CloseDate" VARCHAR(255),
+	"Amount" VARCHAR(255),
+	"StageName" VARCHAR(255),
+	"AccountId" VARCHAR(255),
+	"ContactId" VARCHAR(255),
+	PRIMARY KEY (id)
+);
+
+INSERT INTO
+	"Opportunity"
+VALUES
+	(
+		1,
+		'Illusional Opportunity',
+		'2021-10-03',
+		'136',
+		'In Progress',
+		NULL,
+		'2'
+	);
+INSERT INTO
+	"Opportunity"
+VALUES
+	(
+		2,
+		'Espionage Opportunity',
+		'2021-10-03',
+		'200',
+		'In Progress',
+		NULL,
+		'4'
+	);

--- a/datasets/upsert/upsert_mapping_bulk.yml
+++ b/datasets/upsert/upsert_mapping_bulk.yml
@@ -12,3 +12,15 @@ Insert Contacts:
         - FirstName
         - LastName
         - Email
+Insert Opportunities:
+    api: bulk
+    sf_object: Opportunity
+    fields:
+        - Name
+        - StageName
+        - CloseDate
+    lookups:
+        AccountId:
+            table: Account
+        ContactId:
+            table: Contact

--- a/datasets/upsert/upsert_mapping_rest.yml
+++ b/datasets/upsert/upsert_mapping_rest.yml
@@ -12,3 +12,15 @@ Insert Contacts:
         - FirstName
         - LastName
         - Email
+Insert Opportunities:
+    api: rest
+    sf_object: Opportunity
+    fields:
+        - Name
+        - StageName
+        - CloseDate
+    lookups:
+        AccountId:
+            table: Account
+        ContactId:
+            table: Contact

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -124,9 +124,6 @@ and `external ID <https://help.salesforce.com/s/articleView?id=sf.faq_import_gen
 `upserts <https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/langCon_apex_dml_examples_upsert.htm>`_ 
 and updates by specifying additional settings in a mapping step.
 
-Objects inserted through an upsert are not able to be referred to through lookups uploaded in the same
-```load_data`` task.
-
 .. code-block:: yaml
 
     Insert Accounts:


### PR DESCRIPTION
Allow lookup references to objects inserted or updated in upserts.

# Changes

Nothing for release notes, assuming this ships with the same version as the rest of the Upsert feature. It merely removes a limitation in that feature.

