### PR TITLE
Load certs from the mac keychain but don't use securetransport

### DIFF
--- a/cumulusci/utils/http/requests_utils.py
+++ b/cumulusci/utils/http/requests_utils.py
@@ -54,7 +54,7 @@ def init_requests_trust():
     from requests.adapters import HTTPAdapter
     from requests.utils import DEFAULT_CA_BUNDLE_PATH
 
-    # On macOS, monkey patch SSLContext.load_defauult_locations
+    # On macOS, monkey patch SSLContext.load_default_locations
     # to load CA certs from the system keychain
     if sys.platform == "darwin":
         import ssl

--- a/cumulusci/utils/http/requests_utils.py
+++ b/cumulusci/utils/http/requests_utils.py
@@ -27,18 +27,20 @@ def init_requests_trust():
 
     This is called from cumulusci.__init__ to enact our policy:
 
-    - If a request explicitly sets `verify` to a path
-      (perhaps via the REQUESTS_CA_BUNDLE environment variable),
-      we'll continue to honor that.
+    - On all platforms, block `requests` from passing the `certifi` CA bundle
+      to urllib3, so that urllib3 will instead set up an SSLContext by
+      running SSLContext.load_default_certs()
 
-    - On macOS, fetch CA certs from the system keychain.
+    - On macOS, override SSLContext.load_default_certs() to load certs
+      from the system keychain instead of from OpenSSL's default path.
 
-    - On other platforms, verify certificates using urllib3's default approach,
-      which loads CAs using SSLContext.load_default_certs()
-      and should work on Linux and Windows in most cases.
+    If a request explicitly sets `verify` to a path
+    (perhaps via the REQUESTS_CA_BUNDLE environment variable),
+    the CA certs from that path will still be trusted as well.
 
     The monkey-patching approach may be controversial, but it ensures that:
-    a. we don't have to change every location we are using requests.get or requests.post without an explicit session
+    a. we don't have to change every location we are using requests.get
+       or requests.post without an explicit session
     b. our policy will also apply to 3rd-party libraries that use requests
     """
     if os.environ.get("CUMULUSCI_SYSTEM_CERTS") != "True":

--- a/cumulusci/utils/http/requests_utils.py
+++ b/cumulusci/utils/http/requests_utils.py
@@ -1,4 +1,3 @@
-import functools
 import os
 import subprocess
 import sys
@@ -57,8 +56,10 @@ def init_requests_trust():
     if sys.platform == "darwin":
         import ssl
 
+        cadata = get_macos_ca_certs()
+
         def load_default_certs(self, purpose=ssl.Purpose.SERVER_AUTH):
-            self.load_verify_locations(cadata=get_macos_ca_certs())
+            self.load_verify_locations(cadata=cadata)
 
         ssl.SSLContext.load_default_certs = load_default_certs
 
@@ -75,7 +76,6 @@ def init_requests_trust():
     HTTPAdapter.cert_verify = cert_verify
 
 
-@functools.cache
 def get_macos_ca_certs() -> str:
     # get certs from both the default keychains and the SystemRootCertificates keychain
     result = ""


### PR DESCRIPTION
[update to #3114; no additional release note needed]

# Critical Changes

# Changes

# Issues Closed
