### PR TITLE
Workaround for pip-tools issue upstream

### DIFF
--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -34,7 +34,7 @@ jobs:
                   cache: pip
                   cache-dependency-path: "requirements/*.txt"
             - name: Install dependencies
-              run: make dev-install
+              run: pip install -r requirements_dev.txt
             - name: Build Docs
               run: make docs
 
@@ -55,7 +55,7 @@ jobs:
                   cache: pip
                   cache-dependency-path: "requirements/*.txt"
             - name: Install dependencies
-              run: make dev-install
+              run: pip install -r requirements_dev.txt
             - name: Run Pytest
               run: pytest --cov-report= --cov=cumulusci
             - name: Run coveralls
@@ -73,7 +73,7 @@ jobs:
                   cache: pip
                   cache-dependency-path: "requirements/*.txt"
             - name: Install Python dependencies
-              run: make dev-install
+              run: pip install -r requirements_dev.txt
             - name: Install sfdx
               run: |
                   mkdir sfdx
@@ -132,7 +132,7 @@ jobs:
                   cache: pip
                   cache-dependency-path: "requirements/*.txt"
             - name: Install Python dependencies
-              run: make dev-install
+              run: pip install -r requirements_dev.txt
             - name: Install sfdx
               run: |
                   mkdir sfdx

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -48,9 +48,7 @@ jobs:
                   cache: pip
                   cache-dependency-path: "requirements/*.txt"
             - name: Install Python dependencies
-              run: |
-                  python -m pip install -U pip
-                  make dev-install
+              run: pip install -r requirements_dev.txt
             - name: Install sfdx
               run: |
                   mkdir sfdx


### PR DESCRIPTION
First guess was to pin pip to 22.0.4, but I wondered: What exactly is
pip-sync doing here? There's no virtualenv to synchronize since we get a
fresh environment in each workflow run.
