### PR TITLE
Support lightning radiobuttons

### DIFF
--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -78,6 +78,7 @@ class Salesforce(object):
         """
         try:
             version = int(float(self.get_latest_api_version()))
+
         except RobotNotRunningError:
             # Likely this means we are running in the context of
             # documentation generation. Setting the version to
@@ -1440,7 +1441,8 @@ class Salesforce(object):
         For most input form fields the actual value string will be
         used.  For a checkbox, passing the value "checked" will check
         the checkbox and any other value will uncheck it. Using
-        "unchecked" is recommended for clarity.
+        "unchecked" is recommended for clarity. For radiobuttons, you
+        must pass the string "selected" for the value.
 
         Example:
 
@@ -1451,6 +1453,15 @@ class Salesforce(object):
         | ...  Private                  checked           # checkbox
         | ...  Type                     New Customer      # combobox
         | ...  Primary Campaign Source  The Big Campaign  # picklist
+
+        Example setting a radio button:
+
+        In this example, the radiobutton group has the label
+        "Who sees this list view?", and one of the radiobuttons
+        has the label "All users can see this list view"
+
+        | Input form data
+        | ...  Who sees this list view?::All users can see this list view    selected
 
         This keyword will eventually replace the "populate form"
         keyword once it has been more thoroughly tested in production.

--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -1473,9 +1473,6 @@ class Salesforce(object):
         for label, value in list(zip(it, it)):
             # this uses our custom "label" locator strategy
             locator = f"label:{label}"
-            # FIXME: we should probably only wait for the first label;
-            # after that we can assume the fields have been rendered
-            # so that we fail quickly if we can't find the element
             element = self.selenium.get_webelement(locator)
             self.scroll_element_into_view(locator)
             handler = get_form_handler(element, locator)

--- a/cumulusci/robotframework/form_handlers.py
+++ b/cumulusci/robotframework/form_handlers.py
@@ -164,6 +164,12 @@ class LightningInputHandler(BaseFormHandler):
             checked = self.element.get_attribute("checked")
             if (checked and value != "checked") or (not checked and value == "checked"):
                 self.input_element.send_keys(" ")
+
+        elif self.input_element.get_attribute("type") == "radio":
+            if value.strip().lower() != "selected":
+                raise Exception("value must be 'selected'")
+            self.input_element.send_keys(" ")
+
         else:
             self.clear()
             self.input_element.send_keys(value)

--- a/cumulusci/robotframework/form_handlers.py
+++ b/cumulusci/robotframework/form_handlers.py
@@ -102,6 +102,12 @@ class HTMLInputHandler(BaseFormHandler):
             checked = self.element.is_selected()
             if (checked and value != "checked") or (not checked and value == "checked"):
                 self.element.click()
+
+        elif self.element.get_attribute("type") == "radio":
+            if value.strip().lower() != "selected":
+                raise Exception("value must be 'selected'")
+            self.element.send_keys(" ")
+
         else:
             self.clear()
             self.element.send_keys(value)

--- a/cumulusci/robotframework/locators_54.py
+++ b/cumulusci/robotframework/locators_54.py
@@ -15,3 +15,8 @@ lex_locators["record"]["header"][
 lex_locators["modal"][
     "review_alert"
 ] = "//a[@records-recordediterror_recordediterror and text()='{}']"
+
+lex_locators["list_view_menu"] = {
+    "button": "css:button[title='List View Controls']",
+    "item": "//div[@title='List View Controls']//ul[@role='menu']//li/a[.='{}']",
+}

--- a/cumulusci/robotframework/tests/salesforce/forms.robot
+++ b/cumulusci/robotframework/tests/salesforce/forms.robot
@@ -38,23 +38,16 @@ Require Salesforce object
     Run keyword if  not $result
     ...  log  created object  DEBUG
 
+Go to My Email settings
+    [Documentation]
+    ...  Go directly to the My Email Settings page
+
+    &{org}=  Get org info
+    ${url}=  Set variable
+    ...  ${org['instance_url']}/lightning/settings/personal/EmailSettings/home
+    Go to  ${url}
+
 *** Test Cases ***
-Lightning based radiobutton
-    [Setup]      Run keywords
-    ...  Go to page          Listing    Opportunity
-    ...  AND  Click element  sf:list_view_menu.button
-    ...  AND  Click element  sf:list_view_menu.item:New
-    ...  AND  Wait for modal  New  List View
-    [Teardown]   Click modal button  Cancel
-
-    Input form data
-    ...  Who sees this list view?::All users can see this list view    selected
-
-    # Using the label: locator returns a lightning-input element. We need to find
-    # the actual html input element to verify that it is checked. Ugly, but efficient.
-    ${element}=  Get webelement  label:All users can see this list view
-    Should be true  ${element.find_element_by_xpath(".//input").is_selected()}
-
 Lightning based form - Opportunity
     [Documentation]
     ...  Sets all of the input fields for an opportunity, to make sure
@@ -108,6 +101,42 @@ Non-lightning based form - checkbox
     ...  Leader    unchecked
     Checkbox should not be selected      label:Leader
 
+Lightning based form - radiobutton
+    [Documentation]
+    ...  Verify we can set a lightning radiobutton by its label
+    [Setup]      Run keywords
+    ...  Go to page          Listing    Opportunity
+    ...  AND  Click element  sf:list_view_menu.button
+    ...  AND  Click element  sf:list_view_menu.item:New
+    ...  AND  Wait for modal  New  List View
+    [Teardown]   Click modal button  Cancel
+
+    Input form data
+    ...  Who sees this list view?::All users can see this list view    selected
+
+    # Using the label: locator returns a lightning-input element. We need to find
+    # the actual html input element to verify that it is checked. Ugly, but efficient.
+    ${element}=  Get webelement  label:All users can see this list view
+    Should be true  ${element.find_element_by_xpath(".//input").is_selected()}
+
+Non-lightning based form - radiobutton
+    [Documentation]  Verify we can set a plain non-lightning radiobutton
+
+    [Setup]  Run keywords
+    ...  Go to My Email Settings
+    ...  AND  Select frame  //div[@class="setupcontent"]//iframe
+
+    # The settings page is just about the only page I could find
+    # with old school non-lightning radiobuttons
+    # Thankfully, I can use built-in keywords to validate that
+    # the radiobuttons have actually bet set.
+    Input form data
+    ...  Send through Salesforce  selected
+    Radio button should be set to  use_external_email  0
+
+    Input form data
+    ...  Send through Office 365   selected
+    Radio button should be set to  use_external_email  1
 
 Non-lightning based form - Shipment
     [Documentation]

--- a/cumulusci/robotframework/tests/salesforce/forms.robot
+++ b/cumulusci/robotframework/tests/salesforce/forms.robot
@@ -40,7 +40,6 @@ Require Salesforce object
 
 *** Test Cases ***
 Lightning based radiobutton
-    [tags]       whatever
     [Setup]      Run keywords
     ...  Go to page          Listing    Opportunity
     ...  AND  Click element  sf:list_view_menu.button

--- a/cumulusci/robotframework/tests/salesforce/forms.robot
+++ b/cumulusci/robotframework/tests/salesforce/forms.robot
@@ -7,7 +7,7 @@ Suite Setup     Run keywords
 ...  Initialize Test Objects
 ...  Open test browser
 Suite Teardown  Delete records and close browser
-Force tags      forms  whatever
+Force tags      forms
 
 *** Variables ***
 ${account name}   ACME Labs
@@ -136,11 +136,6 @@ Non-lightning based form - radiobutton
     Input form data
     ...  Send through Salesforce  selected
     Radio button should be set to  use_external_email  0
-
-    Log  attempting to select 'Send through Gmail'
-    Input form data
-    ...  Send through Gmail  selected
-    Radio button should be set to  use_external_email  1
 
 Non-lightning based form - Shipment
     [Documentation]

--- a/cumulusci/robotframework/tests/salesforce/forms.robot
+++ b/cumulusci/robotframework/tests/salesforce/forms.robot
@@ -7,7 +7,7 @@ Suite Setup     Run keywords
 ...  Initialize Test Objects
 ...  Open test browser
 Suite Teardown  Delete records and close browser
-Force tags      forms
+Force tags      forms  whatever
 
 *** Variables ***
 ${account name}   ACME Labs
@@ -122,20 +122,24 @@ Lightning based form - radiobutton
 Non-lightning based form - radiobutton
     [Documentation]  Verify we can set a plain non-lightning radiobutton
 
-    [Setup]  Run keywords
-    ...  Go to My Email Settings
+    [Setup]     Run keywords
+    ...  Skip if  "firefox" in $browser
+    ...  AND  Go to My Email Settings
     ...  AND  Select frame  //div[@class="setupcontent"]//iframe
+    [Teardown]  Unselect frame
 
     # The settings page is just about the only page I could find
     # with old school non-lightning radiobuttons
     # Thankfully, I can use built-in keywords to validate that
     # the radiobuttons have actually bet set.
+    Log  attempting to select 'Send through Salesforce'
     Input form data
     ...  Send through Salesforce  selected
     Radio button should be set to  use_external_email  0
 
+    Log  attempting to select 'Send through Gmail'
     Input form data
-    ...  Send through Office 365   selected
+    ...  Send through Gmail  selected
     Radio button should be set to  use_external_email  1
 
 Non-lightning based form - Shipment
@@ -158,8 +162,6 @@ Non-lightning based form - Shipment
     Input form data
     ...  Ship To Street  2501 Exchange Ave
     ...  Ship To City    Oklahoma City
-
-    capture page screenshot
 
 Fieldsets - Shipment
     [Documentation]

--- a/cumulusci/robotframework/tests/salesforce/forms.robot
+++ b/cumulusci/robotframework/tests/salesforce/forms.robot
@@ -132,9 +132,15 @@ Non-lightning based form - radiobutton
     # with old school non-lightning radiobuttons
     # Thankfully, I can use built-in keywords to validate that
     # the radiobuttons have actually bet set.
-    Log  attempting to select 'Send through Salesforce'
+
+    # make sure it is set to 1
+    Select radio button  use_external_email  1
+
+    # then try to use our keyword to set it
     Input form data
     ...  Send through Salesforce  selected
+
+    # ... and then verify that it was set
     Radio button should be set to  use_external_email  0
 
 Non-lightning based form - Shipment

--- a/cumulusci/robotframework/tests/salesforce/forms.robot
+++ b/cumulusci/robotframework/tests/salesforce/forms.robot
@@ -39,6 +39,23 @@ Require Salesforce object
     ...  log  created object  DEBUG
 
 *** Test Cases ***
+Lightning based radiobutton
+    [tags]       whatever
+    [Setup]      Run keywords
+    ...  Go to page          Listing    Opportunity
+    ...  AND  Click element  sf:list_view_menu.button
+    ...  AND  Click element  sf:list_view_menu.item:New
+    ...  AND  Wait for modal  New  List View
+    [Teardown]   Click modal button  Cancel
+
+    Input form data
+    ...  Who sees this list view?::All users can see this list view    selected
+
+    # Using the label: locator returns a lightning-input element. We need to find
+    # the actual html input element to verify that it is checked. Ugly, but efficient.
+    ${element}=  Get webelement  label:All users can see this list view
+    Should be true  ${element.find_element_by_xpath(".//input").is_selected()}
+
 Lightning based form - Opportunity
     [Documentation]
     ...  Sets all of the input fields for an opportunity, to make sure

--- a/docs/robot/Keywords.html
+++ b/docs/robot/Keywords.html
@@ -1157,7 +1157,9 @@ Input text  //input  ${faker.date(pattern='%Y-%m-%d')}
                             <tr class="kwrow" id="Salesforce.Get Latest Api Version">
                                 <td class="kwname">Get Latest Api Version</td>
                                 <td class="kwargs"></td>
-                                <td class="kwdoc"></td>
+                                <td class="kwdoc">
+                                    <p>Return the API version used by the current org</p>
+                                </td>
                             </tr>
 
                             <tr class="kwrow" id="Salesforce.Get Locator">
@@ -1406,7 +1408,8 @@ Input text  //input  ${faker.date(pattern='%Y-%m-%d')}
                                         will be used. For a checkbox, passing the value
                                         "checked" will check the checkbox and any other
                                         value will uncheck it. Using "unchecked" is
-                                        recommended for clarity.
+                                        recommended for clarity. For radiobuttons, you
+                                        must pass the string "selected" for the value.
                                     </p>
                                     <p>Example:</p>
                                     <pre>
@@ -1417,6 +1420,18 @@ Input form data
 ...  Private                  checked           # checkbox
 ...  Type                     New Customer      # combobox
 ...  Primary Campaign Source  The Big Campaign  # picklist
+</pre
+                                    >
+                                    <p>Example setting a radio button:</p>
+                                    <p>
+                                        In this example, the radiobutton group has the
+                                        label "Who sees this list view?", and one of the
+                                        radiobuttons has the label "All users can see this
+                                        list view"
+                                    </p>
+                                    <pre>
+Input form data
+...  Who sees this list view?::All users can see this list view    selected
 </pre
                                     >
                                     <p>
@@ -3169,7 +3184,7 @@ Populate form
             </div>
         </div>
         <div class="footer">
-            Generated on Tuesday January 25, 03:39 PM - cumulusci v3.51.1
+            Generated on Thursday March 31, 02:13 PM - cumulusci v3.55.0
         </div>
     </body>
 </html>


### PR DESCRIPTION
This adds support for lightning radiobuttons in the robot keyword `input form data`.  

There's one new test in forms.robot that sets and verifies a lightning button. 

# Critical Changes

# Changes
* added support for lightning radiobuttons in the robot keyword `input form data`

# Issues Closed
