### PR TITLE
Support `useralias` in `Open Test Browser` for connected orgs

### DIFF
--- a/cumulusci/robotframework/CumulusCI.py
+++ b/cumulusci/robotframework/CumulusCI.py
@@ -4,7 +4,7 @@ import robot.api.logger
 from robot.libraries.BuiltIn import BuiltIn
 
 from cumulusci.cli.runtime import CliRuntime
-from cumulusci.core.config import TaskConfig
+from cumulusci.core.config import ScratchOrgConfig, TaskConfig
 from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.core.tasks import CURRENT_TASK
 from cumulusci.core.utils import import_global
@@ -116,10 +116,17 @@ class CumulusCI(object):
 
         """
         org = self.org if org is None else self.keychain.get_org(org)
+
         if userfields:
-            access_token = org.get_access_token(**userfields)
-            login_url = f"{org.instance_url}/secur/frontdoor.jsp?sid={access_token}"
-            return login_url
+            if org.get_access_token is not None:
+                # connected persistent org configs won't have the get_access_token method
+                access_token = org.get_access_token(**userfields)
+                login_url = f"{org.instance_url}/secur/frontdoor.jsp?sid={access_token}"
+                return login_url
+            else:
+                access_token = self._find_access_token(org, **userfields)
+                login_url = f"{org.instance_url}/secur/frontdoor.jsp?sid={access_token}"
+                return login_url
         else:
             return org.start_url
 
@@ -264,6 +271,48 @@ class CumulusCI(object):
     def _run_task(self, task):
         task()
         return task.return_values
+
+    def _find_access_token(self, base_org, **userfields):
+        """Search connected orgs for a user and return the access token
+
+        The org config for connected orgs doesn't have an access token
+        for each user. Instead, we have an access token for the org as
+        a whole. This searches all connected org configs for an org
+        with the given user (either by username or alias) and returns
+        the access token for the org.
+
+        It is expected that userfields contains either a 'username'
+        or 'alias' field. If a username is provided, that's what will
+        be used. If not, this function will do a query to find a username
+        that matches the given parameters.
+
+        """
+
+        username = userfields.get("username", None)
+        if username is None:
+            where = [f"{key}='{value}'" for key, value in userfields.items()]
+            query = f"SELECT Username FROM User WHERE {' AND '.join(where)}"
+            result = base_org.salesforce_client.query_all(query).get("records", [])
+            if len(result) == 0:
+                query = ", ".join(where)
+                raise Exception(
+                    f"Couldn't find a username in org {base_org.name} for the specified user ({query})."
+                )
+            elif len(result) > 1:
+                results = ", ".join([user["Username"] for user in result])
+                raise Exception(
+                    f"More than one user matched the search critiera for org {base_org.name} ({results})."
+                )
+            else:
+                username = result[0]["Username"]
+
+        for org_name in self.keychain.list_orgs():
+            org = self.keychain.get_org(org_name)
+            if not isinstance(org, ScratchOrgConfig):
+                if "userinfo" in org.config:
+                    if org.config["userinfo"]["preferred_username"] == username:
+                        return org.access_token
+        return None
 
     def debug(self):
         """Pauses execution and enters the Python debugger."""


### PR DESCRIPTION
Update the `login url` keyword to be able to get the URL for a user in a connected persistent org. See [W-10502445](https://gus.lightning.force.com/a07EE00000jGUN1YAO) and issue #3047

The root of the problem is that the OrgConfig class doesn't define the method `get_access_token` since we don't have per-user access tokens in the config object for this type of org.  Instead, we have a single access token for the org as a whole. 

The solution is to scan all connected orgs for an org that is associated with the given user and then return the access token for that org.

# Critical Changes

# Changes
* The `open test browser` keyword now works when providing the `useralias` argument, when the org is a connected persistent org.
* The `login url` keyword now works when passing in a username or alias for a user in a connected persistent org.
# Issues Closed
* #3047