### PR TITLE
Fix property lookups on config objects

### DIFF
--- a/cumulusci/core/config/base_config.py
+++ b/cumulusci/core/config/base_config.py
@@ -66,7 +66,7 @@ class BaseConfig(object):
                 )
 
                 assert not STRICT_GETATTR, message
-        return self.lookup(name)
+        return self.lookup(name, already_called_getattr=True)
 
     @classmethod
     @lru_cache
@@ -82,7 +82,7 @@ class BaseConfig(object):
             ret.update(d)
         return ret
 
-    def lookup(self, name, default=None):
+    def lookup(self, name, default=None, already_called_getattr=False):
         tree = name.split("__")
         if name.startswith("_"):
             raise AttributeError(f"Attribute {name} not found")
@@ -102,4 +102,7 @@ class BaseConfig(object):
         if value_found:
             return value
         else:
-            return self.defaults.get(name, default)
+            if not already_called_getattr and hasattr(self, name):
+                return getattr(self, name)
+            else:
+                return self.defaults.get(name, default)

--- a/cumulusci/core/config/tests/test_config.py
+++ b/cumulusci/core/config/tests/test_config.py
@@ -372,6 +372,11 @@ class TestBaseProjectConfig:
         config._repo_info = {"url": "https://github.com/SFDO-Tooling/CumulusCI"}
         assert config.repo_url == "https://github.com/SFDO-Tooling/CumulusCI"
 
+    def test_lookup_repo_branch(self):
+        config = BaseProjectConfig(UniversalConfig())
+        config._repo_info = {"branch": "foo-bar-baz"}
+        assert config.lookup("repo_branch") == "foo-bar-baz"
+
     def test_repo_url_no_repo_root(self):
         config = BaseProjectConfig(UniversalConfig())
         with temporary_dir():


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed
* Fixed an issue causing flows that reference properties of the `$project_config` object to fail.