### PR TITLE
Changes to integration testing infrastructure.

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -144,7 +144,10 @@ flows:
                     object: Contact
                     query: "select Id,Email,Name from Contact where LastName='Bluth'"
                     result_file: /tmp/contacts_after.csv
-
+    do_nothing:
+        steps:
+            1:
+                task: None
 orgs:
     scratch:
         prerelease:

--- a/cumulusci/tests/test_integration_infrastructure.py
+++ b/cumulusci/tests/test_integration_infrastructure.py
@@ -77,6 +77,7 @@ class TestIntegrationInfrastructure:
                 },
             )
             task()
+            Path("foo.csv").unlink()
 
         run_code_without_recording(setup)
 
@@ -97,10 +98,11 @@ class TestIntegrationInfrastructure:
 
     @pytest.mark.needs_org()
     @pytest.mark.slow()
-    @pytest.mark.org_shape("qa", "qa_org")
+    @pytest.mark.org_shape("qa", "do_nothing")
     def test_org_shape(self, capture_orgid_using_task, current_org_shape):
         assert (
-            current_org_shape.org_config.sfdx_alias == "CumulusCI__pytest__qa__qa_org"
+            current_org_shape.org_config.sfdx_alias
+            == "CumulusCI__pytest__qa__do_nothing"
         )
         assert self.__class__.remembered_cli_specified_org_id
         generated_org_id = capture_orgid_using_task()
@@ -112,7 +114,7 @@ class TestIntegrationInfrastructure:
 
     @pytest.mark.needs_org()
     @pytest.mark.slow()
-    @pytest.mark.org_shape("qa", "qa_org")
+    @pytest.mark.org_shape("qa", "do_nothing")
     def test_org_shape_reuse(
         self,
         create_task,
@@ -121,7 +123,8 @@ class TestIntegrationInfrastructure:
         capture_orgid_using_task,
     ):
         assert (
-            current_org_shape.org_config.sfdx_alias == "CumulusCI__pytest__qa__qa_org"
+            current_org_shape.org_config.sfdx_alias
+            == "CumulusCI__pytest__qa__do_nothing"
         )
         generated_org_id = capture_orgid_using_task()
         assert generated_org_id == self.__class__.remember_generated_org_id


### PR DESCRIPTION
1. Add a new flow that does nothing, for testing flow-running features.
2. Make the flow entirely optional for other cases where no flow is needed.
3. Fix a bug that arose wherein Scratch orgs were being initialized too late.
4. Clean up test file.

Nothing for release notes.
