### PR TITLE
Unlocked resolution strategy and supporting flows

### DIFF
--- a/cumulusci/core/dependencies/dependencies.py
+++ b/cumulusci/core/dependencies/dependencies.py
@@ -107,7 +107,7 @@ class StaticDependency(Dependency, abc.ABC):
     are already both resolved and flattened)."""
 
     @abc.abstractmethod
-    def install(self, org_config: OrgConfig, retry_options: dict = None):
+    def install(self, org_config: OrgConfig, retry_options: Optional[dict] = None):
         pass
 
     @property
@@ -123,8 +123,8 @@ class DynamicDependency(Dependency, abc.ABC):
     """Abstract base class for dependencies with dynamic references, like GitHub.
     These dependencies must be resolved and flattened before they can be installed."""
 
-    package_dependency: Optional[StaticDependency]
-    password_env_name: Optional[str]
+    package_dependency: Optional[StaticDependency] = None
+    password_env_name: Optional[str] = None
 
     @property
     def is_flattened(self):
@@ -141,13 +141,13 @@ class DynamicDependency(Dependency, abc.ABC):
 class BaseGitHubDependency(DynamicDependency, abc.ABC):
     """Base class for dynamic dependencies that reference a GitHub repo."""
 
-    github: Optional[AnyUrl]
+    github: Optional[AnyUrl] = None
 
-    repo_owner: Optional[str]  # Deprecated - use full URL
-    repo_name: Optional[str]  # Deprecated - use full URL
+    repo_owner: Optional[str] = None  # Deprecated - use full URL
+    repo_name: Optional[str] = None  # Deprecated - use full URL
 
-    tag: Optional[str]
-    ref: Optional[str]
+    tag: Optional[str] = None
+    ref: Optional[str] = None
 
     @property
     @abc.abstractmethod
@@ -182,8 +182,8 @@ class GitHubDynamicSubfolderDependency(BaseGitHubDependency):
     to be resolved to a specific ref. This is always an unmanaged dependency."""
 
     subfolder: str
-    namespace_inject: Optional[str]
-    namespace_strip: Optional[str]
+    namespace_inject: Optional[str] = None
+    namespace_strip: Optional[str] = None
 
     @property
     def is_unmanaged(self):
@@ -222,9 +222,9 @@ class GitHubDynamicDependency(BaseGitHubDependency):
     to be resolved to a specific ref and/or package version."""
 
     unmanaged: bool = False
-    namespace_inject: Optional[str]
-    namespace_strip: Optional[str]
-    password_env_name: Optional[str]
+    namespace_inject: Optional[str] = None
+    namespace_strip: Optional[str] = None
+    password_env_name: Optional[str] = None
 
     skip: List[str] = []
 
@@ -374,10 +374,10 @@ class PackageNamespaceVersionDependency(StaticDependency):
 
     namespace: str
     version: str
-    package_name: Optional[str]
-    version_id: Optional[str]
+    package_name: Optional[str] = None
+    version_id: Optional[str] = None
 
-    password_env_name: Optional[str]
+    password_env_name: Optional[str] = None
 
     @property
     def package(self):
@@ -387,7 +387,7 @@ class PackageNamespaceVersionDependency(StaticDependency):
         self,
         context: BaseProjectConfig,
         org: OrgConfig,
-        options: PackageInstallOptions = None,
+        options: Optional[PackageInstallOptions] = None,
         retry_options=None,
     ):
         if not options:
@@ -436,10 +436,10 @@ class PackageVersionIdDependency(StaticDependency):
     """Static dependency on a package identified by 04t version id."""
 
     version_id: str
-    package_name: Optional[str]
-    version_number: Optional[str]
+    package_name: Optional[str] = None
+    version_number: Optional[str] = None
 
-    password_env_name: Optional[str]
+    password_env_name: Optional[str] = None
 
     @property
     def package(self):
@@ -449,7 +449,7 @@ class PackageVersionIdDependency(StaticDependency):
         self,
         context: BaseProjectConfig,
         org: OrgConfig,
-        options: PackageInstallOptions = None,
+        options: Optional[PackageInstallOptions] = None,
         retry_options=None,
     ):
         if not options:
@@ -489,10 +489,10 @@ class PackageVersionIdDependency(StaticDependency):
 class UnmanagedDependency(StaticDependency, abc.ABC):
     """Abstract base class for static, unmanaged dependencies."""
 
-    unmanaged: Optional[bool]
-    subfolder: Optional[str]
-    namespace_inject: Optional[str]
-    namespace_strip: Optional[str]
+    unmanaged: Optional[bool] = None
+    subfolder: Optional[str] = None
+    namespace_inject: Optional[str] = None
+    namespace_strip: Optional[str] = None
 
     def _get_unmanaged(self, org: OrgConfig):
         if self.unmanaged is None:
@@ -585,11 +585,11 @@ class UnmanagedDependency(StaticDependency, abc.ABC):
 class UnmanagedGitHubRefDependency(UnmanagedDependency):
     """Static dependency on unmanaged metadata in a specific GitHub ref and subfolder."""
 
-    repo_owner: Optional[str]
-    repo_name: Optional[str]
+    repo_owner: Optional[str] = None
+    repo_name: Optional[str] = None
 
     # or
-    github: Optional[AnyUrl]
+    github: Optional[AnyUrl] = None
 
     # and
     ref: str

--- a/cumulusci/core/dependencies/tests/test_resolvers.py
+++ b/cumulusci/core/dependencies/tests/test_resolvers.py
@@ -33,7 +33,7 @@ from cumulusci.core.exceptions import CumulusCIException, DependencyResolutionEr
 
 
 class ConcreteDynamicDependency(DynamicDependency):
-    ref: Optional[str]
+    ref: Optional[str] = None
     resolved: Optional[bool] = False
 
     @property
@@ -482,7 +482,6 @@ class TestGitHubReleaseBranchExactMatchCommitStatusResolver:
         )
 
         assert resolver.can_resolve(dep, project_config)
-
         assert resolver.resolve(dep, project_config) == (
             "feature/232__test_sha",
             PackageVersionIdDependency(

--- a/cumulusci/core/github.py
+++ b/cumulusci/core/github.py
@@ -315,18 +315,16 @@ def find_repo_feature_prefix(repo: Repository) -> str:
     )
 
 
-def find_repo_2gp_context(repo: Repository) -> str:
+def find_repo_commit_status_context(
+    repo: Repository, context_name: str, default: str
+) -> str:
     contents = repo.file_contents(
         "cumulusci.yml",
         ref=repo.branch(repo.default_branch).commit.sha,
     )
     head_cumulusci_yml = cci_safe_load(io.StringIO(contents.decoded.decode("utf-8")))
     return (
-        head_cumulusci_yml.get("project", {})
-        .get("git", {})
-        .get(
-            "2gp_context", "Build Feature Test Package"
-        )  # TODO: source default from our `cumulusci.yml`
+        head_cumulusci_yml.get("project", {}).get("git", {}).get(context_name, default)
     )
 
 

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -959,6 +959,16 @@ flows:
                 flow: config_qa
             3:
                 task: snapshot_changes
+    qa_org_unlocked:
+        group: Org Setup
+        description: Set up an org as a QA environment using an unlocked package
+        steps:
+            1:
+                flow: install_unlocked_commit
+            2:
+                flow: config_qa
+            3:
+                task: snapshot_changes
     regression_org:
         group: Org Setup
         description: Simulates an org that has been upgraded from the latest release of to the current beta and its dependencies, but deploys any unmanaged metadata from the current beta.
@@ -990,6 +1000,24 @@ flows:
                 options:
                     update_dependencies:
                         resolution_strategy: commit_status
+                        dependencies: ^^github_package_data.dependencies
+            3:
+                task: install_managed
+                options:
+                    version: ^^github_package_data.version_id
+    install_unlocked_commit:
+        group: Install / Uninstall
+        description: Install the unlocked package for the current commit
+        steps:
+            1:
+                task: github_package_data
+                options:
+                    context: $project_config.project__git__unlocked_context
+            2:
+                flow: dependencies
+                options:
+                    update_dependencies:
+                        resolution_strategy: unlocked
                         dependencies: ^^github_package_data.dependencies
             3:
                 task: install_managed
@@ -1218,6 +1246,26 @@ flows:
                     version_type: minor
                     skip_validation: True
                     resolution_strategy: commit_status
+    build_unlocked_test_package:
+        group: Release Operations
+        description: Create an Unlocked package version
+        steps:
+            1:
+                task: update_package_xml
+                when: project_config.project__source_format != "sfdx"
+            2:
+                task: create_package_version
+                options:
+                    package_type: Unlocked
+                    package_name: $project_config.project__package__name Unlocked Feature Test
+                    version_type: minor
+                    resolution_strategy: unlocked
+                    org_dependent: True
+                    force_upload: True
+            3:
+                task: promote_package_version
+                options:
+                    version_id: ^^create_package_version.subscriber_package_version_id
     unmanaged_ee:
         group: Deployment
         description: Deploy the unmanaged package metadata and all dependencies to the target EE org
@@ -1330,6 +1378,7 @@ project:
         push_prefix_sandbox: "Sandbox orgs: "
         push_prefix_production: "Production orgs: "
         2gp_context: "Build Feature Test Package"
+        unlocked_context: "Build Unlocked Test Package"
         release_notes:
             parsers:
                 1:
@@ -1356,6 +1405,10 @@ project:
         preproduction: latest_release
         production: latest_release
         resolution_strategies:
+            unlocked:
+                - unlocked_exact_branch
+                - unlocked_release_branch
+                - unlocked_previous_release_branch
             commit_status:
                 - tag
                 - commit_status_exact_branch

--- a/cumulusci/salesforce_api/package_install.py
+++ b/cumulusci/salesforce_api/package_install.py
@@ -58,10 +58,10 @@ class PackageInstallOptions(CCIModel):
 
     activate_remote_site_settings: bool = True
     name_conflict_resolution: NameConflictResolution = NameConflictResolution.BLOCK
-    password: Optional[str]
+    password: Optional[str] = None
     security_type: SecurityType = SecurityType.FULL
-    apex_compile_type: Optional[ApexCompileType]
-    upgrade_type: Optional[UpgradeType]
+    apex_compile_type: Optional[ApexCompileType] = None
+    upgrade_type: Optional[UpgradeType] = None
 
     @staticmethod
     def from_task_options(task_options: dict) -> "PackageInstallOptions":

--- a/cumulusci/schema/cumulusci.jsonschema.json
+++ b/cumulusci/schema/cumulusci.jsonschema.json
@@ -320,6 +320,10 @@
                 "2gp_context": {
                     "title": "2Gp Context",
                     "type": "string"
+                },
+                "unlocked_context": {
+                    "title": "Unlocked Context",
+                    "type": "string"
                 }
             },
             "additionalProperties": false

--- a/cumulusci/utils/yaml/cumulusci_yml.py
+++ b/cumulusci/utils/yaml/cumulusci_yml.py
@@ -109,6 +109,7 @@ class Git(CCIDictModel):
     push_prefix_production: str = None
     release_notes: ReleaseNotes = None
     two_gp_context: str = Field(None, alias="2gp_context")
+    unlocked_context: Optional[str] = None
 
 
 class Plan(CCIDictModel):  # MetaDeploy plans


### PR DESCRIPTION
# Critical Changes

# Changes

- We added a new dependency resolution strategy, `unlocked`. Like our existing dependency strategies using parallel 2GP package builds, this strategy installs parallel unlocked package builds.
- We added the flows `build_unlocked_test_package`, `install_unlocked_commit`, and `qa_org_unlocked` to support use of parallel unlocked packages.

# Issues Closed
