### PR TITLE
Closes #3165 (missing objects in package.xml but required for record …

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -35,3 +35,4 @@ For example:
 (add your name here, when you contribute through a Pull Request!)
 
 * Ed Rivas (jerivas)
+* Gustavo Tandeciarz (dcinzona)

--- a/cumulusci/tasks/salesforce/tests/test_ProfileGrantAllAccess.py
+++ b/cumulusci/tasks/salesforce/tests/test_ProfileGrantAllAccess.py
@@ -287,6 +287,30 @@ def test_expand_package_xml():
     assert "fb__Foo_Bar__c" in {elem.text for elem in types.findall("members")}
 
 
+def test_expand_package_xml_objects():
+    task = create_task(
+        ProfileGrantAllAccess,
+        {"api_names": ["Admin"], "record_types": [{"record_type": "Case.Case"}]},
+    )
+    task.tooling = mock.Mock()
+    package_xml = metadata_tree.fromstring(PACKAGE_XML_BEFORE)
+    task._expand_package_xml_objects(package_xml)
+    types = package_xml.find("types", name="CustomObject")
+    assert "Case" in {elem.text for elem in types.findall("members")}
+
+
+def test_expand_package_xml_objects_no_record_types():
+    task = create_task(
+        ProfileGrantAllAccess,
+        {"api_names": ["Admin"]},
+    )
+    task.tooling = mock.Mock()
+    package_xml = metadata_tree.fromstring(PACKAGE_XML_BEFORE)
+    task._expand_package_xml_objects(package_xml)
+    types = package_xml.find("types", name="CustomObject")
+    assert "Case" not in {elem.text for elem in types.findall("members")}
+
+
 def test_expand_package_xml__broken_package():
     task = create_task(ProfileGrantAllAccess, {"api_names": ["Admin"]})
     task.tooling = mock.Mock()


### PR DESCRIPTION
# Critical Changes
- Added method to append object members to package.xml if not present when running task `update_admin_profile`

# Changes
- New method: `update_profile.py::_expand_package_xml_objects`
- Calling method from `_expand_package_xml` to include previous validation check
- Test coverage

# Issues Closed
- #3165 