### PR TITLE
Add release notes configuration

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,0 @@
-
-# Critical Changes
-
-# Changes
-
-# Issues Closed

--- a/.github/releases.yml
+++ b/.github/releases.yml
@@ -1,0 +1,19 @@
+changelog:
+    exclude:
+        labels:
+            - ignore-for-release
+            - auto-pr
+            - dependencies
+        authors:
+            - app/github-actions
+    categories:
+        - title: Critical Changes 🛠
+          labels:
+              - critical-change
+        - title: Changes 🎉
+          labels:
+              - enhancement
+              - "*"
+        - title: Issues Fixed 🩴
+          labels:
+              - bug

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,1 +1,1 @@
-See https://cumulusci.readthedocs.io/en/stable/contributing.html
+See docs/contributing.rst

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -91,6 +91,11 @@ Before you submit a pull request, check that it meets these guidelines:
 * Code style and file structure is similar to the rest of the project.
 * You have run the ``black`` code formatter.
 * If you are a new contributor, don't forget to add yourself to the ``AUTHORS.rst`` file in your pull request (either GitHub username, or first/last name).
+* You have labeled your pull request:
+  * ``critical-changes`` for breaking changes,
+  * ``enhancement`` for new features,
+  * ``bug`` for when fixing a bug or closing an issue, or
+  * ``ignore-for-release`` for internal changes.
 
 Testing CumulusCI
 -----------------


### PR DESCRIPTION
This PR would change how we generate release notes. Instead of manually collating PRs since the previous release, we can use GitHub's autogenerated release notes feature.

Using the configuration file in this PR, we would now use a label instead of the PR template. Mappings:

1. Critical Changes ↦ `critical-changes`
2. Changes ↦ `enhancements`
3. Issues Fixed ↦ `bug`
4. Use `ignore-for-release` to ignore the PR

Notes could then be generated before a release via:
```shell
$ gh api \
  --method POST \
  -H "Accept: application/vnd.github.v3+json" \
  /repos/SFDO-Tooling/CumulusCI/releases/generate-notes \
  -f tag_name='v3.58.1' -f target_commitish='main' -f previous_tag_name='v3.58.0' |
    jq .body -r |
    sed 's/\(https.*\/\)\([0-9]\{4\}\)$/[#\2](\1\2)/' |
    pandoc -f gfm -t rst
```

Output with the default config:
```rst
What's Changed
--------------

-  Fixing missing code blocks due to whitespace by @dcinzona in
  `#3190 <https://github.com/SFDO-Tooling/CumulusCI/pull/3190>`__
-  Changes to integration testing infrastructure. by @prescod in
  `#3178 <https://github.com/SFDO-Tooling/CumulusCI/pull/3178>`__
-  Refactor \_query_db in load.py by @prescod in
  `#3184 <https://github.com/SFDO-Tooling/CumulusCI/pull/3184>`__
-  Un-pin responses 0.14.0 by @jstvz in
  `#3201 <https://github.com/SFDO-Tooling/CumulusCI/pull/3201>`__
-  More logical assertion by @prescod in
  `#3202 <https://github.com/SFDO-Tooling/CumulusCI/pull/3202>`__
-  Stop requiring project__git__repo_url to publish by @jstvz in
  `#3200 <https://github.com/SFDO-Tooling/CumulusCI/pull/3200>`__
-  Don't derive ``auth_uri`` from ``rest_instance_url`` by @Br4nd0R in
  `#3198 <https://github.com/SFDO-Tooling/CumulusCI/pull/3198>`__
-  fix cookbook typo by @Br4nd0R in
  `#3177 <https://github.com/SFDO-Tooling/CumulusCI/pull/3177>`__
-  Config-None Cleanup by @prescod in
  `#3026 <https://github.com/SFDO-Tooling/CumulusCI/pull/3026>`__
-  Refactor loaddata and fix bugs in ETL Upsert by @prescod in
  `#3183 <https://github.com/SFDO-Tooling/CumulusCI/pull/3183>`__
-  Add robot CLI commands for Playwright installer by @boakley in
  `#3194 <https://github.com/SFDO-Tooling/CumulusCI/pull/3194>`__

New Contributors
----------------

-  @dcinzona made their first contribution in
  `#3190 <https://github.com/SFDO-Tooling/CumulusCI/pull/3190>`__

,**Full Changelog**:
https://github.com/SFDO-Tooling/CumulusCI/compare/v3.58.0...v3.58.1
```

Which could then be added to  HISTORY.rst

### Open Questions
- [x] Which heading should catch unlabeled PRs?