### PR TITLE
Add custom hosted runners

### DIFF
--- a/.github/workflows/chores.yml
+++ b/.github/workflows/chores.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     check_api_versions:
-        runs-on: sfdc-ubuntu-latest
+        runs-on: SFDO-Tooling-Ubuntu
         outputs:
             hub_version: ${{ steps.devhub-api-version.outputs.hub_version }}
             cci_version: ${{ steps.cci-api-version.outputs.cci_version }}
@@ -30,7 +30,7 @@ jobs:
                   version=$(yq '.project.package.api_version' cumulusci/cumulusci.yml)
                   echo "::set-output name=cci_version::$version"
     update_api_versions:
-        runs-on: sfdc-ubuntu-latest
+        runs-on: SFDO-Tooling-Ubuntu
         needs: check_api_versions
         if: ${{ needs.check_api_versions.outputs.hub_version != needs.check_api_versions.outputs.cci_version }}
         env:

--- a/.github/workflows/chores.yml
+++ b/.github/workflows/chores.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     check_api_versions:
-        runs-on: ubuntu-latest
+        runs-on: sfdc-ubuntu-latest
         outputs:
             hub_version: ${{ steps.devhub-api-version.outputs.hub_version }}
             cci_version: ${{ steps.cci-api-version.outputs.cci_version }}
@@ -30,7 +30,7 @@ jobs:
                   version=$(yq '.project.package.api_version' cumulusci/cumulusci.yml)
                   echo "::set-output name=cci_version::$version"
     update_api_versions:
-        runs-on: ubuntu-latest
+        runs-on: sfdc-ubuntu-latest
         needs: check_api_versions
         if: ${{ needs.check_api_versions.outputs.hub_version != needs.check_api_versions.outputs.cci_version }}
         env:

--- a/.github/workflows/chores.yml
+++ b/.github/workflows/chores.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     check_api_versions:
-        runs-on: SFDO-Tooling-Ubuntu
+        runs-on: sfdc-ubuntu-20
         outputs:
             hub_version: ${{ steps.devhub-api-version.outputs.hub_version }}
             cci_version: ${{ steps.cci-api-version.outputs.cci_version }}
@@ -30,7 +30,7 @@ jobs:
                   version=$(yq '.project.package.api_version' cumulusci/cumulusci.yml)
                   echo "::set-output name=cci_version::$version"
     update_api_versions:
-        runs-on: SFDO-Tooling-Ubuntu
+        runs-on: sfdc-ubuntu-20
         needs: check_api_versions
         if: ${{ needs.check_api_versions.outputs.hub_version != needs.check_api_versions.outputs.cci_version }}
         env:

--- a/.github/workflows/chores.yml
+++ b/.github/workflows/chores.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     check_api_versions:
-        runs-on: sfdc-ubuntu-20
+        runs-on: SFDO-Tooling-Ubuntu
         outputs:
             hub_version: ${{ steps.devhub-api-version.outputs.hub_version }}
             cci_version: ${{ steps.cci-api-version.outputs.cci_version }}
@@ -30,7 +30,7 @@ jobs:
                   version=$(yq '.project.package.api_version' cumulusci/cumulusci.yml)
                   echo "::set-output name=cci_version::$version"
     update_api_versions:
-        runs-on: sfdc-ubuntu-20
+        runs-on: SFDO-Tooling-Ubuntu
         needs: check_api_versions
         if: ${{ needs.check_api_versions.outputs.hub_version != needs.check_api_versions.outputs.cci_version }}
         env:

--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -20,7 +20,7 @@ jobs:
     docs:
         name: Build Docs
         if: ${{ github.event_name == 'pull_request' }}
-        runs-on: sfdc-ubuntu-20
+        runs-on: SFDO-Tooling-Ubuntu
         steps:
             - name: "Checkout"
               uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [macos-latest, sfdc-ubuntu-20, sfdc-windows-latest]
+                os: [macos-latest, SFDO-Tooling-Ubuntu, sfdc-windows-latest]
                 python-version: ["3.8", "3.9", "3.10"]
         steps:
             - uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
 
     robot_api:
         name: "Robot: No browser"
-        runs-on: sfdc-ubuntu-20
+        runs-on: SFDO-Tooling-Ubuntu
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python 3.8
@@ -109,7 +109,7 @@ jobs:
                   path: robot/CumulusCI/results
     robot_ui:
         name: "Robot: ${{ matrix.job-name }}"
-        runs-on: sfdc-ubuntu-20
+        runs-on: SFDO-Tooling-Ubuntu
         strategy:
             fail-fast: false
             matrix:
@@ -172,6 +172,6 @@ jobs:
     coveralls_done:
         name: Finalize coveralls
         needs: [unit_tests, robot_api, robot_ui]
-        runs-on: sfdc-ubuntu-20
+        runs-on: SFDO-Tooling-Ubuntu
         steps:
             - run: curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$GITHUB_SHA&payload[status]=done"

--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -20,7 +20,7 @@ jobs:
     docs:
         name: Build Docs
         if: ${{ github.event_name == 'pull_request' }}
-        runs-on: sfdc-ubuntu-latest
+        runs-on: SFDO-Tooling-Ubuntu
         steps:
             - name: "Checkout"
               uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [macos-latest, sfdc-ubuntu-latest, sfdc-windows-latest]
+                os: [macos-latest, SFDO-Tooling-Ubuntu, sfdc-windows-latest]
                 python-version: ["3.8", "3.9", "3.10"]
         steps:
             - uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
 
     robot_api:
         name: "Robot: No browser"
-        runs-on: sfdc-ubuntu-latest
+        runs-on: SFDO-Tooling-Ubuntu
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python 3.8
@@ -109,7 +109,7 @@ jobs:
                   path: robot/CumulusCI/results
     robot_ui:
         name: "Robot: ${{ matrix.job-name }}"
-        runs-on: sfdc-ubuntu-latest
+        runs-on: SFDO-Tooling-Ubuntu
         strategy:
             fail-fast: false
             matrix:
@@ -172,6 +172,6 @@ jobs:
     coveralls_done:
         name: Finalize coveralls
         needs: [unit_tests, robot_api, robot_ui]
-        runs-on: sfdc-ubuntu-latest
+        runs-on: SFDO-Tooling-Ubuntu
         steps:
             - run: curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$GITHUB_SHA&payload[status]=done"

--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -20,7 +20,7 @@ jobs:
     docs:
         name: Build Docs
         if: ${{ github.event_name == 'pull_request' }}
-        runs-on: SFDO-Tooling-Ubuntu
+        runs-on: sfdc-ubuntu-20
         steps:
             - name: "Checkout"
               uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [macos-latest, SFDO-Tooling-Ubuntu, sfdc-windows-latest]
+                os: [macos-latest, sfdc-ubuntu-20, sfdc-windows-latest]
                 python-version: ["3.8", "3.9", "3.10"]
         steps:
             - uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
 
     robot_api:
         name: "Robot: No browser"
-        runs-on: SFDO-Tooling-Ubuntu
+        runs-on: sfdc-ubuntu-20
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python 3.8
@@ -109,7 +109,7 @@ jobs:
                   path: robot/CumulusCI/results
     robot_ui:
         name: "Robot: ${{ matrix.job-name }}"
-        runs-on: SFDO-Tooling-Ubuntu
+        runs-on: sfdc-ubuntu-20
         strategy:
             fail-fast: false
             matrix:
@@ -172,6 +172,6 @@ jobs:
     coveralls_done:
         name: Finalize coveralls
         needs: [unit_tests, robot_api, robot_ui]
-        runs-on: SFDO-Tooling-Ubuntu
+        runs-on: sfdc-ubuntu-20
         steps:
             - run: curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$GITHUB_SHA&payload[status]=done"

--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -20,7 +20,7 @@ jobs:
     docs:
         name: Build Docs
         if: ${{ github.event_name == 'pull_request' }}
-        runs-on: ubuntu-latest
+        runs-on: sfdc-ubuntu-latest
         steps:
             - name: "Checkout"
               uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [macos-latest, ubuntu-latest, windows-latest]
+                os: [macos-latest, sfdc-ubuntu-latest, sfdc-windows-latest]
                 python-version: ["3.8", "3.9", "3.10"]
         steps:
             - uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
 
     robot_api:
         name: "Robot: No browser"
-        runs-on: ubuntu-latest
+        runs-on: sfdc-ubuntu-latest
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python 3.8
@@ -109,7 +109,7 @@ jobs:
                   path: robot/CumulusCI/results
     robot_ui:
         name: "Robot: ${{ matrix.job-name }}"
-        runs-on: ubuntu-latest
+        runs-on: sfdc-ubuntu-latest
         strategy:
             fail-fast: false
             matrix:
@@ -172,6 +172,6 @@ jobs:
     coveralls_done:
         name: Finalize coveralls
         needs: [unit_tests, robot_api, robot_ui]
-        runs-on: ubuntu-latest
+        runs-on: sfdc-ubuntu-latest
         steps:
             - run: curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$GITHUB_SHA&payload[status]=done"

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -38,7 +38,7 @@ env:
 jobs:
     test_release:
         name: "Test Release Flows"
-        runs-on: SFDO-Tooling-Ubuntu
+        runs-on: sfdc-ubuntu-20
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python 3.8

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -38,7 +38,7 @@ env:
 jobs:
     test_release:
         name: "Test Release Flows"
-        runs-on: ubuntu-latest
+        runs-on: sfdc-ubuntu-latest
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python 3.8

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -38,7 +38,7 @@ env:
 jobs:
     test_release:
         name: "Test Release Flows"
-        runs-on: sfdc-ubuntu-20
+        runs-on: SFDO-Tooling-Ubuntu
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python 3.8

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -38,7 +38,7 @@ env:
 jobs:
     test_release:
         name: "Test Release Flows"
-        runs-on: sfdc-ubuntu-latest
+        runs-on: SFDO-Tooling-Ubuntu
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python 3.8

--- a/.github/workflows/slow_integration_tests.yml
+++ b/.github/workflows/slow_integration_tests.yml
@@ -12,7 +12,7 @@ env:
 jobs:
     org_backed_tests:
         name: "Org-connected Tests"
-        runs-on: sfdc-ubuntu-latest
+        runs-on: SFDO-Tooling-Ubuntu
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python 3.8

--- a/.github/workflows/slow_integration_tests.yml
+++ b/.github/workflows/slow_integration_tests.yml
@@ -12,7 +12,7 @@ env:
 jobs:
     org_backed_tests:
         name: "Org-connected Tests"
-        runs-on: SFDO-Tooling-Ubuntu
+        runs-on: sfdc-ubuntu-20
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python 3.8

--- a/.github/workflows/slow_integration_tests.yml
+++ b/.github/workflows/slow_integration_tests.yml
@@ -12,7 +12,7 @@ env:
 jobs:
     org_backed_tests:
         name: "Org-connected Tests"
-        runs-on: sfdc-ubuntu-20
+        runs-on: SFDO-Tooling-Ubuntu
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python 3.8

--- a/.github/workflows/slow_integration_tests.yml
+++ b/.github/workflows/slow_integration_tests.yml
@@ -12,7 +12,7 @@ env:
 jobs:
     org_backed_tests:
         name: "Org-connected Tests"
-        runs-on: ubuntu-latest
+        runs-on: sfdc-ubuntu-latest
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python 3.8


### PR DESCRIPTION
This commit replaces GitHub-hosted runners with custom-hosted ("premium"
in internal documentation) runners with known IP ranges.

The new runners mapped to old labels:

| New                   | Old              | Operating System    |
|-----------------------|------------------|---------------------|
| `sfdc-ubuntu-latest`  | `ubuntu-latest`  | Ubuntu 20.04 LTS    |
| `sfdc-windows-latest` | `windows-latest` | Windows Server 2022 |

The new `runs-on` entries map to labels, and should be stable.

TODO: Determine whether the image used for custom-hosted contains the
same software as the default ubuntu-latest