### PR TITLE
Add automated api version updates via Github Actions

### DIFF
--- a/.github/workflows/chores.yml
+++ b/.github/workflows/chores.yml
@@ -1,0 +1,60 @@
+name: Scheduled Chores
+
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: "0 0 * * 0" # At 00:00 on Sunday
+
+jobs:
+    check_api_versions:
+        runs-on: ubuntu-latest
+        outputs:
+            hub_version: ${{ steps.devhub-api-version.outputs.hub_version }}
+            cci_version: ${{ steps.cci-api-version.outputs.cci_version }}
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  ref: main
+            - name: Set up Python
+              uses: actions/setup-python@v2
+            - name: Get Dev Hub API Version
+              id: devhub-api-version
+              env:
+                  HUB_URL: ${{ format('{0}/services/data', secrets.SFDO_HUB_URL) }}
+              run: |
+                  version=$(curl -s $HUB_URL | jq -r '.[-1] | .version')
+                  echo "::set-output name=hub_version::$version"
+            - name: Get CURRENT_SF_API_VERSION
+              id: cci-api-version
+              run: |
+                  version=$(yq '.project.package.api_version' cumulusci/cumulusci.yml)
+                  echo "::set-output name=cci_version::$version"
+    update_api_versions:
+        runs-on: ubuntu-latest
+        needs: check_api_versions
+        if: ${{ needs.check_api_versions.outputs.hub_version != needs.check_api_versions.outputs.cci_version }}
+        env:
+            VERSION: ${{ needs.check_api_versions.outputs.hub_version }}
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+                  ref: main
+            - name: Set CURRENT_SF_API_VERSION
+              id: set-cci-api-version
+              run: |
+                  yq --indent 4 --inplace '
+                    .project.package.api_version = strenv(VERSION)
+                  ' cumulusci/cumulusci.yml
+            - name: Commit changes
+              run: |
+                  git config user.name github-actions
+                  git config user.email github-actions@github.com
+                  git switch -c "update-sfdc-api-v$VERSION"
+                  git add cumulusci/cumulusci.yml
+                  git commit -m "Automated update to sfdc API version $VERSION"
+                  git push origin "update-sfdc-api-v$VERSION"
+            - env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  gh pr create --fill --label 'auto-pr'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,12 @@ on:
             - cumulusci/version.txt
 
 jobs:
+    run-release-test:
+        uses: ./.github/workflows/release_test.yml@main
     publish-to-pypi:
         name: Publish new release to PyPI
         runs-on: ubuntu-18.04
+        needs: run-release-test
         steps:
             - uses: actions/checkout@main
             - name: Set up Python 3.8

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -1,9 +1,9 @@
 name: Release Test
 
 on:
+    workflow_dispatch:
     push:
         branches:
-            - feature/**
             - main
     pull_request:
         types: [opened, synchronize, reopened] # Default

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -1,10 +1,13 @@
 name: Release Test
 
 on:
+    workflow_call:
     workflow_dispatch:
     push:
         branches:
             - main
+        paths_ignore:
+            - cumulusci/version.txt # Called from release.yml instead
     pull_request:
         types: [opened, synchronize, reopened] # Default
 


### PR DESCRIPTION
Add a new workflow 'chores' containing two jobs:

- `check_api_versions`: polls the sfdo devhub for the latest API
   version, then stores that and the current default version from
   `cumulusci/cumulusci.yml` in its output.
- `update_api_versions`: if the outputs for the check job do not match,
writes the new version to `cumulusci/cumulusci.yml`, commits, pushes,
and creates a PR with those changes.

This job is scheduled to run Sundays at 00:00 UTC.

In addition, the `release_test` workflow now

- is not triggered on every push to feature branches
- may be manually run
- is triggered from the "Release cumulusci" workflow when `version.txt` is included in a `push` event