### PR TITLE
Week 14 Updates

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -32,8 +32,10 @@ click==8.0.3
     # via
     #   -c requirements/prod.txt
     #   black
-colorama==0.4.4
-    # via twine
+commonmark==0.9.1
+    # via
+    #   -c requirements/prod.txt
+    #   rich
 coverage[toml]==6.3.2
     # via
     #   -r requirements/dev.in
@@ -79,7 +81,7 @@ importlib-metadata==4.11.3
     #   keyring
     #   sphinx
     #   twine
-importlib-resources==5.4.0
+importlib-resources==5.6.0
     # via jsonschema
 iniconfig==1.1.1
     # via pytest
@@ -125,7 +127,7 @@ pluggy==1.0.0
     # via
     #   pytest
     #   tox
-pre-commit==2.17.0
+pre-commit==2.18.1
     # via -r requirements/dev.in
 py==1.11.0
     # via
@@ -140,6 +142,7 @@ pygments==2.11.2
     #   -c requirements/prod.txt
     #   furo
     #   readme-renderer
+    #   rich
     #   sphinx
 pyparsing==3.0.7
     # via packaging
@@ -186,6 +189,10 @@ responses==0.14.0
     # via -r requirements/dev.in
 rfc3986==2.0.0
     # via twine
+rich==12.2.0
+    # via
+    #   -c requirements/prod.txt
+    #   twine
 six==1.16.0
     # via
     #   -c requirements/prod.txt
@@ -199,7 +206,7 @@ snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.3.1
     # via beautifulsoup4
-sphinx==4.4.0
+sphinx==4.5.0
     # via
     #   -r requirements/dev.in
     #   furo
@@ -228,9 +235,7 @@ tomli==2.0.1
     #   pytest
 tox==3.24.5
     # via -r requirements/dev.in
-tqdm==4.63.0
-    # via twine
-twine==3.8.0
+twine==4.0.0
     # via -r requirements/dev.in
 typeguard==2.13.3
     # via -r requirements/dev.in
@@ -238,6 +243,7 @@ typing-extensions==4.0.1
     # via
     #   -c requirements/prod.txt
     #   black
+    #   rich
 urllib3==1.26.8
     # via
     #   -c requirements/prod.txt
@@ -248,7 +254,7 @@ vcrpy==4.1.1
     # via
     #   -r requirements/dev.in
     #   pytest-vcr
-virtualenv==20.13.4
+virtualenv==20.14.0
     # via
     #   pre-commit
     #   tox
@@ -260,7 +266,7 @@ wrapt==1.14.0
     # via vcrpy
 yarl==1.7.2
     # via vcrpy
-zipp==3.7.0
+zipp==3.8.0
     # via
     #   -c requirements/prod.txt
     #   importlib-metadata

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -17,7 +17,8 @@ pyyaml
 requests
 requests-futures
 rich
-robotframework
+# check with Bryan about upgrading to v5
+robotframework<5
 robotframework-lint
 robotframework-pabot
 robotframework-requests

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -105,7 +105,7 @@ requests==2.27.1
     #   snowfakery
 requests-futures==1.0.0
     # via -r requirements/prod.in
-rich==12.0.1
+rich==12.2.0
     # via -r requirements/prod.in
 robotframework==4.1.3
     # via
@@ -117,7 +117,7 @@ robotframework==4.1.3
     #   robotframework-stacktrace
 robotframework-lint==1.1
     # via -r requirements/prod.in
-robotframework-pabot==2.5.1
+robotframework-pabot==2.5.2
     # via -r requirements/prod.in
 robotframework-pythonlibcore==3.0.0
     # via robotframework-seleniumlibrary
@@ -156,6 +156,7 @@ sqlalchemy==1.4.31
 typing-extensions==4.0.1
     # via
     #   pydantic
+    #   rich
     #   snowfakery
 unicodecsv==0.14.1
     # via salesforce-bulk
@@ -168,7 +169,7 @@ urllib3==1.26.8
     #   snowfakery
 xmltodict==0.12.0
     # via -r requirements/prod.in
-zipp==3.7.0
+zipp==3.8.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
# Notes (skip for release notes)
* [twine](https://twine.readthedocs.io/en/stable/changelog.html) 4.0.0 is dropping support for py 3.6
* Pinning`robotframework<5` until @boakley can get back to verify that we're ok to move to v5+