### PR TITLE
fix: remove version spec from local workflow call

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
     run-release-test:
-        uses: ./.github/workflows/release_test.yml@main
+        uses: ./.github/workflows/release_test.yml
     publish-to-pypi:
         name: Publish new release to PyPI
         runs-on: ubuntu-18.04


### PR DESCRIPTION
In order to use `@,` we must specify the full path, i.e. `Owner/Repo/.github/...`. However, in the `./.github/...` syntax `main` is implied.

-------

# Critical Changes

# Changes

# Issues Closed