### PR TITLE
Fix Connected Org Docs Typo

### DIFF
--- a/docs/connected-orgs.md
+++ b/docs/connected-orgs.md
@@ -7,8 +7,8 @@ version, or installing to a sandbox for user acceptance testing.
 
 ```{attention}
 A different setup is required to connect to orgs in the context of an
-automated build. See
-`continuous integration [](continuous-integration) for more information.
+automated build. See the
+[continuous integration](continuous-integration) for more information.
 ```
 
 ## The `org connect` Command


### PR DESCRIPTION
There is some extra cruft on the front of a link on the [connected orgs docs page](https://cumulusci.readthedocs.io/en/latest/connected-orgs.html). This fixes that.