### PR TITLE
link missing task or flow when merging configs

### DIFF
--- a/cumulusci/core/tests/test_utils_merge_config.py
+++ b/cumulusci/core/tests/test_utils_merge_config.py
@@ -216,7 +216,9 @@ def test_cleanup_flow_step_override_conflicts__multiple_overrides_of_alternating
     expected_universal_config["flows"]["steps_all_tasks"]["steps"][3] = {}
 
     expected_project_config = copy.deepcopy(project_config)
-    expected_project_config["flows"]["steps_all_tasks"]["steps"][3] = {}
+    expected_project_config["flows"]["steps_all_tasks"]["steps"][3] = {
+        "flow": "custom_flow_two"
+    }
 
     expected_project_local_config = copy.deepcopy(project_local_config)
     expected_project_local_config["flows"]["steps_all_tasks"]["steps"][3] = {
@@ -260,3 +262,15 @@ def test_cleanup_flow_step_override_conflicts__obsolete_flow_with_tasks(
     clean_configs = utils.cleanup_flow_step_override_conflicts(configs)
 
     assert expected_project_config == clean_configs["project_config"]
+
+
+def test_link_missing_task_or_flow():
+    step_config_to_override = {"task": "util_sleep"}
+    overriding_step_config = {"options": {"seconds": 1}}
+
+    assert "task" not in overriding_step_config
+    utils.link_missing_task_or_flow(step_config_to_override, overriding_step_config)
+    assert overriding_step_config == {
+        "task": "util_sleep",
+        "options": {"seconds": 1},
+    }

--- a/cumulusci/core/utils.py
+++ b/cumulusci/core/utils.py
@@ -239,8 +239,25 @@ def remove_overridden_flow_steps_in_config(
                 steps_same_type = steps_are_same_type(
                     overriding_step_config, step_config_to_override
                 )
+
+                link_missing_task_or_flow(
+                    step_config_to_override, overriding_step_config
+                )
+
                 if not steps_same_type:
                     config_to_override["flows"][flow]["steps"][step_num] = {}
+
+
+def link_missing_task_or_flow(
+    step_config_to_override: dict, overriding_step_config: dict
+):
+    """If the incoming override does not have task/flow defined then inherit from
+    the flow step that we're overridding."""
+    if "flow" not in overriding_step_config and "task" not in overriding_step_config:
+        if "task" in step_config_to_override:
+            overriding_step_config["task"] = step_config_to_override["task"]
+        elif "flow" in step_config_to_override:
+            overriding_step_config["flow"] = step_config_to_override["flow"]
 
 
 def cleanup_old_flow_step_replace_syntax(step_config: dict):


### PR DESCRIPTION
# Changes
* Fixed an issue where CumulusCI was incorrectly merging task option overrides.

### QA Notes
I used the following in the standard lib while testing:
```
official_testing_flow:
        group: foo
        description: Does some stuff
        steps:
            1:
                task: util_sleep
            2:
                task: util_sleep
            3:
                task: util_sleep
   ```
   Then I modified the project `cumulusci.yml` to include:
   ```
   flows:
    official_testing_flow:
        steps:
            1:
                # task: util_sleep
                options:
                    seconds: 1
```
* Also verified setting the flow step to a value of `None` still works.