### PR TITLE
Abolish Unittest

### DIFF
--- a/cumulusci/cli/tests/test_runtime.py
+++ b/cumulusci/cli/tests/test_runtime.py
@@ -1,10 +1,10 @@
 import os
 import sys
-import unittest
 from datetime import date, timedelta
 from unittest import mock
 
 import click
+import pytest
 
 import cumulusci
 from cumulusci.cli.runtime import CliRuntime
@@ -12,32 +12,32 @@ from cumulusci.core.config import OrgConfig
 from cumulusci.core.exceptions import ConfigError, OrgNotFound
 
 
-class TestCliRuntime(unittest.TestCase):
+class TestCliRuntime:
     key = "1234567890abcdef"
 
-    def setUp(self):
+    def setup_method(self):
         os.chdir(os.path.dirname(cumulusci.__file__))
         self.environ_mock = mock.patch.dict(os.environ, {"CUMULUSCI_KEY": self.key})
         self.environ_mock.start()
 
-    def tearDown(self):
+    def teardown_method(self):
         self.environ_mock.stop()
 
     def test_init(self):
         config = CliRuntime()
 
         for key in {"cumulusci", "tasks", "flows", "services", "orgs", "project"}:
-            self.assertIn(key, config.universal_config.config)
-        self.assertEqual("CumulusCI", config.project_config.project__name)
+            assert key in config.universal_config.config
+        assert "CumulusCI" == config.project_config.project__name
         for key in {"services", "orgs", "app"}:
-            self.assertIn(key, config.keychain.config)
-        self.assertIn(config.project_config.repo_root, sys.path)
+            assert key in config.keychain.config
+        assert config.project_config.repo_root in sys.path
 
     @mock.patch("cumulusci.cli.runtime.CliRuntime._load_project_config")
     def test_load_project_config_error(self, load_proj_cfg_mock):
         load_proj_cfg_mock.side_effect = ConfigError
 
-        with self.assertRaises(click.UsageError):
+        with pytest.raises(click.UsageError):
             CliRuntime()
 
     @mock.patch("cumulusci.cli.runtime.keyring")
@@ -45,7 +45,7 @@ class TestCliRuntime(unittest.TestCase):
         keyring.get_password.return_value = None
 
         config = CliRuntime()
-        self.assertEqual(self.key, config.keychain.key)
+        assert self.key == config.keychain.key
         keyring.set_password.assert_called_once_with(
             "cumulusci", "CUMULUSCI_KEY", self.key
         )
@@ -57,7 +57,7 @@ class TestCliRuntime(unittest.TestCase):
         keyring.get_password.return_value = "overridden"
 
         config = CliRuntime()
-        self.assertEqual(self.key, config.keychain.key)
+        assert self.key == config.keychain.key
 
     @mock.patch("cumulusci.cli.runtime.keyring")
     def test_get_keychain_key__generates_key(self, keyring):
@@ -68,8 +68,8 @@ class TestCliRuntime(unittest.TestCase):
             keyring.get_password.return_value = None
 
             config = CliRuntime()
-        self.assertNotEqual(self.key, config.keychain.key)
-        self.assertEqual(16, len(config.keychain.key))
+        assert self.key != config.keychain.key
+        assert 16 == len(config.keychain.key)
 
     @mock.patch("cumulusci.cli.runtime.keyring")
     def test_get_keychain_key__warns_if_generated_key_cannot_be_stored(self, keyring):
@@ -86,8 +86,8 @@ class TestCliRuntime(unittest.TestCase):
         config.keychain.get_org.return_value = org_config = OrgConfig({}, "test")
 
         org_name, org_config_result = config.get_org("test")
-        self.assertEqual("test", org_name)
-        self.assertIs(org_config, org_config_result)
+        assert "test" == org_name
+        assert org_config is org_config_result
 
     def test_get_org_default(self):
         config = CliRuntime()
@@ -96,15 +96,15 @@ class TestCliRuntime(unittest.TestCase):
         config.keychain.get_default_org.return_value = ("test", org_config)
 
         org_name, org_config_result = config.get_org()
-        self.assertEqual("test", org_name)
-        self.assertIs(org_config, org_config_result)
+        assert "test" == org_name
+        assert org_config is org_config_result
 
     def test_get_org_missing(self):
         config = CliRuntime()
         config.keychain = mock.Mock()
         config.keychain.get_org.return_value = None
 
-        with self.assertRaises(click.UsageError):
+        with pytest.raises(click.UsageError):
             org_name, org_config_result = config.get_org("test", fail_if_missing=True)
 
     def test_check_org_expired(self):
@@ -126,7 +126,7 @@ class TestCliRuntime(unittest.TestCase):
         config = CliRuntime()
         config.keychain.get_org = mock.Mock(side_effect=OrgNotFound)
 
-        self.assertTrue(config.check_org_overwrite("test"))
+        assert config.check_org_overwrite("test")
 
     def test_check_org_overwrite_scratch_exists(self):
         config = CliRuntime()
@@ -134,7 +134,7 @@ class TestCliRuntime(unittest.TestCase):
             return_value=OrgConfig({"scratch": True, "created": True}, "test")
         )
 
-        with self.assertRaises(click.ClickException):
+        with pytest.raises(click.ClickException):
             config.check_org_overwrite("test")
 
     def test_check_org_overwrite_non_scratch_exists(self):
@@ -143,14 +143,14 @@ class TestCliRuntime(unittest.TestCase):
             return_value=OrgConfig({"scratch": False}, "test")
         )
 
-        with self.assertRaises(click.ClickException):
+        with pytest.raises(click.ClickException):
             config.check_org_overwrite("test")
 
     def test_check_cumulusci_version(self):
         config = CliRuntime()
         config.project_config.minimum_cumulusci_version = "999"
 
-        with self.assertRaises(click.UsageError):
+        with pytest.raises(click.UsageError):
             config.check_cumulusci_version()
 
     @mock.patch("cumulusci.cli.runtime.call")
@@ -162,7 +162,7 @@ class TestCliRuntime(unittest.TestCase):
         config.alert("hello")
         echo_mock.assert_called_once()
         shell_mock.assert_called_once()
-        self.assertIn("osascript", shell_mock.call_args[0][0])
+        assert "osascript" in shell_mock.call_args[0][0]
 
     @mock.patch("cumulusci.cli.runtime.call")
     @mock.patch("cumulusci.cli.runtime.click.echo")
@@ -173,7 +173,7 @@ class TestCliRuntime(unittest.TestCase):
         config.alert("hello")
         echo_mock.assert_called_once()
         shell_mock.assert_called_once()
-        self.assertIn("notify-send", shell_mock.call_args[0][0])
+        assert "notify-send" in shell_mock.call_args[0][0]
 
     @mock.patch("cumulusci.cli.runtime.call")
     @mock.patch("cumulusci.cli.runtime.click.echo")

--- a/cumulusci/cli/tests/test_runtime.py
+++ b/cumulusci/cli/tests/test_runtime.py
@@ -28,7 +28,7 @@ class TestCliRuntime:
 
         for key in {"cumulusci", "tasks", "flows", "services", "orgs", "project"}:
             assert key in config.universal_config.config
-        assert "CumulusCI" == config.project_config.project__name
+        assert config.project_config.project__name == "CumulusCI"
         for key in {"services", "orgs", "app"}:
             assert key in config.keychain.config
         assert config.project_config.repo_root in sys.path
@@ -86,7 +86,7 @@ class TestCliRuntime:
         config.keychain.get_org.return_value = org_config = OrgConfig({}, "test")
 
         org_name, org_config_result = config.get_org("test")
-        assert "test" == org_name
+        assert org_name == "test"
         assert org_config is org_config_result
 
     def test_get_org_default(self):
@@ -96,7 +96,7 @@ class TestCliRuntime:
         config.keychain.get_default_org.return_value = ("test", org_config)
 
         org_name, org_config_result = config.get_org()
-        assert "test" == org_name
+        assert org_name == "test"
         assert org_config is org_config_result
 
     def test_get_org_missing(self):

--- a/cumulusci/cli/tests/test_utils.py
+++ b/cumulusci/cli/tests/test_utils.py
@@ -37,7 +37,7 @@ def test_get_latest_final_version():
         status=200,
     )
     result = utils.get_latest_final_version()
-    assert "1.0.1" == result.base_version
+    assert result.base_version == "1.0.1"
 
 
 @mock.patch("cumulusci.cli.utils.get_installed_version")

--- a/cumulusci/core/config/tests/test_config.py
+++ b/cumulusci/core/config/tests/test_config.py
@@ -2,7 +2,6 @@
 import json
 import os
 import pathlib
-import unittest
 from distutils.version import StrictVersion
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -48,67 +47,67 @@ from cumulusci.utils import temporary_dir, touch
 from cumulusci.utils.yaml.cumulusci_yml import GitHubSourceModel, LocalFolderSourceModel
 
 
-class TestBaseConfig(unittest.TestCase):
+class TestBaseConfig:
     def test_getattr_toplevel_key(self):
         config = BaseConfig()
         config.config = {"foo": "bar"}
-        self.assertEqual(config.foo, "bar")
+        assert config.foo == "bar"
 
     def test_getattr_toplevel_key_missing(self):
         config = BaseConfig()
         config.config = {}
-        self.assertEqual(config.foo, None)
+        assert config.foo is None
 
     def test_getattr_child_key(self):
         config = BaseConfig()
         config.config = {"foo": {"bar": "baz"}}
-        self.assertEqual(config.foo__bar, "baz")
+        assert config.foo__bar == "baz"
 
     def test_getattr_child_parent_key_missing(self):
         config = BaseConfig()
         config.config = {}
-        self.assertEqual(config.foo__bar, None)
+        assert config.foo__bar is None
 
     def test_getattr_child_key_missing(self):
         config = BaseConfig()
         config.config = {"foo": {}}
-        self.assertEqual(config.foo__bar, None)
+        assert config.foo__bar is None
 
     def test_getattr_default_toplevel(self):
         config = BaseConfig()
         config.config = {"foo": "bar"}
         config.defaults = {"foo": "default"}
-        self.assertEqual(config.foo, "bar")
+        assert config.foo == "bar"
 
     def test_getattr_default_toplevel_missing_default(self):
         config = BaseConfig()
         config.config = {"foo": "bar"}
         config.defaults = {}
-        self.assertEqual(config.foo, "bar")
+        assert config.foo == "bar"
 
     def test_getattr_default_toplevel_missing_config(self):
         config = BaseConfig()
         config.config = {}
         config.defaults = {"foo": "default"}
-        self.assertEqual(config.foo, "default")
+        assert config.foo == "default"
 
     def test_getattr_default_child(self):
         config = BaseConfig()
         config.config = {"foo": {"bar": "baz"}}
         config.defaults = {"foo__bar": "default"}
-        self.assertEqual(config.foo__bar, "baz")
+        assert config.foo__bar == "baz"
 
     def test_getattr_default_child_missing_default(self):
         config = BaseConfig()
         config.config = {"foo": {"bar": "baz"}}
         config.defaults = {}
-        self.assertEqual(config.foo__bar, "baz")
+        assert config.foo__bar == "baz"
 
     def test_getattr_default_child_missing_config(self):
         config = BaseConfig()
         config.config = {}
         config.defaults = {"foo__bar": "default"}
-        self.assertEqual(config.foo__bar, "default")
+        assert config.foo__bar == "default"
 
 
 class DummyContents(object):
@@ -208,7 +207,7 @@ class DummyGithub(object):
             raise AssertionError(f"Unexpected repository: {name}")
 
 
-class TestBaseProjectConfig(unittest.TestCase):
+class TestBaseProjectConfig:
     maxDiff = None
 
     def _make_github(self):
@@ -282,12 +281,12 @@ class TestBaseProjectConfig(unittest.TestCase):
         universal_config = UniversalConfig()
         universal_config.config_global = {}
         config = BaseProjectConfig(universal_config)
-        self.assertIs(universal_config.config_global, config.config_global)
+        assert universal_config.config_global is config.config_global
 
     def test_config_universal(self):
         universal_config = UniversalConfig()
         config = BaseProjectConfig(universal_config)
-        self.assertIs(universal_config.config_universal, config.config_universal)
+        assert universal_config.config_universal is config.config_universal
 
     def test_repo_info(self):
         env = {
@@ -303,18 +302,15 @@ class TestBaseProjectConfig(unittest.TestCase):
         with mock.patch.dict(os.environ, env):
             config = BaseProjectConfig(UniversalConfig())
             result = config.repo_info
-        self.assertEqual(
-            {
-                "ci": "heroku",
-                "name": "CumulusCI-Test",
-                "owner": "SFDO-Tooling",
-                "branch": "feature/test",
-                "commit": "HEAD~1",
-                "root": ".",
-                "url": "https://github.com/SFDO-Tooling/CumulusCI-Test.git",
-            },
-            result,
-        )
+        assert {
+            "ci": "heroku",
+            "name": "CumulusCI-Test",
+            "owner": "SFDO-Tooling",
+            "branch": "feature/test",
+            "commit": "HEAD~1",
+            "root": ".",
+            "url": "https://github.com/SFDO-Tooling/CumulusCI-Test.git",
+        } == result
 
     def test_repo_info_missing_env(self):
         env = {
@@ -327,38 +323,38 @@ class TestBaseProjectConfig(unittest.TestCase):
             "CUMULUSCI_REPO_ROOT": ".",
         }
         with mock.patch.dict(os.environ, env):
-            with self.assertRaises(ConfigError):
+            with pytest.raises(ConfigError):
                 config = BaseProjectConfig(UniversalConfig())
                 config.repo_info
 
     def test_repo_root_from_env(self):
         config = BaseProjectConfig(UniversalConfig())
         config._repo_info = {"root": "."}
-        self.assertEqual(".", config.repo_root)
+        assert "." == config.repo_root
 
     def test_repo_name_from_repo_info(self):
         config = BaseProjectConfig(UniversalConfig())
         config._repo_info = {"name": "CumulusCI"}
-        self.assertEqual("CumulusCI", config.repo_name)
+        assert "CumulusCI" == config.repo_name
 
     def test_repo_name_no_repo_root(self):
         config = BaseProjectConfig(UniversalConfig())
         with temporary_dir():
-            self.assertIsNone(config.repo_name)
+            assert config.repo_name is None
 
     def test_repo_name_from_git(self):
         config = BaseProjectConfig(UniversalConfig())
-        self.assertEqual("CumulusCI", config.repo_name)
+        assert "CumulusCI" == config.repo_name
 
     def test_repo_url_from_repo_info(self):
         config = BaseProjectConfig(UniversalConfig())
         config._repo_info = {"url": "https://github.com/SFDO-Tooling/CumulusCI"}
-        self.assertEqual("https://github.com/SFDO-Tooling/CumulusCI", config.repo_url)
+        assert "https://github.com/SFDO-Tooling/CumulusCI" == config.repo_url
 
     def test_repo_url_no_repo_root(self):
         config = BaseProjectConfig(UniversalConfig())
         with temporary_dir():
-            self.assertIsNone(config.repo_url)
+            assert config.repo_url is None
 
     @mock.patch("cumulusci.core.config.project_config.git_path")
     def test_repo_url_from_git(self, git_path):
@@ -376,32 +372,32 @@ class TestBaseProjectConfig(unittest.TestCase):
     def test_repo_owner_from_repo_info(self):
         config = BaseProjectConfig(UniversalConfig())
         config._repo_info = {"owner": "SFDO-Tooling"}
-        self.assertEqual("SFDO-Tooling", config.repo_owner)
+        assert "SFDO-Tooling" == config.repo_owner
 
     def test_repo_owner_no_repo_root(self):
         config = BaseProjectConfig(UniversalConfig())
         with temporary_dir():
-            self.assertIsNone(config.repo_owner)
+            assert config.repo_owner is None
 
     def test_repo_branch_from_repo_info(self):
         config = BaseProjectConfig(UniversalConfig())
         config._repo_info = {"branch": "main"}
-        self.assertEqual("main", config.repo_branch)
+        assert "main" == config.repo_branch
 
     def test_repo_branch_no_repo_root(self):
         config = BaseProjectConfig(UniversalConfig())
         with temporary_dir():
-            self.assertIsNone(config.repo_branch)
+            assert config.repo_branch is None
 
     def test_repo_commit_from_repo_info(self):
         config = BaseProjectConfig(UniversalConfig())
         config._repo_info = {"commit": "abcdef"}
-        self.assertEqual("abcdef", config.repo_commit)
+        assert "abcdef" == config.repo_commit
 
     def test_repo_commit_no_repo_root(self):
         config = BaseProjectConfig(UniversalConfig())
         with temporary_dir():
-            self.assertIsNone(config.repo_commit)
+            assert config.repo_commit is None
 
     def test_repo_commit_no_repo_branch(self):
         config = BaseProjectConfig(UniversalConfig())
@@ -425,7 +421,7 @@ class TestBaseProjectConfig(unittest.TestCase):
                     "8ce67f4519190cd1ec9785105168e21b9599bc27 refs/remotes/origin/main\n"
                 )
 
-            self.assertIsNotNone(config.repo_commit)
+            assert config.repo_commit is not None
 
     def test_get_repo_from_url(self):
         config = BaseProjectConfig(
@@ -454,7 +450,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         )
         config.get_github_api = mock.Mock(return_value=self._make_github())
         result = config.get_latest_tag()
-        self.assertEqual("release/1.1", result)
+        assert "release/1.1" == result
 
     def test_get_latest_tag_matching_prefix(self):
         config = BaseProjectConfig(
@@ -467,7 +463,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         )
         config.get_github_api = mock.Mock(return_value=github)
         result = config.get_latest_tag()
-        self.assertEqual("rel/0.9", result)
+        assert "rel/0.9" == result
 
     def test_get_latest_tag_beta(self):
         config = BaseProjectConfig(
@@ -480,7 +476,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         )
         config.get_github_api = mock.Mock(return_value=self._make_github())
         result = config.get_latest_tag(beta=True)
-        self.assertEqual("beta/1.0-Beta_2", result)
+        assert "beta/1.0-Beta_2" == result
 
     def test_get_latest_tag__beta_not_found(self):
         config = BaseProjectConfig(UniversalConfig())
@@ -517,7 +513,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         )
         config.get_github_api = mock.Mock(return_value=self._make_github())
         result = config.get_latest_version()
-        self.assertEqual("1.1", result)
+        assert "1.1" == result
 
     def test_get_latest_version_beta(self):
         config = BaseProjectConfig(
@@ -530,7 +526,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         )
         config.get_github_api = mock.Mock(return_value=self._make_github())
         result = config.get_latest_version(beta=True)
-        self.assertEqual("1.0 (Beta 2)", result)
+        assert "1.0 (Beta 2)" == result
 
     def test_get_previous_version(self):
         config = BaseProjectConfig(
@@ -543,33 +539,28 @@ class TestBaseProjectConfig(unittest.TestCase):
         )
         config.get_github_api = mock.Mock(return_value=self._make_github())
         result = config.get_previous_version()
-        self.assertEqual("1.0", result)
+        assert "1.0" == result
 
     def test_config_project_path_no_repo_root(self):
         config = BaseProjectConfig(UniversalConfig())
         with temporary_dir():
-            self.assertIsNone(config.config_project_path)
+            assert config.config_project_path is None
 
     def test_get_tag_for_version(self):
         config = BaseProjectConfig(
             UniversalConfig(), {"project": {"git": {"prefix_release": "release/"}}}
         )
-        self.assertEqual("beta/1.0", config.get_tag_for_version("beta/", "1.0"))
+        assert "beta/1.0" == config.get_tag_for_version("beta/", "1.0")
 
     def test_get_tag_for_version__1gp_beta(self):
         config = BaseProjectConfig(
             UniversalConfig(), {"project": {"git": {"prefix_beta": "beta/"}}}
         )
-        self.assertEqual(
-            "beta/1.0-Beta_1", config.get_tag_for_version("beta/", "1.0 (Beta 1)")
-        )
+        assert "beta/1.0-Beta_1" == config.get_tag_for_version("beta/", "1.0 (Beta 1)")
 
     def test_get_tag_for_version__with_tag_prefix_option(self):
         config = BaseProjectConfig(UniversalConfig(), {})
-        self.assertEqual(
-            "custom/1.0",
-            config.get_tag_for_version("custom/", "1.0"),
-        )
+        assert "custom/1.0" == config.get_tag_for_version("custom/", "1.0")
 
     def test_get_version_for_tag(self):
         config = BaseProjectConfig(
@@ -580,7 +571,7 @@ class TestBaseProjectConfig(unittest.TestCase):
                 }
             },
         )
-        self.assertEqual("1.0", config.get_version_for_tag("release/1.0"))
+        assert "1.0" == config.get_version_for_tag("release/1.0")
 
     def test_get_version_for_tag_invalid_beta(self):
         config = BaseProjectConfig(
@@ -591,11 +582,11 @@ class TestBaseProjectConfig(unittest.TestCase):
                 }
             },
         )
-        self.assertEqual(None, config.get_version_for_tag("beta/invalid-format"))
+        assert config.get_version_for_tag("beta/invalid-format") is None
 
     def test_check_keychain(self):
         config = BaseProjectConfig(UniversalConfig())
-        with self.assertRaises(KeychainNotFound):
+        with pytest.raises(KeychainNotFound):
             config._check_keychain()
 
     def test_get_task__included_source(self):
@@ -627,7 +618,7 @@ class TestBaseProjectConfig(unittest.TestCase):
     def test_get_namespace__not_found(self):
         universal_config = UniversalConfig()
         project_config = BaseProjectConfig(universal_config)
-        with self.assertRaises(NamespaceNotFoundError):
+        with pytest.raises(NamespaceNotFoundError):
             project_config.get_namespace("test")
 
     def test_include_source__bad_spec(self):
@@ -750,8 +741,8 @@ class TestBaseProjectConfig(unittest.TestCase):
             )
 
 
-class TestBaseTaskFlowConfig(unittest.TestCase):
-    def setUp(self):
+class TestBaseTaskFlowConfig:
+    def setup_method(self):
         self.task_flow_config = BaseTaskFlowConfig(
             {
                 "tasks": {
@@ -769,14 +760,14 @@ class TestBaseTaskFlowConfig(unittest.TestCase):
 
     def test_list_tasks(self):
         tasks = self.task_flow_config.list_tasks()
-        self.assertEqual(len(tasks), 4)
+        assert len(tasks) == 4
         deploy = [task for task in tasks if task["name"] == "deploy"][0]
-        self.assertEqual(deploy["description"], "Deploy Task")
+        assert deploy["description"] == "Deploy Task"
 
     def test_get_task(self):
         task = self.task_flow_config.get_task("deploy")
-        self.assertIsInstance(task, BaseConfig)
-        self.assertIn(("description", "Deploy Task"), task.config.items())
+        assert isinstance(task, BaseConfig)
+        assert ("description", "Deploy Task") in task.config.items()
 
     def test_get_task__no_class_path(self):
         with pytest.raises(
@@ -804,27 +795,27 @@ class TestBaseTaskFlowConfig(unittest.TestCase):
 
     def test_get_flow(self):
         flow = self.task_flow_config.get_flow("coffee")
-        self.assertIsInstance(flow, BaseConfig)
-        self.assertIn(("description", "Coffee Flow"), flow.config.items())
+        assert isinstance(flow, BaseConfig)
+        assert ("description", "Coffee Flow") in flow.config.items()
 
     def test_no_flow(self):
-        with self.assertRaises(FlowNotFoundError):
+        with pytest.raises(FlowNotFoundError):
             self.task_flow_config.get_flow("water")
 
     def test_list_flows(self):
         flows = self.task_flow_config.list_flows()
-        self.assertEqual(len(flows), 2)
+        assert len(flows) == 2
         coffee = [flow for flow in flows if flow["name"] == "coffee"][0]
-        self.assertEqual(coffee["description"], "Coffee Flow")
+        assert coffee["description"] == "Coffee Flow"
 
     def test_suggested_name(self):
         flows = self.task_flow_config.flows
-        self.assertEqual(len(flows), 2)
+        assert len(flows) == 2
         error_msg = self.task_flow_config.get_suggested_name("bofee", flows)
-        self.assertIn("coffee", error_msg)
+        assert "coffee" in error_msg
 
 
-class TestOrgConfig(unittest.TestCase):
+class TestOrgConfig:
     @mock.patch("cumulusci.core.config.OrgConfig.OAuth2Client")
     def test_refresh_oauth_token(self, OAuth2Client):
         config = OrgConfig(
@@ -907,7 +898,7 @@ class TestOrgConfig(unittest.TestCase):
 
     def test_refresh_oauth_token_no_connected_app(self):
         config = OrgConfig({}, "test")
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             config.refresh_oauth_token(None)
 
     def test_refresh_oauth_token__bad_connected_app(self):
@@ -993,17 +984,17 @@ class TestOrgConfig(unittest.TestCase):
 
     def test_lightning_base_url__instance(self):
         config = OrgConfig({"instance_url": "https://na01.salesforce.com"}, "test")
-        self.assertEqual("https://na01.lightning.force.com", config.lightning_base_url)
+        assert "https://na01.lightning.force.com" == config.lightning_base_url
 
     def test_lightning_base_url__scratch_org(self):
         config = OrgConfig(
             {"instance_url": "https://foo.cs42.my.salesforce.com"}, "test"
         )
-        self.assertEqual("https://foo.lightning.force.com", config.lightning_base_url)
+        assert "https://foo.lightning.force.com" == config.lightning_base_url
 
     def test_lightning_base_url__mydomain(self):
         config = OrgConfig({"instance_url": "https://foo.my.salesforce.com"}, "test")
-        self.assertEqual("https://foo.lightning.force.com", config.lightning_base_url)
+        assert "https://foo.lightning.force.com" == config.lightning_base_url
 
     @responses.activate
     def test_get_salesforce_version(self):
@@ -1039,18 +1030,18 @@ class TestOrgConfig(unittest.TestCase):
             {"instance_url": "https://na01.salesforce.com", "access_token": "TOKEN"},
             "test",
         )
-        self.assertEqual(
-            "https://na01.salesforce.com/secur/frontdoor.jsp?sid=TOKEN",
-            config.start_url,
+        assert (
+            "https://na01.salesforce.com/secur/frontdoor.jsp?sid=TOKEN"
+            == config.start_url
         )
 
     def test_user_id(self):
         config = OrgConfig({"id": "org/user"}, "test")
-        self.assertEqual("user", config.user_id)
+        assert "user" == config.user_id
 
     def test_can_delete(self):
         config = OrgConfig({}, "test")
-        self.assertFalse(config.can_delete())
+        assert not config.can_delete()
 
     @responses.activate
     def test_load_orginfo(self):
@@ -1079,9 +1070,9 @@ class TestOrgConfig(unittest.TestCase):
 
         config._load_orginfo()
 
-        self.assertEqual("Enterprise Edition", config.org_type)
-        self.assertEqual(False, config.is_sandbox)
-        self.assertIsNotNone(config.organization_sobject)
+        assert "Enterprise Edition" == config.org_type
+        assert config.is_sandbox is False
+        assert config.organization_sobject is not None
         assert config.namespace == "ns"
 
     @responses.activate
@@ -1090,7 +1081,7 @@ class TestOrgConfig(unittest.TestCase):
         config = OrgConfig({}, "test")
         config._community_info_cache = {"Kōkua": {"name": "Kōkua"}}
         info = config.get_community_info("Kōkua")
-        self.assertEqual(info["name"], "Kōkua")
+        assert info["name"] == "Kōkua"
 
     @responses.activate
     def test_get_community_info__fetch_if_not_in_cache(self):
@@ -1112,7 +1103,7 @@ class TestOrgConfig(unittest.TestCase):
         )
         config._community_info_cache = {}
         info = config.get_community_info("Kōkua")
-        self.assertEqual(info["name"], "Kōkua")
+        assert info["name"] == "Kōkua"
 
     @mock.patch("cumulusci.core.config.OrgConfig._fetch_community_info")
     def test_community_info_force_refresh(self, mock_fetch):
@@ -1135,7 +1126,7 @@ class TestOrgConfig(unittest.TestCase):
         """Verify an exception is thrown when the community doesn't exist"""
         config = OrgConfig({}, "test")
         expected_exception = "Unable to find community information for 'bogus'"
-        with self.assertRaisesRegex(Exception, expected_exception):
+        with pytest.raises(Exception, match=expected_exception):
             config.get_community_info("bogus")
 
     MOCK_TOOLING_PACKAGE_RESULTS = [
@@ -1284,7 +1275,7 @@ class TestOrgConfig(unittest.TestCase):
 
         assert config.has_minimum_package_version("03350000000DEz4AAG", "3.119")
 
-        with self.assertRaises(CumulusCIException):
+        with pytest.raises(CumulusCIException):
             config.has_minimum_package_version("GW_Volunteers", "1.0")
 
     def test_orginfo_cache_dir_global(self):
@@ -1352,10 +1343,9 @@ class TestOrgConfig(unittest.TestCase):
             },
             "test",
         )
-        self.assertIsNone(
-            config._is_person_accounts_enabled,
-            "_is_person_accounts_enabled should be initialized as None",
-        )
+        assert (
+            config._is_person_accounts_enabled is None
+        ), "_is_person_accounts_enabled should be initialized as None"
 
         responses.add(
             "GET", "https://example.com/services/data", json=[{"version": 48.0}]
@@ -1370,15 +1360,13 @@ class TestOrgConfig(unittest.TestCase):
         # Verify checks describe if _is_person_accounts_enabled is None.
         actual = config.is_person_accounts_enabled
 
-        self.assertEqual(False, actual, "")
-        self.assertEqual(actual, config._is_person_accounts_enabled)
+        assert actual is False, ""
+        assert actual == config._is_person_accounts_enabled
 
         # Verify subsequent calls return cached value.
         config._is_person_accounts_enabled = True
 
-        self.assertEqual(
-            config._is_person_accounts_enabled, config.is_person_accounts_enabled
-        )
+        assert config._is_person_accounts_enabled == config.is_person_accounts_enabled
 
     @responses.activate
     def test_is_person_accounts_enabled__is_enabled(self):
@@ -1390,10 +1378,9 @@ class TestOrgConfig(unittest.TestCase):
             },
             "test",
         )
-        self.assertIsNone(
-            config._is_person_accounts_enabled,
-            "_is_person_accounts_enabled should be initialized as None",
-        )
+        assert (
+            config._is_person_accounts_enabled is None
+        ), "_is_person_accounts_enabled should be initialized as None"
 
         responses.add(
             "GET", "https://example.com/services/data", json=[{"version": 48.0}]
@@ -1408,15 +1395,13 @@ class TestOrgConfig(unittest.TestCase):
         # Verify checks describe if _is_person_accounts_enabled is None.
         actual = config.is_person_accounts_enabled
 
-        self.assertEqual(True, actual, "")
-        self.assertEqual(actual, config._is_person_accounts_enabled)
+        assert actual is True, ""
+        assert actual == config._is_person_accounts_enabled
 
         # Verify subsequent calls return cached value.
         config._is_person_accounts_enabled = False
 
-        self.assertEqual(
-            config._is_person_accounts_enabled, config.is_person_accounts_enabled
-        )
+        assert config._is_person_accounts_enabled == config.is_person_accounts_enabled
 
     @responses.activate
     def test_is_multi_currency_enabled__not_enabled(self):

--- a/cumulusci/core/config/tests/test_config.py
+++ b/cumulusci/core/config/tests/test_config.py
@@ -330,12 +330,12 @@ class TestBaseProjectConfig:
     def test_repo_root_from_env(self):
         config = BaseProjectConfig(UniversalConfig())
         config._repo_info = {"root": "."}
-        assert "." == config.repo_root
+        assert config.repo_root == "."
 
     def test_repo_name_from_repo_info(self):
         config = BaseProjectConfig(UniversalConfig())
         config._repo_info = {"name": "CumulusCI"}
-        assert "CumulusCI" == config.repo_name
+        assert config.repo_name == "CumulusCI"
 
     def test_repo_name_no_repo_root(self):
         config = BaseProjectConfig(UniversalConfig())
@@ -344,12 +344,12 @@ class TestBaseProjectConfig:
 
     def test_repo_name_from_git(self):
         config = BaseProjectConfig(UniversalConfig())
-        assert "CumulusCI" == config.repo_name
+        assert config.repo_name == "CumulusCI"
 
     def test_repo_url_from_repo_info(self):
         config = BaseProjectConfig(UniversalConfig())
         config._repo_info = {"url": "https://github.com/SFDO-Tooling/CumulusCI"}
-        assert "https://github.com/SFDO-Tooling/CumulusCI" == config.repo_url
+        assert config.repo_url == "https://github.com/SFDO-Tooling/CumulusCI"
 
     def test_repo_url_no_repo_root(self):
         config = BaseProjectConfig(UniversalConfig())
@@ -372,7 +372,7 @@ class TestBaseProjectConfig:
     def test_repo_owner_from_repo_info(self):
         config = BaseProjectConfig(UniversalConfig())
         config._repo_info = {"owner": "SFDO-Tooling"}
-        assert "SFDO-Tooling" == config.repo_owner
+        assert config.repo_owner == "SFDO-Tooling"
 
     def test_repo_owner_no_repo_root(self):
         config = BaseProjectConfig(UniversalConfig())
@@ -382,7 +382,7 @@ class TestBaseProjectConfig:
     def test_repo_branch_from_repo_info(self):
         config = BaseProjectConfig(UniversalConfig())
         config._repo_info = {"branch": "main"}
-        assert "main" == config.repo_branch
+        assert config.repo_branch == "main"
 
     def test_repo_branch_no_repo_root(self):
         config = BaseProjectConfig(UniversalConfig())
@@ -392,7 +392,7 @@ class TestBaseProjectConfig:
     def test_repo_commit_from_repo_info(self):
         config = BaseProjectConfig(UniversalConfig())
         config._repo_info = {"commit": "abcdef"}
-        assert "abcdef" == config.repo_commit
+        assert config.repo_commit == "abcdef"
 
     def test_repo_commit_no_repo_root(self):
         config = BaseProjectConfig(UniversalConfig())
@@ -450,7 +450,7 @@ class TestBaseProjectConfig:
         )
         config.get_github_api = mock.Mock(return_value=self._make_github())
         result = config.get_latest_tag()
-        assert "release/1.1" == result
+        assert result == "release/1.1"
 
     def test_get_latest_tag_matching_prefix(self):
         config = BaseProjectConfig(
@@ -463,7 +463,7 @@ class TestBaseProjectConfig:
         )
         config.get_github_api = mock.Mock(return_value=github)
         result = config.get_latest_tag()
-        assert "rel/0.9" == result
+        assert result == "rel/0.9"
 
     def test_get_latest_tag_beta(self):
         config = BaseProjectConfig(
@@ -476,7 +476,7 @@ class TestBaseProjectConfig:
         )
         config.get_github_api = mock.Mock(return_value=self._make_github())
         result = config.get_latest_tag(beta=True)
-        assert "beta/1.0-Beta_2" == result
+        assert result == "beta/1.0-Beta_2"
 
     def test_get_latest_tag__beta_not_found(self):
         config = BaseProjectConfig(UniversalConfig())
@@ -513,7 +513,7 @@ class TestBaseProjectConfig:
         )
         config.get_github_api = mock.Mock(return_value=self._make_github())
         result = config.get_latest_version()
-        assert "1.1" == result
+        assert result == "1.1"
 
     def test_get_latest_version_beta(self):
         config = BaseProjectConfig(
@@ -526,7 +526,7 @@ class TestBaseProjectConfig:
         )
         config.get_github_api = mock.Mock(return_value=self._make_github())
         result = config.get_latest_version(beta=True)
-        assert "1.0 (Beta 2)" == result
+        assert result == "1.0 (Beta 2)"
 
     def test_get_previous_version(self):
         config = BaseProjectConfig(
@@ -539,7 +539,7 @@ class TestBaseProjectConfig:
         )
         config.get_github_api = mock.Mock(return_value=self._make_github())
         result = config.get_previous_version()
-        assert "1.0" == result
+        assert result == "1.0"
 
     def test_config_project_path_no_repo_root(self):
         config = BaseProjectConfig(UniversalConfig())
@@ -550,17 +550,17 @@ class TestBaseProjectConfig:
         config = BaseProjectConfig(
             UniversalConfig(), {"project": {"git": {"prefix_release": "release/"}}}
         )
-        assert "beta/1.0" == config.get_tag_for_version("beta/", "1.0")
+        assert config.get_tag_for_version("beta/", "1.0") == "beta/1.0"
 
     def test_get_tag_for_version__1gp_beta(self):
         config = BaseProjectConfig(
             UniversalConfig(), {"project": {"git": {"prefix_beta": "beta/"}}}
         )
-        assert "beta/1.0-Beta_1" == config.get_tag_for_version("beta/", "1.0 (Beta 1)")
+        assert config.get_tag_for_version("beta/", "1.0 (Beta 1)") == "beta/1.0-Beta_1"
 
     def test_get_tag_for_version__with_tag_prefix_option(self):
         config = BaseProjectConfig(UniversalConfig(), {})
-        assert "custom/1.0" == config.get_tag_for_version("custom/", "1.0")
+        assert config.get_tag_for_version("custom/", "1.0") == "custom/1.0"
 
     def test_get_version_for_tag(self):
         config = BaseProjectConfig(
@@ -571,7 +571,7 @@ class TestBaseProjectConfig:
                 }
             },
         )
-        assert "1.0" == config.get_version_for_tag("release/1.0")
+        assert config.get_version_for_tag("release/1.0") == "1.0"
 
     def test_get_version_for_tag_invalid_beta(self):
         config = BaseProjectConfig(
@@ -984,17 +984,17 @@ class TestOrgConfig:
 
     def test_lightning_base_url__instance(self):
         config = OrgConfig({"instance_url": "https://na01.salesforce.com"}, "test")
-        assert "https://na01.lightning.force.com" == config.lightning_base_url
+        assert config.lightning_base_url == "https://na01.lightning.force.com"
 
     def test_lightning_base_url__scratch_org(self):
         config = OrgConfig(
             {"instance_url": "https://foo.cs42.my.salesforce.com"}, "test"
         )
-        assert "https://foo.lightning.force.com" == config.lightning_base_url
+        assert config.lightning_base_url == "https://foo.lightning.force.com"
 
     def test_lightning_base_url__mydomain(self):
         config = OrgConfig({"instance_url": "https://foo.my.salesforce.com"}, "test")
-        assert "https://foo.lightning.force.com" == config.lightning_base_url
+        assert config.lightning_base_url == "https://foo.lightning.force.com"
 
     @responses.activate
     def test_get_salesforce_version(self):
@@ -1037,7 +1037,7 @@ class TestOrgConfig:
 
     def test_user_id(self):
         config = OrgConfig({"id": "org/user"}, "test")
-        assert "user" == config.user_id
+        assert config.user_id == "user"
 
     def test_can_delete(self):
         config = OrgConfig({}, "test")
@@ -1070,7 +1070,7 @@ class TestOrgConfig:
 
         config._load_orginfo()
 
-        assert "Enterprise Edition" == config.org_type
+        assert config.org_type == "Enterprise Edition"
         assert config.is_sandbox is False
         assert config.organization_sobject is not None
         assert config.namespace == "ns"

--- a/cumulusci/core/config/tests/test_config_expensive.py
+++ b/cumulusci/core/config/tests/test_config_expensive.py
@@ -2,7 +2,6 @@ import io
 import os
 import shutil
 import tempfile
-import unittest
 from datetime import datetime, timedelta
 from pathlib import Path
 from unittest import mock
@@ -38,11 +37,11 @@ def scratch_def_file():
 
 
 @mock.patch("pathlib.Path.home")
-class TestUniversalConfig(unittest.TestCase):
-    def setUp(self):
+class TestUniversalConfig:
+    def setup_method(self):
         self.tempdir_home = Path(tempfile.mkdtemp())
 
-    def tearDown(self):
+    def teardown_method(self):
         shutil.rmtree(self.tempdir_home)
 
     def _create_universal_config_local(self, content):
@@ -62,7 +61,7 @@ class TestUniversalConfig(unittest.TestCase):
         config = UniversalConfig()
         with open(__location__ + "/../../../cumulusci.yml", "r") as f_expected_config:
             expected_config = yaml.safe_load(f_expected_config)
-        self.assertEqual(config.config, expected_config)
+        assert config.config == expected_config
 
     def test_load_universal_config_empty_local(self, mock_class):
         self._create_universal_config_local("")
@@ -72,7 +71,7 @@ class TestUniversalConfig(unittest.TestCase):
         config = UniversalConfig()
         with open(__location__ + "/../../../cumulusci.yml", "r") as f_expected_config:
             expected_config = yaml.safe_load(f_expected_config)
-        self.assertEqual(config.config, expected_config)
+        assert config.config == expected_config
 
     def test_load_universal_config_with_local(self, mock_class):
         local_yaml = "tasks:\n    newtesttask:\n        description: test description"
@@ -87,19 +86,19 @@ class TestUniversalConfig(unittest.TestCase):
             expected_config = yaml.safe_load(f_expected_config)
         expected_config["tasks"]["newtesttask"] = {}
         expected_config["tasks"]["newtesttask"]["description"] = "test description"
-        self.assertEqual(config.config, expected_config)
+        assert config.config == expected_config
 
 
 @mock.patch("pathlib.Path.home")
-class TestBaseProjectConfig(unittest.TestCase):
-    def setUp(self):
+class TestBaseProjectConfig:
+    def setup_method(self):
         self.tempdir_home = Path(tempfile.mkdtemp())
         self.tempdir_project = tempfile.mkdtemp()
         self.project_name = "TestRepo"
         self.current_commit = "abcdefg1234567890"
         self.current_branch = "main"
 
-    def tearDown(self):
+    def teardown_method(self):
         shutil.rmtree(self.tempdir_home)
         shutil.rmtree(self.tempdir_project)
 
@@ -154,7 +153,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         mock_class.return_value = self.tempdir_home
         with cd(self.tempdir_project):
             universal_config = UniversalConfig()
-            with self.assertRaises(NotInProject):
+            with pytest.raises(NotInProject):
                 BaseProjectConfig(universal_config)
 
     def test_load_project_config_no_config(self, mock_class):
@@ -162,7 +161,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         os.mkdir(os.path.join(self.tempdir_project, ".git"))
         with cd(self.tempdir_project):
             universal_config = UniversalConfig()
-            with self.assertRaises(ProjectConfigNotFound):
+            with pytest.raises(ProjectConfigNotFound):
                 BaseProjectConfig(universal_config)
 
     def test_load_project_config_empty_config(self, mock_class):
@@ -177,7 +176,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         with cd(self.tempdir_project):
             universal_config = UniversalConfig()
             config = BaseProjectConfig(universal_config)
-            self.assertEqual(config.config_project, {})
+            assert config.config_project == {}
 
     def test_load_project_config_valid_config(self, mock_class):
         mock_class.return_value = self.tempdir_home
@@ -192,8 +191,8 @@ class TestBaseProjectConfig(unittest.TestCase):
         with cd(self.tempdir_project):
             universal_config = UniversalConfig()
             config = BaseProjectConfig(universal_config)
-            self.assertEqual(config.project__package__name, "TestProject")
-            self.assertEqual(config.project__package__namespace, "testproject")
+            assert config.project__package__name == "TestProject"
+            assert config.project__package__namespace == "testproject"
 
     def test_repo_owner(self, mock_class):
         mock_class.return_value = self.tempdir_home
@@ -206,7 +205,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         with cd(self.tempdir_project):
             universal_config = UniversalConfig()
             config = BaseProjectConfig(universal_config)
-            self.assertEqual(config.repo_owner, "TestOwner")
+            assert config.repo_owner == "TestOwner"
 
     def test_repo_branch(self, mock_class):
         mock_class.return_value = self.tempdir_home
@@ -219,7 +218,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         with cd(self.tempdir_project):
             universal_config = UniversalConfig()
             config = BaseProjectConfig(universal_config)
-            self.assertEqual(config.repo_branch, self.current_branch)
+            assert config.repo_branch == self.current_branch
 
     def test_repo_commit(self, mock_class):
         mock_class.return_value = self.tempdir_home
@@ -232,7 +231,7 @@ class TestBaseProjectConfig(unittest.TestCase):
         with cd(self.tempdir_project):
             universal_config = UniversalConfig()
             config = BaseProjectConfig(universal_config)
-            self.assertEqual(config.repo_commit, self.current_commit)
+            assert config.repo_commit == self.current_commit
 
     def test_load_project_config_local(self, mock_class):
         mock_class.return_value = self.tempdir_home
@@ -249,8 +248,8 @@ class TestBaseProjectConfig(unittest.TestCase):
         with cd(self.tempdir_project):
             universal_config = UniversalConfig()
             config = BaseProjectConfig(universal_config)
-            self.assertNotEqual(config.config_project_local, {})
-            self.assertEqual(config.project__package__api_version, 45.0)
+            assert config.config_project_local != {}
+            assert config.project__package__api_version == 45.0
 
     def test_load_additional_yaml(self, mock_class):
         mock_class.return_value = self.tempdir_home
@@ -266,12 +265,12 @@ class TestBaseProjectConfig(unittest.TestCase):
         with cd(self.tempdir_project):
             universal_config = UniversalConfig()
             config = BaseProjectConfig(universal_config, additional_yaml=content)
-            self.assertNotEqual(config.config_additional_yaml, {})
-            self.assertEqual(config.project__package__api_version, 45.0)
+            assert config.config_additional_yaml != {}
+            assert config.project__package__api_version == 45.0
 
 
 @mock.patch("sarge.Command")
-class TestScratchOrgConfig(unittest.TestCase):
+class TestScratchOrgConfig:
     def test_scratch_info(self, Command):
         result = b"""{
     "result": {
@@ -290,19 +289,16 @@ class TestScratchOrgConfig(unittest.TestCase):
         config = ScratchOrgConfig({"username": "test", "created": True}, "test")
         info = config.scratch_info
 
-        self.assertEqual(
-            info,
-            {
-                "access_token": "access!token",
-                "instance_url": "url",
-                "org_id": "access",
-                "password": "password",
-                "username": "username",
-                "created_date": "1970-01-01T00:00:00Z",
-                "expiration_date": "1970-01-08",
-            },
-        )
-        self.assertIs(info, config._sfdx_info)
+        assert info == {
+            "access_token": "access!token",
+            "instance_url": "url",
+            "org_id": "access",
+            "password": "password",
+            "username": "username",
+            "created_date": "1970-01-01T00:00:00Z",
+            "expiration_date": "1970-01-08",
+        }
+        assert info is config._sfdx_info
         for key in (
             "access_token",
             "instance_url",
@@ -311,13 +307,13 @@ class TestScratchOrgConfig(unittest.TestCase):
             "username",
         ):
             assert key in config.config
-        self.assertTrue(config._sfdx_info_date)
+        assert config._sfdx_info_date
 
     def test_scratch_info_memoized(self, Command):
         config = ScratchOrgConfig({"username": "test", "created": True}, "test")
         config._sfdx_info = _marker = object()
         info = config.scratch_info
-        self.assertIs(info, _marker)
+        assert info is _marker
 
     def test_sfdx_info_non_json_response(self, Command):
         Command.return_value = mock.Mock(
@@ -325,7 +321,7 @@ class TestScratchOrgConfig(unittest.TestCase):
         )
 
         config = SfdxOrgConfig({"username": "test", "created": True}, "test")
-        with self.assertRaises(SfdxOrgException):
+        with pytest.raises(SfdxOrgException):
             config.sfdx_info
 
     def test_scratch_info_command_error(self, Command):
@@ -353,14 +349,14 @@ class TestScratchOrgConfig(unittest.TestCase):
         with temporary_dir():
             with open("tmp.json", "w") as f:
                 f.write("{}")
-            with self.assertRaises(ScratchOrgException):
+            with pytest.raises(ScratchOrgException):
                 config.scratch_info
 
     def test_access_token(self, Command):
         config = ScratchOrgConfig({}, "test")
         _marker = object()
         config._sfdx_info = {"access_token": _marker}
-        self.assertIs(config.access_token, _marker)
+        assert config.access_token is _marker
 
     def test_get_access_token(self, Command):
         """Verify that get_access_token calls out to sfdx"""
@@ -442,21 +438,21 @@ class TestScratchOrgConfig(unittest.TestCase):
         config = ScratchOrgConfig({}, "test")
         _marker = object()
         config._sfdx_info = {"instance_url": _marker}
-        self.assertIs(config.instance_url, _marker)
+        assert config.instance_url is _marker
 
     def test_org_id_from_config(self, Command):
         config = ScratchOrgConfig({"org_id": "test"}, "test")
-        self.assertEqual(config.org_id, "test")
+        assert config.org_id == "test"
 
     def test_org_id_from_sfdx_info(self, Command):
         config = ScratchOrgConfig({}, "test")
         _marker = object()
         config._sfdx_info = {"org_id": _marker}
-        self.assertIs(config.org_id, _marker)
+        assert config.org_id is _marker
 
     def test_user_id_from_config(self, Command):
         config = ScratchOrgConfig({"user_id": "test"}, "test")
-        self.assertEqual(config.user_id, "test")
+        assert config.user_id == "test"
 
     def test_user_id_from_org(self, Command):
         sf = mock.Mock()
@@ -468,28 +464,28 @@ class TestScratchOrgConfig(unittest.TestCase):
             "access_token": "token",
         }
         with mock.patch("cumulusci.core.config.OrgConfig.salesforce_client", sf):
-            self.assertEqual(config.user_id, "test")
+            assert config.user_id == "test"
 
     def test_username_from_sfdx_info(self, Command):
         config = ScratchOrgConfig({}, "test")
         _marker = object()
         config._sfdx_info = {"username": _marker}
-        self.assertIs(config.username, _marker)
+        assert config.username is _marker
 
     def test_password_from_config(self, Command):
         config = ScratchOrgConfig({"password": "test"}, "test")
-        self.assertEqual(config.password, "test")
+        assert config.password == "test"
 
     def test_password_from_sfdx_info(self, Command):
         config = ScratchOrgConfig({}, "test")
         _marker = object()
         config._sfdx_info = {"password": _marker}
-        self.assertIs(config.password, _marker)
+        assert config.password is _marker
 
     def test_email_address_from_config(self, Command):
         config = ScratchOrgConfig({"email_address": "test@example.com"}, "test")
 
-        self.assertEqual("test@example.com", config.email_address)
+        assert "test@example.com" == config.email_address
         Command.return_value.assert_not_called()
 
     def test_email_address_from_git(self, Command):
@@ -498,7 +494,7 @@ class TestScratchOrgConfig(unittest.TestCase):
             stdout=io.BytesIO(b"test@example.com"), stderr=io.BytesIO(b""), returncode=0
         )
 
-        self.assertEqual("test@example.com", config.email_address)
+        assert "test@example.com" == config.email_address
         config.email_address  # Make sure value is cached
         p.run.assert_called_once()
 
@@ -508,61 +504,61 @@ class TestScratchOrgConfig(unittest.TestCase):
             stdout=io.BytesIO(b""), stderr=io.BytesIO(b""), returncode=0
         )
 
-        self.assertEqual(None, config.email_address)
+        assert config.email_address is None
         p.run.assert_called_once()
 
     def test_days(self, Command):
         config = ScratchOrgConfig({"days": 2}, "test")
-        self.assertEqual(config.days, 2)
+        assert config.days == 2
 
     def test_days_default(self, Command):
         config = ScratchOrgConfig({}, "test")
-        self.assertEqual(config.days, 1)
+        assert config.days == 1
 
     def test_format_days(self, Command):
         config = ScratchOrgConfig({"days": 2}, "test")
-        self.assertEqual(config.format_org_days(), "2")
+        assert config.format_org_days() == "2"
         now = datetime.now()
         config.date_created = now
-        self.assertEqual(config.format_org_days(), "1/2")
+        assert config.format_org_days() == "1/2"
         config.date_created = now - timedelta(days=3)
-        self.assertEqual(config.format_org_days(), "2")
+        assert config.format_org_days() == "2"
 
     def test_expired(self, Command):
         config = ScratchOrgConfig({"days": 1}, "test")
         now = datetime.now()
         config.date_created = now
-        self.assertFalse(config.expired)
+        assert not config.expired
         config.date_created = now - timedelta(days=2)
-        self.assertTrue(config.expired)
+        assert config.expired
 
     def test_expires(self, Command):
         config = ScratchOrgConfig({"days": 1}, "test")
         now = datetime.now()
         config.date_created = now
-        self.assertEqual(config.expires, now + timedelta(days=1))
+        assert config.expires == now + timedelta(days=1)
 
         config = ScratchOrgConfig({"days": 1}, "test")
         config.date_created = None
-        self.assertIsNone(config.expires)
+        assert config.expires is None
 
     def test_days_alive(self, Command):
         config = ScratchOrgConfig({}, "test")
         config.date_created = datetime.now()
-        self.assertEqual(config.days_alive, 1)
+        assert config.days_alive == 1
 
     def test_active(self, Command):
         config = ScratchOrgConfig({}, "test")
         config.date_created = None
-        self.assertFalse(config.active)
+        assert not config.active
 
         config = ScratchOrgConfig({}, "test")
         config.date_created = datetime.now()
-        self.assertTrue(config.active)
+        assert config.active
 
         config = ScratchOrgConfig({}, "test")
         config.date_created = datetime.now() - timedelta(days=10)
-        self.assertFalse(config.active)
+        assert not config.active
 
     def test_create_org(self, Command):
         out = b"Successfully created scratch org: ORG_ID, username: USERNAME"
@@ -586,12 +582,12 @@ class TestScratchOrgConfig(unittest.TestCase):
             config.create_org()
 
         p.run.assert_called_once()
-        self.assertEqual(config.config["org_id"], "ORG_ID")
-        self.assertEqual(config.config["username"], "USERNAME")
-        self.assertIn("date_created", config.config)
+        assert config.config["org_id"] == "ORG_ID"
+        assert config.config["username"] == "USERNAME"
+        assert "date_created" in config.config
         config.generate_password.assert_called_once()
-        self.assertTrue(config.config["created"])
-        self.assertEqual(config.scratch_org_type, "workspace")
+        assert config.config["created"]
+        assert config.scratch_org_type == "workspace"
 
     def test_create_org_no_config_file(self, Command):
         config = ScratchOrgConfig({}, "test")
@@ -611,9 +607,9 @@ class TestScratchOrgConfig(unittest.TestCase):
             with open("tmp.json", "w") as f:
                 f.write("{}")
 
-            with self.assertRaises(ScratchOrgException) as ctx:
+            with pytest.raises(ScratchOrgException) as ctx:
                 config.create_org()
-                self.assertIn("scratcherror", str(ctx.error))
+                assert "scratcherror" in str(ctx.error)
 
     def test_generate_password(self, Command):
         p = mock.Mock(
@@ -647,7 +643,7 @@ class TestScratchOrgConfig(unittest.TestCase):
 
     def test_can_delete(self, Command):
         config = ScratchOrgConfig({"date_created": datetime.now()}, "test")
-        self.assertTrue(config.can_delete())
+        assert config.can_delete()
 
     def test_delete_org(self, Command):
         Command.return_value = mock.Mock(
@@ -678,7 +674,7 @@ class TestScratchOrgConfig(unittest.TestCase):
         )
 
         config = ScratchOrgConfig({"username": "test", "created": True}, "test")
-        with self.assertRaises(ScratchOrgException):
+        with pytest.raises(ScratchOrgException):
             config.delete_org()
 
     def test_force_refresh_oauth_token(self, Command):
@@ -697,7 +693,7 @@ class TestScratchOrgConfig(unittest.TestCase):
         )
 
         config = ScratchOrgConfig({"username": "test"}, "test")
-        with self.assertRaises(SfdxOrgException):
+        with pytest.raises(SfdxOrgException):
             config.force_refresh_oauth_token()
 
     def test_refresh_oauth_token(self, Command):
@@ -724,7 +720,7 @@ class TestScratchOrgConfig(unittest.TestCase):
         config.refresh_oauth_token(keychain=None)
 
         config.force_refresh_oauth_token.assert_called_once()
-        self.assertTrue(config._sfdx_info)
+        assert config._sfdx_info
 
     def test_choose_devhub(self, Command):
         mock_keychain = mock.Mock()

--- a/cumulusci/core/config/tests/test_config_expensive.py
+++ b/cumulusci/core/config/tests/test_config_expensive.py
@@ -607,9 +607,9 @@ class TestScratchOrgConfig:
             with open("tmp.json", "w") as f:
                 f.write("{}")
 
-            with pytest.raises(ScratchOrgException) as ctx:
+            with pytest.raises(ScratchOrgException) as e:
                 config.create_org()
-                assert "scratcherror" in str(ctx.error)
+            assert "scratcherror" in str(e.value)
 
     def test_generate_password(self, Command):
         p = mock.Mock(

--- a/cumulusci/core/config/tests/test_config_expensive.py
+++ b/cumulusci/core/config/tests/test_config_expensive.py
@@ -485,7 +485,7 @@ class TestScratchOrgConfig:
     def test_email_address_from_config(self, Command):
         config = ScratchOrgConfig({"email_address": "test@example.com"}, "test")
 
-        assert "test@example.com" == config.email_address
+        assert config.email_address == "test@example.com"
         Command.return_value.assert_not_called()
 
     def test_email_address_from_git(self, Command):
@@ -494,7 +494,7 @@ class TestScratchOrgConfig:
             stdout=io.BytesIO(b"test@example.com"), stderr=io.BytesIO(b""), returncode=0
         )
 
-        assert "test@example.com" == config.email_address
+        assert config.email_address == "test@example.com"
         config.email_address  # Make sure value is cached
         p.run.assert_called_once()
 

--- a/cumulusci/core/sfdx.py
+++ b/cumulusci/core/sfdx.py
@@ -132,7 +132,7 @@ def convert_sfdx_source(
     with contextlib.ExitStack() as stack:
         # Convert SFDX -> MDAPI format if path exists but does not have package.xml
         if (
-            len(os.listdir(path))  # path == None -> CWD
+            len(os.listdir(path))  # path is None -> CWD
             and get_source_format_for_path(path) is SourceFormat.SFDX
         ):
             logger.info("Converting from SFDX to MDAPI format.")

--- a/cumulusci/core/tests/test_exceptions.py
+++ b/cumulusci/core/tests/test_exceptions.py
@@ -1,17 +1,11 @@
-import unittest
-
 from cumulusci.core import exceptions
 
 
-class TestExceptions(unittest.TestCase):
+class TestExceptions:
     def test_ApexCompilationException_str(self):
         err = exceptions.ApexCompilationException(42, "Too many braces")
-        self.assertEqual(
-            "Apex compilation failed on line 42: Too many braces", str(err)
-        )
+        assert "Apex compilation failed on line 42: Too many braces" == str(err)
 
     def test_ApexException(self):
         err = exceptions.ApexException("Things got real", "Anon line 1")
-        self.assertEqual(
-            "Apex error: Things got real\n  Stacktrace:\n  Anon line 1", str(err)
-        )
+        assert "Apex error: Things got real\n  Stacktrace:\n  Anon line 1" == str(err)

--- a/cumulusci/core/tests/test_exceptions.py
+++ b/cumulusci/core/tests/test_exceptions.py
@@ -4,8 +4,8 @@ from cumulusci.core import exceptions
 class TestExceptions:
     def test_ApexCompilationException_str(self):
         err = exceptions.ApexCompilationException(42, "Too many braces")
-        assert "Apex compilation failed on line 42: Too many braces" == str(err)
+        assert str(err) == "Apex compilation failed on line 42: Too many braces"
 
     def test_ApexException(self):
         err = exceptions.ApexException("Things got real", "Anon line 1")
-        assert "Apex error: Things got real\n  Stacktrace:\n  Anon line 1" == str(err)
+        assert str(err) == "Apex error: Things got real\n  Stacktrace:\n  Anon line 1"

--- a/cumulusci/core/tests/test_flowrunner.py
+++ b/cumulusci/core/tests/test_flowrunner.py
@@ -264,7 +264,7 @@ class SimpleTestFlowCoordinator(AbstractFlowCoordinatorTest):
         )
 
         # the first step should have the option
-        assert "bar" == flow.steps[0].task_config["options"]["response"]
+        assert flow.steps[0].task_config["options"]["response"] == "bar"
 
     def test_init__nested_options(self):
         self.project_config.config["flows"]["test"] = {
@@ -275,7 +275,7 @@ class SimpleTestFlowCoordinator(AbstractFlowCoordinatorTest):
         }
         flow_config = self.project_config.get_flow("test")
         flow = FlowCoordinator(self.project_config, flow_config)
-        assert "bar" == flow.steps[0].task_config["options"]["foo"]
+        assert flow.steps[0].task_config["options"]["foo"] == "bar"
 
     def test_init__bad_classpath(self):
         self.project_config.config["tasks"] = {
@@ -456,7 +456,7 @@ class SimpleTestFlowCoordinator(AbstractFlowCoordinatorTest):
         flow = FlowCoordinator(self.project_config, flow_config)
         flow.run(self.org_config)
         # the flow results for the second task should be 'name'
-        assert "supername" == flow.results[1].result
+        assert flow.results[1].result == "supername"
 
     def test_run__option_backref_not_found(self):
         # instantiate a flow with two tasks
@@ -492,7 +492,7 @@ class SimpleTestFlowCoordinator(AbstractFlowCoordinatorTest):
         flow = FlowCoordinator(self.project_config, flow_config)
         flow.run(self.org_config)
 
-        assert "supername" == flow.results[-1].result
+        assert flow.results[-1].result == "supername"
 
     def test_run__skip_flow_None(self):
         flow_config = FlowConfig(
@@ -607,7 +607,7 @@ class SimpleTestFlowCoordinator(AbstractFlowCoordinatorTest):
 class StepSpecTest:
     def test_repr(self):
         spec = StepSpec(1, "test_task", {}, None, None, skip=True)
-        assert "<!SKIP! StepSpec 1:test_task {}>" == repr(spec)
+        assert repr(spec) == "<!SKIP! StepSpec 1:test_task {}>"
 
 
 class PreflightFlowCoordinatorTest(AbstractFlowCoordinatorTest):

--- a/cumulusci/core/tests/test_flowrunner.py
+++ b/cumulusci/core/tests/test_flowrunner.py
@@ -52,10 +52,9 @@ class _SfdcTask(BaseTask):
         return -1
 
 
-class AbstractFlowCoordinatorTest(object):
+class AbstractFlowCoordinatorTest:
     @classmethod
     def setup_class(cls):
-        super(AbstractFlowCoordinatorTest, cls).setup_class()
         logger = logging.getLogger(cumulusci.__name__)
         logger.setLevel(logging.DEBUG)
         cls._flow_log_handler = MockLoggingHandler(logging.DEBUG)
@@ -76,7 +75,7 @@ class AbstractFlowCoordinatorTest(object):
         pass
 
 
-class FullParseTestFlowCoordinator(AbstractFlowCoordinatorTest):
+class TestFullParseTestFlowCoordinator(AbstractFlowCoordinatorTest):
     def test_each_flow(self):
         for flow_name in [
             flow_info["name"] for flow_info in self.project_config.list_flows()
@@ -90,7 +89,7 @@ class FullParseTestFlowCoordinator(AbstractFlowCoordinatorTest):
             print(f"Parsed flow {flow_name} as {len(flow.steps)} steps")
 
 
-class SimpleTestFlowCoordinator(AbstractFlowCoordinatorTest):
+class TestSimpleTestFlowCoordinator(AbstractFlowCoordinatorTest):
     """Tests the expectations of a BaseFlow caller"""
 
     def _setup_project_config(self):
@@ -604,13 +603,13 @@ class SimpleTestFlowCoordinator(AbstractFlowCoordinatorTest):
         save.assert_called_once()
 
 
-class StepSpecTest:
+class TestStepSpec:
     def test_repr(self):
         spec = StepSpec(1, "test_task", {}, None, None, skip=True)
         assert repr(spec) == "<!SKIP! StepSpec 1:test_task {}>"
 
 
-class PreflightFlowCoordinatorTest(AbstractFlowCoordinatorTest):
+class TestPreflightFlowCoordinatorTest(AbstractFlowCoordinatorTest):
     def test_run(self):
         flow_config = FlowConfig(
             {

--- a/cumulusci/core/tests/test_github.py
+++ b/cumulusci/core/tests/test_github.py
@@ -466,11 +466,11 @@ class TestGithub(GithubApiTestMixin):
         resp = Response()
         resp.status_code = 401
         exc = AuthenticationFailed(resp)
-        assert "" == check_github_sso_auth(exc)
+        assert check_github_sso_auth(exc) == ""
 
         resp.status_code = 403
         exc = ForbiddenError(resp)
-        assert "" == check_github_sso_auth(exc)
+        assert check_github_sso_auth(exc) == ""
 
     @mock.patch("webbrowser.open")
     def test_check_github_sso_unauthorized_token(self, browser_open):
@@ -658,7 +658,7 @@ class TestGithub(GithubApiTestMixin):
 
         returned_token = get_oauth_device_flow_token()
 
-        assert "expected_access_token" == returned_token
+        assert returned_token == "expected_access_token"
         get_token.assert_called_once()
         get_code.assert_called_once()
         browser_open.assert_called_with("https://github.com/login/device")

--- a/cumulusci/core/tests/test_source.py
+++ b/cumulusci/core/tests/test_source.py
@@ -13,7 +13,7 @@ import yaml
 from cumulusci.core.config import BaseProjectConfig, ServiceConfig, UniversalConfig
 from cumulusci.core.exceptions import DependencyResolutionError, GithubApiError
 from cumulusci.core.keychain import BaseProjectKeychain
-from cumulusci.tasks.release_notes.tests.utils import MockUtil
+from cumulusci.tasks.release_notes.tests.utils import MockUtilBase
 from cumulusci.utils import temporary_dir, touch
 from cumulusci.utils.yaml.cumulusci_yml import (
     GitHubSourceModel,
@@ -24,7 +24,7 @@ from cumulusci.utils.yaml.cumulusci_yml import (
 from ..source import GitHubSource, LocalFolderSource
 
 
-class TestGitHubSource(MockUtil):
+class TestGitHubSource(MockUtilBase):
     def setup_method(self):
         self.repo_api_url = "https://api.github.com/repos/TestOwner/TestRepo"
         universal_config = UniversalConfig()

--- a/cumulusci/core/tests/test_source.py
+++ b/cumulusci/core/tests/test_source.py
@@ -1,7 +1,6 @@
 import io
 import os
 import pathlib
-import unittest
 import zipfile
 from base64 import b64encode
 from tempfile import TemporaryDirectory
@@ -25,8 +24,8 @@ from cumulusci.utils.yaml.cumulusci_yml import (
 from ..source import GitHubSource, LocalFolderSource
 
 
-class TestGitHubSource(unittest.TestCase, MockUtil):
-    def setUp(self):
+class TestGitHubSource(MockUtil):
+    def setup_method(self):
         self.repo_api_url = "https://api.github.com/repos/TestOwner/TestRepo"
         universal_config = UniversalConfig()
         self.project_config = BaseProjectConfig(
@@ -50,7 +49,7 @@ class TestGitHubSource(unittest.TestCase, MockUtil):
             ),
         )
 
-    def tearDown(self):
+    def teardown_method(self):
         self.repo_root.cleanup()
 
     @responses.activate

--- a/cumulusci/core/tests/test_utils.py
+++ b/cumulusci/core/tests/test_utils.py
@@ -72,8 +72,8 @@ class TestUtils:
             assert [filename] == utils.process_glob_list_arg("**/*.resource")
 
     def test_decode_to_unicode(self):
-        assert "\xfc" == utils.decode_to_unicode(b"\xfc")
-        assert "\u2603" == utils.decode_to_unicode("\u2603")
+        assert utils.decode_to_unicode(b"\xfc") == "\xfc"
+        assert utils.decode_to_unicode("\u2603") == "\u2603"
         assert utils.decode_to_unicode(None) is None
 
 

--- a/cumulusci/core/tests/test_utils.py
+++ b/cumulusci/core/tests/test_utils.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 import re
-import unittest
 
 import pytest
 import pytz
@@ -12,17 +11,17 @@ from cumulusci.utils import temporary_dir, touch
 from .. import utils
 
 
-class TestUtils(unittest.TestCase):
+class TestUtils:
     def test_parse_datetime(self):
         dt = utils.parse_datetime("2018-07-30", "%Y-%m-%d")
-        self.assertEqual(dt, datetime.datetime(2018, 7, 30, 0, 0, 0, 0, pytz.UTC))
+        assert dt == datetime.datetime(2018, 7, 30, 0, 0, 0, 0, pytz.UTC)
 
     def test_process_bool_arg(self):
         for arg in (True, "True", "true", "1"):
-            self.assertTrue(utils.process_bool_arg(arg))
+            assert utils.process_bool_arg(arg)
 
         for arg in (False, "False", "false", "0"):
-            self.assertFalse(utils.process_bool_arg(arg))
+            assert not utils.process_bool_arg(arg)
 
         import warnings
 
@@ -36,9 +35,9 @@ class TestUtils(unittest.TestCase):
             utils.process_bool_arg("xyzzy")
 
     def test_process_list_arg(self):
-        self.assertEqual([1, 2], utils.process_list_arg([1, 2]))
-        self.assertEqual(["a", "b"], utils.process_list_arg("a, b"))
-        self.assertEqual(None, utils.process_list_arg(None))
+        assert [1, 2] == utils.process_list_arg([1, 2])
+        assert ["a", "b"] == utils.process_list_arg("a, b")
+        assert utils.process_list_arg(None) is None
 
     def test_process_glob_list_arg(self):
         with temporary_dir():
@@ -46,55 +45,51 @@ class TestUtils(unittest.TestCase):
             touch("bar.robot")
 
             # Expect passing arg as list works.
-            self.assertEqual(
-                ["foo.py", "bar.robot"],
-                utils.process_glob_list_arg(["foo.py", "bar.robot"]),
+            assert ["foo.py", "bar.robot"] == utils.process_glob_list_arg(
+                ["foo.py", "bar.robot"]
             )
 
             # Falsy arg should return an empty list
-            self.assertEqual([], utils.process_glob_list_arg(None))
-            self.assertEqual([], utils.process_glob_list_arg(""))
-            self.assertEqual([], utils.process_glob_list_arg([]))
+            assert [] == utils.process_glob_list_arg(None)
+            assert [] == utils.process_glob_list_arg("")
+            assert [] == utils.process_glob_list_arg([])
 
             # Expect output to be in order given
-            self.assertEqual(
-                ["foo.py", "bar.robot"],
-                utils.process_glob_list_arg("foo.py, bar.robot"),
+            assert ["foo.py", "bar.robot"] == utils.process_glob_list_arg(
+                "foo.py, bar.robot"
             )
 
             # Expect sorted output of glob results
-            self.assertEqual(["bar.robot", "foo.py"], utils.process_glob_list_arg("*"))
+            assert ["bar.robot", "foo.py"] == utils.process_glob_list_arg("*")
 
             # Patterns that don't match any files
-            self.assertEqual(
-                ["*.bar", "x.y.z"], utils.process_glob_list_arg("*.bar, x.y.z")
-            )
+            assert ["*.bar", "x.y.z"] == utils.process_glob_list_arg("*.bar, x.y.z")
 
             # Recursive
             os.mkdir("subdir")
             filename = os.path.join("subdir", "baz.resource")
             touch(filename)
-            self.assertEqual([filename], utils.process_glob_list_arg("**/*.resource"))
+            assert [filename] == utils.process_glob_list_arg("**/*.resource")
 
     def test_decode_to_unicode(self):
-        self.assertEqual("\xfc", utils.decode_to_unicode(b"\xfc"))
-        self.assertEqual("\u2603", utils.decode_to_unicode("\u2603"))
-        self.assertEqual(None, utils.decode_to_unicode(None))
+        assert "\xfc" == utils.decode_to_unicode(b"\xfc")
+        assert "\u2603" == utils.decode_to_unicode("\u2603")
+        assert utils.decode_to_unicode(None) is None
 
 
-class TestDictMerger(unittest.TestCase):
+class TestDictMerger:
     """some stuff that didnt get covered by usual usage"""
 
     def test_merge_into_list(self):
         combo = utils.dictmerge([1, 2], 3)
-        self.assertSequenceEqual(combo, [1, 2, 3])
+        assert combo == [1, 2, 3]
 
     def test_cant_merge_into_dict(self):
-        with self.assertRaises(ConfigMergeError):
+        with pytest.raises(ConfigMergeError):
             utils.dictmerge({"a": "b"}, 2)
 
     def test_cant_merge_nonsense(self):
-        with self.assertRaises(ConfigMergeError):
+        with pytest.raises(ConfigMergeError):
             utils.dictmerge(pytz, 2)
 
 

--- a/cumulusci/core/tests/test_utils_merge_config.py
+++ b/cumulusci/core/tests/test_utils_merge_config.py
@@ -43,14 +43,14 @@ def test_init():
 
 
 def test_merge_failure():
-    with pytest.raises(ConfigMergeError) as cm:
+    with pytest.raises(ConfigMergeError) as e:
         utils.merge_config(
             {
                 "universal_config": {"hello": "world", "test": {"sample": 1}},
                 "user_config": {"hello": "christian", "test": [1, 2]},
             }
         )
-    exception = cm.value
+    exception = e.value
     assert exception.config_name == "user_config"
 
 

--- a/cumulusci/core/tests/utils.py
+++ b/cumulusci/core/tests/utils.py
@@ -14,6 +14,8 @@ class MockLoggingHandler(logging.Handler):
 
     Messages are available from an instance's ``messages`` dict, in order,
     indexed by a lowercase log level string (e.g., 'debug', 'info', etc.).
+
+    TODO: Should be replaced by caplog at some point.
     """
 
     def __init__(self, *args, **kwargs):

--- a/cumulusci/core/tests/utils.py
+++ b/cumulusci/core/tests/utils.py
@@ -35,7 +35,7 @@ class MockLoggingHandler(logging.Handler):
             self.release()
 
     def reset(self):
-        """Reset the handler in TestCase.setUp() to clear the msg list"""
+        """Reset the handler in TestCase.setup_method() to clear the msg list"""
         self.acquire()
         try:
             for message_list in list(self.messages.values()):
@@ -99,8 +99,7 @@ class EnvironmentVarGuard(collections.abc.MutableMapping):
 
 class MockLoggerMixin(object):
     @classmethod
-    def setUpClass(cls):
-        super(MockLoggerMixin, cls).setUpClass()
+    def setup_class(cls):
         logger = logging.getLogger(cumulusci.core.tasks.__name__)
         logger.setLevel(logging.DEBUG)
         cls._task_log_handler = MockLoggingHandler(logging.DEBUG)

--- a/cumulusci/oauth/tests/test_client.py
+++ b/cumulusci/oauth/tests/test_client.py
@@ -102,7 +102,7 @@ class TestOAuth2Client:
             body=b'{"message":"SENTINEL"}',
         )
         info = client.refresh_token("token")
-        assert "SENTINEL" == info["message"]
+        assert info["message"] == "SENTINEL"
 
     @responses.activate
     def test_auth_code_flow___http(self, http_client):

--- a/cumulusci/robotframework/tests/salesforce/test_testlistener.py
+++ b/cumulusci/robotframework/tests/salesforce/test_testlistener.py
@@ -1,12 +1,10 @@
-import unittest
-
 import pytest
 from TestListener import TestListener
 
 
-class TestTestListener(unittest.TestCase):
+class TestTestListener:
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.listener = TestListener()
 
     def test_reset_test_listener_keyword_log(self):

--- a/cumulusci/robotframework/tests/test_cumulusci_library.py
+++ b/cumulusci/robotframework/tests/test_cumulusci_library.py
@@ -1,8 +1,8 @@
 import logging
-import unittest
 from pathlib import Path
 from unittest import mock
 
+import pytest
 import robot.api.logger
 
 from cumulusci.core.config import BaseProjectConfig, UniversalConfig
@@ -12,8 +12,8 @@ from cumulusci.robotframework.CumulusCI import CumulusCI
 from cumulusci.utils import temporary_dir
 
 
-class TestCumulusCILibrary(MockLoggerMixin, unittest.TestCase):
-    def setUp(self):
+class TestCumulusCILibrary(MockLoggerMixin):
+    def setup_method(self):
         self.universal_config = UniversalConfig()
         self.project_config = BaseProjectConfig(
             self.universal_config,
@@ -43,7 +43,7 @@ class TestCumulusCILibrary(MockLoggerMixin, unittest.TestCase):
     def test_run_task(self):
         """Smoke test; can we run the command task?"""
         result = self.cumulusci.run_task("get_pwd")
-        self.assertEqual(result["returncode"], 0)
+        assert result["returncode"] == 0
 
     def test_run_task_robot_logger(self):
         """Verify that 'run task' uses the robot logger"""
@@ -51,7 +51,7 @@ class TestCumulusCILibrary(MockLoggerMixin, unittest.TestCase):
             self.cumulusci.run_task("get_pwd")
             args, kwargs = self.cumulusci._run_task.call_args
             task = args[0]
-            self.assertEqual(task.logger, robot.api.logger)
+            assert task.logger == robot.api.logger
 
     def test_robot_logger_supports_warning(self):
         """Verify that 'run task' uses a logger that supports .warning()
@@ -122,10 +122,10 @@ class TestCumulusCILibrary(MockLoggerMixin, unittest.TestCase):
             )
             args, kwargs = self.cumulusci._run_task.call_args
             task = args[0]
-            self.assertEqual(task.logger, robot.api.logger)
+            assert task.logger == robot.api.logger
 
     def test_run_unknown_task(self):
-        with self.assertRaises(TaskNotFoundError):
+        with pytest.raises(TaskNotFoundError):
             self.cumulusci.run_task("bogus")
 
     def test_cross_project_task(self):
@@ -151,11 +151,11 @@ class TestCumulusCILibrary(MockLoggerMixin, unittest.TestCase):
                 self.cumulusci.run_task("example:whatever")
 
                 args, kwargs = self.cumulusci._run_task.call_args
-                self.assertEqual(len(args), 1)
+                assert len(args) == 1
 
                 # make sure it's not using the current project config
                 # for the task, and that the config it _is_ using is
                 # rooted in the directory we created
                 task = args[0]
-                self.assertNotEqual(task.project_config, self.cumulusci.project_config)
-                self.assertEqual(tmpdir, Path(task.project_config.repo_root))
+                assert task.project_config != self.cumulusci.project_config
+                assert tmpdir == Path(task.project_config.repo_root)

--- a/cumulusci/robotframework/tests/test_locator_manager.py
+++ b/cumulusci/robotframework/tests/test_locator_manager.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest import mock
 
 import pytest
@@ -18,10 +17,9 @@ def mock_get_library_instance(name):
     return mock_libs[name]
 
 
-class TestTranslateLocator(unittest.TestCase):
+class TestTranslateLocator:
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setup_class(cls):
         LOCATORS.clear()
         register_locators(
             prefix="test",
@@ -95,10 +93,9 @@ class TestTranslateLocator(unittest.TestCase):
             translate_locator("test", "foo.not.valid")
 
 
-class TestLocateElement(unittest.TestCase):
+class TestLocateElement:
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setup_class(cls):
         LOCATORS.clear()
         register_locators(
             prefix="test",
@@ -129,8 +126,8 @@ class TestLocateElement(unittest.TestCase):
             )
 
 
-class TestRegisterLocators(unittest.TestCase):
-    def setUp(self):
+class TestRegisterLocators:
+    def setup_method(self):
         LOCATORS.clear()
 
     def test_register_locators(self):
@@ -138,7 +135,7 @@ class TestRegisterLocators(unittest.TestCase):
         register_locators("test", {"foo": "//div/foo"})
 
         expected = {"test": {"foo": "//div/foo"}}
-        self.assertDictEqual(LOCATORS, expected)
+        assert LOCATORS == expected
 
     def test_multiple_registrations(self):
         """Verify that more than one prefix can be registered"""
@@ -147,7 +144,7 @@ class TestRegisterLocators(unittest.TestCase):
         register_locators("test2", {"bar": "//div/bar"})
 
         expected = {"test1": {"foo": "//div/foo"}, "test2": {"bar": "//div/bar"}}
-        self.assertDictEqual(LOCATORS, expected)
+        assert LOCATORS == expected
 
     def test_register_locators_merge(self):
         """Verify that calling register_locators will merge the new locators
@@ -158,4 +155,4 @@ class TestRegisterLocators(unittest.TestCase):
         register_locators("test1", {"foo": {"two": "//div/two"}})
 
         expected = {"test1": {"foo": {"one": "//div/one", "two": "//div/two"}}}
-        self.assertDictEqual(LOCATORS, expected)
+        assert LOCATORS == expected

--- a/cumulusci/robotframework/tests/test_pageobjects.py
+++ b/cumulusci/robotframework/tests/test_pageobjects.py
@@ -15,7 +15,6 @@ BarTestPage has two.
 
 import os.path
 import sys
-import unittest
 from contextlib import contextmanager
 from unittest import mock
 
@@ -93,7 +92,7 @@ def reload_PageObjects(*args):
 # We have to mock out _get_context or the robot libraries will
 # throw an exception saying it cannot access the execution context.
 @mock.patch("robot.libraries.BuiltIn.BuiltIn._get_context")
-class TestPageObjects(unittest.TestCase):
+class TestPageObjects:
     def test_PageObject(self, get_context_mock, get_library_instance_mock):
         """Smoke test to make sure the default registry is set up and keywords exist"""
 
@@ -108,7 +107,7 @@ class TestPageObjects(unittest.TestCase):
                 "wait_for_page_object",
             ]
             actual_keywords = po.get_keyword_names()
-            self.assertEqual(actual_keywords, expected_keywords)
+            assert actual_keywords == expected_keywords
 
             # fmt: off
             # This is much easier to read than if black were to reformat it.
@@ -122,7 +121,7 @@ class TestPageObjects(unittest.TestCase):
             }
             # fmt: on
             actual_registry = {key: repr(value) for key, value in po.registry.items()}
-            self.assertEqual(actual_registry, expected_registry)
+            assert actual_registry == expected_registry
 
     def test_file_in_pythonpath(self, get_context_mock, get_library_instance_mock):
         """Verify we can find a page object via PYTHONPATH"""
@@ -172,7 +171,7 @@ class TestPageObjects(unittest.TestCase):
             }
             # fmt: on
             actual_registry = {key: repr(value) for key, value in po.registry.items()}
-            self.assertEqual(actual_registry, expected_registry)
+            assert actual_registry == expected_registry
 
     def test_namespaced_object_name(self, get_context_mock, get_library_instance_mock):
         """Verify that the object name is prefixed by the namespace when there's a namespace"""
@@ -187,7 +186,7 @@ class TestPageObjects(unittest.TestCase):
                 )
 
                 pobj = po.get_page_object("Test", "Foo__c")
-                self.assertEqual(pobj.object_name, "foobar__Foo__c")
+                assert pobj.object_name == "foobar__Foo__c"
 
     def test_non_namespaced_object_name(
         self, get_context_mock, get_library_instance_mock
@@ -202,7 +201,7 @@ class TestPageObjects(unittest.TestCase):
                 )
 
                 pobj = po.get_page_object("Test", "Foo__c")
-                self.assertEqual(pobj.object_name, "Foo__c")
+                assert pobj.object_name == "Foo__c"
 
     def test_go_to_page_with_locator(self, get_context_mock, get_library_instance_mock):
         """Verify 'Go to page' accepts and uses a locator argument
@@ -240,7 +239,7 @@ class TestPageObjects(unittest.TestCase):
     "robot.libraries.BuiltIn.BuiltIn.get_library_instance",
     side_effect=MockGetLibraryInstance(),
 )
-class TestBasePage(unittest.TestCase):
+class TestBasePage:
     """Some low-level tests of page object classes"""
 
     def test_no_implicit_wait(self, mock_get_library_instance):

--- a/cumulusci/robotframework/tests/test_salesforce.py
+++ b/cumulusci/robotframework/tests/test_salesforce.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest import mock
 
 import pytest
@@ -9,11 +8,7 @@ from cumulusci.robotframework.Salesforce import Salesforce
 
 
 # _init_locators has a special code block
-class TestSeleniumLibrary(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        super(TestSeleniumLibrary, cls).setUpClass()
-
+class TestSeleniumLibrary:
     def test_init_locators(self):
         """Verify that locators are initialized if not passed in"""
         with mock.patch.object(Salesforce, "_init_locators"):
@@ -27,10 +22,9 @@ class TestSeleniumLibrary(unittest.TestCase):
 
 
 @mock.patch("robot.libraries.BuiltIn.BuiltIn._get_context")
-class TestKeyword_wait_until_salesforce_is_ready(unittest.TestCase):
+class TestKeyword_wait_until_salesforce_is_ready:
     @classmethod
-    def setUpClass(cls):
-        super(TestKeyword_wait_until_salesforce_is_ready, cls).setUpClass()
+    def setup_class(cls):
         cls.sflib = Salesforce(locators={"body": "//whatever"})
 
     def test_successful_page_load(self, mock_robot_context):
@@ -63,8 +57,8 @@ class TestKeyword_wait_until_salesforce_is_ready(unittest.TestCase):
         with mock.patch.object(Salesforce, "wait_for_aura", return_value=True):
             self.sflib.selenium.get_webelement.side_effect = ElementNotFound()
 
-            with self.assertRaisesRegex(
-                Exception, "Timed out waiting for a lightning page"
+            with pytest.raises(
+                Exception, match="Timed out waiting for a lightning page"
             ):
                 # The timeout needs to be longer than the duration of
                 # one loop iteration, but less than the retry interval
@@ -76,18 +70,17 @@ class TestKeyword_wait_until_salesforce_is_ready(unittest.TestCase):
 
 
 @mock.patch("robot.libraries.BuiltIn.BuiltIn._get_context")
-class TestKeyword_breakpoint(unittest.TestCase):
+class TestKeyword_breakpoint:
     @classmethod
-    def setUpClass(cls):
-        super(TestKeyword_breakpoint, cls).setUpClass()
+    def setup_class(cls):
         cls.sflib = Salesforce(locators={"body": "//whatever"})
 
     def test_breakpoint(self, mock_robot_context):
         """Verify that the keyword doesn't raise an exception"""
-        self.assertIsNone(self.sflib.breakpoint())
+        assert self.sflib.breakpoint() is None
 
 
-class TestKeyword_elapsed_time_for_last_record(unittest.TestCase):
+class TestKeyword_elapsed_time_for_last_record:
     @responses.activate
     def test_elapsed_time_for_last_record__query_empty(self):
         sflib = Salesforce()

--- a/cumulusci/robotframework/tests/test_salesforce_locators.py
+++ b/cumulusci/robotframework/tests/test_salesforce_locators.py
@@ -1,4 +1,3 @@
-import unittest
 from pathlib import Path
 from unittest import mock
 
@@ -9,7 +8,7 @@ from cumulusci.robotframework.Salesforce import Salesforce
 
 # FIXME: we shouldn't have to tweak these tests for every
 # version. The tests should be smarter.
-class TestLocators(unittest.TestCase):
+class TestLocators:
     @mock.patch("cumulusci.robotframework.Salesforce.Salesforce.get_latest_api_version")
     def test_locators_in_robot_context(self, get_latest_api_version):
         """Verify we can get locators for the current org api version"""
@@ -24,7 +23,7 @@ class TestLocators(unittest.TestCase):
         expected = "cumulusci.robotframework.locators_53"
         actual = sf.locators_module.__name__
         message = "expected to load '{}', actually loaded '{}'".format(expected, actual)
-        self.assertEqual(expected, actual, message)
+        assert expected == actual, message
 
     @mock.patch(
         "robot.libraries.BuiltIn.BuiltIn.get_library_instance",
@@ -46,7 +45,7 @@ class TestLocators(unittest.TestCase):
 
         actual = sf.locators_module.__name__
         message = "expected to load '{}', actually loaded '{}'".format(expected, actual)
-        self.assertEqual(expected, actual, message)
+        assert expected == actual, message
 
     def test_locators_53(self):
         """Verify that locators_53 is a superset of the locators_52
@@ -65,10 +64,8 @@ class TestLocators(unittest.TestCase):
         keys_50 = set(locators_52.lex_locators)
         keys_51 = set(locators_53.lex_locators)
 
-        self.assertNotEqual(
-            id(locators_52.lex_locators),
-            id(locators_53.lex_locators),
-            "locators_52.lex_locators and locators_53.lex_locators are the same object",
-        )
-        self.assertTrue(len(keys_50) > 0)
-        self.assertTrue(keys_50.issubset(keys_51))
+        assert id(locators_52.lex_locators) != id(
+            locators_53.lex_locators
+        ), "locators_52.lex_locators and locators_53.lex_locators are the same object"
+        assert len(keys_50) > 0
+        assert keys_50.issubset(keys_51)

--- a/cumulusci/robotframework/tests/test_template_util.py
+++ b/cumulusci/robotframework/tests/test_template_util.py
@@ -1,9 +1,7 @@
-import unittest
-
 from cumulusci.core import template_utils
 
 
-class TemplateUtils(unittest.TestCase):
+class TemplateUtils:
     def test_string_generator(self):
         x = 100
         y = template_utils.StringGenerator(lambda: str(x))

--- a/cumulusci/robotframework/tests/test_template_util.py
+++ b/cumulusci/robotframework/tests/test_template_util.py
@@ -1,7 +1,7 @@
 from cumulusci.core import template_utils
 
 
-class TemplateUtils:
+class TestTemplateUtils:
     def test_string_generator(self):
         x = 100
         y = template_utils.StringGenerator(lambda: str(x))

--- a/cumulusci/robotframework/tests/test_utils.py
+++ b/cumulusci/robotframework/tests/test_utils.py
@@ -1,6 +1,5 @@
 import shutil
 import tempfile
-import unittest
 from pathlib import Path
 from unittest import mock
 
@@ -8,8 +7,8 @@ import cumulusci.robotframework.utils as robot_utils
 from cumulusci.utils import touch
 
 
-class TestRobotframeworkUtils(unittest.TestCase):
-    def setUp(self):
+class TestRobotframeworkUtils:
+    def setup_method(self):
         robot_utils.BuiltIn = mock.Mock(name="BuiltIn")
         self.mock_selib = robot_utils.BuiltIn().get_library_instance("SeleniumLibrary")
 
@@ -37,9 +36,9 @@ class TestRobotframeworkUtils(unittest.TestCase):
         self.mock_selib.failure_occurred.assert_not_called()
 
 
-class TestGetLocatorModule(unittest.TestCase):
+class TestGetLocatorModule:
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         # get_locator_module uses __file__ to locate the locator
         # module. We'll point it to a temporary directory so that
         # we can control what files we test against.
@@ -57,7 +56,7 @@ class TestGetLocatorModule(unittest.TestCase):
         cls.patched_utils.start()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         shutil.rmtree(cls.tempdir)
         cls.patched_utils.stop()
 

--- a/cumulusci/salesforce_api/tests/test_metadata.py
+++ b/cumulusci/salesforce_api/tests/test_metadata.py
@@ -50,7 +50,10 @@ class DummyPackageZipBuilder(BasePackageZipBuilder):
         return
 
 
-class BaseTestMetadataApi:
+# TODO: Should this be renamed? Is it intended that it be a "Pure"
+#       base class or a test-class of its own, as it was under
+#       the unittest framework?
+class TestBaseTestMetadataApi:
     api_class = BaseMetadataApiCall
     envelope_start = None
     envelope_status = status_envelope
@@ -521,7 +524,7 @@ class BaseTestMetadataApi:
         assert res.content == response.content
 
 
-class TestBaseMetadataApiCall(BaseTestMetadataApi):
+class TestBaseMetadataApiCall(TestBaseTestMetadataApi):
     def test_build_envelope_start_no_envelope(self):
         task = self._create_task()
         api = self._create_instance(task)
@@ -560,7 +563,7 @@ class TestBaseMetadataApiCall(BaseTestMetadataApi):
         assert resp.content == response
 
 
-class TestApiDeploy(BaseTestMetadataApi):
+class TestApiDeploy(TestBaseTestMetadataApi):
     api_class = ApiDeploy
     envelope_status = deploy_status_envelope
 
@@ -780,7 +783,7 @@ class TestApiDeploy(BaseTestMetadataApi):
         assert api._get_action(False, False) == "Update"
 
 
-class TestApiListMetadata(BaseTestMetadataApi):
+class TestApiListMetadata(TestBaseTestMetadataApi):
     api_class = ApiListMetadata
     envelope_start = list_metadata_start_envelope
 
@@ -840,7 +843,7 @@ class TestApiListMetadata(BaseTestMetadataApi):
             api()
 
 
-class TestApiRetrieveUnpackaged(BaseTestMetadataApi):
+class TestApiRetrieveUnpackaged(TestBaseTestMetadataApi):
     maxDiff = None
     api_class = ApiRetrieveUnpackaged
     envelope_start = retrieve_unpackaged_start_envelope
@@ -896,7 +899,7 @@ class TestApiRetrieveUnpackaged(BaseTestMetadataApi):
         )
 
 
-class TestApiRetrieveInstalledPackages(BaseTestMetadataApi):
+class TestApiRetrieveInstalledPackages(TestBaseTestMetadataApi):
     api_class = ApiRetrieveInstalledPackages
 
     def _create_instance(self, task, api_version=None):

--- a/cumulusci/salesforce_api/tests/test_metadata.py
+++ b/cumulusci/salesforce_api/tests/test_metadata.py
@@ -1,7 +1,6 @@
 import datetime
 import http.client
 import io
-import unittest
 from collections import defaultdict
 from xml.dom.minidom import parseString
 
@@ -51,13 +50,13 @@ class DummyPackageZipBuilder(BasePackageZipBuilder):
         return
 
 
-class BaseTestMetadataApi(unittest.TestCase):
+class BaseTestMetadataApi:
     api_class = BaseMetadataApiCall
     envelope_start = None
     envelope_status = status_envelope
     envelope_result = result_envelope
 
-    def setUp(self):
+    def setup_method(self):
 
         # Set up the mock values
         self.repo_name = "TestRepo"
@@ -103,10 +102,8 @@ class BaseTestMetadataApi(unittest.TestCase):
     def test_init(self):
         task = self._create_task()
         api = self._create_instance(task)
-        self.assertEqual(api.task, task)
-        self.assertEqual(
-            api.api_version, self.project_config.project__package__api_version
-        )
+        assert api.task == task
+        assert api.api_version == self.project_config.project__package__api_version
 
     def test_build_endpoint_url(self):
         org_config = {
@@ -115,13 +112,10 @@ class BaseTestMetadataApi(unittest.TestCase):
         }
         task = self._create_task(org_config=org_config)
         api = self._create_instance(task)
-        self.assertEqual(
-            api._build_endpoint_url(),
-            "{}/services/Soap/m/{}/{}".format(
-                org_config["instance_url"],
-                self.project_config.project__package__api_version,
-                task.org_config.org_id,
-            ),
+        assert api._build_endpoint_url() == "{}/services/Soap/m/{}/{}".format(
+            org_config["instance_url"],
+            self.project_config.project__package__api_version,
+            task.org_config.org_id,
         )
 
     def test_build_endpoint_url_mydomain(self):
@@ -131,12 +125,12 @@ class BaseTestMetadataApi(unittest.TestCase):
         }
         task = self._create_task(org_config=org_config)
         api = self._create_instance(task)
-        self.assertEqual(
-            api._build_endpoint_url(),
-            "https://test-org.na12.my.salesforce.com/services/Soap/m/{}/{}".format(
+        assert (
+            api._build_endpoint_url()
+            == "https://test-org.na12.my.salesforce.com/services/Soap/m/{}/{}".format(
                 self.project_config.project__package__api_version,
                 task.org_config.org_id,
-            ),
+            )
         )
 
     def test_build_endpoint_url_apiversion(self):
@@ -147,11 +141,8 @@ class BaseTestMetadataApi(unittest.TestCase):
         task = self._create_task(org_config=org_config)
         api_version = "43.0"
         api = self._create_instance(task, api_version=api_version)
-        self.assertEqual(
-            api._build_endpoint_url(),
-            "{}/services/Soap/m/{}/{}".format(
-                org_config["instance_url"], api_version, task.org_config.org_id
-            ),
+        assert api._build_endpoint_url() == "{}/services/Soap/m/{}/{}".format(
+            org_config["instance_url"], api_version, task.org_config.org_id
         )
 
     def test_build_envelope_result(self):
@@ -163,7 +154,7 @@ class BaseTestMetadataApi(unittest.TestCase):
         else:
             expected = self.envelope_result.format(process_id="123")
         api.process_id = "123"
-        self.assertEqual(api._build_envelope_result(), expected)
+        assert api._build_envelope_result() == expected
 
     def test_build_envelope_start(self):
         task = self._create_task()
@@ -174,7 +165,7 @@ class BaseTestMetadataApi(unittest.TestCase):
         else:
             expected = self._expected_envelope_start()
 
-        self.assertEqual(api._build_envelope_start(), expected)
+        assert api._build_envelope_start() == expected
 
     def _expected_envelope_start(self):
         return self.envelope_start.format(
@@ -191,21 +182,18 @@ class BaseTestMetadataApi(unittest.TestCase):
         else:
             expected = self.envelope_status.format(process_id=process_id)
         api.process_id = process_id
-        self.assertEqual(api._build_envelope_status(), expected)
+        assert api._build_envelope_status() == expected
 
     def test_build_headers(self):
         action = "foo"
         message = "12345678"
         task = self._create_task()
         api = self._create_instance(task)
-        self.assertEqual(
-            api._build_headers(action, message),
-            {
-                "Content-Type": "text/xml; charset=UTF-8",
-                "Content-Length": "8",
-                "SOAPAction": "foo",
-            },
-        )
+        assert api._build_headers(action, message) == {
+            "Content-Type": "text/xml; charset=UTF-8",
+            "Content-Length": "8",
+            "SOAPAction": "foo",
+        }
 
     @responses.activate
     def test_call_faultcode(self):
@@ -220,7 +208,7 @@ class BaseTestMetadataApi(unittest.TestCase):
             api.soap_envelope_start = "{api_version}"
         response = '<?xml version="1.0" encoding="UTF-8"?><faultcode>foo</faultcode>'
         self._mock_call_mdapi(api, response)
-        with self.assertRaises(MetadataApiError):
+        with pytest.raises(MetadataApiError):
             api()
 
     @responses.activate
@@ -250,7 +238,7 @@ class BaseTestMetadataApi(unittest.TestCase):
         resp = api()
         expected_resp = self._expected_call_success_result(response_result)
 
-        self.assertEqual(resp, expected_resp)
+        assert resp == expected_resp
 
     def _expected_call_success_result(self, response_result):
         return response_result
@@ -262,27 +250,27 @@ class BaseTestMetadataApi(unittest.TestCase):
         task = self._create_task()
         api = self._create_instance(task)
         dom = parseString("<foo>bar</foo>")
-        self.assertEqual(api._get_element_value(dom, "foo"), "bar")
+        assert api._get_element_value(dom, "foo") == "bar"
 
     def test_get_element_value_not_found(self):
         task = self._create_task()
         api = self._create_instance(task)
         dom = parseString("<foo>bar</foo>")
-        self.assertEqual(api._get_element_value(dom, "baz"), None)
+        assert api._get_element_value(dom, "baz") is None
 
     def test_get_element_value_empty(self):
         task = self._create_task()
         api = self._create_instance(task)
         dom = parseString("<foo />")
-        self.assertEqual(api._get_element_value(dom, "foo"), None)
+        assert api._get_element_value(dom, "foo") is None
 
     def test_get_check_interval(self):
         task = self._create_task()
         api = self._create_instance(task)
         api.check_num = 1
-        self.assertEqual(api._get_check_interval(), 1)
+        assert api._get_check_interval() == 1
         api.check_num = 10
-        self.assertEqual(api._get_check_interval(), 4)
+        assert api._get_check_interval() == 4
 
     @responses.activate
     def test_get_response_faultcode(self):
@@ -297,7 +285,7 @@ class BaseTestMetadataApi(unittest.TestCase):
             api.soap_envelope_start = "{api_version}"
         response = '<?xml version="1.0" encoding="UTF-8"?><faultcode>foo</faultcode>'
         self._mock_call_mdapi(api, response)
-        with self.assertRaises(MetadataApiError):
+        with pytest.raises(MetadataApiError):
             api._get_response()
 
     @responses.activate
@@ -317,7 +305,7 @@ class BaseTestMetadataApi(unittest.TestCase):
         response += "\n  <faultstring>bar</faultstring>"
         response += "\n</test>"
         self._mock_call_mdapi(api, response)
-        with self.assertRaises(MetadataApiError):
+        with pytest.raises(MetadataApiError):
             api._get_response()
 
     @responses.activate
@@ -333,9 +321,9 @@ class BaseTestMetadataApi(unittest.TestCase):
             api.soap_envelope_start = "{api_version}"
         response = '<?xml version="1.0" encoding="UTF-8"?><faultcode>sf:INVALID_SESSION_ID</faultcode>'
         self._mock_call_mdapi(api, response)
-        with self.assertRaises(MetadataApiError):
+        with pytest.raises(MetadataApiError):
             api._get_response()
-        self.assertEqual(api.status, "Failed")
+        assert api.status == "Failed"
 
     @responses.activate
     def test_get_response_faultcode_invalid_session_refresh(self):
@@ -362,7 +350,7 @@ class BaseTestMetadataApi(unittest.TestCase):
             self._mock_call_mdapi(api, response)
 
         resp = api._get_response()
-        self.assertEqual(resp.content, mock_responses[2])
+        assert resp.content == mock_responses[2]
 
     @responses.activate
     def test_get_response_start_error_500(self):
@@ -382,7 +370,7 @@ class BaseTestMetadataApi(unittest.TestCase):
         response = '<?xml version="1.0" encoding="UTF-8"?><foo>start</foo>'
         self._mock_call_mdapi(api, response, status_code)
 
-        with self.assertRaises(MetadataApiError):
+        with pytest.raises(MetadataApiError):
             api._get_response()
 
     @responses.activate
@@ -404,7 +392,7 @@ class BaseTestMetadataApi(unittest.TestCase):
         self._mock_call_mdapi(api, response)
         self._mock_call_mdapi(api, response, status_code)
 
-        with self.assertRaises(MetadataApiError):
+        with pytest.raises(MetadataApiError):
             api._get_response()
 
     @responses.activate
@@ -432,7 +420,7 @@ class BaseTestMetadataApi(unittest.TestCase):
 
         resp = api._get_response()
 
-        self.assertEqual(resp.content, response_result)
+        assert resp.content == response_result
 
     @responses.activate
     def test_get_response_status_loop_twice(self):
@@ -464,11 +452,11 @@ class BaseTestMetadataApi(unittest.TestCase):
 
         resp = api._get_response()
 
-        self.assertEqual(resp.content, response_result)
+        assert resp.content == response_result
 
-        self.assertEqual(api.status, "Done")
+        assert api.status == "Done"
 
-        self.assertEqual(api.check_num, 4)
+        assert api.check_num == 4
 
     def test_process_response_status_no_done_element(self):
         task = self._create_task()
@@ -479,8 +467,8 @@ class BaseTestMetadataApi(unittest.TestCase):
             b'<?xml version="1.0" encoding="UTF-8"?><foo>status</foo>'
         )
         res = api._process_response_status(response)
-        self.assertEqual(api.status, "Failed")
-        self.assertEqual(res.content, response.content)
+        assert api.status == "Failed"
+        assert res.content == response.content
 
     def test_process_response_status_done_is_true(self):
         task = self._create_task()
@@ -491,8 +479,8 @@ class BaseTestMetadataApi(unittest.TestCase):
             b'<?xml version="1.0" encoding="UTF-8"?><done>true</done>'
         )
         res = api._process_response_status(response)
-        self.assertEqual(api.status, "Done")
-        self.assertEqual(res.content, response.content)
+        assert api.status == "Done"
+        assert res.content == response.content
 
     def test_process_response_status_pending(self):
         task = self._create_task()
@@ -503,8 +491,8 @@ class BaseTestMetadataApi(unittest.TestCase):
             b'<?xml version="1.0" encoding="UTF-8"?><done>false</done>'
         )
         res = api._process_response_status(response)
-        self.assertEqual(api.status, "Pending")
-        self.assertEqual(res.content, response.content)
+        assert api.status == "Pending"
+        assert res.content == response.content
 
     def test_process_response_status_in_progress(self):
         task = self._create_task()
@@ -516,8 +504,8 @@ class BaseTestMetadataApi(unittest.TestCase):
         )
         api.status = "InProgress"
         res = api._process_response_status(response)
-        self.assertEqual(api.status, "InProgress")
-        self.assertEqual(res.content, response.content)
+        assert api.status == "InProgress"
+        assert res.content == response.content
 
     def test_process_response_status_in_progress_state_detail(self):
         task = self._create_task()
@@ -529,8 +517,8 @@ class BaseTestMetadataApi(unittest.TestCase):
         )
         api.status = "InProgress"
         res = api._process_response_status(response)
-        self.assertEqual(api.status, "InProgress")
-        self.assertEqual(res.content, response.content)
+        assert api.status == "InProgress"
+        assert res.content == response.content
 
 
 class TestBaseMetadataApiCall(BaseTestMetadataApi):
@@ -543,17 +531,17 @@ class TestBaseMetadataApiCall(BaseTestMetadataApi):
     def test_build_envelope_status_no_envelope(self):
         task = self._create_task()
         api = self._create_instance(task)
-        self.assertEqual(api._build_envelope_status(), None)
+        assert api._build_envelope_status() is None
 
     def test_build_envelope_result_no_envelope(self):
         task = self._create_task()
         api = self._create_instance(task)
-        self.assertEqual(api._build_envelope_result(), None)
+        assert api._build_envelope_result() is None
 
     def test_get_response_no_start_env(self):
         task = self._create_task()
         api = self._create_instance(task)
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             api._get_response()
 
     @responses.activate
@@ -569,15 +557,15 @@ class TestBaseMetadataApiCall(BaseTestMetadataApi):
         response = b'<?xml version="1.0" encoding="UTF-8"?><foo />'
         self._mock_call_mdapi(api, response)
         resp = api._get_response()
-        self.assertEqual(resp.content, response)
+        assert resp.content == response
 
 
 class TestApiDeploy(BaseTestMetadataApi):
     api_class = ApiDeploy
     envelope_status = deploy_status_envelope
 
-    def setUp(self):
-        super(TestApiDeploy, self).setUp()
+    def setup_method(self):
+        super(TestApiDeploy, self).setup_method()
         self.package_zip = DummyPackageZipBuilder().as_base64()
 
     def _expected_envelope_start(self):
@@ -617,37 +605,37 @@ class TestApiDeploy(BaseTestMetadataApi):
     def test_init_no_purge_on_delete(self):
         task = self._create_task()
         api = self._create_instance(task, purge_on_delete=False)
-        self.assertEqual(api.purge_on_delete, "false")
+        assert api.purge_on_delete == "false"
 
     def test_init_default_check_only(self):
         task = self._create_task()
         api = self._create_instance(task)
-        self.assertEqual(api.check_only, "false")
+        assert api.check_only == "false"
 
     def test_init_check_only(self):
         task = self._create_task()
         api = self._create_instance(task, check_only=True)
-        self.assertEqual(api.check_only, "true")
+        assert api.check_only == "true"
 
     def test_init_default_test_level(self):
         task = self._create_task()
         api = self._create_instance(task)
-        self.assertEqual(api.test_level, None)
+        assert api.test_level is None
 
     def test_init_test_level(self):
         task = self._create_task()
         api = self._create_instance(task, test_level="NoTestRun")
-        self.assertEqual(api.test_level, "NoTestRun")
+        assert api.test_level == "NoTestRun"
 
     def test_init_default_run_tests(self):
         task = self._create_task()
         api = self._create_instance(task)
-        self.assertEqual(api.run_tests, [])
+        assert api.run_tests == []
 
     def test_init_run_tests(self):
         task = self._create_task()
         api = self._create_instance(task, run_tests=["TestA", "TestB"])
-        self.assertEqual(api.run_tests, ["TestA", "TestB"])
+        assert api.run_tests == ["TestA", "TestB"]
 
     def test_build_envelope_status__run_specified_tests(self):
         task = self._create_task()
@@ -681,10 +669,10 @@ class TestApiDeploy(BaseTestMetadataApi):
 </componentFailures>"""
             ).encode()
         )
-        with self.assertRaises(MetadataComponentFailure) as cm:
+        with pytest.raises(MetadataComponentFailure) as e:
             api._process_response(response)
         expected = "Update of CustomObject Test__c: Error on line 1, col 1: problem"
-        self.assertEqual(expected, str(cm.exception))
+        assert expected == str(e.value)
 
     def test_process_response_metadata_failure_no_lineno(self):
         task = self._create_task()
@@ -703,10 +691,10 @@ class TestApiDeploy(BaseTestMetadataApi):
 </componentFailures>"""
             ).encode()
         )
-        with self.assertRaises(MetadataComponentFailure) as cm:
+        with pytest.raises(MetadataComponentFailure) as e:
             api._process_response(response)
         expected = "Update of CustomObject Test__c: Error: problem"
-        self.assertEqual(expected, str(cm.exception))
+        assert expected == str(e.value)
 
     def test_process_response_metadata_failure_no_file_name(self):
         task = self._create_task()
@@ -724,10 +712,10 @@ class TestApiDeploy(BaseTestMetadataApi):
 </componentFailures>"""
             ).encode()
         )
-        with self.assertRaises(MetadataComponentFailure) as cm:
+        with pytest.raises(MetadataComponentFailure) as e:
             api._process_response(response)
         expected = "Update of CustomObject: Error: problem"
-        self.assertEqual(expected, str(cm.exception))
+        assert expected == str(e.value)
 
     def test_process_response_problem(self):
         task = self._create_task()
@@ -739,10 +727,10 @@ class TestApiDeploy(BaseTestMetadataApi):
                 details="""<problem>problem</problem>"""
             ).encode()
         )
-        with self.assertRaises(MetadataApiError) as cm:
+        with pytest.raises(MetadataApiError) as e:
             api._process_response(response)
         expected = "problem"
-        self.assertEqual(expected, str(cm.exception))
+        assert expected == str(e.value)
 
     def test_process_response_test_failure(self):
         task = self._create_task()
@@ -760,10 +748,10 @@ class TestApiDeploy(BaseTestMetadataApi):
 """
             ).encode()
         )
-        with self.assertRaises(ApexTestException) as cm:
+        with pytest.raises(ApexTestException) as e:
             api._process_response(response)
         expected = "Apex Test Failure: from namespace test: stack"
-        self.assertEqual(expected, str(cm.exception))
+        assert expected == str(e.value)
 
     def test_process_response_no_status(self):
         task = self._create_task()
@@ -772,7 +760,7 @@ class TestApiDeploy(BaseTestMetadataApi):
         response.status_code = 200
         response.raw = io.BytesIO(b"<bogus />")
         status = api._process_response(response)
-        self.assertEqual(status, "Failed")
+        assert status == "Failed"
 
     def test_process_response_failure_but_no_message(self):
         task = self._create_task()
@@ -780,24 +768,24 @@ class TestApiDeploy(BaseTestMetadataApi):
         response = Response()
         response.status_code = 200
         response.raw = io.BytesIO(b"<status>Failed</status>")
-        with self.assertRaises(MetadataApiError) as cm:
+        with pytest.raises(MetadataApiError) as e:
             api._process_response(response)
-        self.assertEqual(response.text, str(cm.exception))
+        assert response.text == str(e.value)
 
     def test_get_action(self):
         task = self._create_task()
         api = self._create_instance(task)
-        self.assertEqual("Create", api._get_action(True, False))
-        self.assertEqual("Delete", api._get_action(False, True))
-        self.assertEqual("Update", api._get_action(False, False))
+        assert "Create" == api._get_action(True, False)
+        assert "Delete" == api._get_action(False, True)
+        assert "Update" == api._get_action(False, False)
 
 
 class TestApiListMetadata(BaseTestMetadataApi):
     api_class = ApiListMetadata
     envelope_start = list_metadata_start_envelope
 
-    def setUp(self):
-        super(TestApiListMetadata, self).setUp()
+    def setup_method(self):
+        super(TestApiListMetadata, self).setup_method()
         self.metadata_type = "CustomObject"
         self.metadata = None
         self.folder = None
@@ -848,7 +836,7 @@ class TestApiListMetadata(BaseTestMetadataApi):
         api = self._create_instance(task)
 
         self._mock_call_mdapi(api, list_metadata_result_bad_val)
-        with self.assertRaises(MetadataParseError):
+        with pytest.raises(MetadataParseError):
             api()
 
 
@@ -857,8 +845,8 @@ class TestApiRetrieveUnpackaged(BaseTestMetadataApi):
     api_class = ApiRetrieveUnpackaged
     envelope_start = retrieve_unpackaged_start_envelope
 
-    def setUp(self):
-        super(TestApiRetrieveUnpackaged, self).setUp()
+    def setup_method(self):
+        super(TestApiRetrieveUnpackaged, self).setup_method()
         self.package_xml = """<?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <version>41.0</version>
@@ -902,9 +890,9 @@ class TestApiRetrieveUnpackaged(BaseTestMetadataApi):
 
         zip_file = api()
 
-        self.assertEqual(
-            zip_file.namelist(),
-            self._expected_call_success_result(response_result).namelist(),
+        assert (
+            zip_file.namelist()
+            == self._expected_call_success_result(response_result).namelist()
         )
 
 
@@ -927,7 +915,7 @@ class TestApiRetrieveInstalledPackages(BaseTestMetadataApi):
             deploy_result.format(status="testing", extra="").encode()
         )
         resp = api._process_response(response)
-        self.assertEqual(resp, {})
+        assert resp == {}
 
     def test_process_response_zipstr_no_packages(self):
         task = self._create_task()
@@ -941,7 +929,7 @@ class TestApiRetrieveInstalledPackages(BaseTestMetadataApi):
             ).encode()
         )
         resp = api._process_response(response)
-        self.assertEqual(resp, {})
+        assert resp == {}
 
     def test_process_response_zipstr_one_package(self):
         task = self._create_task()
@@ -954,15 +942,15 @@ class TestApiRetrieveInstalledPackages(BaseTestMetadataApi):
             ).encode()
         )
         resp = api._process_response(response)
-        self.assertEqual(resp, {"foo": "1.1"})
+        assert resp == {"foo": "1.1"}
 
 
 class TestApiRetrievePackaged(TestApiRetrieveUnpackaged):
     api_class = ApiRetrievePackaged
     envelope_start = retrieve_packaged_start_envelope
 
-    def setUp(self):
-        super(TestApiRetrievePackaged, self).setUp()
+    def setup_method(self):
+        super(TestApiRetrievePackaged, self).setup_method()
         self.package_name = "Test Package"
 
     def _expected_envelope_start(self):
@@ -981,5 +969,5 @@ class TestApiRetrievePackaged(TestApiRetrieveUnpackaged):
         response.raw = io.BytesIO(
             b"INVALID_CROSS_REFERENCE_KEY: No package named Test Package"
         )
-        with self.assertRaises(CumulusCIException):
+        with pytest.raises(CumulusCIException):
             api._process_response(response)

--- a/cumulusci/salesforce_api/tests/test_metadata.py
+++ b/cumulusci/salesforce_api/tests/test_metadata.py
@@ -775,9 +775,9 @@ class TestApiDeploy(BaseTestMetadataApi):
     def test_get_action(self):
         task = self._create_task()
         api = self._create_instance(task)
-        assert "Create" == api._get_action(True, False)
-        assert "Delete" == api._get_action(False, True)
-        assert "Update" == api._get_action(False, False)
+        assert api._get_action(True, False) == "Create"
+        assert api._get_action(False, True) == "Delete"
+        assert api._get_action(False, False) == "Update"
 
 
 class TestApiListMetadata(BaseTestMetadataApi):

--- a/cumulusci/salesforce_api/tests/test_metadata.py
+++ b/cumulusci/salesforce_api/tests/test_metadata.py
@@ -849,7 +849,7 @@ class TestApiRetrieveUnpackaged(TestBaseTestMetadataApi):
     envelope_start = retrieve_unpackaged_start_envelope
 
     def setup_method(self):
-        super(TestApiRetrieveUnpackaged, self).setup_method()
+        super().setup_method()
         self.package_xml = """<?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <version>41.0</version>
@@ -953,7 +953,7 @@ class TestApiRetrievePackaged(TestApiRetrieveUnpackaged):
     envelope_start = retrieve_packaged_start_envelope
 
     def setup_method(self):
-        super(TestApiRetrievePackaged, self).setup_method()
+        super().setup_method()
         self.package_name = "Test Package"
 
     def _expected_envelope_start(self):

--- a/cumulusci/salesforce_api/tests/test_package_zip.py
+++ b/cumulusci/salesforce_api/tests/test_package_zip.py
@@ -2,8 +2,9 @@ import base64
 import io
 import os
 import pathlib
-import unittest
 import zipfile
+
+import pytest
 
 from cumulusci.salesforce_api.package_zip import (
     BasePackageZipBuilder,
@@ -339,39 +340,39 @@ class TestMetadataPackageZipBuilder:
             assert b"FeatureParameterInteger" not in package_xml
 
 
-class TestCreatePackageZipBuilder(unittest.TestCase):
+class TestCreatePackageZipBuilder:
     def test_init__missing_name(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             CreatePackageZipBuilder(None, "43.0")
 
     def test_init__missing_api_version(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             CreatePackageZipBuilder("TestPackage", None)
 
 
-class TestInstallPackageZipBuilder(unittest.TestCase):
+class TestInstallPackageZipBuilder:
     def test_init__missing_namespace(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             InstallPackageZipBuilder(None, "1.0")
 
     def test_init__missing_version(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             InstallPackageZipBuilder("testns", None)
 
 
-class TestDestructiveChangesZipBuilder(unittest.TestCase):
+class TestDestructiveChangesZipBuilder:
     def test_call(self):
         builder = DestructiveChangesZipBuilder("", "1.0")
         names = builder.zf.namelist()
-        self.assertIn("package.xml", names)
-        self.assertIn("destructiveChanges.xml", names)
+        assert "package.xml" in names
+        assert "destructiveChanges.xml" in names
 
 
-class TestUninstallPackageZipBuilder(unittest.TestCase):
+class TestUninstallPackageZipBuilder:
     def test_init__missing_namespace(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             UninstallPackageZipBuilder(None, "1.0")
 
     def test_call(self):
         builder = UninstallPackageZipBuilder("testns", "1.0")
-        self.assertIn("destructiveChanges.xml", builder.zf.namelist())
+        assert "destructiveChanges.xml" in builder.zf.namelist()

--- a/cumulusci/tasks/apex/tests/test_apex_tasks.py
+++ b/cumulusci/tasks/apex/tests/test_apex_tasks.py
@@ -730,7 +730,7 @@ class TestRunApexTests(MockLoggerMixin):
         task_config = TaskConfig({"options": {"managed": True, "namespace": "testns"}})
         task = RunApexTests(self.project_config, task_config, self.org_config)
         namespace = task._get_namespace_filter()
-        assert "'testns'" == namespace
+        assert namespace == "'testns'"
 
     def test_get_namespace_filter__managed_no_namespace(self):
         task_config = TaskConfig({"options": {"managed": True}})

--- a/cumulusci/tasks/bulkdata/tests/test_base_generate_data_tasks.py
+++ b/cumulusci/tasks/bulkdata/tests/test_base_generate_data_tasks.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 from unittest import mock
 
 from sqlalchemy import Unicode
@@ -27,7 +26,7 @@ class DummyBaseBatchDataTask(BaseGenerateDataTask):
         DummyBaseBatchDataTask.was_called = True
 
 
-class TestBaseBatchDataTask(unittest.TestCase):
+class TestBaseBatchDataTask:
     def test_BaseBatchDataTask(self):
         mapping_file = os.path.join(os.path.dirname(__file__), "mapping_v2.yml")
         with temporary_dir() as d:

--- a/cumulusci/tasks/bulkdata/tests/test_delete.py
+++ b/cumulusci/tasks/bulkdata/tests/test_delete.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest import mock
 
 import pytest
@@ -17,7 +16,7 @@ from cumulusci.tasks.bulkdata.tests.utils import _make_task
 from cumulusci.tests.util import mock_describe_calls
 
 
-class TestDeleteData(unittest.TestCase):
+class TestDeleteData:
     @responses.activate
     @mock.patch("cumulusci.tasks.bulkdata.delete.get_query_operation")
     @mock.patch("cumulusci.tasks.bulkdata.delete.get_dml_operation")
@@ -111,7 +110,7 @@ class TestDeleteData(unittest.TestCase):
                 DataOperationResult("001000000000001", False, None),
             ]
         )
-        with self.assertRaises(BulkDataException):
+        with pytest.raises(BulkDataException):
             task()
 
     @responses.activate
@@ -126,7 +125,7 @@ class TestDeleteData(unittest.TestCase):
         query_mock.return_value.job_result = DataOperationJobResult(
             DataOperationStatus.JOB_FAILURE, [], 0, 0
         )
-        with self.assertRaises(BulkDataException):
+        with pytest.raises(BulkDataException):
             task()
 
     @responses.activate
@@ -147,7 +146,7 @@ class TestDeleteData(unittest.TestCase):
                 DataOperationResult("001000000000001", False, None),
             ]
         )
-        with self.assertRaises(BulkDataException):
+        with pytest.raises(BulkDataException):
             task()
 
     @responses.activate
@@ -307,7 +306,7 @@ class TestDeleteData(unittest.TestCase):
         query_mock.return_value.job_result = DataOperationJobResult(
             DataOperationStatus.JOB_FAILURE, [], 0, 0
         )
-        with self.assertRaises(BulkDataException):
+        with pytest.raises(BulkDataException):
             task()
 
     @responses.activate
@@ -371,16 +370,16 @@ class TestDeleteData(unittest.TestCase):
         assert t._object_description("a") == "all a objects"
 
     def test_init_options(self):
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             _make_task(DeleteData, {"options": {"objects": ""}})
 
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             _make_task(DeleteData, {"options": {"objects": "a,b", "where": "x='y'"}})
 
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             _make_task(DeleteData, {"options": {"objects": "a", "api": "blah"}})
 
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             _make_task(
                 DeleteData,
                 {"options": {"objects": "a", "api": "rest", "hardDelete": True}},

--- a/cumulusci/tasks/bulkdata/tests/test_extract.py
+++ b/cumulusci/tasks/bulkdata/tests/test_extract.py
@@ -126,14 +126,14 @@ class TestExtractData:
 
             with create_engine(task.options["database_url"]).connect() as conn:
                 household = next(conn.execute("select * from households"))
-                assert "1" == household.sf_id
+                assert household.sf_id == "1"
                 assert not hasattr(household, "IsPersonAccount")
-                assert "HH_Account" == household.record_type
+                assert household.record_type == "HH_Account"
 
                 contact = next(conn.execute("select * from contacts"))
-                assert "2" == contact.sf_id
+                assert contact.sf_id == "2"
                 assert not hasattr(contact, "IsPersonAccount")
-                assert "1" == contact.household_id
+                assert contact.household_id == "1"
 
     @responses.activate
     @mock.patch("cumulusci.tasks.bulkdata.extract.get_query_operation")
@@ -181,14 +181,14 @@ class TestExtractData:
             with create_engine(task.options["database_url"]).connect() as conn:
 
                 household = next(conn.execute("select * from households"))
-                assert "1" == household.sf_id
-                assert "false" == household.IsPersonAccount
-                assert "HH_Account" == household.record_type
+                assert household.sf_id == "1"
+                assert household.IsPersonAccount == "false"
+                assert household.record_type == "HH_Account"
 
                 contact = next(conn.execute("select * from contacts"))
-                assert "2" == contact.sf_id
-                assert "true" == contact.IsPersonAccount
-                assert "1" == contact.household_id
+                assert contact.sf_id == "2"
+                assert contact.IsPersonAccount == "true"
+                assert contact.household_id == "1"
 
     @responses.activate
     @mock.patch("cumulusci.tasks.bulkdata.extract.get_query_operation")

--- a/cumulusci/tasks/bulkdata/tests/test_factory_utils.py
+++ b/cumulusci/tasks/bulkdata/tests/test_factory_utils.py
@@ -1,7 +1,7 @@
 import os
-import unittest
 
 import factory
+import pytest
 
 from cumulusci.tasks.bulkdata import factory_utils
 from cumulusci.tasks.bulkdata.tests.dummy_data_factory import (
@@ -12,7 +12,7 @@ from cumulusci.tasks.bulkdata.tests.utils import _make_task
 from cumulusci.utils import temporary_dir
 
 
-class TestFactoryUtils(unittest.TestCase):
+class TestFactoryUtils:
     def test_factory(self):
         mapping_file = os.path.join(os.path.dirname(__file__), "mapping_vanilla_sf.yml")
 
@@ -32,7 +32,7 @@ class TestFactoryUtils(unittest.TestCase):
             task()
 
 
-class TestAdder(unittest.TestCase):
+class TestAdder:
     def test_adder(self):
         a = factory_utils.Adder(10)
         b = a(20)
@@ -45,11 +45,11 @@ class TestAdder(unittest.TestCase):
         assert a(0) == 3
 
 
-class TestFactories(unittest.TestCase):
+class TestFactories:
     def test_factories(self):
         class Broken(factory.alchemy.SQLAlchemyModelFactory):
             class Meta:
                 model = "xyzzy"
 
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             factory_utils.Factories(None, {}, {"A": ContactFactory, "B": Broken})

--- a/cumulusci/tasks/bulkdata/tests/test_generate_and_load.py
+++ b/cumulusci/tasks/bulkdata/tests/test_generate_and_load.py
@@ -1,8 +1,9 @@
 import os.path
-import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import mock
+
+import pytest
 
 from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.tasks.bulkdata import GenerateAndLoadData
@@ -10,7 +11,7 @@ from cumulusci.tasks.bulkdata import GenerateAndLoadData
 from .utils import _make_task
 
 
-class TestGenerateAndLoadData(unittest.TestCase):
+class TestGenerateAndLoadData:
     @mock.patch("cumulusci.tasks.bulkdata.GenerateAndLoadData._dataload")
     def test_generate_and_load_data(self, _dataload):
         mapping_file = os.path.join(os.path.dirname(__file__), "mapping_vanilla_sf.yml")
@@ -69,7 +70,7 @@ class TestGenerateAndLoadData(unittest.TestCase):
             }
         }
 
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             _make_task(GenerateAndLoadData, options)
 
     @mock.patch("cumulusci.tasks.bulkdata.GenerateAndLoadData._dataload")
@@ -78,10 +79,10 @@ class TestGenerateAndLoadData(unittest.TestCase):
 
         options = {"options": {"num_records": 20, "mapping": mapping_file}}
 
-        with self.assertRaises(TaskOptionsError) as e:
+        with pytest.raises(TaskOptionsError) as e:
             _make_task(GenerateAndLoadData, options)
 
-        assert "No data generation task" in str(e.exception)
+        assert "No data generation task" in str(e.value)
 
     @mock.patch("cumulusci.tasks.bulkdata.GenerateAndLoadData._dataload")
     def test_batchsize_matches_numrecords(self, _dataload):
@@ -103,7 +104,7 @@ class TestGenerateAndLoadData(unittest.TestCase):
         _dataload.assert_called_once()
 
     def test_bad_mapping_file_path(self):
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             _make_task(
                 GenerateAndLoadData,
                 {
@@ -118,7 +119,7 @@ class TestGenerateAndLoadData(unittest.TestCase):
 
     @mock.patch("cumulusci.tasks.bulkdata.GenerateAndLoadData._dataload")
     def test_missing_mapping_file_when_needed(self, _dataload):
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             task = _make_task(
                 GenerateAndLoadData,
                 {
@@ -148,7 +149,7 @@ class TestGenerateAndLoadData(unittest.TestCase):
         assert calls[0][1][0]["generate_mapping_file"]
 
     def test_bad_options(self):
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             _make_task(
                 GenerateAndLoadData,
                 {
@@ -205,7 +206,7 @@ class TestGenerateAndLoadData(unittest.TestCase):
             "cumulusci.tasks.bulkdata.generate_and_load_data.GenerateAndLoadData._setup_engine",
             _setup_engine,
         ):
-            with self.assertRaises(TaskOptionsError):
+            with pytest.raises(TaskOptionsError):
                 task = _make_task(
                     GenerateAndLoadData,
                     {

--- a/cumulusci/tasks/bulkdata/tests/test_generate_from_snowfakery_task.py
+++ b/cumulusci/tasks/bulkdata/tests/test_generate_from_snowfakery_task.py
@@ -1,4 +1,3 @@
-import unittest
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -48,7 +47,7 @@ def run_task(task=GenerateDataFromYaml, **options):
         yield database_url
 
 
-class TestGenerateFromDataTask(unittest.TestCase):
+class TestGenerateFromDataTask:
     def assertRowsCreated(self, database_url):
         engine = create_engine(database_url)
         connection = engine.connect()
@@ -58,7 +57,7 @@ class TestGenerateFromDataTask(unittest.TestCase):
         return accounts
 
     def test_no_options(self):
-        with self.assertRaises(Exception):
+        with pytest.raises(Exception):
             _make_task(GenerateDataFromYaml, {})
 
     def test_simple(self):
@@ -78,7 +77,7 @@ class TestGenerateFromDataTask(unittest.TestCase):
             self.assertRowsCreated(database_url)
 
     def test_inaccessible_generator_yaml(self):
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             task = _make_task(
                 GenerateDataFromYaml,
                 {
@@ -93,7 +92,7 @@ class TestGenerateFromDataTask(unittest.TestCase):
 
     def test_vars(self):
         with temp_sqlite_database_url() as database_url:
-            with self.assertWarns(UserWarning):
+            with pytest.warns(UserWarning):
                 task = _make_task(
                     GenerateDataFromYaml,
                     {
@@ -238,13 +237,13 @@ class TestGenerateFromDataTask(unittest.TestCase):
             assert len(records) == 14 % 6  # leftovers
 
     def test_mismatched_options(self):
-        with self.assertRaises(TaskOptionsError) as e:
+        with pytest.raises(TaskOptionsError) as e:
             task = _make_task(
                 GenerateDataFromYaml,
                 {"options": {"generator_yaml": sample_yaml, "num_records": 10}},
             )
             task()
-        assert "without num_records_tablename" in str(e.exception)
+        assert "without num_records_tablename" in str(e.value)
 
     def generate_continuation_data(self, fileobj):
         g = data_generator_runtime.Globals()
@@ -279,7 +278,7 @@ class TestGenerateFromDataTask(unittest.TestCase):
                 assert dict(rows[0])["id"] == 6
 
     def test_with_nonexistent_continuation_file(self):
-        with self.assertRaises(TaskOptionsError) as e:
+        with pytest.raises(TaskOptionsError) as e:
             with temp_sqlite_database_url() as database_url:
                 task = _make_task(
                     GenerateDataFromYaml,
@@ -296,8 +295,8 @@ class TestGenerateFromDataTask(unittest.TestCase):
                 rows = self.assertRowsCreated(database_url)
                 assert dict(rows[0])["id"] == 6
 
-        assert "jazz" in str(e.exception)
-        assert "does not exist" in str(e.exception)
+        assert "jazz" in str(e.value)
+        assert "does not exist" in str(e.value)
 
     def test_generate_continuation_file(self):
         with temporary_file_path("cont.yml") as temp_continuation_file:

--- a/cumulusci/tasks/bulkdata/tests/test_generatemapping.py
+++ b/cumulusci/tasks/bulkdata/tests/test_generatemapping.py
@@ -1,4 +1,3 @@
-import unittest
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -48,28 +47,28 @@ def _Field(name: str, dct=None, **kwargs):
     return SQLField(name=name, **kwargs)
 
 
-class TestMappingGenerator(unittest.TestCase):
+class TestMappingGenerator:
     def test_defaults_options(self):
         t = _make_task(GenerateMapping, {"options": {"path": "t"}})
 
-        self.assertEqual([], t.options["ignore"])
-        self.assertEqual("", t.options["namespace_prefix"])
-        self.assertEqual("ask", t.options["break_cycles"])
-        self.assertEqual([], t.options["include"])
+        assert [] == t.options["ignore"]
+        assert "" == t.options["namespace_prefix"]
+        assert "ask" == t.options["break_cycles"]
+        assert [] == t.options["include"]
 
     def test_postfixes_underscores_to_namespace(self):
         t = _make_task(
             GenerateMapping, {"options": {"namespace_prefix": "t", "path": "t"}}
         )
 
-        self.assertEqual("t__", t.options["namespace_prefix"])
+        assert "t__" == t.options["namespace_prefix"]
 
     def test_splits_ignore_string(self):
         t = _make_task(
             GenerateMapping, {"options": {"ignore": "Account, Contact", "path": "t"}}
         )
 
-        self.assertEqual(["Account", "Contact"], t.options["ignore"])
+        assert ["Account", "Contact"] == t.options["ignore"]
 
     def test_accepts_ignore_list(self):
         t = _make_task(
@@ -77,14 +76,14 @@ class TestMappingGenerator(unittest.TestCase):
             {"options": {"ignore": ["Account", "Contact"], "path": "t"}},
         )
 
-        self.assertEqual(["Account", "Contact"], t.options["ignore"])
+        assert ["Account", "Contact"] == t.options["ignore"]
 
     def test_accepts_include_list(self):
         t = _make_task(
             GenerateMapping, {"options": {"include": ["Foo", "Bar"], "path": "t"}}
         )
 
-        self.assertEqual(["Foo", "Bar"], t.options["include"])
+        assert ["Foo", "Bar"] == t.options["include"]
 
     @responses.activate
     def test_checks_include_list(self):
@@ -102,45 +101,37 @@ class TestMappingGenerator(unittest.TestCase):
     def test_is_any_custom_api_name(self):
         t = _make_task(GenerateMapping, {"options": {"path": "t"}})
 
-        self.assertTrue(t._is_any_custom_api_name("Custom__c"))
-        self.assertFalse(t._is_any_custom_api_name("Standard"))
+        assert t._is_any_custom_api_name("Custom__c")
+        assert not t._is_any_custom_api_name("Standard")
 
     def test_is_our_custom_api_name(self):
         t = _make_task(GenerateMapping, {"options": {"path": "t"}})
 
-        self.assertTrue(t._is_our_custom_api_name("Custom__c"))
-        self.assertFalse(t._is_our_custom_api_name("Standard"))
-        self.assertFalse(t._is_our_custom_api_name("t__Custom__c"))
-        self.assertFalse(t._is_our_custom_api_name("f__Custom__c"))
+        assert t._is_our_custom_api_name("Custom__c")
+        assert not t._is_our_custom_api_name("Standard")
+        assert not t._is_our_custom_api_name("t__Custom__c")
+        assert not t._is_our_custom_api_name("f__Custom__c")
 
         t.options["namespace_prefix"] = "t__"
-        self.assertTrue(t._is_our_custom_api_name("Custom__c"))
-        self.assertTrue(t._is_our_custom_api_name("t__Custom__c"))
-        self.assertFalse(t._is_our_custom_api_name("f__Custom__c"))
+        assert t._is_our_custom_api_name("Custom__c")
+        assert t._is_our_custom_api_name("t__Custom__c")
+        assert not t._is_our_custom_api_name("f__Custom__c")
 
     def test_is_core_field(self):
         t = _make_task(GenerateMapping, {"options": {"path": "t"}})
 
-        self.assertTrue(t._is_core_field("Name"))
-        self.assertFalse(t._is_core_field("Custom__c"))
+        assert t._is_core_field("Name")
+        assert not t._is_core_field("Custom__c")
 
     def test_is_object_mappable(self):
         t = _make_task(GenerateMapping, {"options": {"ignore": "Account", "path": "t"}})
 
-        self.assertTrue(
-            t._is_object_mappable({"name": "Contact", "customSetting": False})
+        assert t._is_object_mappable({"name": "Contact", "customSetting": False})
+        assert not t._is_object_mappable({"name": "Account", "customSetting": False})
+        assert not t._is_object_mappable(
+            {"name": "Contact__ChangeEvent", "customSetting": False}
         )
-        self.assertFalse(
-            t._is_object_mappable({"name": "Account", "customSetting": False})
-        )
-        self.assertFalse(
-            t._is_object_mappable(
-                {"name": "Contact__ChangeEvent", "customSetting": False}
-            )
-        )
-        self.assertFalse(
-            t._is_object_mappable({"name": "Custom__c", "customSetting": True})
-        )
+        assert not t._is_object_mappable({"name": "Custom__c", "customSetting": True})
 
     def test_is_field_mappable(self):
         t = _make_task(
@@ -149,98 +140,76 @@ class TestMappingGenerator(unittest.TestCase):
 
         t.mapping_objects = ["Account", "Contact"]
 
-        self.assertTrue(
-            t._is_field_mappable(
-                "Account",
-                {"name": "Name", "type": "string", "label": "Name", "createable": True},
-            )
+        assert t._is_field_mappable(
+            "Account",
+            {"name": "Name", "type": "string", "label": "Name", "createable": True},
         )
-        self.assertFalse(
-            t._is_field_mappable(
-                "Account",
-                {"name": "Name", "type": "base64", "label": "Name", "createable": True},
-            )
+        assert not t._is_field_mappable(
+            "Account",
+            {"name": "Name", "type": "base64", "label": "Name", "createable": True},
         )
-        self.assertFalse(
-            t._is_field_mappable(
-                "Account",
-                {
-                    "name": "Name",
-                    "type": "string",
-                    "label": "Name (Deprecated)",
-                    "createable": True,
-                },
-            )
+        assert not t._is_field_mappable(
+            "Account",
+            {
+                "name": "Name",
+                "type": "string",
+                "label": "Name (Deprecated)",
+                "createable": True,
+            },
         )
-        self.assertFalse(
-            t._is_field_mappable(
-                "Account",
-                {
-                    "name": "ParentId",
-                    "type": "reference",
-                    "label": "Parent",
-                    "createable": True,
-                    "referenceTo": ["Account"],
-                },
-            )
+        assert not t._is_field_mappable(
+            "Account",
+            {
+                "name": "ParentId",
+                "type": "reference",
+                "label": "Parent",
+                "createable": True,
+                "referenceTo": ["Account"],
+            },
         )
-        self.assertFalse(
-            t._is_field_mappable(
-                "Account",
-                {
-                    "name": "Name",
-                    "type": "string",
-                    "label": "Name",
-                    "createable": False,
-                },
-            )
+        assert not t._is_field_mappable(
+            "Account",
+            {
+                "name": "Name",
+                "type": "string",
+                "label": "Name",
+                "createable": False,
+            },
         )
-        self.assertFalse(
-            t._is_field_mappable(
-                "Contact",
-                {
-                    "name": "OwnerId",
-                    "type": "reference",
-                    "label": "Owner",
-                    "createable": True,
-                    "referenceTo": ["User", "Group"],
-                },
-            )
+        assert not t._is_field_mappable(
+            "Contact",
+            {
+                "name": "OwnerId",
+                "type": "reference",
+                "label": "Owner",
+                "createable": True,
+                "referenceTo": ["User", "Group"],
+            },
         )
 
     def test_has_our_custom_fields(self):
         t = _make_task(GenerateMapping, {"options": {"path": "t"}})
         sobject = _SObject("Blah", [_Field(name="CustomObject__c")])
-        self.assertTrue(t._has_our_custom_fields(sobject))
-        self.assertTrue(
-            t._has_our_custom_fields(
-                _SObject("Blah", [_Field("Custom__c"), _Field("Standard")])
-            )
+        assert t._has_our_custom_fields(sobject)
+        assert t._has_our_custom_fields(
+            _SObject("Blah", [_Field("Custom__c"), _Field("Standard")])
         )
-        self.assertFalse(
-            t._has_our_custom_fields(_SObject("Blah", [_Field("Standard")]))
-        )
-        self.assertFalse(t._has_our_custom_fields(_SObject("Blah", [])))
+        assert not t._has_our_custom_fields(_SObject("Blah", [_Field("Standard")]))
+        assert not t._has_our_custom_fields(_SObject("Blah", []))
 
     def test_is_lookup_to_included_object(self):
         t = _make_task(GenerateMapping, {"options": {"path": "t"}})
 
         t.mapping_objects = ["Account"]
 
-        self.assertTrue(
-            t._is_lookup_to_included_object(
-                {"type": "reference", "referenceTo": ["Account"]}
-            )
+        assert t._is_lookup_to_included_object(
+            {"type": "reference", "referenceTo": ["Account"]}
         )
-        self.assertFalse(
-            t._is_lookup_to_included_object(
-                {"type": "reference", "referenceTo": ["Contact"]}
-            )
+        assert not t._is_lookup_to_included_object(
+            {"type": "reference", "referenceTo": ["Contact"]}
         )
-        self.assertFalse(
-            t._is_lookup_to_included_object(
-                {"type": "reference", "referenceTo": ["Account", "Contact"]}
-            )
+        assert not t._is_lookup_to_included_object(
+            {"type": "reference", "referenceTo": ["Account", "Contact"]}
         )
 
     @contextmanager
@@ -291,17 +260,18 @@ class TestMappingGenerator(unittest.TestCase):
             with open("mapping.yaml", "r") as fh:
                 content = yaml.safe_load(fh)
 
-            self.assertEqual(["Insert Parent", "Insert Child__c"], list(content.keys()))
-            self.assertEqual("Parent", t.mapping["Insert Parent"]["sf_object"])
-            self.assertEqual(["Custom__c"], t.mapping["Insert Parent"]["fields"])
+            assert ["Insert Parent", "Insert Child__c"] == list(content.keys())
+            assert "Parent" == t.mapping["Insert Parent"]["sf_object"]
+            assert ["Custom__c"] == t.mapping["Insert Parent"]["fields"]
 
-            self.assertEqual("Child__c", t.mapping["Insert Child__c"]["sf_object"])
+            assert "Child__c" == t.mapping["Insert Child__c"]["sf_object"]
             assert "fields" not in t.mapping["Insert Child__c"]
-            self.assertEqual(
-                ["Account__c"], list(t.mapping["Insert Child__c"]["lookups"].keys())
+            assert ["Account__c"] == list(
+                t.mapping["Insert Child__c"]["lookups"].keys()
             )
-            self.assertEqual(
-                "Parent", t.mapping["Insert Child__c"]["lookups"]["Account__c"]["table"]
+            assert (
+                "Parent"
+                == t.mapping["Insert Child__c"]["lookups"]["Account__c"]["table"]
             )
 
     @responses.activate
@@ -326,7 +296,7 @@ class TestMappingGenerator(unittest.TestCase):
             t._init_task()
             t._collect_objects(schema)
 
-        self.assertEqual(set(["Account", "Custom__c"]), set(t.mapping_objects))
+        assert set(["Account", "Custom__c"]) == set(t.mapping_objects)
 
     @responses.activate
     def test_collect_objects__force_include_objects(self):
@@ -352,8 +322,8 @@ class TestMappingGenerator(unittest.TestCase):
             t._init_task()
             t._collect_objects(schema)
 
-        self.assertEqual(
-            set(["Account", "Custom__c", "Contact", "User"]), set(t.mapping_objects)
+        assert set(["Account", "Custom__c", "Contact", "User"]) == set(
+            t.mapping_objects
         )
 
     @responses.activate
@@ -382,9 +352,7 @@ class TestMappingGenerator(unittest.TestCase):
             t._collect_objects(schema)
         assert len(t.mapping_objects) == 3
 
-        self.assertEqual(
-            set(["Account", "Custom__c", "Contact"]), set(t.mapping_objects)
-        )
+        assert set(["Account", "Custom__c", "Contact"]) == set(t.mapping_objects)
 
     @responses.activate
     def test_collect_objects__custom_lookup_fields(self):
@@ -416,9 +384,7 @@ class TestMappingGenerator(unittest.TestCase):
             t._init_task()
             t._collect_objects(schema)
 
-        self.assertEqual(
-            set(["Account", "Custom__c", "Contact"]), set(t.mapping_objects)
-        )
+        assert set(["Account", "Custom__c", "Contact"]) == set(t.mapping_objects)
 
     @responses.activate
     def test_collect_objects__master_detail_fields(self):
@@ -450,9 +416,8 @@ class TestMappingGenerator(unittest.TestCase):
             t._init_task()
             t._collect_objects(schema)
 
-        self.assertEqual(
-            set(["Account", "OpportunityLineItem", "Opportunity"]),
-            set(t.mapping_objects),
+        assert set(["Account", "OpportunityLineItem", "Opportunity"]) == set(
+            t.mapping_objects
         )
 
     @responses.activate
@@ -491,9 +456,8 @@ class TestMappingGenerator(unittest.TestCase):
             t._init_task()
             t._collect_objects(schema)
 
-        self.assertEqual(
-            set(["Account", "OpportunityLineItem", "Opportunity"]),
-            set(t.mapping_objects),
+        assert set(["Account", "OpportunityLineItem", "Opportunity"]) == set(
+            t.mapping_objects
         )
 
     def test_simplify_schema(self):
@@ -579,8 +543,8 @@ class TestMappingGenerator(unittest.TestCase):
         ]
         with _temp_schema_for_tests(describe_data) as org_schema:
             t._simplify_schema(org_schema)
-        self.assertIn("RecordTypeId", t.simple_schema["Opportunity"])
-        self.assertNotIn("RecordTypeId", t.simple_schema["Account"])
+        assert "RecordTypeId" in t.simple_schema["Opportunity"]
+        assert "RecordTypeId" not in t.simple_schema["Account"]
 
     @mock.patch("click.prompt")
     def test_build_mapping(self, prompt):
@@ -614,28 +578,24 @@ class TestMappingGenerator(unittest.TestCase):
         }
 
         t._build_mapping()
-        self.assertEqual(["Insert Account", "Insert Child__c"], list(t.mapping.keys()))
-        self.assertEqual("Account", t.mapping["Insert Account"]["sf_object"])
-        self.assertEqual(["Name"], t.mapping["Insert Account"]["fields"])
-        self.assertEqual(
-            ["Dependent__c"], list(t.mapping["Insert Account"]["lookups"].keys())
-        )
-        self.assertEqual(
-            "Child__c", t.mapping["Insert Account"]["lookups"]["Dependent__c"]["table"]
+        assert ["Insert Account", "Insert Child__c"] == list(t.mapping.keys())
+        assert "Account" == t.mapping["Insert Account"]["sf_object"]
+        assert ["Name"] == t.mapping["Insert Account"]["fields"]
+        assert ["Dependent__c"] == list(t.mapping["Insert Account"]["lookups"].keys())
+        assert (
+            "Child__c"
+            == t.mapping["Insert Account"]["lookups"]["Dependent__c"]["table"]
         )
 
-        self.assertEqual("Child__c", t.mapping["Insert Child__c"]["sf_object"])
-        self.assertEqual(["Name"], t.mapping["Insert Child__c"]["fields"])
-        self.assertEqual(
-            ["Account__c", "Self__c"],
-            list(t.mapping["Insert Child__c"]["lookups"].keys()),
+        assert "Child__c" == t.mapping["Insert Child__c"]["sf_object"]
+        assert ["Name"] == t.mapping["Insert Child__c"]["fields"]
+        assert ["Account__c", "Self__c"] == list(
+            t.mapping["Insert Child__c"]["lookups"].keys()
         )
-        self.assertEqual(
-            "Account", t.mapping["Insert Child__c"]["lookups"]["Account__c"]["table"]
+        assert (
+            "Account" == t.mapping["Insert Child__c"]["lookups"]["Account__c"]["table"]
         )
-        self.assertEqual(
-            "Child__c", t.mapping["Insert Child__c"]["lookups"]["Self__c"]["table"]
-        )
+        assert "Child__c" == t.mapping["Insert Child__c"]["lookups"]["Self__c"]["table"]
 
     @mock.patch("click.prompt")
     def test_build_mapping__strip_namespace(self, prompt):
@@ -678,31 +638,24 @@ class TestMappingGenerator(unittest.TestCase):
         }
 
         t._build_mapping()
-        self.assertEqual(
-            ["Insert Parent__c", "Insert Child__c"], list(t.mapping.keys())
-        )
-        self.assertEqual("Parent__c", t.mapping["Insert Parent__c"]["sf_object"])
-        self.assertEqual(["Name"], t.mapping["Insert Parent__c"]["fields"])
-        self.assertEqual(
-            ["Dependent__c"], list(t.mapping["Insert Parent__c"]["lookups"].keys())
-        )
-        self.assertEqual(
-            "Child__c",
-            t.mapping["Insert Parent__c"]["lookups"]["Dependent__c"]["table"],
+        assert ["Insert Parent__c", "Insert Child__c"] == list(t.mapping.keys())
+        assert "Parent__c" == t.mapping["Insert Parent__c"]["sf_object"]
+        assert ["Name"] == t.mapping["Insert Parent__c"]["fields"]
+        assert ["Dependent__c"] == list(t.mapping["Insert Parent__c"]["lookups"].keys())
+        assert (
+            "Child__c"
+            == t.mapping["Insert Parent__c"]["lookups"]["Dependent__c"]["table"]
         )
 
-        self.assertEqual("Child__c", t.mapping["Insert Child__c"]["sf_object"])
-        self.assertEqual(["Name"], t.mapping["Insert Child__c"]["fields"])
-        self.assertEqual(
-            ["Parent__c", "Self__c"],
-            list(t.mapping["Insert Child__c"]["lookups"].keys()),
+        assert "Child__c" == t.mapping["Insert Child__c"]["sf_object"]
+        assert ["Name"] == t.mapping["Insert Child__c"]["fields"]
+        assert ["Parent__c", "Self__c"] == list(
+            t.mapping["Insert Child__c"]["lookups"].keys()
         )
-        self.assertEqual(
-            "Parent__c", t.mapping["Insert Child__c"]["lookups"]["Parent__c"]["table"]
+        assert (
+            "Parent__c" == t.mapping["Insert Child__c"]["lookups"]["Parent__c"]["table"]
         )
-        self.assertEqual(
-            "Child__c", t.mapping["Insert Child__c"]["lookups"]["Self__c"]["table"]
-        )
+        assert "Child__c" == t.mapping["Insert Child__c"]["lookups"]["Self__c"]["table"]
 
     @mock.patch("click.prompt")
     def test_build_mapping__no_strip_namespace_if_dup_component(self, prompt):
@@ -735,31 +688,28 @@ class TestMappingGenerator(unittest.TestCase):
 
         t._build_mapping()
 
-        self.assertEqual(
-            set(["Insert Parent__c", "Insert ns__Child__c", "Insert Child__c"]),
-            set(t.mapping.keys()),
+        assert set(
+            ["Insert Parent__c", "Insert ns__Child__c", "Insert Child__c"]
+        ) == set(t.mapping.keys())
+
+        assert "ns__Child__c" == t.mapping["Insert ns__Child__c"]["sf_object"]
+        assert ["Name", "Test__c", "ns__Test__c"] == t.mapping["Insert ns__Child__c"][
+            "fields"
+        ]
+        assert set(["ns__Parent__c", "Parent__c"]) == set(
+            t.mapping["Insert ns__Child__c"]["lookups"].keys()
+        )
+        assert (
+            "Parent__c"
+            == t.mapping["Insert ns__Child__c"]["lookups"]["ns__Parent__c"]["table"]
+        )
+        assert (
+            "ns__Child__c"
+            == t.mapping["Insert ns__Child__c"]["lookups"]["Parent__c"]["table"]
         )
 
-        self.assertEqual("ns__Child__c", t.mapping["Insert ns__Child__c"]["sf_object"])
-        self.assertEqual(
-            ["Name", "Test__c", "ns__Test__c"],
-            t.mapping["Insert ns__Child__c"]["fields"],
-        )
-        self.assertEqual(
-            set(["ns__Parent__c", "Parent__c"]),
-            set(t.mapping["Insert ns__Child__c"]["lookups"].keys()),
-        )
-        self.assertEqual(
-            "Parent__c",
-            t.mapping["Insert ns__Child__c"]["lookups"]["ns__Parent__c"]["table"],
-        )
-        self.assertEqual(
-            "ns__Child__c",
-            t.mapping["Insert ns__Child__c"]["lookups"]["Parent__c"]["table"],
-        )
-
-        self.assertEqual("Child__c", t.mapping["Insert Child__c"]["sf_object"])
-        self.assertEqual(["Name"], t.mapping["Insert Child__c"]["fields"])
+        assert "Child__c" == t.mapping["Insert Child__c"]["sf_object"]
+        assert ["Name"] == t.mapping["Insert Child__c"]["fields"]
 
     def test_build_mapping__warns_polymorphic_lookups(self):
         t = _make_task(GenerateMapping, {"options": {"path": "t"}})
@@ -809,7 +759,7 @@ class TestMappingGenerator(unittest.TestCase):
             },
         )
 
-        self.assertEqual(["Account", "Contact", "Opportunity", "Custom__c"], stack)
+        assert ["Account", "Contact", "Opportunity", "Custom__c"] == stack
 
     @mock.patch("click.prompt")
     def test_split_dependencies__interviews_for_cycles(self, prompt):
@@ -817,35 +767,33 @@ class TestMappingGenerator(unittest.TestCase):
 
         prompt.return_value = "Account"
 
-        self.assertEqual(
-            ["Custom__c", "Account", "Contact", "Opportunity"],
-            t._split_dependencies(
-                ["Account", "Contact", "Opportunity", "Custom__c"],
-                {
-                    "Account": {
-                        "Contact": {
-                            "Primary_Contact__c": _Field(
-                                "Primary_Contact__c", {"nillable": True}
-                            )
-                        }
-                    },
+        assert [
+            "Custom__c",
+            "Account",
+            "Contact",
+            "Opportunity",
+        ] == t._split_dependencies(
+            ["Account", "Contact", "Opportunity", "Custom__c"],
+            {
+                "Account": {
                     "Contact": {
-                        "Account": {
-                            "AccountId": _Field("AccountId", {"nillable": True})
-                        }
-                    },
-                    "Opportunity": {
-                        "Account": {
-                            "AccountId": _Field("AccountId", {"nillable": True})
-                        },
-                        "Contact": {
-                            "Primary_Contact__c": _Field(
-                                "Primary_Contact__c", {"nillable": True}
-                            )
-                        },
+                        "Primary_Contact__c": _Field(
+                            "Primary_Contact__c", {"nillable": True}
+                        )
+                    }
+                },
+                "Contact": {
+                    "Account": {"AccountId": _Field("AccountId", {"nillable": True})}
+                },
+                "Opportunity": {
+                    "Account": {"AccountId": _Field("AccountId", {"nillable": True})},
+                    "Contact": {
+                        "Primary_Contact__c": _Field(
+                            "Primary_Contact__c", {"nillable": True}
+                        )
                     },
                 },
-            ),
+            },
         )
 
     @mock.patch("click.prompt")
@@ -883,9 +831,7 @@ class TestMappingGenerator(unittest.TestCase):
             },
         )
 
-        self.assertEqual(
-            ["Custom__c", "Account", "Contact", "Opportunity"], split_dependencies
-        )
+        assert ["Custom__c", "Account", "Contact", "Opportunity"] == split_dependencies
         assert not choice.mock_calls
 
     @mock.patch("click.prompt")
@@ -911,9 +857,7 @@ class TestMappingGenerator(unittest.TestCase):
             },
         )
 
-        self.assertEqual(
-            ["Contact", "Opportunity", "Account", "Custom__c"], split_dependencies
-        )
+        assert ["Contact", "Opportunity", "Account", "Custom__c"] == split_dependencies
 
     @mock.patch("click.prompt")
     @mock.patch("random.choice")
@@ -955,10 +899,12 @@ class TestMappingGenerator(unittest.TestCase):
             },
         )
 
-        self.assertEqual(
-            ["Custom__c", "ContactLike__c", "AccountLike__c", "OpportunityLike__c"],
-            split_dependencies,
-        )
+        assert [
+            "Custom__c",
+            "ContactLike__c",
+            "AccountLike__c",
+            "OpportunityLike__c",
+        ] == split_dependencies
         random_choice.assert_not_called()
 
     @mock.patch("click.prompt")
@@ -969,37 +915,34 @@ class TestMappingGenerator(unittest.TestCase):
 
         prompt.return_value = AssertionError("Shouldn't be called")
 
-        self.assertEqual(
-            set(["Custom__c", "Account", "Contact", "Opportunity"]),
-            set(
-                t._split_dependencies(
-                    ["Account", "Contact", "Opportunity", "Custom__c"],
-                    {
+        assert set(["Custom__c", "Account", "Contact", "Opportunity"]) == set(
+            t._split_dependencies(
+                ["Account", "Contact", "Opportunity", "Custom__c"],
+                {
+                    "Account": {
+                        "Contact": {
+                            "Primary_Contact__c": _Field(
+                                "Primary_Contact__c", {"nillable": True}
+                            )
+                        }
+                    },
+                    "Contact": {
                         "Account": {
-                            "Contact": {
-                                "Primary_Contact__c": _Field(
-                                    "Primary_Contact__c", {"nillable": True}
-                                )
-                            }
+                            "AccountId": _Field("AccountId", {"nillable": True})
+                        }
+                    },
+                    "Opportunity": {
+                        "Account": {
+                            "AccountId": _Field("AccountId", {"nillable": True})
                         },
                         "Contact": {
-                            "Account": {
-                                "AccountId": _Field("AccountId", {"nillable": True})
-                            }
-                        },
-                        "Opportunity": {
-                            "Account": {
-                                "AccountId": _Field("AccountId", {"nillable": True})
-                            },
-                            "Contact": {
-                                "Primary_Contact__c": _Field(
-                                    "Primary_Contact__c", {"nillable": True}
-                                )
-                            },
+                            "Primary_Contact__c": _Field(
+                                "Primary_Contact__c", {"nillable": True}
+                            )
                         },
                     },
-                )
-            ),
+                },
+            )
         )
 
     @mock.patch("click.prompt")
@@ -1009,25 +952,22 @@ class TestMappingGenerator(unittest.TestCase):
         )
         prompt.return_value = "Custom__c"
 
-        self.assertEqual(
-            set(["Custom__c", "Account", "Contact", "Opportunity"]),
-            set(
-                t._split_dependencies(
-                    ["Account", "Contact", "Opportunity", "Custom__c"],
-                    {
-                        "Account": {
-                            "Custom__c": {
-                                "Custom__c": _Field("Custom__c", {"nillable": False})
-                            }
-                        },
+        assert set(["Custom__c", "Account", "Contact", "Opportunity"]) == set(
+            t._split_dependencies(
+                ["Account", "Contact", "Opportunity", "Custom__c"],
+                {
+                    "Account": {
                         "Custom__c": {
-                            "Account": {
-                                "Account__c": _Field("Account__c", {"nillable": False})
-                            }
-                        },
+                            "Custom__c": _Field("Custom__c", {"nillable": False})
+                        }
                     },
-                )
-            ),
+                    "Custom__c": {
+                        "Account": {
+                            "Account__c": _Field("Account__c", {"nillable": False})
+                        }
+                    },
+                },
+            )
         )
 
         prompt.assert_called_once()

--- a/cumulusci/tasks/bulkdata/tests/test_generatemapping.py
+++ b/cumulusci/tasks/bulkdata/tests/test_generatemapping.py
@@ -52,8 +52,8 @@ class TestMappingGenerator:
         t = _make_task(GenerateMapping, {"options": {"path": "t"}})
 
         assert [] == t.options["ignore"]
-        assert "" == t.options["namespace_prefix"]
-        assert "ask" == t.options["break_cycles"]
+        assert t.options["namespace_prefix"] == ""
+        assert t.options["break_cycles"] == "ask"
         assert [] == t.options["include"]
 
     def test_postfixes_underscores_to_namespace(self):
@@ -61,7 +61,7 @@ class TestMappingGenerator:
             GenerateMapping, {"options": {"namespace_prefix": "t", "path": "t"}}
         )
 
-        assert "t__" == t.options["namespace_prefix"]
+        assert t.options["namespace_prefix"] == "t__"
 
     def test_splits_ignore_string(self):
         t = _make_task(
@@ -261,10 +261,10 @@ class TestMappingGenerator:
                 content = yaml.safe_load(fh)
 
             assert ["Insert Parent", "Insert Child__c"] == list(content.keys())
-            assert "Parent" == t.mapping["Insert Parent"]["sf_object"]
+            assert t.mapping["Insert Parent"]["sf_object"] == "Parent"
             assert ["Custom__c"] == t.mapping["Insert Parent"]["fields"]
 
-            assert "Child__c" == t.mapping["Insert Child__c"]["sf_object"]
+            assert t.mapping["Insert Child__c"]["sf_object"] == "Child__c"
             assert "fields" not in t.mapping["Insert Child__c"]
             assert ["Account__c"] == list(
                 t.mapping["Insert Child__c"]["lookups"].keys()
@@ -579,7 +579,7 @@ class TestMappingGenerator:
 
         t._build_mapping()
         assert ["Insert Account", "Insert Child__c"] == list(t.mapping.keys())
-        assert "Account" == t.mapping["Insert Account"]["sf_object"]
+        assert t.mapping["Insert Account"]["sf_object"] == "Account"
         assert ["Name"] == t.mapping["Insert Account"]["fields"]
         assert ["Dependent__c"] == list(t.mapping["Insert Account"]["lookups"].keys())
         assert (
@@ -587,7 +587,7 @@ class TestMappingGenerator:
             == t.mapping["Insert Account"]["lookups"]["Dependent__c"]["table"]
         )
 
-        assert "Child__c" == t.mapping["Insert Child__c"]["sf_object"]
+        assert t.mapping["Insert Child__c"]["sf_object"] == "Child__c"
         assert ["Name"] == t.mapping["Insert Child__c"]["fields"]
         assert ["Account__c", "Self__c"] == list(
             t.mapping["Insert Child__c"]["lookups"].keys()
@@ -595,7 +595,7 @@ class TestMappingGenerator:
         assert (
             "Account" == t.mapping["Insert Child__c"]["lookups"]["Account__c"]["table"]
         )
-        assert "Child__c" == t.mapping["Insert Child__c"]["lookups"]["Self__c"]["table"]
+        assert t.mapping["Insert Child__c"]["lookups"]["Self__c"]["table"] == "Child__c"
 
     @mock.patch("click.prompt")
     def test_build_mapping__strip_namespace(self, prompt):
@@ -639,7 +639,7 @@ class TestMappingGenerator:
 
         t._build_mapping()
         assert ["Insert Parent__c", "Insert Child__c"] == list(t.mapping.keys())
-        assert "Parent__c" == t.mapping["Insert Parent__c"]["sf_object"]
+        assert t.mapping["Insert Parent__c"]["sf_object"] == "Parent__c"
         assert ["Name"] == t.mapping["Insert Parent__c"]["fields"]
         assert ["Dependent__c"] == list(t.mapping["Insert Parent__c"]["lookups"].keys())
         assert (
@@ -647,7 +647,7 @@ class TestMappingGenerator:
             == t.mapping["Insert Parent__c"]["lookups"]["Dependent__c"]["table"]
         )
 
-        assert "Child__c" == t.mapping["Insert Child__c"]["sf_object"]
+        assert t.mapping["Insert Child__c"]["sf_object"] == "Child__c"
         assert ["Name"] == t.mapping["Insert Child__c"]["fields"]
         assert ["Parent__c", "Self__c"] == list(
             t.mapping["Insert Child__c"]["lookups"].keys()
@@ -655,7 +655,7 @@ class TestMappingGenerator:
         assert (
             "Parent__c" == t.mapping["Insert Child__c"]["lookups"]["Parent__c"]["table"]
         )
-        assert "Child__c" == t.mapping["Insert Child__c"]["lookups"]["Self__c"]["table"]
+        assert t.mapping["Insert Child__c"]["lookups"]["Self__c"]["table"] == "Child__c"
 
     @mock.patch("click.prompt")
     def test_build_mapping__no_strip_namespace_if_dup_component(self, prompt):
@@ -692,7 +692,7 @@ class TestMappingGenerator:
             ["Insert Parent__c", "Insert ns__Child__c", "Insert Child__c"]
         ) == set(t.mapping.keys())
 
-        assert "ns__Child__c" == t.mapping["Insert ns__Child__c"]["sf_object"]
+        assert t.mapping["Insert ns__Child__c"]["sf_object"] == "ns__Child__c"
         assert ["Name", "Test__c", "ns__Test__c"] == t.mapping["Insert ns__Child__c"][
             "fields"
         ]
@@ -708,7 +708,7 @@ class TestMappingGenerator:
             == t.mapping["Insert ns__Child__c"]["lookups"]["Parent__c"]["table"]
         )
 
-        assert "Child__c" == t.mapping["Insert Child__c"]["sf_object"]
+        assert t.mapping["Insert Child__c"]["sf_object"] == "Child__c"
         assert ["Name"] == t.mapping["Insert Child__c"]["fields"]
 
     def test_build_mapping__warns_polymorphic_lookups(self):

--- a/cumulusci/tasks/bulkdata/tests/test_snowfakery.py
+++ b/cumulusci/tasks/bulkdata/tests/test_snowfakery.py
@@ -1023,7 +1023,7 @@ class TestSnowfakery:
     #             {"options": {"generator_yaml": sample_yaml, "num_records": 10}},
     #         )
     #         task()
-    #     assert "without num_records_tablename" in str(e.exception)
+    #     assert "without num_records_tablename" in str(e.value)
 
     # def generate_continuation_data(self, fileobj):
     #     g = data_generator_runtime.Globals()
@@ -1075,8 +1075,8 @@ class TestSnowfakery:
     #             rows = self.assertRowsCreated(database_url)
     #             assert dict(rows[0])["id"] == 6
 
-    #     assert "jazz" in str(e.exception)
-    #     assert "does not exist" in str(e.exception)
+    #     assert "jazz" in str(e.value)
+    #     assert "does not exist" in str(e.value)
 
     # def test_generate_continuation_file(self):
     #     with temporary_file_path("cont.yml") as temp_continuation_file:

--- a/cumulusci/tasks/bulkdata/tests/test_step.py
+++ b/cumulusci/tasks/bulkdata/tests/test_step.py
@@ -1,6 +1,5 @@
 import io
 import json
-import unittest
 from unittest import mock
 
 import pytest
@@ -38,7 +37,7 @@ BULK_BATCH_RESPONSE = """<root xmlns="http://ns">
 </root>"""
 
 
-class TestDownloadFile(unittest.TestCase):
+class TestDownloadFile:
     @responses.activate
     def test_download_file(self):
         url = "https://example.com"
@@ -51,7 +50,7 @@ class TestDownloadFile(unittest.TestCase):
             assert f.read() == "TEST\u2014"
 
 
-class TestBulkDataJobTaskMixin(unittest.TestCase):
+class TestBulkDataJobTaskMixin:
     @responses.activate
     def test_job_state_from_batches(self):
         mixin = BulkJobMixin()
@@ -237,7 +236,7 @@ class TestBulkDataJobTaskMixin(unittest.TestCase):
         mixin.logger.error.assert_any_call("Batch failure message: Test2")
 
 
-class TestBulkApiQueryOperation(unittest.TestCase):
+class TestBulkApiQueryOperation:
     def test_query(self):
         context = mock.Mock()
         query = BulkApiQueryOperation(
@@ -375,7 +374,7 @@ class TestBulkApiQueryOperation(unittest.TestCase):
         assert list(results) == []
 
 
-class TestBulkApiDmlOperation(unittest.TestCase):
+class TestBulkApiDmlOperation:
     def test_start(self):
         context = mock.Mock()
         context.bulk.create_job.return_value = "JOB"
@@ -614,7 +613,7 @@ class TestBulkApiDmlOperation(unittest.TestCase):
         step.job_id = "JOB"
         step.batch_ids = ["BATCH1", "BATCH2"]
 
-        with self.assertRaises(BulkDataException):
+        with pytest.raises(BulkDataException):
             list(step.get_results())
 
     @mock.patch("cumulusci.tasks.bulkdata.step.download_file")

--- a/cumulusci/tasks/bulkdata/tests/test_updates.py
+++ b/cumulusci/tasks/bulkdata/tests/test_updates.py
@@ -506,6 +506,6 @@ class TestUpdatesIntegrationTests:
             task.logger = mock.Mock()
             task()
             last_message = task.logger.mock_calls[-1].args[0]
-            assert "All account objects successfully updated (6)." == str(
-                last_message
+            assert (
+                str(last_message) == "All account objects successfully updated (6)."
             ), str(last_message)

--- a/cumulusci/tasks/bulkdata/tests/test_utils.py
+++ b/cumulusci/tasks/bulkdata/tests/test_utils.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 from unittest import mock
 
 import responses
@@ -30,7 +29,7 @@ def create_db_memory():
     return engine, metadata
 
 
-class TestSqlAlchemyMixin(unittest.TestCase):
+class TestSqlAlchemyMixin:
     @mock.patch("cumulusci.tasks.bulkdata.utils.Table")
     @mock.patch("cumulusci.tasks.bulkdata.utils.mapper")
     def test_create_record_type_table(self, mapper, table):
@@ -40,7 +39,7 @@ class TestSqlAlchemyMixin(unittest.TestCase):
 
         util._create_record_type_table("Account_rt_mapping")
 
-        self.assertIn("Account_rt_mapping", util.models)
+        assert "Account_rt_mapping" in util.models
 
     @responses.activate
     def test_extract_record_types(self):
@@ -93,7 +92,7 @@ class TestSqlAlchemyMixin(unittest.TestCase):
         assert session.query(model).count() == 10
 
 
-class TestCreateTable(unittest.TestCase):
+class TestCreateTable:
     def test_create_table_legacy_oid_mapping(self):
         mapping_file = os.path.join(os.path.dirname(__file__), "mapping_v1.yml")
 
@@ -128,7 +127,7 @@ class TestCreateTable(unittest.TestCase):
             assert isinstance(t.columns["email"].type, Unicode)
 
 
-class TestBatching(unittest.TestCase):
+class TestBatching:
     def test_batching_no_remainder(self):
         batches = list(generate_batches(num_records=20, batch_size=10))
         assert batches == [(10, 0, 2), (10, 1, 2)], batches

--- a/cumulusci/tasks/github/tests/test_merge.py
+++ b/cumulusci/tasks/github/tests/test_merge.py
@@ -1,7 +1,7 @@
 import http.client
-import unittest
 
 import github3
+import pytest
 import responses
 from testfixtures import LogCapture
 
@@ -12,8 +12,8 @@ from cumulusci.tasks.release_notes.tests.utils import MockUtil
 from cumulusci.tests.util import DummyOrgConfig, create_project_config
 
 
-class TestMergeBranch(unittest.TestCase, MockUtil):
-    def setUp(self):
+class TestMergeBranch(MockUtil):
+    def setup_method(self):
 
         # Set up the mock values
         self.repo = "TestRepo"
@@ -151,7 +151,7 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
         self._mock_branch_does_not_exist(self.branch)
 
         task = self._create_task()
-        with self.assertRaises(GithubApiNotFoundError):
+        with pytest.raises(GithubApiNotFoundError):
             task()
         assert 2 == len(responses.calls)
 
@@ -242,7 +242,7 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
         )
         self._mock_merge(http.client.INTERNAL_SERVER_ERROR)
         task = self._create_task()
-        with self.assertRaises(github3.GitHubError):
+        with pytest.raises(github3.GitHubError):
             task()
 
     @responses.activate
@@ -480,8 +480,8 @@ class TestMergeBranch(unittest.TestCase, MockUtil):
                 ),
             ]
             actual_log = self._get_log_lines(log)
-            self.assertEqual(expected_log, actual_log)
-        self.assertEqual(9, len(responses.calls))
+            assert expected_log == actual_log
+        assert 9 == len(responses.calls)
 
     @responses.activate
     def test_branches_to_merge__main_to_feature_and_next_release(self):

--- a/cumulusci/tasks/github/tests/test_merge.py
+++ b/cumulusci/tasks/github/tests/test_merge.py
@@ -8,11 +8,11 @@ from testfixtures import LogCapture
 from cumulusci.core.config import ServiceConfig, TaskConfig
 from cumulusci.core.exceptions import GithubApiNotFoundError
 from cumulusci.tasks.github import MergeBranch
-from cumulusci.tasks.release_notes.tests.utils import MockUtil
+from cumulusci.tasks.release_notes.tests.utils import MockUtilBase
 from cumulusci.tests.util import DummyOrgConfig, create_project_config
 
 
-class TestMergeBranch(MockUtil):
+class TestMergeBranch(MockUtilBase):
     def setup_method(self):
 
         # Set up the mock values

--- a/cumulusci/tasks/github/tests/test_publish.py
+++ b/cumulusci/tasks/github/tests/test_publish.py
@@ -1,6 +1,5 @@
 import json
 import tempfile
-import unittest
 from pathlib import Path
 from unittest import mock
 
@@ -18,8 +17,8 @@ from cumulusci.tasks.github.tests.util_github_api import GithubApiTestMixin
 from cumulusci.tests.util import create_project_config
 
 
-class TestPublishSubtree(unittest.TestCase, GithubApiTestMixin):
-    def setUp(self):
+class TestPublishSubtree(GithubApiTestMixin):
+    def setup_method(self):
         self.repo_owner = "TestOwner"
         self.repo_name = "TestRepo"
         self.repo_api_url = (

--- a/cumulusci/tasks/github/tests/test_publish.py
+++ b/cumulusci/tasks/github/tests/test_publish.py
@@ -473,7 +473,7 @@ class TestPublishSubtree(GithubApiTestMixin):
         task = PublishSubtree(self.project_config, task_config)
         with pytest.raises(GithubException) as exc:
             task()
-        assert "Release for release/1.0 not found" == str(exc.value)
+        assert str(exc.value) == "Release for release/1.0 not found"
 
     @responses.activate
     @mock.patch("cumulusci.tasks.github.publish.download_extract_github_from_repo")
@@ -543,7 +543,7 @@ class TestPublishSubtree(GithubApiTestMixin):
         task = PublishSubtree(self.project_config, task_config)
         with pytest.raises(GithubException) as exc:
             task()
-        assert "Ref for tag release/1.0 already exists in target repo" == str(exc.value)
+        assert str(exc.value) == "Ref for tag release/1.0 already exists in target repo"
 
     def test_ref_nor_tag_name_error(self):
         task_config = TaskConfig(
@@ -557,7 +557,7 @@ class TestPublishSubtree(GithubApiTestMixin):
         )
         with pytest.raises(TaskOptionsError) as exc:
             PublishSubtree(self.project_config, task_config)
-        assert "Either `ref` or `tag_name` option is required." == str(exc.value)
+        assert str(exc.value) == "Either `ref` or `tag_name` option is required."
 
     def test_renames_not_list_error(self):
         task_config = TaskConfig(
@@ -722,7 +722,7 @@ class TestPublishSubtree(GithubApiTestMixin):
             task()
 
             extract_github.assert_called_once()
-            assert "feature/publish" == extract_github.call_args[1]["ref"]
+            assert extract_github.call_args[1]["ref"] == "feature/publish"
             commit_dir.assert_called_once()
             expected_commit_message = "Published content from ref feature/publish"
             assert commit_dir.call_args[1]["commit_message"] == expected_commit_message

--- a/cumulusci/tasks/github/tests/test_pull_request.py
+++ b/cumulusci/tasks/github/tests/test_pull_request.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest import mock
 
 from cumulusci.core.config import ServiceConfig, TaskConfig
@@ -6,7 +5,7 @@ from cumulusci.tasks.github import PullRequests
 from cumulusci.tests.util import create_project_config
 
 
-class TestPullRequests(unittest.TestCase):
+class TestPullRequests:
     def test_run_task(self):
         project_config = create_project_config()
         project_config.keychain.set_service(

--- a/cumulusci/tasks/github/tests/test_release_report.py
+++ b/cumulusci/tasks/github/tests/test_release_report.py
@@ -1,4 +1,3 @@
-import unittest
 from datetime import datetime
 
 import pytz
@@ -10,8 +9,8 @@ from cumulusci.tasks.github.tests.util_github_api import GithubApiTestMixin
 from cumulusci.tests.util import create_project_config
 
 
-class TestReleaseReport(unittest.TestCase, GithubApiTestMixin):
-    def setUp(self):
+class TestReleaseReport(GithubApiTestMixin):
+    def setup_method(self):
         self.repo_owner = "TestOwner"
         self.repo_name = "TestRepo"
         self.repo_api_url = "https://api.github.com/repos/{}/{}".format(
@@ -81,21 +80,16 @@ Production orgs: 2018-09-01""",
             ),
         )
         task()
-        self.assertEqual(
-            [
-                {
-                    "beta": False,
-                    "name": "1.0",
-                    "tag": "rel/2.0",
-                    "time_created": datetime(2018, 1, 1, 0, 0, tzinfo=pytz.UTC),
-                    "time_push_production": datetime(
-                        2018, 9, 1, 0, 0, 0, 5, tzinfo=pytz.UTC
-                    ),
-                    "time_push_sandbox": datetime(
-                        2018, 8, 1, 0, 0, 0, 2, tzinfo=pytz.UTC
-                    ),
-                    "url": "",
-                }
-            ],
-            task.return_values["releases"],
-        )
+        assert [
+            {
+                "beta": False,
+                "name": "1.0",
+                "tag": "rel/2.0",
+                "time_created": datetime(2018, 1, 1, 0, 0, tzinfo=pytz.UTC),
+                "time_push_production": datetime(
+                    2018, 9, 1, 0, 0, 0, 5, tzinfo=pytz.UTC
+                ),
+                "time_push_sandbox": datetime(2018, 8, 1, 0, 0, 0, 2, tzinfo=pytz.UTC),
+                "url": "",
+            }
+        ] == task.return_values["releases"]

--- a/cumulusci/tasks/github/tests/test_tag.py
+++ b/cumulusci/tasks/github/tests/test_tag.py
@@ -63,7 +63,7 @@ class TestCloneTag(GithubApiTestMixin):
         )
         task = CloneTag(self.project_config, task_config)
         task()
-        assert "release/1.0" == task.result.tag
+        assert task.result.tag == "release/1.0"
 
     @responses.activate
     def test_run_task__tag_not_found(self):

--- a/cumulusci/tasks/github/tests/test_tag.py
+++ b/cumulusci/tasks/github/tests/test_tag.py
@@ -1,5 +1,4 @@
-import unittest
-
+import pytest
 import responses
 
 from cumulusci.core.config import ServiceConfig, TaskConfig
@@ -9,8 +8,8 @@ from cumulusci.tasks.github.tests.util_github_api import GithubApiTestMixin
 from cumulusci.tests.util import create_project_config
 
 
-class TestCloneTag(unittest.TestCase, GithubApiTestMixin):
-    def setUp(self):
+class TestCloneTag(GithubApiTestMixin):
+    def setup_method(self):
         self.repo_owner = "TestOwner"
         self.repo_name = "TestRepo"
         self.repo_api_url = "https://api.github.com/repos/{}/{}".format(
@@ -64,7 +63,7 @@ class TestCloneTag(unittest.TestCase, GithubApiTestMixin):
         )
         task = CloneTag(self.project_config, task_config)
         task()
-        self.assertEqual("release/1.0", task.result.tag)
+        assert "release/1.0" == task.result.tag
 
     @responses.activate
     def test_run_task__tag_not_found(self):
@@ -87,5 +86,5 @@ class TestCloneTag(unittest.TestCase, GithubApiTestMixin):
             {"options": {"src_tag": "beta/1.0-Beta_1", "tag": "release/1.0"}}
         )
         task = CloneTag(self.project_config, task_config)
-        with self.assertRaises(GithubApiNotFoundError):
+        with pytest.raises(GithubApiNotFoundError):
             task()

--- a/cumulusci/tasks/github/tests/test_util.py
+++ b/cumulusci/tasks/github/tests/test_util.py
@@ -112,9 +112,9 @@ class TestCommitDir:
         with pytest.raises(GithubException):
             commit._validate_dirs("bogus", None)
         _, repo_dir = commit._validate_dirs(".", None)
-        assert "" == repo_dir
+        assert repo_dir == ""
         _, repo_dir = commit._validate_dirs(".", "./test/")
-        assert "test" == repo_dir
+        assert repo_dir == "test"
 
     def test_call__error_creating_tree(self):
         with temporary_dir() as d:

--- a/cumulusci/tasks/github/tests/test_util.py
+++ b/cumulusci/tasks/github/tests/test_util.py
@@ -1,7 +1,7 @@
 import hashlib
-import unittest
 from unittest import mock
 
+import pytest
 from github3.git import Tree
 from github3.repos import Repository
 
@@ -10,7 +10,7 @@ from cumulusci.tasks.github.util import CommitDir
 from cumulusci.utils import temporary_dir
 
 
-class TestCommitDir(unittest.TestCase):
+class TestCommitDir:
     def test_call(self):
         with temporary_dir() as d:
             repo = mock.Mock(spec=Repository)
@@ -109,12 +109,12 @@ class TestCommitDir(unittest.TestCase):
     def test_validate_dirs(self):
         repo = mock.Mock(spec=Repository)
         commit = CommitDir(repo)
-        with self.assertRaises(GithubException):
+        with pytest.raises(GithubException):
             commit._validate_dirs("bogus", None)
         _, repo_dir = commit._validate_dirs(".", None)
-        self.assertEqual("", repo_dir)
+        assert "" == repo_dir
         _, repo_dir = commit._validate_dirs(".", "./test/")
-        self.assertEqual("test", repo_dir)
+        assert "test" == repo_dir
 
     def test_call__error_creating_tree(self):
         with temporary_dir() as d:
@@ -128,7 +128,7 @@ class TestCommitDir(unittest.TestCase):
             with open("new", "w") as f:
                 f.write("new")
             commit = CommitDir(repo)
-            with self.assertRaises(GithubException):
+            with pytest.raises(GithubException):
                 commit(d, "main", commit_message="msg")
 
     def test_call__error_creating_commit(self):
@@ -143,7 +143,7 @@ class TestCommitDir(unittest.TestCase):
             with open("new", "w") as f:
                 f.write("new")
             commit = CommitDir(repo)
-            with self.assertRaises(GithubException):
+            with pytest.raises(GithubException):
                 commit(d, "main", commit_message="msg")
 
     def test_call__error_updating_head(self):
@@ -160,19 +160,19 @@ class TestCommitDir(unittest.TestCase):
             with open("new", "w") as f:
                 f.write("new")
             commit = CommitDir(repo)
-            with self.assertRaises(GithubException):
+            with pytest.raises(GithubException):
                 commit(d, "main", commit_message="msg")
 
     def test_create_blob__handles_decode_error(self):
         repo = mock.Mock(spec=Repository)
         commit = CommitDir(repo)
         commit.dry_run = False
-        self.assertTrue(commit._create_blob(b"\x9c", "local_path"))
+        assert commit._create_blob(b"\x9c", "local_path")
 
     def test_create_blob__error(self):
         repo = mock.Mock(spec=Repository)
         repo.create_blob.return_value = None
         commit = CommitDir(repo)
         commit.dry_run = False
-        with self.assertRaises(GithubException):
-            self.assertTrue(commit._create_blob(b"", "local_path"))
+        with pytest.raises(GithubException):
+            assert commit._create_blob(b"", "local_path")

--- a/cumulusci/tasks/github/tests/util_github_api.py
+++ b/cumulusci/tasks/github/tests/util_github_api.py
@@ -8,7 +8,7 @@ from cumulusci.tests.util import random_sha
 date_format = "%Y-%m-%dT%H:%M:%SZ"
 
 
-class GithubApiTestMixin(object):
+class GithubApiTestMixin:
     """Mixin that provide common values and mocked http responses for tests of code that talks to the Github API"""
 
     def init_github(self):

--- a/cumulusci/tasks/metadata/tests/test_ee_src.py
+++ b/cumulusci/tasks/metadata/tests/test_ee_src.py
@@ -1,6 +1,7 @@
 import os
-import unittest
 from unittest import mock
+
+import pytest
 
 from cumulusci.core.config import BaseProjectConfig, TaskConfig, UniversalConfig
 from cumulusci.core.exceptions import TaskOptionsError
@@ -8,7 +9,7 @@ from cumulusci.tasks.metadata.ee_src import CreateUnmanagedEESrc, RevertUnmanage
 from cumulusci.utils import temporary_dir
 
 
-class TestCreateUnmanagedEESrc(unittest.TestCase):
+class TestCreateUnmanagedEESrc:
     @mock.patch("cumulusci.tasks.metadata.ee_src.remove_xml_element_directory")
     def test_run_task(self, remove_xml_element_directory):
         with temporary_dir() as path:
@@ -34,7 +35,7 @@ class TestCreateUnmanagedEESrc(unittest.TestCase):
         project_config = BaseProjectConfig(UniversalConfig(), config={"noyaml": True})
         task_config = TaskConfig({"options": {"path": "bogus", "revert_path": "bogus"}})
         task = CreateUnmanagedEESrc(project_config, task_config)
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             task()
 
     def test_run_task__revert_path_already_exists(self):
@@ -46,11 +47,11 @@ class TestCreateUnmanagedEESrc(unittest.TestCase):
                 {"options": {"path": path, "revert_path": revert_path}}
             )
             task = CreateUnmanagedEESrc(project_config, task_config)
-            with self.assertRaises(TaskOptionsError):
+            with pytest.raises(TaskOptionsError):
                 task()
 
 
-class TestRevertUnmanagedEESrc(unittest.TestCase):
+class TestRevertUnmanagedEESrc:
     def test_run_task(self):
         with temporary_dir() as revert_path:
             with open(os.path.join(revert_path, "file"), "w"):
@@ -66,11 +67,11 @@ class TestRevertUnmanagedEESrc(unittest.TestCase):
             )
             task = RevertUnmanagedEESrc(project_config, task_config)
             task()
-            self.assertTrue(os.path.exists(os.path.join(path, "file")))
+            assert os.path.exists(os.path.join(path, "file"))
 
     def test_run_task__revert_path_not_found(self):
         project_config = BaseProjectConfig(UniversalConfig(), config={"noyaml": True})
         task_config = TaskConfig({"options": {"path": "bogus", "revert_path": "bogus"}})
         task = RevertUnmanagedEESrc(project_config, task_config)
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             task()

--- a/cumulusci/tasks/metadata/tests/test_managed_src.py
+++ b/cumulusci/tasks/metadata/tests/test_managed_src.py
@@ -1,5 +1,6 @@
 import os
-import unittest
+
+import pytest
 
 from cumulusci.core.config import BaseProjectConfig, TaskConfig, UniversalConfig
 from cumulusci.core.exceptions import TaskOptionsError
@@ -7,7 +8,7 @@ from cumulusci.tasks.metadata.managed_src import CreateManagedSrc, RevertManaged
 from cumulusci.utils import temporary_dir
 
 
-class TestCreateManagedSrc(unittest.TestCase):
+class TestCreateManagedSrc:
     def test_run_task(self):
         with temporary_dir() as path:
             os.mkdir(os.path.join(path, "classes"))
@@ -27,13 +28,13 @@ class TestCreateManagedSrc(unittest.TestCase):
             task()
             with open(class_path, "r") as f:
                 result = f.read()
-            self.assertEqual("", result)
+            assert "" == result
 
     def test_run_task__path_not_found(self):
         project_config = BaseProjectConfig(UniversalConfig(), config={"noyaml": True})
         task_config = TaskConfig({"options": {"path": "bogus", "revert_path": "bogus"}})
         task = CreateManagedSrc(project_config, task_config)
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             task()
 
     def test_run_task__revert_path_already_exists(self):
@@ -45,11 +46,11 @@ class TestCreateManagedSrc(unittest.TestCase):
                 {"options": {"path": path, "revert_path": revert_path}}
             )
             task = CreateManagedSrc(project_config, task_config)
-            with self.assertRaises(TaskOptionsError):
+            with pytest.raises(TaskOptionsError):
                 task()
 
 
-class TestRevertManagedSrc(unittest.TestCase):
+class TestRevertManagedSrc:
     def test_run_task(self):
         with temporary_dir() as revert_path:
             with open(os.path.join(revert_path, "file"), "w"):
@@ -65,11 +66,11 @@ class TestRevertManagedSrc(unittest.TestCase):
             )
             task = RevertManagedSrc(project_config, task_config)
             task()
-            self.assertTrue(os.path.exists(os.path.join(path, "file")))
+            assert os.path.exists(os.path.join(path, "file"))
 
     def test_run_task__revert_path_not_found(self):
         project_config = BaseProjectConfig(UniversalConfig(), config={"noyaml": True})
         task_config = TaskConfig({"options": {"path": "bogus", "revert_path": "bogus"}})
         task = RevertManagedSrc(project_config, task_config)
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             task()

--- a/cumulusci/tasks/metadata/tests/test_managed_src.py
+++ b/cumulusci/tasks/metadata/tests/test_managed_src.py
@@ -28,7 +28,7 @@ class TestCreateManagedSrc:
             task()
             with open(class_path, "r") as f:
                 result = f.read()
-            assert "" == result
+            assert result == ""
 
     def test_run_task__path_not_found(self):
         project_config = BaseProjectConfig(UniversalConfig(), config={"noyaml": True})

--- a/cumulusci/tasks/metadata/tests/test_modify.py
+++ b/cumulusci/tasks/metadata/tests/test_modify.py
@@ -1,5 +1,6 @@
 import os
-import unittest
+
+import pytest
 
 from cumulusci.core.config import BaseProjectConfig, TaskConfig, UniversalConfig
 from cumulusci.core.exceptions import TaskOptionsError
@@ -7,7 +8,7 @@ from cumulusci.tasks.metadata.modify import RemoveElementsXPath
 from cumulusci.utils import temporary_dir
 
 
-class TestRemoveElementsXPath(unittest.TestCase):
+class TestRemoveElementsXPath:
     def _run_task(self, options):
         project_config = BaseProjectConfig(UniversalConfig(), config={"noyaml": True})
         task_config = TaskConfig({"options": options})
@@ -25,13 +26,13 @@ class TestRemoveElementsXPath(unittest.TestCase):
             return result
 
     def test_cli_errors(self):
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             self._run_task({})
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             self._run_task({"path": "foo"})
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             self._run_task({"xpath": "foo"})
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             self._run_task(
                 {
                     "XPath": "foo",
@@ -45,18 +46,14 @@ class TestRemoveElementsXPath(unittest.TestCase):
             xml="<root>a<todelete/></root>",
             options={"xpath": "todelete", "path": "test.xml"},
         )
-        self.assertEqual(
-            '<?xml version="1.0" encoding="UTF-8"?>\n<root>a</root>\n', result
-        )
+        assert '<?xml version="1.0" encoding="UTF-8"?>\n<root>a</root>\n' == result
 
     def test_run_task(self):
         result = self._run_xml_through_task(
             "<root>a<todelete/></root>",
             {"elements": [{"path": "test.xml", "xpath": "./todelete"}]},
         )
-        self.assertEqual(
-            '<?xml version="1.0" encoding="UTF-8"?>\n<root>a</root>\n', result
-        )
+        assert '<?xml version="1.0" encoding="UTF-8"?>\n<root>a</root>\n' == result
 
     def test_salesforce_encoding(self):
         result = self._run_xml_through_task(
@@ -66,9 +63,9 @@ class TestRemoveElementsXPath(unittest.TestCase):
                 "output_style": "salesforce",
             },
         )
-        self.assertEqual(
-            '<?xml version="1.0" encoding="UTF-8"?>\n<root xmlns="http://soap.sforce.com/2006/04/metadata"><a>&quot;&apos;</a>\n</root>\n',
-            result,
+        assert (
+            '<?xml version="1.0" encoding="UTF-8"?>\n<root xmlns="http://soap.sforce.com/2006/04/metadata"><a>&quot;&apos;</a>\n</root>\n'
+            == result
         )
 
     def test_namespaces_ns(self):
@@ -79,9 +76,9 @@ class TestRemoveElementsXPath(unittest.TestCase):
                 "output_style": "salesforce",
             },
         )
-        self.assertEqual(
-            '<?xml version="1.0" encoding="UTF-8"?>\n<root xmlns="http://soap.sforce.com/2006/04/metadata"><a>&quot;&apos;</a>\n</root>\n',
-            result,
+        assert (
+            '<?xml version="1.0" encoding="UTF-8"?>\n<root xmlns="http://soap.sforce.com/2006/04/metadata"><a>&quot;&apos;</a>\n</root>\n'
+            == result
         )
 
     def test_regular_expressions(self):
@@ -97,9 +94,9 @@ class TestRemoveElementsXPath(unittest.TestCase):
                 "output_style": "salesforce",
             },
         )
-        self.assertEqual(
-            '<?xml version="1.0" encoding="UTF-8"?>\n<root xmlns="http://soap.sforce.com/2006/04/metadata"><todelete>baz</todelete>\n</root>\n',
-            result,
+        assert (
+            '<?xml version="1.0" encoding="UTF-8"?>\n<root xmlns="http://soap.sforce.com/2006/04/metadata"><todelete>baz</todelete>\n</root>\n'
+            == result
         )
 
     def test_comment(self):
@@ -110,9 +107,9 @@ class TestRemoveElementsXPath(unittest.TestCase):
                 "output_style": "salesforce",
             },
         )
-        self.assertEqual(
-            '<?xml version="1.0" encoding="UTF-8"?>\n<root><a><!-- Foo --></a>\n</root>\n',
-            result,
+        assert (
+            '<?xml version="1.0" encoding="UTF-8"?>\n<root><a><!-- Foo --></a>\n</root>\n'
+            == result
         )
 
     def test_empty_element(self):
@@ -123,6 +120,4 @@ class TestRemoveElementsXPath(unittest.TestCase):
                 "output_style": "salesforce",
             },
         )
-        self.assertEqual(
-            '<?xml version="1.0" encoding="UTF-8"?>\n<root><a/>\n</root>\n', result
-        )
+        assert '<?xml version="1.0" encoding="UTF-8"?>\n<root><a/>\n</root>\n' == result

--- a/cumulusci/tasks/metadata/tests/test_package.py
+++ b/cumulusci/tasks/metadata/tests/test_package.py
@@ -1,6 +1,7 @@
 import os
-import unittest
 from unittest import mock
+
+import pytest
 
 from cumulusci.core.config import (
     BaseProjectConfig,
@@ -32,11 +33,11 @@ from cumulusci.utils import temporary_dir, touch
 __location__ = os.path.dirname(os.path.realpath(__file__))
 
 
-class TestPackageXmlGenerator(unittest.TestCase):
+class TestPackageXmlGenerator:
     def test_metadata_sort_key(self):
         md = ["a__Test__c", "Test__c"]
         md.sort(key=metadata_sort_key)
-        self.assertEqual(["Test__c", "a__Test__c"], md)
+        assert ["Test__c", "a__Test__c"] == md
 
     def test_package_name_urlencoding(self):
         api_version = "36.0"
@@ -52,7 +53,7 @@ class TestPackageXmlGenerator(unittest.TestCase):
             generator = PackageXmlGenerator(path, api_version, package_name)
             package_xml = generator()
 
-        self.assertEqual(package_xml, expected)
+        assert package_xml == expected
 
     def test_namespaced_report_folder(self):
         api_version = "36.0"
@@ -66,7 +67,7 @@ class TestPackageXmlGenerator(unittest.TestCase):
             expected_package_xml = f.read().strip()
         package_xml = generator()
 
-        self.assertEqual(package_xml, expected_package_xml)
+        assert package_xml == expected_package_xml
 
     def test_delete_namespaced_report_folder(self):
         api_version = "36.0"
@@ -80,13 +81,13 @@ class TestPackageXmlGenerator(unittest.TestCase):
             expected_package_xml = f.read().strip()
         package_xml = generator()
 
-        self.assertEqual(package_xml, expected_package_xml)
+        assert package_xml == expected_package_xml
 
     def test_parse_types_unknown_md_type(self):
         with temporary_dir() as path:
             os.mkdir(os.path.join(path, "bogus"))
             generator = PackageXmlGenerator(path, "43.0", "Test Package")
-            with self.assertRaises(MetadataParserMissingError):
+            with pytest.raises(MetadataParserMissingError):
                 generator.parse_types()
 
     def test_render_xml__managed(self):
@@ -100,7 +101,7 @@ class TestPackageXmlGenerator(unittest.TestCase):
                 uninstall_class="Uninstall",
             )
             result = generator()
-            self.assertEqual(EXPECTED_MANAGED, result)
+            assert EXPECTED_MANAGED == result
 
 
 EXPECTED_MANAGED = """<?xml version="1.0" encoding="UTF-8"?>
@@ -112,7 +113,7 @@ EXPECTED_MANAGED = """<?xml version="1.0" encoding="UTF-8"?>
 </Package>"""
 
 
-class TestBaseMetadataParser(unittest.TestCase):
+class TestBaseMetadataParser:
     def test_parse_items__skips_files(self):
         with temporary_dir() as path:
             # create files that should be ignored by the parser
@@ -134,33 +135,33 @@ class TestBaseMetadataParser(unittest.TestCase):
 
     def test_check_delete_excludes__not_deleting(self):
         parser = BaseMetadataParser("TestMDT", None, "object", delete=False)
-        self.assertFalse(parser.check_delete_excludes("asdf"))
+        assert not parser.check_delete_excludes("asdf")
 
     def test_parse_item(self):
         parser = BaseMetadataParser("TestMDT", None, "object", delete=False)
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             parser._parse_item("asdf")
 
     def test_render_xml__no_members(self):
         parser = BaseMetadataParser("TestMDT", None, "object", delete=False)
-        self.assertIsNone(parser.render_xml())
+        assert parser.render_xml() is None
 
 
-class TestMetadataFilenameParser(unittest.TestCase):
+class TestMetadataFilenameParser:
     def test_parse_item(self):
         parser = MetadataFilenameParser("TestMDT", None, "object", delete=False)
         result = parser._parse_item("Test.object")
-        self.assertEqual(["Test"], result)
+        assert ["Test"] == result
 
     def test_parse_item_translates_namespace_tokens(self):
         with temporary_dir() as path:
             touch("___NAMESPACE___Foo__c.object")
             parser = MetadataFilenameParser("TestMDT", path, "object", delete=False)
             parser.parse_items()
-        self.assertEqual(["%%%NAMESPACE%%%Foo__c"], parser.members)
+        assert ["%%%NAMESPACE%%%Foo__c"] == parser.members
 
 
-class TestMetadataFolderParser(unittest.TestCase):
+class TestMetadataFolderParser:
     def test_parse_item(self):
         with temporary_dir() as path:
             item_path = os.path.join(path, "Test")
@@ -174,17 +175,17 @@ class TestMetadataFolderParser(unittest.TestCase):
             with open(os.path.join(item_path, "Test.object"), "w"):
                 pass
             parser = MetadataFolderParser("TestMDT", path, "object", delete=False)
-            self.assertEqual(["Test", "Test/Test"], parser._parse_item("Test"))
+            assert ["Test", "Test/Test"] == parser._parse_item("Test")
 
     def test_parse_item__non_directory(self):
         with temporary_dir() as path:
             with open(os.path.join(path, "file"), "w"):
                 pass
             parser = MetadataFolderParser("TestMDT", path, "object", delete=False)
-            self.assertEqual([], parser._parse_item("file"))
+            assert [] == parser._parse_item("file")
 
 
-class TestBundleParser(unittest.TestCase):
+class TestBundleParser:
     def test_parse_item(self):
         with temporary_dir() as path:
             item_path = os.path.join(path, "Test")
@@ -195,17 +196,17 @@ class TestBundleParser(unittest.TestCase):
             with open(os.path.join(item_path, "Test.object"), "w"):
                 pass
             parser = BundleParser("TestMDT", path, "object", delete=False)
-            self.assertEqual(["Test"], parser._parse_item("Test"))
+            assert ["Test"] == parser._parse_item("Test")
 
     def test_parse_item__non_directory(self):
         with temporary_dir() as path:
             with open(os.path.join(path, "file"), "w"):
                 pass
             parser = BundleParser("TestMDT", path, "object", delete=False)
-            self.assertEqual([], parser._parse_item("file"))
+            assert [] == parser._parse_item("file")
 
 
-class TestLWCBundleParser(unittest.TestCase):
+class TestLWCBundleParser:
     def test_parse_item(self):
         with temporary_dir() as path:
             item_path = os.path.join(path, "Test")
@@ -218,7 +219,7 @@ class TestLWCBundleParser(unittest.TestCase):
             parser = LWCBundleParser(
                 "LightningComponentBundle", path, "object", delete=False
             )
-            self.assertEqual(["Test"], parser._parse_item("Test"))
+            assert ["Test"] == parser._parse_item("Test")
 
     def test_parse_item__no_tests_mocks(self):
         with temporary_dir() as path:
@@ -228,7 +229,7 @@ class TestLWCBundleParser(unittest.TestCase):
             parser = LWCBundleParser(
                 "LightningComponentBundle", path, None, delete=False
             )
-            self.assertEqual([], parser._parse_item("__tests__"))
+            assert [] == parser._parse_item("__tests__")
 
     def test_parse_item__non_directory(self):
         with temporary_dir() as path:
@@ -237,10 +238,10 @@ class TestLWCBundleParser(unittest.TestCase):
             parser = LWCBundleParser(
                 "LightningComponentBundle", path, None, delete=False
             )
-            self.assertEqual([], parser._parse_item("file"))
+            assert [] == parser._parse_item("file")
 
 
-class TestMetadataXmlElementParser(unittest.TestCase):
+class TestMetadataXmlElementParser:
     def test_parser(self):
         with temporary_dir() as path:
             with open(os.path.join(path, "Test.test"), "w") as f:
@@ -256,18 +257,17 @@ class TestMetadataXmlElementParser(unittest.TestCase):
                 "TestMDT", path, "test", delete=False, item_xpath="./sf:test"
             )
             result = parser()
-            self.assertEqual(
-                """    <types>
+            assert """    <types>
         <members>Test.Test</members>
         <name>TestMDT</name>
-    </types>""",
-                "\n".join(result),
+    </types>""" == "\n".join(
+                result
             )
 
     def test_parser__missing_item_xpath(self):
-        with self.assertRaises(ParserConfigurationError):
+        with pytest.raises(ParserConfigurationError):
             parser = MetadataXmlElementParser("TestMDT", None, "test", False)
-            self.assertIsNotNone(parser)
+            assert parser is not None
 
     def test_parser__missing_name(self):
         with temporary_dir() as path:
@@ -281,11 +281,11 @@ class TestMetadataXmlElementParser(unittest.TestCase):
             parser = MetadataXmlElementParser(
                 "TestMDT", path, "test", delete=False, item_xpath="./sf:test"
             )
-            with self.assertRaises(MissingNameElementError):
+            with pytest.raises(MissingNameElementError):
                 parser()
 
 
-class TestCustomLabelsParser(unittest.TestCase):
+class TestCustomLabelsParser:
     def test_parser(self):
         with temporary_dir() as path:
             with open(os.path.join(path, "custom.labels"), "w") as f:
@@ -300,46 +300,46 @@ class TestCustomLabelsParser(unittest.TestCase):
             parser = CustomLabelsParser(
                 "CustomLabels", path, "labels", False, item_xpath="./sf:labels"
             )
-            self.assertEqual(["TestLabel"], parser._parse_item("custom.labels"))
+            assert ["TestLabel"] == parser._parse_item("custom.labels")
 
 
-class TestCustomObjectParser(unittest.TestCase):
+class TestCustomObjectParser:
     def test_parse_item(self):
         parser = CustomObjectParser("CustomObject", None, "object", False)
-        self.assertEqual(["Test__c"], parser._parse_item("Test__c.object"))
+        assert ["Test__c"] == parser._parse_item("Test__c.object")
 
     def test_parse_item__skips_namespaced(self):
         parser = CustomObjectParser("CustomObject", None, "object", False)
-        self.assertEqual([], parser._parse_item("ns__Object__c.object"))
+        assert [] == parser._parse_item("ns__Object__c.object")
 
     def test_parse_item__skips_standard(self):
         parser = CustomObjectParser("CustomObject", None, "object", False)
-        self.assertEqual([], parser._parse_item("Account.object"))
+        assert [] == parser._parse_item("Account.object")
 
 
-class TestRecordTypeParser(unittest.TestCase):
+class TestRecordTypeParser:
     def test_check_delete_excludes(self):
         parser = RecordTypeParser(
             "RecordType", None, "object", True, "./sf:recordTypes"
         )
-        self.assertTrue(parser.check_delete_excludes("asdf"))
+        assert parser.check_delete_excludes("asdf")
 
 
-class TestBusinessProcessParser(unittest.TestCase):
+class TestBusinessProcessParser:
     def test_check_delete_excludes(self):
         parser = BusinessProcessParser(
             "BusinessProcess", None, "object", True, "./sf:businessProcesses"
         )
-        self.assertTrue(parser.check_delete_excludes("asdf"))
+        assert parser.check_delete_excludes("asdf")
 
 
-class TestDocumentParser(unittest.TestCase):
+class TestDocumentParser:
     def test_parse_subitem(self):
         parser = DocumentParser("Document", None, None, False)
-        self.assertEqual(["folder/doc"], parser._parse_subitem("folder", "doc"))
+        assert ["folder/doc"] == parser._parse_subitem("folder", "doc")
 
 
-class TestUpdatePackageXml(unittest.TestCase):
+class TestUpdatePackageXml:
     def test_run_task(self):
         src_path = os.path.join(
             __location__, "package_metadata", "namespaced_report_folder"
@@ -364,4 +364,4 @@ class TestUpdatePackageXml(unittest.TestCase):
             task()
             with open(output_path, "r") as f:
                 result = f.read()
-            self.assertEqual(expected, result)
+            assert expected == result

--- a/cumulusci/tasks/metadata_etl/tests/test_field_sets.py
+++ b/cumulusci/tasks/metadata_etl/tests/test_field_sets.py
@@ -1,9 +1,10 @@
-import pytest
 import logging
 
+import pytest
+
 from cumulusci.core.exceptions import TaskOptionsError
-from cumulusci.tasks.salesforce.tests.util import create_task
 from cumulusci.tasks.metadata_etl.field_sets import AddFieldsToFieldSet
+from cumulusci.tasks.salesforce.tests.util import create_task
 from cumulusci.utils.xml import metadata_tree
 
 OBJECT_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
@@ -152,4 +153,4 @@ class TestAddFieldsToFieldSet:
         )
         tree = metadata_tree.fromstring(OBJECT_XML)
         with pytest.raises(TaskOptionsError):
-            result = task._transform_entity(tree, "Case")
+            task._transform_entity(tree, "Case")

--- a/cumulusci/tasks/metadata_etl/tests/test_layouts.py
+++ b/cumulusci/tasks/metadata_etl/tests/test_layouts.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 
 from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.tasks.metadata_etl.layouts import (
@@ -563,7 +563,7 @@ MOCK_ADD_FIELDS_LAYOUT = """<?xml version="1.0" encoding="UTF-8"?>
 """
 
 
-class TestAddFieldsToPageLayout(unittest.TestCase):
+class TestAddFieldsToPageLayout:
     def test_add_fields_positioning(self):
         """Testing the positioning keywords [top|bottom|before|after]"""
         task = create_task(
@@ -806,13 +806,13 @@ class TestAddFieldsToPageLayout(unittest.TestCase):
         )
         tree = metadata_tree.fromstring(MOCK_ADD_FIELDS_LAYOUT.format().encode("utf-8"))
 
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             task._transform_entity(tree, "Layout")
 
     def test_add_fields_position_type_column(self):
         """Check positioning root validators column relative"""
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             create_task(
                 AddFieldsToPageLayout,
                 {
@@ -836,7 +836,7 @@ class TestAddFieldsToPageLayout(unittest.TestCase):
     def test_add_fields_position_type_field(self):
         """Check positioning root validators field relative"""
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             create_task(
                 AddFieldsToPageLayout,
                 {

--- a/cumulusci/tasks/preflight/tests/test_licenses.py
+++ b/cumulusci/tasks/preflight/tests/test_licenses.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest.mock import Mock
 
 from cumulusci.tasks.preflight.licenses import (
@@ -9,7 +8,7 @@ from cumulusci.tasks.preflight.licenses import (
 from cumulusci.tasks.salesforce.tests.util import create_task
 
 
-class TestLicensePreflights(unittest.TestCase):
+class TestLicensePreflights:
     def test_license_preflight(self):
         task = create_task(GetAvailableLicenses, {})
         task._init_api = Mock()

--- a/cumulusci/tasks/preflight/tests/test_permset_preflights.py
+++ b/cumulusci/tasks/preflight/tests/test_permset_preflights.py
@@ -1,11 +1,10 @@
-import unittest
 from unittest.mock import Mock
 
 from cumulusci.tasks.preflight.permsets import GetPermissionSetAssignments
 from cumulusci.tasks.salesforce.tests.util import create_task
 
 
-class TestPermsetPreflights(unittest.TestCase):
+class TestPermsetPreflights:
     def test_assigned_permset_preflight(self):
         task = create_task(GetPermissionSetAssignments, {})
         task._init_api = Mock()

--- a/cumulusci/tasks/preflight/tests/test_recordtypes.py
+++ b/cumulusci/tasks/preflight/tests/test_recordtypes.py
@@ -1,11 +1,10 @@
-import unittest
 from unittest.mock import Mock
 
 from cumulusci.tasks.preflight.recordtypes import CheckSObjectRecordTypes
 from cumulusci.tasks.salesforce.tests.util import create_task
 
 
-class TestRecordTypePreflights(unittest.TestCase):
+class TestRecordTypePreflights:
     def test_record_type_preflight(self):
         task = create_task(CheckSObjectRecordTypes, {})
         task.tooling = Mock()

--- a/cumulusci/tasks/preflight/tests/test_sobjects.py
+++ b/cumulusci/tasks/preflight/tests/test_sobjects.py
@@ -1,6 +1,6 @@
-import unittest
 from unittest.mock import Mock
 
+import pytest
 from simple_salesforce.exceptions import SalesforceMalformedRequest
 
 from cumulusci.core.exceptions import TaskOptionsError
@@ -12,7 +12,7 @@ from cumulusci.tasks.preflight.sobjects import (
 from cumulusci.tasks.salesforce.tests.util import create_task
 
 
-class TestCheckSObjectsAvailable(unittest.TestCase):
+class TestCheckSObjectsAvailable:
     def test_sobject_preflight(self):
         task = create_task(CheckSObjectsAvailable, {})
 
@@ -27,7 +27,7 @@ class TestCheckSObjectsAvailable(unittest.TestCase):
         assert task.return_values == {"Network", "Account"}
 
 
-class TestCheckSObjectPerms(unittest.TestCase):
+class TestCheckSObjectPerms:
     def test_sobject_perms_preflight(self):
         task = create_task(
             CheckSObjectPerms,
@@ -96,11 +96,11 @@ class TestCheckSObjectPerms(unittest.TestCase):
         assert task.return_values is False
 
     def test_sobject_perms_preflight__bad_options(self):
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             create_task(CheckSObjectPerms, {"permissions": True})
 
 
-class TestCheckSObjectOWDs(unittest.TestCase):
+class TestCheckSObjectOWDs:
     def test_sobject_preflight__positive(self):
         task = create_task(
             CheckSObjectOWDs,
@@ -218,14 +218,14 @@ class TestCheckSObjectOWDs(unittest.TestCase):
         assert task.return_values is False
 
     def test_sobject_preflight__task_options(self):
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             create_task(CheckSObjectOWDs, {})
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             create_task(
                 CheckSObjectOWDs,
                 {"org_wide_defaults": [{"internal_sharing_model": "Private"}]},
             )
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             create_task(
                 CheckSObjectOWDs, {"org_wide_defaults": [{"api_name": "Account"}]}
             )

--- a/cumulusci/tasks/push/tests/test_push_api.py
+++ b/cumulusci/tasks/push/tests/test_push_api.py
@@ -282,12 +282,12 @@ def test_sf_push_return_query_records(sf_push_api):
 
 def test_sf_push_format_where(sf_push_api):
     returned = sf_push_api.format_where_clause(None)
-    assert "" == returned
+    assert returned == ""
 
     default_where = "Id='001000000XXX000'"
     sf_push_api.default_where = {"Account": default_where}
     returned = sf_push_api.format_where_clause(None, "Object__c")
-    assert "" == returned
+    assert returned == ""
 
     returned = sf_push_api.format_where_clause(None, "Account")
     assert " WHERE ({})".format(default_where) == returned

--- a/cumulusci/tasks/release_notes/tests/test_generator.py
+++ b/cumulusci/tasks/release_notes/tests/test_generator.py
@@ -116,7 +116,7 @@ class TestGithubReleaseNotesGenerator(GithubApiTestMixin):
         assert generator.last_tag is None
         assert generator.change_notes.current_tag == self.current_tag
         assert generator.change_notes._last_tag is None
-        assert "04t" == generator.version_id
+        assert generator.version_id == "04t"
 
     @responses.activate
     def test_init_with_last_tag(self):
@@ -143,7 +143,7 @@ class TestGithubReleaseNotesGenerator(GithubApiTestMixin):
         generator.empty_change_notes.extend([pr1, pr2])
         content = render_empty_pr_section(generator.empty_change_notes)
         assert 3 == len(content)
-        assert "\n# Pull requests with no release notes" == content[0]
+        assert content[0] == "\n# Pull requests with no release notes"
         assert (
             "\n* {} [[PR{}]({})]".format(pr1.title, pr1.number, pr1.html_url)
             == content[1]
@@ -169,8 +169,8 @@ class TestGithubReleaseNotesGenerator(GithubApiTestMixin):
 
         split_content = content.split("\r\n")
         assert 4 == len(split_content)
-        assert "new content" == split_content[0]
-        assert "\n# Pull requests with no release notes" == split_content[1]
+        assert split_content[0] == "new content"
+        assert split_content[1] == "\n# Pull requests with no release notes"
         assert (
             "\n* Pull Request #{0} [[PR{0}]({1})]".format(pr1.number, pr1.html_url)
             == split_content[2]

--- a/cumulusci/tasks/release_notes/tests/test_generator.py
+++ b/cumulusci/tasks/release_notes/tests/test_generator.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 import json
 import os
-import unittest
 from unittest import mock
 
 import pytest
@@ -51,11 +50,11 @@ class DummyParser(BaseChangeNotesParser):
         return "dummy parser output"
 
 
-class TestBaseReleaseNotesGenerator(unittest.TestCase):
+class TestBaseReleaseNotesGenerator:
     def test_render_no_parsers(self):
         release_notes = BaseReleaseNotesGenerator()
         content = release_notes.render()
-        self.assertEqual(content, "")
+        assert content == ""
 
     def test_render_dummy_parsers(self):
         release_notes = BaseReleaseNotesGenerator()
@@ -65,16 +64,16 @@ class TestBaseReleaseNotesGenerator(unittest.TestCase):
             "# Dummy 1\r\n\r\ndummy parser output\r\n\r\n"
             + "# Dummy 2\r\n\r\ndummy parser output"
         )
-        self.assertEqual(release_notes.render(), expected)
+        assert release_notes.render() == expected
 
 
-class TestStaticReleaseNotesGenerator(unittest.TestCase):
+class TestStaticReleaseNotesGenerator:
     def test_init_parser(self):
         release_notes = StaticReleaseNotesGenerator([])
         assert len(release_notes.parsers) == 3
 
 
-class TestDirectoryReleaseNotesGenerator(unittest.TestCase):
+class TestDirectoryReleaseNotesGenerator:
     def test_init_parser(self):
         release_notes = DirectoryReleaseNotesGenerator("change_notes")
         assert len(release_notes.parsers) == 3
@@ -89,11 +88,11 @@ class TestDirectoryReleaseNotesGenerator(unittest.TestCase):
         print("-------------------------------------")
         print(content)
 
-        self.assertEqual(content, expected)
+        assert content == expected
 
 
-class TestGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTestMixin):
-    def setUp(self):
+class TestGithubReleaseNotesGenerator(GithubApiTestMixin):
+    def setup_method(self):
         self.current_tag = "prod/1.4"
         self.last_tag = "prod/1.3"
         self.github_info = {
@@ -112,12 +111,12 @@ class TestGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTestMixin):
         generator = GithubReleaseNotesGenerator(
             self.gh, github_info, PARSER_CONFIG, self.current_tag, version_id="04t"
         )
-        self.assertEqual(generator.github_info, github_info)
-        self.assertEqual(generator.current_tag, self.current_tag)
-        self.assertEqual(generator.last_tag, None)
-        self.assertEqual(generator.change_notes.current_tag, self.current_tag)
-        self.assertEqual(generator.change_notes._last_tag, None)
-        self.assertEqual("04t", generator.version_id)
+        assert generator.github_info == github_info
+        assert generator.current_tag == self.current_tag
+        assert generator.last_tag is None
+        assert generator.change_notes.current_tag == self.current_tag
+        assert generator.change_notes._last_tag is None
+        assert "04t" == generator.version_id
 
     @responses.activate
     def test_init_with_last_tag(self):
@@ -126,11 +125,11 @@ class TestGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTestMixin):
         generator = GithubReleaseNotesGenerator(
             self.gh, github_info, PARSER_CONFIG, self.current_tag, self.last_tag
         )
-        self.assertEqual(generator.github_info, github_info)
-        self.assertEqual(generator.current_tag, self.current_tag)
-        self.assertEqual(generator.last_tag, self.last_tag)
-        self.assertEqual(generator.change_notes.current_tag, self.current_tag)
-        self.assertEqual(generator.change_notes._last_tag, self.last_tag)
+        assert generator.github_info == github_info
+        assert generator.current_tag == self.current_tag
+        assert generator.last_tag == self.last_tag
+        assert generator.change_notes.current_tag == self.current_tag
+        assert generator.change_notes._last_tag == self.last_tag
 
     @responses.activate
     def test_render_empty_pr_section(self):
@@ -143,15 +142,15 @@ class TestGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTestMixin):
         pr2 = repo.pull_request(2)
         generator.empty_change_notes.extend([pr1, pr2])
         content = render_empty_pr_section(generator.empty_change_notes)
-        self.assertEqual(3, len(content))
-        self.assertEqual("\n# Pull requests with no release notes", content[0])
-        self.assertEqual(
-            "\n* {} [[PR{}]({})]".format(pr1.title, pr1.number, pr1.html_url),
-            content[1],
+        assert 3 == len(content)
+        assert "\n# Pull requests with no release notes" == content[0]
+        assert (
+            "\n* {} [[PR{}]({})]".format(pr1.title, pr1.number, pr1.html_url)
+            == content[1]
         )
-        self.assertEqual(
-            "\n* {} [[PR{}]({})]".format(pr2.title, pr2.number, pr2.html_url),
-            content[2],
+        assert (
+            "\n* {} [[PR{}]({})]".format(pr2.title, pr2.number, pr2.html_url)
+            == content[2]
         )
 
     @responses.activate
@@ -169,16 +168,16 @@ class TestGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTestMixin):
         content = generator._update_release_content(release, "new content")
 
         split_content = content.split("\r\n")
-        self.assertEqual(4, len(split_content))
-        self.assertEqual("new content", split_content[0])
-        self.assertEqual("\n# Pull requests with no release notes", split_content[1])
-        self.assertEqual(
-            "\n* Pull Request #{0} [[PR{0}]({1})]".format(pr1.number, pr1.html_url),
-            split_content[2],
+        assert 4 == len(split_content)
+        assert "new content" == split_content[0]
+        assert "\n# Pull requests with no release notes" == split_content[1]
+        assert (
+            "\n* Pull Request #{0} [[PR{0}]({1})]".format(pr1.number, pr1.html_url)
+            == split_content[2]
         )
-        self.assertEqual(
-            "\n* Pull Request #{0} [[PR{0}]({1})]".format(pr2.number, pr2.html_url),
-            split_content[3],
+        assert (
+            "\n* Pull Request #{0} [[PR{0}]({1})]".format(pr2.number, pr2.html_url)
+            == split_content[3]
         )
 
     @responses.activate
@@ -198,9 +197,9 @@ class TestGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTestMixin):
         generator._parse_change_note(pr3)
 
         # PR1 is "non-empty" second two are "empty"
-        self.assertEqual(2, len(generator.empty_change_notes))
-        self.assertEqual(2, generator.empty_change_notes[0].number)
-        self.assertEqual(3, generator.empty_change_notes[1].number)
+        assert 2 == len(generator.empty_change_notes)
+        assert 2 == generator.empty_change_notes[0].number
+        assert 3 == generator.empty_change_notes[1].number
 
     def _create_generator(self):
         generator = GithubReleaseNotesGenerator(
@@ -209,8 +208,8 @@ class TestGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTestMixin):
         return generator
 
 
-class TestPublishingGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTestMixin):
-    def setUp(self):
+class TestPublishingGithubReleaseNotesGenerator(GithubApiTestMixin):
+    def setup_method(self):
         self.init_github()
         self.github_info = {
             "github_owner": "TestOwner",
@@ -236,8 +235,8 @@ class TestPublishingGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTest
         # render content
         content = generator.render()
         # verify
-        self.assertEqual(len(responses.calls._calls), 1)
-        self.assertEqual(content, expected_release_body)
+        assert len(responses.calls._calls) == 1
+        assert content == expected_release_body
 
     @responses.activate
     def test_publish_update_no_body(self):
@@ -252,8 +251,8 @@ class TestPublishingGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTest
         # render content
         content = generator.render()
         # verify
-        self.assertEqual(len(responses.calls._calls), 1)
-        self.assertEqual(content, expected_release_body)
+        assert len(responses.calls._calls) == 1
+        assert content == expected_release_body
 
     @responses.activate
     def test_publish_update_content_before(self):
@@ -271,8 +270,8 @@ class TestPublishingGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTest
         release = generator._get_release()
         content = generator._update_release_content(release, content)
         # verify
-        self.assertEqual(len(responses.calls._calls), 3)
-        self.assertEqual(content, expected_release_body)
+        assert len(responses.calls._calls) == 3
+        assert content == expected_release_body
 
     @responses.activate
     def test_publish_update_content_after(self):
@@ -290,8 +289,8 @@ class TestPublishingGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTest
         release = generator._get_release()
         content = generator._update_release_content(release, content)
         # verify
-        self.assertEqual(len(responses.calls._calls), 3)
-        self.assertEqual(content, expected_release_body)
+        assert len(responses.calls._calls) == 3
+        assert content == expected_release_body
 
     @responses.activate
     def test_publish_update_content_before_and_after(self):
@@ -309,8 +308,8 @@ class TestPublishingGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTest
         release = generator._get_release()
         content = generator._update_release_content(release, content)
         # verify
-        self.assertEqual(len(responses.calls._calls), 3)
-        self.assertEqual(content, expected_release_body)
+        assert len(responses.calls._calls) == 3
+        assert content == expected_release_body
 
     @responses.activate
     def test_publish_update_content_between(self):
@@ -334,8 +333,8 @@ class TestPublishingGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTest
         release = generator._get_release()
         content = generator._update_release_content(release, content)
         # verify
-        self.assertEqual(len(responses.calls._calls), 3)
-        self.assertEqual(content, expected_release_body)
+        assert len(responses.calls._calls) == 3
+        assert content == expected_release_body
 
     @responses.activate
     def test_publish_update_content_before_after_and_between(self):
@@ -363,8 +362,8 @@ class TestPublishingGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTest
         release = generator._get_release()
         content = generator._update_release_content(release, content)
         # verify
-        self.assertEqual(len(responses.calls._calls), 3)
-        self.assertEqual(content, expected_release_body)
+        assert len(responses.calls._calls) == 3
+        assert content == expected_release_body
 
     @responses.activate
     def test_publish_update_content_missing(self):
@@ -382,8 +381,8 @@ class TestPublishingGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTest
         release = generator._get_release()
         content = generator._update_release_content(release, content)
         # verify
-        self.assertEqual(len(responses.calls._calls), 3)
-        self.assertEqual(content, expected_release_body)
+        assert len(responses.calls._calls) == 3
+        assert content == expected_release_body
 
     def _create_generator(self, current_tag, last_tag=None):
         generator = GithubReleaseNotesGenerator(
@@ -405,7 +404,7 @@ class TestPublishingGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTest
             return_value=mock.sentinel.content
         )
         result = generator()
-        self.assertIs(mock.sentinel.content, result)
+        assert mock.sentinel.content is result
         base_generator.assert_called_once()
         release.edit.assert_called_once()
 
@@ -418,7 +417,7 @@ class TestPublishingGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTest
             url="{}/releases/tags/prod/1.0".format(self.mock_util.repo_url),
             status=404,
         )
-        with self.assertRaises(CumulusCIException):
+        with pytest.raises(CumulusCIException):
             generator()
 
 

--- a/cumulusci/tasks/release_notes/tests/test_parser.py
+++ b/cumulusci/tasks/release_notes/tests/test_parser.py
@@ -1,8 +1,8 @@
 import http.client
-import unittest
 import urllib.parse
 from unittest import mock
 
+import pytest
 import responses
 
 from cumulusci.core.exceptions import GithubApiNotFoundError
@@ -36,63 +36,63 @@ PARSER_CONFIG = [
 ]
 
 
-class TestBaseChangeNotesParser(unittest.TestCase):
+class TestBaseChangeNotesParser:
     def test_parse(self):
         parser = BaseChangeNotesParser("Title")
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             parser.parse()
 
     def test_render(self):
         parser = BaseChangeNotesParser("Title")
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             parser.render()
 
 
-class TestChangeNotesLinesParser(unittest.TestCase):
-    def setUp(self):
+class TestChangeNotesLinesParser:
+    def setup_method(self):
         self.title = "Title"
 
     def test_parse_no_start_line(self):
         change_note = "foo\r\nbar\r\n"
         parser = ChangeNotesLinesParser(None, self.title)
         line_added = parser.parse(change_note)
-        self.assertEqual(parser.content, [])
-        self.assertFalse(line_added)
+        assert parser.content == []
+        assert not line_added
 
     def test_parse_start_line_no_content(self):
         change_note = "# {}\r\n\r\n".format(self.title)
         parser = ChangeNotesLinesParser(None, self.title)
         line_added = parser.parse(change_note)
-        self.assertEqual(parser.content, [])
-        self.assertFalse(line_added)
+        assert parser.content == []
+        assert not line_added
 
     def test_parse_start_line_no_end_line(self):
         change_note = "# {}\r\nfoo\r\nbar".format(self.title)
         parser = ChangeNotesLinesParser(None, self.title)
         line_added = parser.parse(change_note)
-        self.assertEqual(parser.content, ["foo", "bar"])
-        self.assertEqual(True, line_added)
+        assert parser.content == ["foo", "bar"]
+        assert line_added is True
 
     def test_parse_start_line_end_at_header(self):
         change_note = "# {}\r\nfoo\r\n# Another Header\r\nbar".format(self.title)
         parser = ChangeNotesLinesParser(None, self.title)
         line_added = parser.parse(change_note)
-        self.assertEqual(parser.content, ["foo"])
-        self.assertTrue(line_added)
+        assert parser.content == ["foo"]
+        assert line_added
 
     def test_parse_start_line_no_content_no_end_line(self):
         change_note = "# {}".format(self.title)
         parser = ChangeNotesLinesParser(None, self.title)
         line_added = parser.parse(change_note)
-        self.assertEqual(parser.content, [])
-        self.assertFalse(line_added)
+        assert parser.content == []
+        assert not line_added
 
     def test_parse_multiple_start_lines_without_end_lines(self):
         change_note = "# {0}\r\nfoo\r\n# {0}\r\nbar\r\n".format(self.title)
         parser = ChangeNotesLinesParser(None, self.title)
         line_added = parser.parse(change_note)
-        self.assertEqual(parser.content, ["foo", "bar"])
-        self.assertTrue(line_added)
+        assert parser.content == ["foo", "bar"]
+        assert line_added
 
     def test_parse_multiple_start_lines_with_end_lines(self):
         change_note = "# {0}\r\nfoo\r\n\r\n# {0}\r\nbar\r\n\r\nincluded\r\n\r\n# not included".format(
@@ -100,8 +100,8 @@ class TestChangeNotesLinesParser(unittest.TestCase):
         )
         parser = ChangeNotesLinesParser(None, self.title)
         line_added = parser.parse(change_note)
-        self.assertEqual(parser.content, ["foo", "bar", "included"])
-        self.assertTrue(line_added)
+        assert parser.content == ["foo", "bar", "included"]
+        assert line_added
 
     def test_parse_multi_level_indent(self):
         change_note = "# {0}\r\nfoo \r\n    bar  \r\n        baz \r\n".format(
@@ -109,56 +109,53 @@ class TestChangeNotesLinesParser(unittest.TestCase):
         )
         parser = ChangeNotesLinesParser(None, self.title)
         line_added = parser.parse(change_note)
-        self.assertEqual(parser.content, ["foo", "    bar", "        baz"])
-        self.assertTrue(line_added)
+        assert parser.content == ["foo", "    bar", "        baz"]
+        assert line_added
 
     def test_parse_subheading(self):
         change_note = "# {0}\r\n## Subheading\r\nfoo".format(self.title)
         parser = ChangeNotesLinesParser(None, self.title)
         line_added = parser.parse(change_note)
-        self.assertEqual([], parser.content)
-        self.assertEqual({"Subheading": ["foo"]}, parser.h2)
-        self.assertTrue(line_added)
+        assert [] == parser.content
+        assert {"Subheading": ["foo"]} == parser.h2
+        assert line_added
 
     def test_parse_subheading_from_another_section(self):
         change_note = "## Subheading\r\n# {0}\r\nfoo".format(self.title)
         parser = ChangeNotesLinesParser(None, self.title)
         line_added = parser.parse(change_note)
-        self.assertEqual(["foo"], parser.content)
-        self.assertEqual({}, parser.h2)
-        self.assertTrue(line_added)
+        assert ["foo"] == parser.content
+        assert {} == parser.h2
+        assert line_added
 
     def test_render_no_content(self):
         parser = ChangeNotesLinesParser(None, self.title)
-        self.assertEqual(parser.render(), "")
+        assert parser.render() == ""
 
     def test_render_one_content(self):
         parser = ChangeNotesLinesParser(None, self.title)
         content = ["foo"]
         parser.content = content
-        self.assertEqual(
-            parser.render(), "# {}\r\n\r\n{}".format(self.title, content[0])
-        )
+        assert parser.render() == "# {}\r\n\r\n{}".format(self.title, content[0])
 
     def test_render_multiple_content(self):
         parser = ChangeNotesLinesParser(None, self.title)
         content = ["foo", "bar"]
         parser.content = content
-        self.assertEqual(
-            parser.render(), "# {}\r\n\r\n{}".format(self.title, "\r\n".join(content))
+        assert parser.render() == "# {}\r\n\r\n{}".format(
+            self.title, "\r\n".join(content)
         )
 
     def test_render_subheadings(self):
         parser = ChangeNotesLinesParser(None, self.title)
         parser.h2 = {"Subheading": ["foo"]}
-        self.assertEqual(
-            parser.render(),
-            "# {}\r\n\r\n\r\n## Subheading\r\n\r\nfoo".format(self.title),
+        assert parser.render() == "# {}\r\n\r\n\r\n## Subheading\r\n\r\nfoo".format(
+            self.title
         )
 
 
-class TestGithubLinesParser(unittest.TestCase):
-    def setUp(self):
+class TestGithubLinesParser:
+    def setup_method(self):
         self.title = "Title"
 
     def test_parse(self):
@@ -168,9 +165,9 @@ class TestGithubLinesParser(unittest.TestCase):
             number=1, html_url="http://pr", body="# {}\r\n\r\nfoo".format(self.title)
         )
         parser.parse(pr)
-        self.assertEqual(1, parser.pr_number)
-        self.assertEqual("http://pr", parser.pr_url)
-        self.assertEqual(["foo [[PR1](http://pr)]"], parser.content)
+        assert 1 == parser.pr_number
+        assert "http://pr" == parser.pr_url
+        assert ["foo [[PR1](http://pr)]"] == parser.content
 
     def test_parse_empty_pull_request_body(self):
         generator = mock.Mock(link_pr=True)
@@ -180,15 +177,15 @@ class TestGithubLinesParser(unittest.TestCase):
         assert not line_added
 
 
-class TestIssuesParser(unittest.TestCase):
-    def setUp(self):
+class TestIssuesParser:
+    def setup_method(self):
         self.title = "Issues"
 
     def test_issue_numbers(self):
         change_note = "# {}\r\nfix #2\r\nfix #3\r\nfix #5\r\n".format(self.title)
         parser = IssuesParser(None, self.title)
         parser.parse(change_note)
-        self.assertEqual(parser.content, [2, 3, 5])
+        assert parser.content == [2, 3, 5]
 
     def test_issue_numbers_with_links(self):
         change_note = "# {}\r\nfix [#2](https://issue)\r\nfix [#3](http://issue)\r\nfix #5\r\n".format(
@@ -196,13 +193,13 @@ class TestIssuesParser(unittest.TestCase):
         )
         parser = IssuesParser(None, self.title)
         parser.parse(change_note)
-        self.assertEqual(parser.content, [2, 3, 5])
+        assert parser.content == [2, 3, 5]
 
     def test_issue_numbers_and_other_numbers(self):
         change_note = "# {}\r\nfixes #2 but not # 3 or 5".format(self.title)
         parser = IssuesParser(None, self.title)
         parser.parse(change_note)
-        self.assertEqual(parser.content, [2])
+        assert parser.content == [2]
 
     def test_multiple_issue_numbers_per_line(self):
         change_note = "# {}\r\nfix #2 also does fix #3 and fix #5\r\n".format(
@@ -210,16 +207,16 @@ class TestIssuesParser(unittest.TestCase):
         )
         parser = IssuesParser(None, self.title)
         parser.parse(change_note)
-        self.assertEqual(parser.content, [2, 3, 5])
+        assert parser.content == [2, 3, 5]
 
     def test_render(self):
         parser = IssuesParser(None, self.title)
         parser.content = ["1: foo"]
-        self.assertEqual("# Issues\r\n\r\n#1: foo", parser.render())
+        assert "# Issues\r\n\r\n#1: foo" == parser.render()
 
 
-class TestGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
-    def setUp(self):
+class TestGithubIssuesParser(GithubApiTestMixin):
+    def setup_method(self):
         self.init_github()
         self.gh = get_github_api("TestUser", "TestPass")
         self.title = "Issues"
@@ -244,7 +241,7 @@ class TestGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
         parser.parse(pull_request)
         pr_url = "https://github.com/TestOwner/TestRepo/pulls/{}".format(self.pr_number)
         expected_content = self._create_expected_content([2, 3, 5], pr_url)
-        self.assertEqual(parser.content, expected_content)
+        assert parser.content == expected_content
 
     @responses.activate
     def test_issue_numbers_and_other_numbers(self):
@@ -258,7 +255,7 @@ class TestGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
         parser.parse(pull_request)
         pr_url = "https://github.com/TestOwner/TestRepo/pulls/{}".format(self.pr_number)
         expected_content = self._create_expected_content([2], pr_url)
-        self.assertEqual(parser.content, expected_content)
+        assert parser.content == expected_content
 
     @responses.activate
     def test_no_issue_numbers(self):
@@ -271,7 +268,7 @@ class TestGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
         pull_request = repo.pull_request(pr_number)
         parser = GithubIssuesParser(generator, self.title)
         parser.parse(pull_request)
-        self.assertEqual(parser.content, [])
+        assert parser.content == []
 
     @responses.activate
     def test_render_issue_number_valid(self):
@@ -292,7 +289,7 @@ class TestGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
         expected_render = self._create_expected_render(
             self.issue_number_valid, expected_response["title"], True
         )
-        self.assertEqual(parser.render(), expected_render)
+        assert parser.render() == expected_render
 
     @responses.activate
     def test_render_issue_number_invalid(self):
@@ -314,12 +311,12 @@ class TestGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
                 "pr_url": self.pr_url,
             }
         ]
-        with self.assertRaises(GithubApiNotFoundError):
+        with pytest.raises(GithubApiNotFoundError):
             parser.render()
 
     def test_init__issues_disabled(self):
         generator = mock.Mock(has_issues=False)
-        with self.assertRaises(GithubIssuesError):
+        with pytest.raises(GithubIssuesError):
             GithubIssuesParser(generator, self.title)
 
     def _create_expected_content(self, issue_numbers, pr_url):
@@ -341,8 +338,8 @@ class TestGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
         return generator
 
 
-class TestCommentingGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
-    def setUp(self):
+class TestCommentingGithubIssuesParser(GithubApiTestMixin):
+    def setup_method(self):
         self.init_github()
         self.gh = get_github_api("TestUser", "TestPass")
         self.mock_util = MockUtil("TestOwner", "TestRepo")
@@ -399,8 +396,8 @@ class TestCommentingGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
             issue_number, expected_issue["title"], False
         )
         render = parser.render()
-        self.assertEqual(render, expected_render)
-        self.assertEqual(len(responses.calls._calls), 2)
+        assert render == expected_render
+        assert len(responses.calls._calls) == 2
 
     @responses.activate
     def test_render_issue_with_beta_comment(self):
@@ -435,8 +432,8 @@ class TestCommentingGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
             issue_number, expected_issue["title"], False
         )
         render = parser.render()
-        self.assertEqual(render, expected_render)
-        self.assertEqual(len(responses.calls._calls), 3)
+        assert render == expected_render
+        assert len(responses.calls._calls) == 3
 
     @responses.activate
     def test_render_issue_without_beta_comment(self):
@@ -476,8 +473,8 @@ class TestCommentingGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
         expected_render = self._create_expected_render(
             issue_number, expected_issue["title"], False
         )
-        self.assertEqual(parser.render(), expected_render)
-        self.assertEqual(len(responses.calls._calls), 4)
+        assert parser.render() == expected_render
+        assert len(responses.calls._calls) == 4
 
     @responses.activate
     def test_render_issue_with_prod_comment(self):
@@ -511,8 +508,8 @@ class TestCommentingGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
         expected_render = self._create_expected_render(
             issue_number, expected_issue["title"], False
         )
-        self.assertEqual(parser.render(), expected_render)
-        self.assertEqual(len(responses.calls._calls), 3)
+        assert parser.render() == expected_render
+        assert len(responses.calls._calls) == 3
 
     @responses.activate
     def test_render_issue_without_prod_comment(self):
@@ -553,8 +550,8 @@ class TestCommentingGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
             issue_number, expected_issue["title"], False
         )
         render = parser.render()
-        self.assertEqual(render, expected_render)
-        self.assertEqual(len(responses.calls._calls), 4)
+        assert render == expected_render
+        assert len(responses.calls._calls) == 4
 
     def _create_expected_render(self, issue_number, issue_title, link_pr):
         render = "# {}\r\n\r\n#{}: {}".format(self.title, issue_number, issue_title)

--- a/cumulusci/tasks/release_notes/tests/test_parser.py
+++ b/cumulusci/tasks/release_notes/tests/test_parser.py
@@ -166,7 +166,7 @@ class TestGithubLinesParser:
         )
         parser.parse(pr)
         assert 1 == parser.pr_number
-        assert "http://pr" == parser.pr_url
+        assert parser.pr_url == "http://pr"
         assert ["foo [[PR1](http://pr)]"] == parser.content
 
     def test_parse_empty_pull_request_body(self):
@@ -212,7 +212,7 @@ class TestIssuesParser:
     def test_render(self):
         parser = IssuesParser(None, self.title)
         parser.content = ["1: foo"]
-        assert "# Issues\r\n\r\n#1: foo" == parser.render()
+        assert parser.render() == "# Issues\r\n\r\n#1: foo"
 
 
 class TestGithubIssuesParser(GithubApiTestMixin):

--- a/cumulusci/tasks/release_notes/tests/test_provider.py
+++ b/cumulusci/tasks/release_notes/tests/test_provider.py
@@ -462,6 +462,6 @@ class TestGithubChangeNotesProvider(GithubApiTestMixin):
         tag = "beta/1.0-Beta_1"
         generator = self._create_generator(tag)
         provider = GithubChangeNotesProvider(generator, tag)
-        assert "1.0-Beta_1" == provider._get_version_from_tag(tag)
+        assert provider._get_version_from_tag(tag) == "1.0-Beta_1"
         with pytest.raises(ValueError):
             provider._get_version_from_tag("bogus")

--- a/cumulusci/tasks/release_notes/tests/test_task.py
+++ b/cumulusci/tasks/release_notes/tests/test_task.py
@@ -175,7 +175,7 @@ class TestParentPullRequestNotes(GithubApiTestMixin):
             task.repo, "main", self.PARENT_BRANCH_NAME
         )
         assert 1 == actual_pull_request.number
-        assert "Body" == actual_pull_request.body
+        assert actual_pull_request.body == "Body"
 
     @mock.patch("cumulusci.tasks.release_notes.task.get_pull_requests_with_base_branch")
     def test_get_parent_pull_request__pull_request_not_found(

--- a/cumulusci/tasks/release_notes/tests/utils.py
+++ b/cumulusci/tasks/release_notes/tests/utils.py
@@ -5,14 +5,9 @@ import responses
 from cumulusci.tasks.github.tests.util_github_api import GithubApiTestMixin
 
 
-class MockUtil(GithubApiTestMixin):
+class MockUtilBase(GithubApiTestMixin):
     BASE_HTML_URL = "https://github.com"
     BASE_API_URL = "https://api.github.com"
-
-    def __init__(self, owner, repo):
-        self.owner = owner
-        self.repo = repo
-        self.init_github()
 
     @property
     def html_url(self):
@@ -141,3 +136,10 @@ class MockUtil(GithubApiTestMixin):
             json=[self._get_expected_pull_request(1, 1)],
             status=http.client.OK,
         )
+
+
+class MockUtil(MockUtilBase):
+    def __init__(self, owner, repo):
+        self.owner = owner
+        self.repo = repo
+        self.init_github()

--- a/cumulusci/tasks/robotframework/tests/test_robot_lint.py
+++ b/cumulusci/tasks/robotframework/tests/test_robot_lint.py
@@ -2,7 +2,6 @@ import os.path
 import shutil
 import tempfile
 import textwrap
-import unittest
 from pathlib import Path
 
 import pytest
@@ -15,8 +14,8 @@ from cumulusci.tasks.salesforce.tests.util import create_task
 from cumulusci.tests.util import create_project_config
 
 
-class TestRobotLint(MockLoggerMixin, unittest.TestCase):
-    def setUp(self):
+class TestRobotLint(MockLoggerMixin):
+    def setup_method(self):
         self.tmpdir = tempfile.mkdtemp(dir=".")
         self.task_config = TaskConfig()
         self._task_log_handler.reset()
@@ -28,7 +27,7 @@ class TestRobotLint(MockLoggerMixin, unittest.TestCase):
         lint_defaults = str((here / "lint_defaults.txt").resolve())
         self.base_args = ["--argumentfile", lint_defaults]
 
-    def tearDown(self):
+    def teardown_method(self):
         shutil.rmtree(self.tmpdir)
 
     def make_test_file(self, data, suffix=".robot", name="test", dir=None):
@@ -108,7 +107,7 @@ class TestRobotLint(MockLoggerMixin, unittest.TestCase):
         """Verify we pass the default rules to rflint"""
 
         task = create_task(RobotLint, {"path": self.tmpdir})
-        self.assertEqual(task._get_args(), self.base_args)
+        assert task._get_args() == self.base_args
 
     def test_configure_option(self):
         """Verify that rule configuration options are passed to rflint"""
@@ -122,7 +121,7 @@ class TestRobotLint(MockLoggerMixin, unittest.TestCase):
             "--configure",
             "FileTooLong:123",
         ]
-        self.assertEqual(task._get_args(), expected)
+        assert task._get_args() == expected
 
     def test_error_option(self):
         """Verify that error option is propertly translated to rflint options"""
@@ -130,7 +129,7 @@ class TestRobotLint(MockLoggerMixin, unittest.TestCase):
             RobotLint, {"path": self.tmpdir, "error": "LineTooLong,FileTooLong"}
         )
         expected = self.base_args + ["--error", "LineTooLong", "--error", "FileTooLong"]
-        self.assertEqual(task._get_args(), expected)
+        assert task._get_args() == expected
 
     def test_ignore_option(self):
         """Verify that ignore option is propertly translated to rflint options"""
@@ -144,7 +143,7 @@ class TestRobotLint(MockLoggerMixin, unittest.TestCase):
             "--ignore",
             "TooFewTestSteps",
         ]
-        self.assertEqual(task._get_args(), expected)
+        assert task._get_args() == expected
 
     def test_warning_option(self):
         """Verify that warning option is propertly translated to rflint options"""
@@ -158,7 +157,7 @@ class TestRobotLint(MockLoggerMixin, unittest.TestCase):
             "--warning",
             "TrailingWhitespace",
         ]
-        self.assertEqual(task._get_args(), expected)
+        assert task._get_args() == expected
 
     def test_ignore_all(self):
         """Verify that -o ignore all works as expected
@@ -213,7 +212,7 @@ class TestRobotLint(MockLoggerMixin, unittest.TestCase):
         # path with one wildcard should find one file
         task = create_task(RobotLint, {"path": "{}/*.resource".format(self.tmpdir)})
         files = sorted(task._get_files())
-        self.assertEqual(files, [file1])
+        assert files == [file1]
 
         # two paths with wildcards should find all three files
         task = create_task(
@@ -221,7 +220,7 @@ class TestRobotLint(MockLoggerMixin, unittest.TestCase):
             {"path": "{dir}/*.resource, {dir}/*.robot".format(dir=self.tmpdir)},
         )
         files = sorted(task._get_files())
-        self.assertEqual(files, [file1, file2, file3])
+        assert files == [file1, file2, file3]
 
     def test_folder_for_path(self):
         """Verify that if the path is a folder, we process all files in the folder"""
@@ -231,7 +230,7 @@ class TestRobotLint(MockLoggerMixin, unittest.TestCase):
 
         task = create_task(RobotLint, {"path": self.tmpdir})
         files = sorted(task._get_files())
-        self.assertEqual(files, [file1, file2, file3])
+        assert files == [file1, file2, file3]
 
     def test_recursive_folder(self):
         """Verify that subdirectories are included when finding files"""
@@ -240,4 +239,4 @@ class TestRobotLint(MockLoggerMixin, unittest.TestCase):
 
         task = create_task(RobotLint, {"path": self.tmpdir})
         files = sorted(task._get_files())
-        self.assertEqual(files, [file1])
+        assert files == [file1]

--- a/cumulusci/tasks/robotframework/tests/test_robot_parallel.py
+++ b/cumulusci/tasks/robotframework/tests/test_robot_parallel.py
@@ -3,7 +3,6 @@ Tests for the robot task, specifically for options related to running tests in p
 """
 
 import sys
-import unittest
 from pathlib import Path
 from unittest import mock
 
@@ -11,7 +10,7 @@ from cumulusci.tasks.robotframework import Robot
 from cumulusci.tasks.salesforce.tests.util import create_task
 
 
-class TestRobotParallel(unittest.TestCase):
+class TestRobotParallel:
     """Tests for the robot task when running tests with pabot"""
 
     @mock.patch("cumulusci.tasks.robotframework.robotframework.robot_run")

--- a/cumulusci/tasks/salesforce/tests/test_CreateCommunity.py
+++ b/cumulusci/tasks/salesforce/tests/test_CreateCommunity.py
@@ -1,8 +1,8 @@
 import json
-import unittest
 from datetime import datetime
 from unittest import mock
 
+import pytest
 import responses
 from simple_salesforce.exceptions import SalesforceMalformedRequest
 
@@ -26,7 +26,7 @@ task_options_no_url_path_prefix = {
 }
 
 
-class test_CreateCommunity(unittest.TestCase):
+class test_CreateCommunity:
     @responses.activate
     def test_creates_community(self):
         cc_task = create_task(CreateCommunity, task_options)
@@ -50,10 +50,10 @@ class test_CreateCommunity(unittest.TestCase):
 
         cc_task()
 
-        self.assertEqual(3, len(responses.calls))
-        self.assertEqual(community_url, responses.calls[1].request.url)
-        self.assertEqual(community_url, responses.calls[2].request.url)
-        self.assertEqual(
+        assert 3 == len(responses.calls)
+        assert community_url == responses.calls[1].request.url
+        assert community_url == responses.calls[2].request.url
+        assert (
             json.dumps(
                 {
                     "name": "Test Community",
@@ -61,8 +61,8 @@ class test_CreateCommunity(unittest.TestCase):
                     "templateName": "VF Template",
                     "urlPathPrefix": "test",
                 }
-            ),
-            responses.calls[1].request.body,
+            )
+            == responses.calls[1].request.body
         )
 
     @responses.activate
@@ -88,10 +88,10 @@ class test_CreateCommunity(unittest.TestCase):
 
         cc_task()
 
-        self.assertEqual(3, len(responses.calls))
-        self.assertEqual(community_url, responses.calls[1].request.url)
-        self.assertEqual(community_url, responses.calls[2].request.url)
-        self.assertEqual(
+        assert 3 == len(responses.calls)
+        assert community_url == responses.calls[1].request.url
+        assert community_url == responses.calls[2].request.url
+        assert (
             json.dumps(
                 {
                     "name": "Test Community",
@@ -99,8 +99,8 @@ class test_CreateCommunity(unittest.TestCase):
                     "templateName": "VF Template",
                     "urlPathPrefix": "",
                 }
-            ),
-            responses.calls[1].request.body,
+            )
+            == responses.calls[1].request.body
         )
 
     @responses.activate
@@ -117,7 +117,7 @@ class test_CreateCommunity(unittest.TestCase):
             json={"communities": [{"name": "Test Community", "id": "000000000000000"}]},
         )
 
-        with self.assertRaises(Exception):
+        with pytest.raises(Exception):
             cc_task()
 
     @responses.activate
@@ -197,7 +197,7 @@ class test_CreateCommunity(unittest.TestCase):
         )
 
         cc_task._init_task()
-        with self.assertRaises(SalesforceMalformedRequest):
+        with pytest.raises(SalesforceMalformedRequest):
             cc_task._run_task()()
 
     @responses.activate
@@ -226,7 +226,7 @@ class test_CreateCommunity(unittest.TestCase):
         )
 
         cc_task._init_task()
-        with self.assertRaises(SalesforceMalformedRequest):
+        with pytest.raises(SalesforceMalformedRequest):
             cc_task._run_task()()
 
     @responses.activate
@@ -247,7 +247,7 @@ class test_CreateCommunity(unittest.TestCase):
         cc_task.time_start = datetime.now()
         cc_task._poll_action()
 
-        self.assertFalse(cc_task.poll_complete)
+        assert not cc_task.poll_complete
 
     @responses.activate
     def test_waits_for_community_result__complete(self):
@@ -267,12 +267,12 @@ class test_CreateCommunity(unittest.TestCase):
         cc_task.time_start = datetime.now()
         cc_task._poll_action()
 
-        self.assertTrue(cc_task.poll_complete)
+        assert cc_task.poll_complete
         cc_task.logger.info.assert_called_once_with("Community 000000000000000 created")
 
     def test_throws_exception_for_timeout(self):
         cc_task = create_task(CreateCommunity, task_options)
 
         cc_task.time_start = datetime(2019, 1, 1)
-        with self.assertRaises(SalesforceException):
+        with pytest.raises(SalesforceException):
             cc_task._poll_action()

--- a/cumulusci/tasks/salesforce/tests/test_CreateCommunity.py
+++ b/cumulusci/tasks/salesforce/tests/test_CreateCommunity.py
@@ -26,7 +26,7 @@ task_options_no_url_path_prefix = {
 }
 
 
-class test_CreateCommunity:
+class TestCreateCommunity:
     @responses.activate
     def test_creates_community(self):
         cc_task = create_task(CreateCommunity, task_options)

--- a/cumulusci/tasks/salesforce/tests/test_CreatePackage.py
+++ b/cumulusci/tasks/salesforce/tests/test_CreatePackage.py
@@ -1,6 +1,5 @@
 import base64
 import io
-import unittest
 import zipfile
 
 from cumulusci.core.config import BaseProjectConfig, UniversalConfig
@@ -9,7 +8,7 @@ from cumulusci.tasks.salesforce import CreatePackage
 from .util import create_task
 
 
-class TestCreatePackage(unittest.TestCase):
+class TestCreatePackage:
     def test_get_package_zip(self):
         project_config = BaseProjectConfig(
             UniversalConfig(),

--- a/cumulusci/tasks/salesforce/tests/test_Deploy.py
+++ b/cumulusci/tasks/salesforce/tests/test_Deploy.py
@@ -1,8 +1,9 @@
 import base64
 import io
 import os
-import unittest
 import zipfile
+
+import pytest
 
 from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.core.flowrunner import StepSpec
@@ -12,7 +13,7 @@ from cumulusci.utils import temporary_dir, touch
 from .util import create_task
 
 
-class TestDeploy(unittest.TestCase):
+class TestDeploy:
     def test_get_api(self):
         with temporary_dir() as path:
             touch("package.xml")
@@ -29,7 +30,7 @@ class TestDeploy(unittest.TestCase):
 
             api = task._get_api()
             zf = zipfile.ZipFile(io.BytesIO(base64.b64decode(api.package_zip)), "r")
-            self.assertIn("package.xml", zf.namelist())
+            assert "package.xml" in zf.namelist()
 
     def test_get_api__managed(self):
         with temporary_dir() as path:
@@ -40,7 +41,7 @@ class TestDeploy(unittest.TestCase):
 
             api = task._get_api()
             zf = zipfile.ZipFile(io.BytesIO(base64.b64decode(api.package_zip)), "r")
-            self.assertIn("package.xml", zf.namelist())
+            assert "package.xml" in zf.namelist()
 
     def test_get_api__additional_options(self):
         with temporary_dir() as path:
@@ -73,7 +74,7 @@ class TestDeploy(unittest.TestCase):
 
             api = task._get_api()
             zf = zipfile.ZipFile(io.BytesIO(base64.b64decode(api.package_zip)), "r")
-            self.assertIn("package.xml", zf.namelist())
+            assert "package.xml" in zf.namelist()
 
     def test_get_api__static_resources(self):
         with temporary_dir() as path:
@@ -108,11 +109,11 @@ class TestDeploy(unittest.TestCase):
                 api = task._get_api()
                 zf = zipfile.ZipFile(io.BytesIO(base64.b64decode(api.package_zip)), "r")
                 namelist = zf.namelist()
-                self.assertIn("staticresources/TestBundle.resource", namelist)
-                self.assertIn("staticresources/TestBundle.resource-meta.xml", namelist)
+                assert "staticresources/TestBundle.resource" in namelist
+                assert "staticresources/TestBundle.resource-meta.xml" in namelist
                 package_xml = zf.read("package.xml").decode()
-                self.assertIn("<name>StaticResource</name>", package_xml)
-                self.assertIn("<members>TestBundle</members>", package_xml)
+                assert "<name>StaticResource</name>" in package_xml
+                assert "<members>TestBundle</members>" in package_xml
 
     def test_get_api__missing_path(self):
         task = create_task(
@@ -140,7 +141,7 @@ class TestDeploy(unittest.TestCase):
             assert api is None
 
     def test_init_options(self):
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             create_task(
                 Deploy,
                 {
@@ -150,12 +151,12 @@ class TestDeploy(unittest.TestCase):
                 },
             )
 
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             create_task(
                 Deploy, {"path": "empty", "test_level": "Test", "unmanaged": False}
             )
 
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             create_task(
                 Deploy,
                 {

--- a/cumulusci/tasks/salesforce/tests/test_DeployBundles.py
+++ b/cumulusci/tasks/salesforce/tests/test_DeployBundles.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 from unittest import mock
 
 from cumulusci.core.flowrunner import StepSpec
@@ -9,7 +8,7 @@ from cumulusci.utils import temporary_dir
 from .util import create_task
 
 
-class TestDeployBundles(unittest.TestCase):
+class TestDeployBundles:
     def test_run_task(self):
         with temporary_dir() as path:
             os.mkdir("src")
@@ -42,36 +41,33 @@ class TestDeployBundles(unittest.TestCase):
                 project_config=task.project_config,
             )
             steps = task.freeze(step)
-            self.assertEqual(
-                [
-                    {
-                        "is_required": True,
-                        "kind": "metadata",
-                        "name": "Deploy unpackaged/test",
-                        "path": "deploy_bundles.test",
-                        "source": None,
-                        "step_num": "1.1",
-                        "task_class": "cumulusci.tasks.salesforce.UpdateDependencies",
-                        "task_config": {
-                            "options": {
-                                "dependencies": [
-                                    {
-                                        "ref": task.project_config.repo_commit,
-                                        "github": "https://github.com/TestOwner/TestRepo",
-                                        "subfolder": "unpackaged/test",
-                                        "namespace_inject": None,
-                                    }
-                                ]
-                            },
-                            "checks": [],
+            assert [
+                {
+                    "is_required": True,
+                    "kind": "metadata",
+                    "name": "Deploy unpackaged/test",
+                    "path": "deploy_bundles.test",
+                    "source": None,
+                    "step_num": "1.1",
+                    "task_class": "cumulusci.tasks.salesforce.UpdateDependencies",
+                    "task_config": {
+                        "options": {
+                            "dependencies": [
+                                {
+                                    "ref": task.project_config.repo_commit,
+                                    "github": "https://github.com/TestOwner/TestRepo",
+                                    "subfolder": "unpackaged/test",
+                                    "namespace_inject": None,
+                                }
+                            ]
                         },
-                    }
-                ],
-                steps,
-            )
+                        "checks": [],
+                    },
+                }
+            ] == steps
 
     def test_freeze__bad_path(self):
         task = create_task(DeployBundles, {"path": "/bogus"})
         step = StepSpec(1, "deploy_bundles", task.task_config, None, None)
         steps = task.freeze(step)
-        self.assertEqual([], steps)
+        assert [] == steps

--- a/cumulusci/tasks/salesforce/tests/test_EnsureRecordTypes.py
+++ b/cumulusci/tasks/salesforce/tests/test_EnsureRecordTypes.py
@@ -1,6 +1,7 @@
 import os
-import unittest
 from unittest import mock
+
+import pytest
 
 from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.tasks.salesforce import EnsureRecordTypes
@@ -113,7 +114,7 @@ OPPORTUNITY_DESCRIBE_WITH_RTS = {
 }
 
 
-class TestEnsureRecordTypes(unittest.TestCase):
+class TestEnsureRecordTypes:
     def test_infers_correct_business_process(self):
         task = create_task(
             EnsureRecordTypes,
@@ -131,9 +132,9 @@ class TestEnsureRecordTypes(unittest.TestCase):
 
         task._infer_requirements()
 
-        self.assertTrue(task.options["generate_business_process"])
-        self.assertTrue(task.options["generate_record_type"])
-        self.assertEqual("Test", task.options["stage_name"])
+        assert task.options["generate_business_process"]
+        assert task.options["generate_record_type"]
+        assert "Test" == task.options["stage_name"]
 
     def test_no_business_process_where_unneeded(self):
         task = create_task(
@@ -150,9 +151,9 @@ class TestEnsureRecordTypes(unittest.TestCase):
 
         task._infer_requirements()
 
-        self.assertFalse(task.options["generate_business_process"])
-        self.assertTrue(task.options["generate_record_type"])
-        self.assertNotIn("stage_name", task.options)
+        assert not task.options["generate_business_process"]
+        assert task.options["generate_record_type"]
+        assert "stage_name" not in task.options
 
     def test_generates_record_type_and_business_process(self):
         # Asserts Record Type Description is optional.
@@ -176,11 +177,11 @@ class TestEnsureRecordTypes(unittest.TestCase):
             task._build_package()
             with open(os.path.join("objects", "Opportunity.object"), "r") as f:
                 opp_contents = f.read()
-                self.assertEqual(OPPORTUNITY_METADATA, opp_contents)
-                self.assertMultiLineEqual(OPPORTUNITY_METADATA, opp_contents)
+                assert OPPORTUNITY_METADATA == opp_contents
+                assert OPPORTUNITY_METADATA == opp_contents
             with open(os.path.join("package.xml"), "r") as f:
                 pkg_contents = f.read()
-                self.assertMultiLineEqual(PACKAGE_XML, pkg_contents)
+                assert PACKAGE_XML == pkg_contents
 
     def test_generates_record_type_and_business_process__case(self):
         # Asserts Record Type Description is added and truncated to 255 characters.
@@ -203,10 +204,10 @@ class TestEnsureRecordTypes(unittest.TestCase):
             task._build_package()
             with open(os.path.join("objects", "Case.object"), "r") as f:
                 opp_contents = f.read()
-                self.assertMultiLineEqual(CASE_METADATA, opp_contents)
+                assert CASE_METADATA == opp_contents
             with open(os.path.join("package.xml"), "r") as f:
                 pkg_contents = f.read()
-                self.assertMultiLineEqual(PACKAGE_XML, pkg_contents)
+                assert PACKAGE_XML == pkg_contents
 
     def test_generates_record_type_only(self):
         # Asserts Record Type Description is added when the Description is less than 255 characters.
@@ -229,10 +230,10 @@ class TestEnsureRecordTypes(unittest.TestCase):
             task._build_package()
             with open(os.path.join("objects", "Account.object"), "r") as f:
                 opp_contents = f.read()
-                self.assertMultiLineEqual(ACCOUNT_METADATA, opp_contents)
+                assert ACCOUNT_METADATA == opp_contents
             with open(os.path.join("package.xml"), "r") as f:
                 pkg_contents = f.read()
-                self.assertMultiLineEqual(PACKAGE_XML, pkg_contents)
+                assert PACKAGE_XML == pkg_contents
 
     def test_no_action_if_existing_record_types(self):
         task = create_task(
@@ -251,8 +252,8 @@ class TestEnsureRecordTypes(unittest.TestCase):
 
         task._infer_requirements()
 
-        self.assertFalse(task.options["generate_business_process"])
-        self.assertFalse(task.options["generate_record_type"])
+        assert not task.options["generate_business_process"]
+        assert not task.options["generate_record_type"]
 
     def test_second_rt_if_force_create(self):
         # Asserts a second Record Type is added even when RTs already exist when force_create is True
@@ -277,10 +278,10 @@ class TestEnsureRecordTypes(unittest.TestCase):
             task._build_package()
             with open(os.path.join("objects", "Account.object"), "r") as f:
                 obj_contents = f.read()
-                self.assertMultiLineEqual(ACCOUNT_METADATA, obj_contents)
+                assert ACCOUNT_METADATA == obj_contents
             with open(os.path.join("package.xml"), "r") as f:
                 pkg_contents = f.read()
-                self.assertMultiLineEqual(PACKAGE_XML, pkg_contents)
+                assert PACKAGE_XML == pkg_contents
 
     def test_executes_deployment(self):
         task = create_task(
@@ -324,7 +325,7 @@ class TestEnsureRecordTypes(unittest.TestCase):
         task._deploy.assert_not_called()
 
     def test_init_options(self):
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             create_task(
                 EnsureRecordTypes,
                 {
@@ -334,7 +335,7 @@ class TestEnsureRecordTypes(unittest.TestCase):
                 },
             )
 
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             create_task(
                 EnsureRecordTypes,
                 {

--- a/cumulusci/tasks/salesforce/tests/test_EnsureRecordTypes.py
+++ b/cumulusci/tasks/salesforce/tests/test_EnsureRecordTypes.py
@@ -134,7 +134,7 @@ class TestEnsureRecordTypes:
 
         assert task.options["generate_business_process"]
         assert task.options["generate_record_type"]
-        assert "Test" == task.options["stage_name"]
+        assert task.options["stage_name"] == "Test"
 
     def test_no_business_process_where_unneeded(self):
         task = create_task(

--- a/cumulusci/tasks/salesforce/tests/test_ListCommunities.py
+++ b/cumulusci/tasks/salesforce/tests/test_ListCommunities.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import unittest
+
 
 import responses
 
@@ -10,7 +10,7 @@ from .util import create_task
 task_options = {}
 
 
-class test_ListCommunities(unittest.TestCase):
+class test_ListCommunities:
     @responses.activate
     def test_lists_community(self):
         cc_task = create_task(ListCommunities, task_options)

--- a/cumulusci/tasks/salesforce/tests/test_ListCommunities.py
+++ b/cumulusci/tasks/salesforce/tests/test_ListCommunities.py
@@ -10,7 +10,7 @@ from .util import create_task
 task_options = {}
 
 
-class test_ListCommunities:
+class TestListCommunities:
     @responses.activate
     def test_lists_community(self):
         cc_task = create_task(ListCommunities, task_options)

--- a/cumulusci/tasks/salesforce/tests/test_ListCommunityTemplates.py
+++ b/cumulusci/tasks/salesforce/tests/test_ListCommunityTemplates.py
@@ -1,5 +1,3 @@
-import unittest
-
 import responses
 
 from cumulusci.tasks.salesforce import ListCommunityTemplates
@@ -9,7 +7,7 @@ from .util import create_task
 task_options = {}
 
 
-class test_ListCommunityTemplates(unittest.TestCase):
+class test_ListCommunityTemplates:
     @responses.activate
     def test_lists_community_templates(self):
         cc_task = create_task(ListCommunityTemplates, task_options)
@@ -47,5 +45,5 @@ class test_ListCommunityTemplates(unittest.TestCase):
 
         cc_task()
 
-        self.assertEqual(1, len(responses.calls))
-        self.assertEqual(community_url, responses.calls[0].request.url)
+        assert 1 == len(responses.calls)
+        assert community_url == responses.calls[0].request.url

--- a/cumulusci/tasks/salesforce/tests/test_ListCommunityTemplates.py
+++ b/cumulusci/tasks/salesforce/tests/test_ListCommunityTemplates.py
@@ -7,7 +7,7 @@ from .util import create_task
 task_options = {}
 
 
-class test_ListCommunityTemplates:
+class TestListCommunityTemplates:
     @responses.activate
     def test_lists_community_templates(self):
         cc_task = create_task(ListCommunityTemplates, task_options)

--- a/cumulusci/tasks/salesforce/tests/test_PackageUpload.py
+++ b/cumulusci/tasks/salesforce/tests/test_PackageUpload.py
@@ -63,7 +63,7 @@ class TestPackageUpload:
             return_value=mock.Mock(create=mock.Mock(return_value={"id": "UPLOAD_ID"}))
         )
         task()
-        assert "SUCCESS" == task.upload["Status"]
+        assert task.upload["Status"] == "SUCCESS"
 
     def test_set_package_id(self):
         name = "Test Release"
@@ -262,7 +262,7 @@ class TestPackageUpload:
         )
         with pytest.raises(ApexTestException):
             task()
-        assert "ERROR" == task.upload["Status"]
+        assert task.upload["Status"] == "ERROR"
 
     def test_get_one__no_result(self):
         task = create_task(PackageUpload, {"name": "Test Release"})

--- a/cumulusci/tasks/salesforce/tests/test_PublishCommunity.py
+++ b/cumulusci/tasks/salesforce/tests/test_PublishCommunity.py
@@ -1,5 +1,4 @@
-import unittest
-
+import pytest
 import responses
 from simple_salesforce.exceptions import SalesforceResourceNotFound
 
@@ -12,7 +11,7 @@ task_options = {"name": "Test Community"}
 task_options_with_id = {"name": "Test Community", "community_id": "000000000000000000"}
 
 
-class test_PublishCommunity(unittest.TestCase):
+class test_PublishCommunity:
     @responses.activate
     def test_publishes_community(self):
         cc_task = create_task(PublishCommunity, task_options)
@@ -73,9 +72,9 @@ class test_PublishCommunity(unittest.TestCase):
 
         cc_task()
 
-        self.assertEqual(2, len(responses.calls))
-        self.assertEqual(communities_url, responses.calls[0].request.url)
-        self.assertEqual(community_publish_url, responses.calls[1].request.url)
+        assert 2 == len(responses.calls)
+        assert communities_url == responses.calls[0].request.url
+        assert community_publish_url == responses.calls[1].request.url
 
     @responses.activate
     def test_publishes_community_with_id(self):
@@ -100,8 +99,8 @@ class test_PublishCommunity(unittest.TestCase):
 
         cc_task()
 
-        self.assertEqual(1, len(responses.calls))
-        self.assertEqual(community_publish_url, responses.calls[0].request.url)
+        assert 1 == len(responses.calls)
+        assert community_publish_url == responses.calls[0].request.url
 
     @responses.activate
     def test_throws_exception_for_bad_name(self):
@@ -145,7 +144,7 @@ class test_PublishCommunity(unittest.TestCase):
         )
 
         cc_task._init_task()
-        with self.assertRaises(SalesforceException):
+        with pytest.raises(SalesforceException):
             cc_task._run_task()
 
     @responses.activate
@@ -169,7 +168,7 @@ class test_PublishCommunity(unittest.TestCase):
             ],
         )
 
-        with self.assertRaises(SalesforceResourceNotFound):
+        with pytest.raises(SalesforceResourceNotFound):
             cc_task._init_task()
             cc_task._run_task()
 
@@ -178,5 +177,5 @@ class test_PublishCommunity(unittest.TestCase):
         cc_task = create_task(PublishCommunity, {})
 
         cc_task._init_task()
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             cc_task._run_task()

--- a/cumulusci/tasks/salesforce/tests/test_PublishCommunity.py
+++ b/cumulusci/tasks/salesforce/tests/test_PublishCommunity.py
@@ -11,7 +11,7 @@ task_options = {"name": "Test Community"}
 task_options_with_id = {"name": "Test Community", "community_id": "000000000000000000"}
 
 
-class test_PublishCommunity:
+class TestPublishCommunity:
     @responses.activate
     def test_publishes_community(self):
         cc_task = create_task(PublishCommunity, task_options)

--- a/cumulusci/tasks/salesforce/tests/test_RetrievePackaged.py
+++ b/cumulusci/tasks/salesforce/tests/test_RetrievePackaged.py
@@ -1,6 +1,5 @@
 import io
 import os
-import unittest
 import zipfile
 from unittest import mock
 
@@ -11,7 +10,7 @@ from cumulusci.utils import temporary_dir
 from .util import create_task
 
 
-class TestRetrievePackaged(unittest.TestCase):
+class TestRetrievePackaged:
     def test_run_task(self):
         with temporary_dir() as path:
             project_config = create_project_config()
@@ -21,4 +20,4 @@ class TestRetrievePackaged(unittest.TestCase):
             zf.writestr("TestPackage/testfile", "test")
             task.api_class = mock.Mock(return_value=mock.Mock(return_value=zf))
             task()
-            self.assertTrue(os.path.exists(os.path.join(path, "testfile")))
+            assert os.path.exists(os.path.join(path, "testfile"))

--- a/cumulusci/tasks/salesforce/tests/test_RetrieveReportsAndDashboards.py
+++ b/cumulusci/tasks/salesforce/tests/test_RetrieveReportsAndDashboards.py
@@ -1,6 +1,6 @@
-import unittest
 from unittest import mock
 
+import pytest
 import responses
 
 from cumulusci.core.exceptions import TaskOptionsError
@@ -10,7 +10,7 @@ from cumulusci.utils import temporary_dir
 from .util import create_task
 
 
-class TestRetrievePackaged(unittest.TestCase):
+class TestRetrievePackaged:
     @responses.activate
     def test_get_api(self):
         with temporary_dir() as path:
@@ -33,7 +33,7 @@ class TestRetrievePackaged(unittest.TestCase):
             task.api_class = mock.Mock()
             task._get_api()
             package_xml = task.api_class.call_args[0][1]
-            self.assertEqual(
+            assert (
                 """<?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <types>
@@ -47,10 +47,10 @@ class TestRetrievePackaged(unittest.TestCase):
         <name>Report</name>
     </types>
     <version>43.0</version>
-</Package>""",
-                package_xml,
+</Package>"""
+                == package_xml
             )
 
     def test_init__missing_options(self):
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             create_task(RetrieveReportsAndDashboards, {"path": None})

--- a/cumulusci/tasks/salesforce/tests/test_RetrieveUnpackaged.py
+++ b/cumulusci/tasks/salesforce/tests/test_RetrieveUnpackaged.py
@@ -18,4 +18,4 @@ class TestRetrieveUnpackaged:
             )
             task.api_class = mock.Mock()
             task._get_api()
-            assert "PACKAGE" == task.api_class.call_args[0][1]
+            assert task.api_class.call_args[0][1] == "PACKAGE"

--- a/cumulusci/tasks/salesforce/tests/test_RetrieveUnpackaged.py
+++ b/cumulusci/tasks/salesforce/tests/test_RetrieveUnpackaged.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 from unittest import mock
 
 from cumulusci.tasks.salesforce import RetrieveUnpackaged
@@ -8,7 +7,7 @@ from cumulusci.utils import temporary_dir
 from .util import create_task
 
 
-class TestRetrieveUnpackaged(unittest.TestCase):
+class TestRetrieveUnpackaged:
     def test_get_api(self):
         with temporary_dir() as path:
             with open(os.path.join(path, "package.xml"), "w") as f:
@@ -19,4 +18,4 @@ class TestRetrieveUnpackaged(unittest.TestCase):
             )
             task.api_class = mock.Mock()
             task._get_api()
-            self.assertEqual("PACKAGE", task.api_class.call_args[0][1])
+            assert "PACKAGE" == task.api_class.call_args[0][1]

--- a/cumulusci/tasks/salesforce/tests/test_UninstallLocal.py
+++ b/cumulusci/tasks/salesforce/tests/test_UninstallLocal.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest import mock
 
 from cumulusci.tasks.salesforce import UninstallLocal
@@ -7,10 +6,10 @@ from cumulusci.utils import temporary_dir
 from .util import create_task
 
 
-class TestUninstallLocal(unittest.TestCase):
+class TestUninstallLocal:
     @mock.patch("cumulusci.tasks.metadata.package.PackageXmlGenerator.__call__")
     def test_get_destructive_changes(self, PackageXmlGenerator):
         with temporary_dir() as path:
             task = create_task(UninstallLocal, {"path": path})
             PackageXmlGenerator.return_value = mock.sentinel.package_xml
-            self.assertEqual(mock.sentinel.package_xml, task._get_destructive_changes())
+            assert mock.sentinel.package_xml == task._get_destructive_changes()

--- a/cumulusci/tasks/salesforce/tests/test_UninstallLocalBundles.py
+++ b/cumulusci/tasks/salesforce/tests/test_UninstallLocalBundles.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 from unittest import mock
 
 from cumulusci.tasks.salesforce import UninstallLocalBundles
@@ -8,7 +7,7 @@ from cumulusci.utils import temporary_dir
 from .util import create_task
 
 
-class TestUninstallLocalBundles(unittest.TestCase):
+class TestUninstallLocalBundles:
     def test_run_task(self):
         with temporary_dir() as path:
             os.mkdir("bundle")

--- a/cumulusci/tasks/salesforce/tests/test_UninstallLocalNamespacedBundles.py
+++ b/cumulusci/tasks/salesforce/tests/test_UninstallLocalNamespacedBundles.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest import mock
 
 from cumulusci.tasks.salesforce import UninstallLocalNamespacedBundles
@@ -8,7 +7,7 @@ from cumulusci.utils import temporary_dir
 from .util import create_task
 
 
-class TestUninstallLocalNamespacedBundles(unittest.TestCase):
+class TestUninstallLocalNamespacedBundles:
     @mock.patch("cumulusci.tasks.metadata.package.PackageXmlGenerator.__call__")
     def test_get_destructive_changes(self, PackageXmlGenerator):
         with temporary_dir() as path:
@@ -20,4 +19,4 @@ class TestUninstallLocalNamespacedBundles(unittest.TestCase):
                 project_config,
             )
             PackageXmlGenerator.return_value = "%TOKEN%"
-            self.assertEqual("ns__", task._get_destructive_changes())
+            assert "ns__" == task._get_destructive_changes()

--- a/cumulusci/tasks/salesforce/tests/test_UninstallLocalNamespacedBundles.py
+++ b/cumulusci/tasks/salesforce/tests/test_UninstallLocalNamespacedBundles.py
@@ -19,4 +19,4 @@ class TestUninstallLocalNamespacedBundles:
                 project_config,
             )
             PackageXmlGenerator.return_value = "%TOKEN%"
-            assert "ns__" == task._get_destructive_changes()
+            assert task._get_destructive_changes() == "ns__"

--- a/cumulusci/tasks/salesforce/tests/test_UninstallPackage.py
+++ b/cumulusci/tasks/salesforce/tests/test_UninstallPackage.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest import mock
 
 from cumulusci.tasks.salesforce import UninstallPackage
@@ -7,7 +6,7 @@ from cumulusci.tests.util import create_project_config
 from .util import create_task
 
 
-class TestUninstallPackage(unittest.TestCase):
+class TestUninstallPackage:
     @mock.patch(
         "cumulusci.salesforce_api.package_zip.UninstallPackageZipBuilder.__call__"
     )

--- a/cumulusci/tasks/salesforce/tests/test_UninstallPackagedIncremental.py
+++ b/cumulusci/tasks/salesforce/tests/test_UninstallPackagedIncremental.py
@@ -1,8 +1,9 @@
 import io
 import os
-import unittest
 import zipfile
 from unittest import mock
+
+import pytest
 
 from cumulusci.core.exceptions import CumulusCIException
 from cumulusci.tasks.salesforce import UninstallPackagedIncremental
@@ -12,7 +13,7 @@ from cumulusci.utils import temporary_dir
 from .util import create_task
 
 
-class TestUninstallPackagedIncremental(unittest.TestCase):
+class TestUninstallPackagedIncremental:
     def test_get_destructive_changes(self):
         with temporary_dir():
             os.mkdir("src")
@@ -78,7 +79,7 @@ class TestUninstallPackagedIncremental(unittest.TestCase):
             )
             task._retrieve_packaged = mock.Mock(return_value=zf)
             result = task._get_destructive_changes()
-            self.assertEqual(
+            assert (
                 """<?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <types>
@@ -90,8 +91,8 @@ class TestUninstallPackagedIncremental(unittest.TestCase):
         <name>CustomObject</name>
     </types>
     <version>43.0</version>
-</Package>""",
-                result,
+</Package>"""
+                == result
             )
 
     def test_get_destructive_changes__no_package_xml(self):
@@ -105,7 +106,7 @@ class TestUninstallPackagedIncremental(unittest.TestCase):
             },
             project_config,
         )
-        with self.assertRaises(CumulusCIException):
+        with pytest.raises(CumulusCIException):
             task._get_destructive_changes()
 
     def test_dry_run(self):

--- a/cumulusci/tasks/salesforce/tests/test_activate_flow.py
+++ b/cumulusci/tasks/salesforce/tests/test_activate_flow.py
@@ -1,6 +1,6 @@
 import json
-import unittest
 
+import pytest
 import responses
 
 from cumulusci.core.exceptions import TaskOptionsError
@@ -9,7 +9,7 @@ from cumulusci.tasks.salesforce.activate_flow import ActivateFlow
 from .util import create_task
 
 
-class TestActivateFlow(unittest.TestCase):
+class TestActivateFlow:
     @responses.activate
     def test_activate_some_flow_processes(self):
         cc_task = create_task(
@@ -47,7 +47,7 @@ class TestActivateFlow(unittest.TestCase):
         responses.add(method=responses.PATCH, url=activate_url, status=204, json=data)
 
         cc_task()
-        self.assertEqual(2, len(responses.calls))
+        assert 2 == len(responses.calls)
 
     @responses.activate
     def test_activate_all_flow_processes(self):
@@ -97,10 +97,10 @@ class TestActivateFlow(unittest.TestCase):
         responses.add(method=responses.PATCH, url=activate_url, status=204, json=data)
         responses.add(method=responses.PATCH, url=activate_url2, status=204, json=data)
         cc_task()
-        self.assertEqual(3, len(responses.calls))
+        assert 3 == len(responses.calls)
 
     @responses.activate
     def test_activate_no_flow_processes(self):
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             cc_task = create_task(ActivateFlow, {"developer_names": []})
             cc_task()

--- a/cumulusci/tasks/salesforce/tests/test_base_tasks.py
+++ b/cumulusci/tasks/salesforce/tests/test_base_tasks.py
@@ -1,7 +1,8 @@
 import io
-import unittest
 import zipfile
 from unittest import mock
+
+import pytest
 
 from cumulusci.core.config import OrgConfig, TaskConfig
 from cumulusci.core.exceptions import ServiceNotConfigured
@@ -18,8 +19,8 @@ from cumulusci.utils import temporary_dir
 from . import create_task
 
 
-class TestBaseSalesforceTask(unittest.TestCase):
-    def setUp(self):
+class TestBaseSalesforceTask:
+    def setup_method(self):
         self.project_config = create_project_config()
         self.project_config.keychain = mock.Mock()
         self.project_config.keychain.get_service.side_effect = ServiceNotConfigured
@@ -33,7 +34,7 @@ class TestBaseSalesforceTask(unittest.TestCase):
             task = BaseSalesforceTask(
                 self.project_config, self.task_config, self.org_config
             )
-            with self.assertRaises(NotImplementedError):
+            with pytest.raises(NotImplementedError):
                 task()
 
     def test_update_credentials(self):
@@ -54,17 +55,17 @@ class TestBaseSalesforceTask(unittest.TestCase):
         self.project_config.keychain.set_org.assert_called_once()
 
 
-class TestBaseSalesforceApiTask(unittest.TestCase):
+class TestBaseSalesforceApiTask:
     def test_sf_instance(self):
         org_config = OrgConfig(
             {"instance_url": "https://foo/", "access_token": "TOKEN"}, "test"
         )
         task = create_task(BaseSalesforceApiTask, org_config=org_config)
         task._init_task()
-        self.assertFalse(task.sf.sf_instance.endswith("/"))
+        assert not task.sf.sf_instance.endswith("/")
 
 
-class TestBaseSalesforceMetadataApiTask(unittest.TestCase):
+class TestBaseSalesforceMetadataApiTask:
     def test_run_task(self):
         task = create_task(BaseSalesforceMetadataApiTask)
         api = mock.Mock()
@@ -73,7 +74,7 @@ class TestBaseSalesforceMetadataApiTask(unittest.TestCase):
         api.assert_called_once()
 
 
-class TestBaseRetrieveMetadata(unittest.TestCase):
+class TestBaseRetrieveMetadata:
     def test_process_namespace(self):
         with temporary_dir() as path:
             task = create_task(
@@ -87,10 +88,10 @@ class TestBaseRetrieveMetadata(unittest.TestCase):
             )
             zf = zipfile.ZipFile(io.BytesIO(), "w")
             result = task._process_namespace(zf)
-            self.assertIsInstance(result, zipfile.ZipFile)
+            assert isinstance(result, zipfile.ZipFile)
 
 
-class TestBaseUninstallMetadata(unittest.TestCase):
+class TestBaseUninstallMetadata:
     def test_get_api(self):
         with temporary_dir() as path:
             task = create_task(BaseUninstallMetadata, {"path": path})

--- a/cumulusci/tasks/salesforce/tests/test_custom_settings_wait.py
+++ b/cumulusci/tasks/salesforce/tests/test_custom_settings_wait.py
@@ -1,5 +1,4 @@
-import unittest
-
+import pytest
 import responses
 
 from cumulusci.core.config import BaseProjectConfig, TaskConfig, UniversalConfig
@@ -10,8 +9,8 @@ from cumulusci.tasks.salesforce.custom_settings_wait import CustomSettingValueWa
 from cumulusci.tests.util import DummyOrgConfig
 
 
-class TestRunCustomSettingsWait(MockLoggerMixin, unittest.TestCase):
-    def setUp(self):
+class TestRunCustomSettingsWait(MockLoggerMixin):
+    def setup_method(self):
         self.api_version = 42.0
         self.universal_config = UniversalConfig(
             {"project": {"api_version": self.api_version}}
@@ -152,10 +151,10 @@ class TestRunCustomSettingsWait(MockLoggerMixin, unittest.TestCase):
             ],
         )
 
-        with self.assertRaises(TaskOptionsError) as e:
+        with pytest.raises(TaskOptionsError) as e:
             task()
 
-        assert "supported" in str(e.exception)
+        assert "supported" in str(e.value)
 
     def test_apply_namespace__managed(self):
         self.project_config.config["project"]["package"]["namespace"] = "ns"

--- a/cumulusci/tasks/salesforce/tests/test_network_member_group.py
+++ b/cumulusci/tasks/salesforce/tests/test_network_member_group.py
@@ -1,12 +1,13 @@
-import unittest
 from unittest.mock import Mock, call
+
+import pytest
 
 from cumulusci.core.exceptions import CumulusCIException, SalesforceException
 from cumulusci.tasks.salesforce.network_member_group import CreateNetworkMemberGroups
 from cumulusci.tasks.salesforce.tests.util import create_task
 
 
-class TestCreateNetworkMemberGroups(unittest.TestCase):
+class TestCreateNetworkMemberGroups:
     """
     Unit tests cumulusci.tasks.salesforce.network_member_group.CreateNetworkMemberGroups.
     """
@@ -22,13 +23,13 @@ class TestCreateNetworkMemberGroups(unittest.TestCase):
         task.format_soql = Mock()
 
         # Execute the test.
-        with self.assertRaises(SalesforceException) as context:
+        with pytest.raises(SalesforceException) as context:
             task._get_network_id(network_name)
 
         # Assert scenario execute as expected.
-        self.assertEqual(
-            f'No Network record found with Name "{network_name}"',
-            context.exception.args[0],
+        assert (
+            f'No Network record found with Name "{network_name}"'
+            == context.value.args[0]
         )
 
         task.sf.query_all.assert_called_once_with(
@@ -50,7 +51,7 @@ class TestCreateNetworkMemberGroups(unittest.TestCase):
         actual = task._get_network_id(network_name)
 
         # Assert scenario execute as expected.
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
         task.sf.query_all.assert_called_once_with(
             f"SELECT Id FROM Network WHERE Name = '{network_name}' LIMIT 1"
@@ -78,7 +79,7 @@ class TestCreateNetworkMemberGroups(unittest.TestCase):
         actual = task._get_network_member_group_parent_ids(network_id)
 
         # Assert scenario execute as expected.
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
         task.sf.query_all.assert_called_once_with(
             f"SELECT ParentId FROM NetworkMemberGroup WHERE NetworkId = '{network_id}'"
@@ -115,7 +116,7 @@ class TestCreateNetworkMemberGroups(unittest.TestCase):
         actual = task._get_parent_ids_by_name(sobject_type, record_names)
 
         # Assert scenario execute as expected.
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
         task.sf.query_all.assert_called_once_with(
             "SELECT Id, Name FROM {} WHERE Name IN ('{}')".format(
@@ -153,7 +154,7 @@ class TestCreateNetworkMemberGroups(unittest.TestCase):
         actual = task._get_parent_ids_by_name(sobject_type, record_names)
 
         # Assert scenario execute as expected.
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
         task.sf.query_all.assert_called_once_with(
             "SELECT Id, Label FROM {} WHERE Label IN ('{}')".format(
@@ -250,13 +251,13 @@ class TestCreateNetworkMemberGroups(unittest.TestCase):
         task.sf.NetworkMemberGroup.create = Mock(insert_response)
 
         # Execute the test.
-        with self.assertRaises(CumulusCIException) as context:
+        with pytest.raises(CumulusCIException) as context:
             task._create_network_member_group(sobject_type, parent_name, parent_id)
 
         # Assert scenario execute as expected.
-        self.assertEqual(
-            f'No {sobject_type} record found with Name "{parent_name}"',
-            context.exception.args[0],
+        assert (
+            f'No {sobject_type} record found with Name "{parent_name}"'
+            == context.value.args[0]
         )
 
         task.sf.NetworkMemberGroup.create.assert_not_called()
@@ -334,13 +335,13 @@ class TestCreateNetworkMemberGroups(unittest.TestCase):
         task.sf.NetworkMemberGroup.create.return_value = insert_response
 
         # Execute the test.
-        with self.assertRaises(SalesforceException) as context:
+        with pytest.raises(SalesforceException) as context:
             task._create_network_member_group(sobject_type, parent_name, parent_id)
 
         # Assert scenario execute as expected.
-        self.assertEqual(
-            f'Error creating NetworkMemberGroup for Network "{task._network_id}" for parent {sobject_type} "{parent_name}" {parent_id}.   Errors: {", ".join(errors)}',
-            context.exception.args[0],
+        assert (
+            f'Error creating NetworkMemberGroup for Network "{task._network_id}" for parent {sobject_type} "{parent_name}" {parent_id}.   Errors: {", ".join(errors)}'
+            == context.value.args[0]
         )
 
         task.sf.NetworkMemberGroup.create.assert_called_once_with(
@@ -368,13 +369,13 @@ class TestCreateNetworkMemberGroups(unittest.TestCase):
         task.sf.NetworkMemberGroup.create = Mock(return_value=insert_response)
 
         # Execute the test.
-        with self.assertRaises(SalesforceException) as context:
+        with pytest.raises(SalesforceException) as e:
             task._create_network_member_group(sobject_type, parent_name, parent_id)
 
         # Assert scenario execute as expected.
-        self.assertEqual(
-            f'Error creating NetworkMemberGroup for Network "{task._network_id}" for parent {sobject_type} "{parent_name}" {parent_id}.   Errors: {", ".join([])}',
-            context.exception.args[0],
+        assert (
+            f'Error creating NetworkMemberGroup for Network "{task._network_id}" for parent {sobject_type} "{parent_name}" {parent_id}.   Errors: {", ".join([])}'
+            == e.value.args[0]
         )
 
         task.sf.NetworkMemberGroup.create.assert_called_once_with(

--- a/cumulusci/tasks/salesforce/tests/test_org_settings.py
+++ b/cumulusci/tasks/salesforce/tests/test_org_settings.py
@@ -1,10 +1,10 @@
-from unittest.mock import Mock
 import base64
 import io
 import json
 import os
 import pathlib
 import zipfile
+from unittest.mock import Mock
 
 import pytest
 
@@ -13,6 +13,7 @@ from cumulusci.tasks.salesforce.org_settings import (
     build_settings_package,
 )
 from cumulusci.utils import temporary_dir
+
 from .util import create_task
 
 
@@ -274,8 +275,13 @@ class TestBuildSettingsPackage:
     </nested>
 </OtherSettings>"""
             )
+
+            rm_ws = "".maketrans("", "", " \t \n")
+
             assert (
-                (pathlib.Path(path) / "objects" / "Account.object").read_text()
+                (pathlib.Path(path) / "objects" / "Account.object")
+                .read_text()
+                .translate(rm_ws)
                 == """<?xml version="1.0" encoding="UTF-8"?>
 <Object xmlns="http://soap.sforce.com/2006/04/metadata">
     <sharingModel>Public</sharingModel>
@@ -283,15 +289,15 @@ class TestBuildSettingsPackage:
         <fullName>Default</fullName>
         <label>Default</label>
         <active>true</active>
-        
     </recordTypes>
-        
-
-</Object>"""
+</Object>""".translate(
+                    rm_ws
+                )
             )
-            print((pathlib.Path(path) / "objects" / "Solution.object").read_text())
             assert (
-                (pathlib.Path(path) / "objects" / "Solution.object").read_text()
+                (pathlib.Path(path) / "objects" / "Solution.object")
+                .read_text()
+                .translate(rm_ws)
                 == """<?xml version="1.0" encoding="UTF-8"?>
 <Object xmlns="http://soap.sforce.com/2006/04/metadata">
 
@@ -301,14 +307,15 @@ class TestBuildSettingsPackage:
         <active>true</active>
         <businessProcess>DefaultSolution</businessProcess>
     </recordTypes>
-        
+
     <businessProcesses>
         <fullName>DefaultSolution</fullName>
         <isActive>true</isActive>
         <values>
             <fullName>Draft</fullName>
-            
         </values>
     </businessProcesses>
-</Object>"""
+</Object>""".translate(
+                    rm_ws
+                )
             )

--- a/cumulusci/tasks/salesforce/tests/test_profiles.py
+++ b/cumulusci/tasks/salesforce/tests/test_profiles.py
@@ -113,7 +113,7 @@ def test_run_task_success():
         RESPONSE_SUCCESS,
     )
     result = task._run_task()
-    assert "001R0000029IyDPIA0" == result
+    assert result == "001R0000029IyDPIA0"
     assert responses.calls[0].request.params == {
         "q": "SELECT Id, Name FROM UserLicense WHERE Name = 'Foo' LIMIT 1"
     }

--- a/cumulusci/tasks/salesforce/users/tests/test_photos.py
+++ b/cumulusci/tasks/salesforce/users/tests/test_photos.py
@@ -26,7 +26,7 @@ def test_join_errors():
         ],
     )
 
-    assert "Error message 1.; Error message 2.; Error message 3." == join_errors(e)
+    assert join_errors(e) == "Error message 1.; Error message 2.; Error message 3."
 
 
 class TestUploadProfilePhoto:

--- a/cumulusci/tasks/tests/test_datadictionary.py
+++ b/cumulusci/tasks/tests/test_datadictionary.py
@@ -30,7 +30,7 @@ from cumulusci.utils.xml import metadata_tree
 from cumulusci.utils.yaml.cumulusci_yml import cci_safe_load
 
 
-class test_GenerateDataDictionary:
+class TestGenerateDataDictionary:
     def test_version_from_tag_name(self):
         task = create_task(GenerateDataDictionary, {})
 

--- a/cumulusci/tasks/tests/test_datadictionary.py
+++ b/cumulusci/tasks/tests/test_datadictionary.py
@@ -1,8 +1,9 @@
 import io
-import unittest
 from collections import defaultdict
 from distutils.version import LooseVersion
 from unittest.mock import Mock, call, mock_open, patch
+
+import pytest
 
 from cumulusci.core.config import BaseConfig
 from cumulusci.core.dependencies.dependencies import (
@@ -29,7 +30,7 @@ from cumulusci.utils.xml import metadata_tree
 from cumulusci.utils.yaml.cumulusci_yml import cci_safe_load
 
 
-class test_GenerateDataDictionary(unittest.TestCase):
+class test_GenerateDataDictionary:
     def test_version_from_tag_name(self):
         task = create_task(GenerateDataDictionary, {})
 
@@ -1396,7 +1397,7 @@ class test_GenerateDataDictionary(unittest.TestCase):
         project_config = create_project_config()
         project_config.project__name = "Project"
 
-        with self.assertRaises(DependencyParseError):
+        with pytest.raises(DependencyParseError):
             create_task(
                 GenerateDataDictionary,
                 {"additional_dependencies": [{"namespace": "foo"}]},
@@ -1407,7 +1408,7 @@ class test_GenerateDataDictionary(unittest.TestCase):
         project_config = create_project_config()
         project_config.project__name = "Project"
 
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             create_task(
                 GenerateDataDictionary,
                 {"additional_dependencies": [{"namespace": "foo", "version": "1.0"}]},
@@ -1418,7 +1419,7 @@ class test_GenerateDataDictionary(unittest.TestCase):
         project_config = create_project_config()
         project_config.project__name = "Project"
 
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             create_task(
                 GenerateDataDictionary,
                 {
@@ -1470,7 +1471,7 @@ class test_GenerateDataDictionary(unittest.TestCase):
         ]
         project_config.get_repo_from_url = Mock(return_value=None)
 
-        with self.assertRaises(DependencyResolutionError):
+        with pytest.raises(DependencyResolutionError):
             task._get_repo_dependencies(
                 parse_dependencies(project_config.project__dependencies)
             )

--- a/cumulusci/tasks/tests/test_metadeploy.py
+++ b/cumulusci/tasks/tests/test_metadeploy.py
@@ -378,7 +378,7 @@ class TestPublish(GithubApiTestMixin):
         version = task._find_or_create_version(
             {"url": "http://EXISTING_PRODUCT", "id": "abcdef"}
         )
-        assert "http://EXISTING_VERSION" == version["url"]
+        assert version["url"] == "http://EXISTING_VERSION"
 
     @responses.activate
     def test_find_or_create_version__commit(self):
@@ -409,7 +409,7 @@ class TestPublish(GithubApiTestMixin):
         version = task._find_or_create_version(
             {"url": "http://EXISTING_PRODUCT", "id": "abcdef"}
         )
-        assert "http://EXISTING_VERSION" == version["url"]
+        assert version["url"] == "http://EXISTING_VERSION"
 
     @responses.activate
     def test_find_product__not_found(self):
@@ -506,7 +506,7 @@ class TestPublish(GithubApiTestMixin):
             "install",
             {"slug": "install"},
         )
-        assert "https://NEW_PLANTEMPLATE" == plantemplate["url"]
+        assert plantemplate["url"] == "https://NEW_PLANTEMPLATE"
 
     def test_freeze_steps__skip(self):
         project_config = create_project_config()

--- a/cumulusci/tasks/tests/test_metadeploy.py
+++ b/cumulusci/tasks/tests/test_metadeploy.py
@@ -2,11 +2,11 @@ import io
 import json
 import shutil
 import tempfile
-import unittest
 import zipfile
 from base64 import b64encode
 from pathlib import Path
 
+import pytest
 import requests
 import responses
 import yaml
@@ -18,7 +18,7 @@ from cumulusci.tasks.metadeploy import BaseMetaDeployTask, Publish
 from cumulusci.tests.util import create_project_config
 
 
-class TestBaseMetaDeployTask(unittest.TestCase):
+class TestBaseMetaDeployTask:
     maxDiff = None
 
     @responses.activate
@@ -34,7 +34,7 @@ class TestBaseMetaDeployTask(unittest.TestCase):
         task_config = TaskConfig()
         task = BaseMetaDeployTask(project_config, task_config)
         task._init_task()
-        with self.assertRaises(requests.exceptions.HTTPError):
+        with pytest.raises(requests.exceptions.HTTPError):
             task._call_api("GET", "/rest")
 
     @responses.activate
@@ -60,10 +60,10 @@ class TestBaseMetaDeployTask(unittest.TestCase):
         task = BaseMetaDeployTask(project_config, task_config)
         task._init_task()
         results = task._call_api("GET", "/rest", collect_pages=True)
-        self.assertEqual([1, 2], results)
+        assert [1, 2] == results
 
 
-class TestPublish(unittest.TestCase, GithubApiTestMixin):
+class TestPublish(GithubApiTestMixin):
     maxDiff = None
 
     @responses.activate
@@ -105,11 +105,11 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
                 }
             }
         )
-        with self.assertRaises(CumulusCIException) as e:
+        with pytest.raises(CumulusCIException) as e:
             task = Publish(project_config, task_config)
             task()
 
-        assert "Admin API" in str(e.exception)
+        assert "Admin API" in str(e.value)
 
     @responses.activate
     def test_run_task(self):
@@ -273,58 +273,55 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
 
         steps = json.loads(responses.calls[-2].request.body)["steps"]
         self.maxDiff = None
-        self.assertEqual(
-            [
-                {
-                    "is_required": True,
-                    "kind": "managed",
-                    "name": "Install Test Product 1.0",
-                    "path": "install_prod.install_managed",
-                    "source": None,
-                    "step_num": "1/2",
-                    "task_class": "cumulusci.tasks.salesforce.InstallPackageVersion",
-                    "task_config": {
-                        "options": {
-                            "namespace": "ns",
-                            "version": "1.0",
-                            "interactive": False,
-                            "base_package_url_format": "{}",
-                        },
-                        "checks": [],
+        assert [
+            {
+                "is_required": True,
+                "kind": "managed",
+                "name": "Install Test Product 1.0",
+                "path": "install_prod.install_managed",
+                "source": None,
+                "step_num": "1/2",
+                "task_class": "cumulusci.tasks.salesforce.InstallPackageVersion",
+                "task_config": {
+                    "options": {
+                        "namespace": "ns",
+                        "version": "1.0",
+                        "interactive": False,
+                        "base_package_url_format": "{}",
                     },
+                    "checks": [],
                 },
-                {
-                    "is_required": True,
-                    "kind": "metadata",
-                    "name": "Update Admin Profile",
-                    "path": "install_prod.config_managed.update_admin_profile",
-                    "source": None,
-                    "step_num": "1/3/2",
-                    "task_class": "cumulusci.tasks.salesforce.ProfileGrantAllAccess",
-                    "task_config": {
-                        "options": {
-                            "namespace_inject": "ns",
-                            "include_packaged_objects": False,
-                        },
-                        "checks": [],
+            },
+            {
+                "is_required": True,
+                "kind": "metadata",
+                "name": "Update Admin Profile",
+                "path": "install_prod.config_managed.update_admin_profile",
+                "source": None,
+                "step_num": "1/3/2",
+                "task_class": "cumulusci.tasks.salesforce.ProfileGrantAllAccess",
+                "task_config": {
+                    "options": {
+                        "namespace_inject": "ns",
+                        "include_packaged_objects": False,
                     },
+                    "checks": [],
                 },
-                {
-                    "name": "util_sleep",
-                    "kind": "other",
-                    "is_required": True,
-                    "path": "util_sleep",
-                    "step_num": "2",
-                    "task_class": "cumulusci.tasks.util.Sleep",
-                    "task_config": {
-                        "options": {"seconds": 5},
-                        "checks": [{"when": "False", "action": "error"}],
-                    },
-                    "source": None,
+            },
+            {
+                "name": "util_sleep",
+                "kind": "other",
+                "is_required": True,
+                "path": "util_sleep",
+                "step_num": "2",
+                "task_class": "cumulusci.tasks.util.Sleep",
+                "task_config": {
+                    "options": {"seconds": 5},
+                    "checks": [{"when": "False", "action": "error"}],
                 },
-            ],
-            steps,
-        )
+                "source": None,
+            },
+        ] == steps
 
         labels = json.loads(en_labels_path.read_text())
         assert labels == {
@@ -381,7 +378,7 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
         version = task._find_or_create_version(
             {"url": "http://EXISTING_PRODUCT", "id": "abcdef"}
         )
-        self.assertEqual("http://EXISTING_VERSION", version["url"])
+        assert "http://EXISTING_VERSION" == version["url"]
 
     @responses.activate
     def test_find_or_create_version__commit(self):
@@ -412,7 +409,7 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
         version = task._find_or_create_version(
             {"url": "http://EXISTING_PRODUCT", "id": "abcdef"}
         )
-        self.assertEqual("http://EXISTING_VERSION", version["url"])
+        assert "http://EXISTING_VERSION" == version["url"]
 
     @responses.activate
     def test_find_product__not_found(self):
@@ -431,7 +428,7 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
         task_config = TaskConfig({"options": {"tag": "release/1.0"}})
         task = Publish(project_config, task_config)
         task._init_task()
-        with self.assertRaises(Exception):
+        with pytest.raises(Exception):
             task._find_product()
 
     def test_init_task__no_tag_or_commit(self):
@@ -443,7 +440,7 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
         )
         task_config = TaskConfig({"options": {}})
         task = Publish(project_config, task_config)
-        with self.assertRaises(TaskOptionsError):
+        with pytest.raises(TaskOptionsError):
             task._init_task()
 
     @responses.activate
@@ -467,7 +464,7 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
         task_config = TaskConfig({"options": {"tag": "release/1.0", "plan": "install"}})
         task = Publish(project_config, task_config)
         task._init_task()
-        self.assertEqual(expected_plans, task.plan_configs)
+        assert expected_plans == task.plan_configs
 
     @responses.activate
     def test_find_or_create_plan_template__not_found(self):
@@ -509,7 +506,7 @@ class TestPublish(unittest.TestCase, GithubApiTestMixin):
             "install",
             {"slug": "install"},
         )
-        self.assertEqual("https://NEW_PLANTEMPLATE", plantemplate["url"])
+        assert "https://NEW_PLANTEMPLATE" == plantemplate["url"]
 
     def test_freeze_steps__skip(self):
         project_config = create_project_config()

--- a/cumulusci/tasks/tests/test_metaxml.py
+++ b/cumulusci/tasks/tests/test_metaxml.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 from unittest import mock
 
 from cumulusci.core.config import BaseProjectConfig, TaskConfig, UniversalConfig
@@ -8,7 +7,7 @@ from cumulusci.tasks.metaxml import UpdateApi, UpdateDependencies
 from cumulusci.utils import temporary_dir
 
 
-class TestUpdateApi(unittest.TestCase):
+class TestUpdateApi:
     def test_run_task(self):
         with temporary_dir() as d:
             os.mkdir(".git")
@@ -32,17 +31,17 @@ class TestUpdateApi(unittest.TestCase):
 
             with open(meta_xml_path, "r") as f:
                 result = f.read()
-            self.assertEqual(
+            assert (
                 """<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>43.0</apiVersion>
 </ApexClass>
-""",
-                result,
+"""
+                == result
             )
 
 
-class TestUpdateDependencies(unittest.TestCase):
+class TestUpdateDependencies:
     @mock.patch("cumulusci.tasks.metaxml.get_static_dependencies")
     def test_run_task(self, get_static_dependencies):
         get_static_dependencies.return_value = [
@@ -81,7 +80,7 @@ class TestUpdateDependencies(unittest.TestCase):
 
             with open(meta_xml_path, "r") as f:
                 result = f.read()
-            self.assertEqual(
+            assert (
                 """<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <packageVersions>
@@ -95,6 +94,6 @@ class TestUpdateDependencies(unittest.TestCase):
         <minorNumber>1</minorNumber>
     </packageVersions>
 </ApexClass>
-""",
-                result,
+"""
+                == result
             )

--- a/cumulusci/tasks/tests/test_promote_package_version.py
+++ b/cumulusci/tasks/tests/test_promote_package_version.py
@@ -394,8 +394,8 @@ class TestPromotePackageVersion(GithubApiTestMixin):
         ]
         with caplog.at_level(logging.INFO):
             task._process_two_gp_deps(dependencies)
-        assert "Total 2GP dependencies: 1" == caplog.records[1].message
-        assert "Unpromoted 2GP dependencies: 1" == caplog.records[2].message
+        assert caplog.records[1].message == "Total 2GP dependencies: 1"
+        assert caplog.records[2].message == "Unpromoted 2GP dependencies: 1"
         assert (
             "This package depends on other packages that have not yet been promoted."
             == caplog.records[4].message

--- a/cumulusci/tasks/tests/test_pushfails.py
+++ b/cumulusci/tasks/tests/test_pushfails.py
@@ -1,6 +1,5 @@
 import csv
 import os.path
-import unittest
 from unittest import mock
 
 from cumulusci.tasks.push.pushfails import ReportPushFailures
@@ -31,7 +30,7 @@ def error_record(gack=False, ErrorTitle="Unexpected Error"):  # type: (bool) -> 
     }
 
 
-class TestPushFailureTask(unittest.TestCase):
+class TestPushFailureTask:
     def test_run_task(
         self,
     ):
@@ -73,15 +72,13 @@ class TestPushFailureTask(unittest.TestCase):
         task._init_class = _init_class
         with temporary_dir():
             task()
-            self.assertEqual(2, task.sf.query_all.call_count)
-            self.assertTrue(
-                os.path.isfile(task.result), "the result file does not exist"
-            )
+            assert 2 == task.sf.query_all.call_count
+            assert os.path.isfile(task.result), "the result file does not exist"
             with open(task.result, "r") as f:
                 reader = csv.DictReader(f)
                 rows = list(reader)
-            self.assertEqual(len(rows), 2)
-            self.assertEqual(rows[1]["Stacktrace Id"], "-4532")
+            assert len(rows) == 2
+            assert rows[1]["Stacktrace Id"] == "-4532"
 
     def test_run_task__no_results(self):
         task = create_task(ReportPushFailures, options={"request_id": "123"})
@@ -96,4 +93,4 @@ class TestPushFailureTask(unittest.TestCase):
 
         task._init_class = _init_class
         task()
-        self.assertFalse(os.path.isfile(task.options["result_file"]))
+        assert not os.path.isfile(task.options["result_file"])

--- a/cumulusci/tasks/tests/test_salesforce.py
+++ b/cumulusci/tasks/tests/test_salesforce.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest.mock import MagicMock, patch
 
 from cumulusci.core.config import (
@@ -16,8 +15,8 @@ from cumulusci.tasks.salesforce import BaseSalesforceApiTask
     "cumulusci.tasks.salesforce.BaseSalesforceTask._update_credentials",
     MagicMock(return_value=None),
 )
-class TestSalesforceToolingTask(unittest.TestCase):
-    def setUp(self):
+class TestSalesforceToolingTask:
+    def setup_method(self):
         self.api_version = 36.0
         self.universal_config = UniversalConfig(
             {"project": {"package": {"api_version": self.api_version}}}
@@ -49,15 +48,15 @@ class TestSalesforceToolingTask(unittest.TestCase):
         task._init_task()
         obj = task._get_tooling_object("TestObject")
         url = self.base_tooling_url + "sobjects/TestObject/"
-        self.assertEqual(obj.base_url, url)
+        assert obj.base_url == url
 
     def test_default_client_name(self):
         task = BaseSalesforceApiTask(
             self.project_config, self.task_config, self.org_config
         )
         task._init_task()
-        self.assertIn("Sforce-Call-Options", task.sf.headers)
-        self.assertIn("CumulusCI/", task.sf.headers["Sforce-Call-Options"])
+        assert "Sforce-Call-Options" in task.sf.headers
+        assert "CumulusCI/" in task.sf.headers["Sforce-Call-Options"]
 
     def test_connected_app_client_name(self):
         self.project_config.keychain.set_service(
@@ -68,6 +67,6 @@ class TestSalesforceToolingTask(unittest.TestCase):
             self.project_config, self.task_config, self.org_config
         )
         task._init_task()
-        self.assertIn("Sforce-Call-Options", task.sf.headers)
-        self.assertNotIn("CumulusCI/", task.sf.headers["Sforce-Call-Options"])
-        self.assertIn("test123", task.sf.headers["Sforce-Call-Options"])
+        assert "Sforce-Call-Options" in task.sf.headers
+        assert "CumulusCI/" not in task.sf.headers["Sforce-Call-Options"]
+        assert "test123" in task.sf.headers["Sforce-Call-Options"]

--- a/cumulusci/tasks/tests/test_sfdx.py
+++ b/cumulusci/tasks/tests/test_sfdx.py
@@ -1,6 +1,6 @@
 """ Tests for the SFDX Command Wrapper"""
 
-import unittest
+
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
@@ -18,10 +18,10 @@ from cumulusci.tasks.salesforce.tests.util import create_task
 from cumulusci.tasks.sfdx import SFDXBaseTask, SFDXJsonTask, SFDXOrgTask
 
 
-class TestSFDXBaseTask(MockLoggerMixin, unittest.TestCase):
+class TestSFDXBaseTask(MockLoggerMixin):
     """Tests for the Base Task type"""
 
-    def setUp(self):
+    def setup_method(self):
         self.universal_config = UniversalConfig()
         self.project_config = BaseProjectConfig(
             self.universal_config, config={"noyaml": True}
@@ -45,8 +45,8 @@ class TestSFDXBaseTask(MockLoggerMixin, unittest.TestCase):
         except CommandException:
             pass
 
-        self.assertEqual("force:org", task.options["command"])
-        self.assertEqual("sfdx force:org --help", task._get_command())
+        assert "force:org" == task.options["command"]
+        assert "sfdx force:org --help" == task._get_command()
 
     @patch("cumulusci.tasks.command.Command._run_task", MagicMock(return_value=None))
     def test_keychain_org_creds(self):
@@ -71,9 +71,9 @@ class TestSFDXBaseTask(MockLoggerMixin, unittest.TestCase):
         task()
 
         org_config.refresh_oauth_token.assert_called_once()
-        self.assertIn("SFDX_INSTANCE_URL", task._get_env())
-        self.assertIn("SFDX_DEFAULTUSERNAME", task._get_env())
-        self.assertIn(access_token, task._get_env()["SFDX_DEFAULTUSERNAME"])
+        assert "SFDX_INSTANCE_URL" in task._get_env()
+        assert "SFDX_DEFAULTUSERNAME" in task._get_env()
+        assert access_token in task._get_env()["SFDX_DEFAULTUSERNAME"]
 
     def test_scratch_org_username(self):
         """Scratch Org credentials are passed by -u flag"""
@@ -81,14 +81,14 @@ class TestSFDXBaseTask(MockLoggerMixin, unittest.TestCase):
         org_config = ScratchOrgConfig({"username": "test@example.com"}, "test")
 
         task = SFDXOrgTask(self.project_config, self.task_config, org_config)
-        self.assertIn("-u test@example.com", task._get_command())
+        assert "-u test@example.com" in task._get_command()
 
 
-class TestSFDXJsonTask(unittest.TestCase):
+class TestSFDXJsonTask:
     def test_get_command(self):
         task = create_task(SFDXJsonTask)
         command = task._get_command()
-        self.assertEqual("sfdx force:mdapi:deploy --json", command)
+        assert "sfdx force:mdapi:deploy --json" == command
 
     def test_process_output(self):
         task = create_task(SFDXJsonTask)

--- a/cumulusci/tasks/tests/test_sfdx.py
+++ b/cumulusci/tasks/tests/test_sfdx.py
@@ -45,8 +45,8 @@ class TestSFDXBaseTask(MockLoggerMixin):
         except CommandException:
             pass
 
-        assert "force:org" == task.options["command"]
-        assert "sfdx force:org --help" == task._get_command()
+        assert task.options["command"] == "force:org"
+        assert task._get_command() == "sfdx force:org --help"
 
     @patch("cumulusci.tasks.command.Command._run_task", MagicMock(return_value=None))
     def test_keychain_org_creds(self):
@@ -88,7 +88,7 @@ class TestSFDXJsonTask:
     def test_get_command(self):
         task = create_task(SFDXJsonTask)
         command = task._get_command()
-        assert "sfdx force:mdapi:deploy --json" == command
+        assert command == "sfdx force:mdapi:deploy --json"
 
     def test_process_output(self):
         task = create_task(SFDXJsonTask)

--- a/cumulusci/tasks/tests/test_util.py
+++ b/cumulusci/tasks/tests/test_util.py
@@ -180,7 +180,7 @@ class TestUtilTasks:
         task.logger = DummyLogger()
         task()
         output = task.logger.get_output()
-        assert "Beginning task: LogLine\n\ntest" == output
+        assert output == "Beginning task: LogLine\n\ntest"
 
     def test_PassOptionAsResult(self):
         task_config = TaskConfig({"options": {"result": "test"}})
@@ -188,7 +188,7 @@ class TestUtilTasks:
             self.project_config, task_config, self.org_config
         )
         task()
-        assert "test" == task.result
+        assert task.result == "test"
 
     def test_PassOptionAsReturnValue(self):
         task_config = TaskConfig({"options": {"key": "foo", "value": "bar"}})
@@ -196,4 +196,4 @@ class TestUtilTasks:
             self.project_config, task_config, self.org_config
         )
         result = task()
-        assert "bar" == result["foo"]
+        assert result["foo"] == "bar"

--- a/cumulusci/tests/test_utils.py
+++ b/cumulusci/tests/test_utils.py
@@ -600,9 +600,9 @@ Options\n------------------------------------------\n\n
         assert utils.PIPX_UPDATE_CMD == upgrade_cmd
 
     def test_convert_to_snake_case(self):
-        assert "one_two" == utils.convert_to_snake_case("OneTwo")
-        assert "one_two" == utils.convert_to_snake_case("ONETwo")
-        assert "one_two" == utils.convert_to_snake_case("One_Two")
+        assert utils.convert_to_snake_case("OneTwo") == "one_two"
+        assert utils.convert_to_snake_case("ONETwo") == "one_two"
+        assert utils.convert_to_snake_case("One_Two") == "one_two"
 
     @mock.patch("sarge.Command")
     def test_get_git_config(self, Command):
@@ -610,7 +610,7 @@ Options\n------------------------------------------\n\n
             stdout=io.BytesIO(b"test@example.com"), stderr=io.BytesIO(b""), returncode=0
         )
 
-        assert "test@example.com" == utils.get_git_config("user.email")
+        assert utils.get_git_config("user.email") == "test@example.com"
         assert (
             sarge.shell_format('git config --get "{0!s}"', "user.email")
             == Command.call_args[0][0]

--- a/cumulusci/utils/tests/test_fileutils.py
+++ b/cumulusci/utils/tests/test_fileutils.py
@@ -158,7 +158,7 @@ class _TestFSResourceShared:
         abspath = "c:\\foo\\bar"
         with open_fs_resource(abspath) as f:
             if sys.platform == "win32":
-                assert "c:\\foo\\bar" == str(f.getsyspath()), str(f.getsyspath())
+                assert str(f.getsyspath()), str(f.getsyspath()) == "c:\\foo\\bar"
 
 
 class TestFSResource(_TestFSResourceShared):

--- a/cumulusci/utils/tests/test_fileutils.py
+++ b/cumulusci/utils/tests/test_fileutils.py
@@ -158,7 +158,7 @@ class _TestFSResourceShared:
         abspath = "c:\\foo\\bar"
         with open_fs_resource(abspath) as f:
             if sys.platform == "win32":
-                assert str(f.getsyspath()), str(f.getsyspath()) == "c:\\foo\\bar"
+                assert str(f.getsyspath()), str(f.getsyspath()) == r"c:\foo\bar"
 
 
 class TestFSResource(_TestFSResourceShared):


### PR DESCRIPTION
Nothing for release notes

Abolish unittest.TestCase and replace it with pytest's simpler and more powerful syntax.

Beyond consistency, the other reason to do this is so that we can use fixtures in these classes.