### PR TITLE
Pass secrets into release_test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,14 @@ on:
 jobs:
     run-release-test:
         uses: ./.github/workflows/release_test.yml
+        secrets:
+            CUMULUSCI_ORG_packaging: ${{ secrets.CUMULUSCI_ORG_packaging }}
+            CUMULUSCI_SERVICE_github: ${{ secrets.CUMULUSCI_SERVICE_github }}
+            GITHUB_APP_KEY: ${{ secrets.CCITEST_APP_KEY }}
+            SFDX_CLIENT_ID: ${{ secrets.SFDX_CLIENT_ID }}
+            SFDX_HUB_KEY: ${{ secrets.SFDX_HUB_KEY }}
+            SFDX_HUB_KEY_BASE64: ${{ secrets.SFDX_HUB_KEY_BASE64 }}
+            SFDX_HUB_USERNAME: ${{ secrets.SFDX_HUB_USERNAME }}
     publish-to-pypi:
         name: Publish new release to PyPI
         runs-on: ubuntu-18.04

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -7,6 +7,20 @@ on:
             - main
     pull_request:
         types: [opened, synchronize, reopened] # Default
+    workflow_call:
+        secrets:
+            CUMULUSCI_ORG_packaging:
+                required: true
+            CUMULUSCI_SERVICE_github:
+                required: true
+            SFDX_CLIENT_ID:
+                required: true
+            SFDX_HUB_KEY:
+                required: true
+            SFDX_HUB_KEY_BASE64:
+                required: true
+            SFDX_HUB_USERNAME:
+                required: true
 
 env:
     CUMULUSCI_ORG_scratch: '{"config_file": "orgs/dev.json", "scratch": true}'


### PR DESCRIPTION
When we made the release test reuseable we missed that secrets need to
be defined in the workflow_call defn. [docs]

[docs]: https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow

-------

# Critical Changes

# Changes

# Issues Closed