### PR TITLE
Import persistent orgs from the SFDX keychain

### DIFF
--- a/cumulusci/cli/org.py
+++ b/cumulusci/cli/org.py
@@ -10,6 +10,7 @@ from rich.console import Console
 
 from cumulusci.cli.ui import CliTable, SimpleSalesforceUIHelpers
 from cumulusci.core.config import OrgConfig, ScratchOrgConfig
+from cumulusci.core.config.sfdx_org_config import SfdxOrgConfig
 from cumulusci.core.exceptions import OrgNotFound
 from cumulusci.oauth.client import (
     PROD_LOGIN_URL,
@@ -20,7 +21,7 @@ from cumulusci.oauth.client import (
 from cumulusci.salesforce_api.utils import get_simple_salesforce_connection
 from cumulusci.utils import parse_api_datetime
 
-from .runtime import pass_runtime
+from .runtime import CliRuntime, pass_runtime
 
 
 @click.group("org", help="Commands for connecting and interacting with Salesforce orgs")
@@ -240,32 +241,56 @@ def org_default(runtime, org_name, unset):
             click.echo("There is no default org")
 
 
-@org.command(name="import", help="Import a scratch org from Salesforce DX")
+@org.command(name="import", help="Import an org from Salesforce DX")
 @click.argument("username_or_alias")
 @orgname_option_or_argument(required=True)
 @pass_runtime(require_keychain=True)
-def org_import(runtime, username_or_alias, org_name):
-    org_config = {"username": username_or_alias}
-    scratch_org_config = ScratchOrgConfig(
-        org_config, org_name, runtime.keychain, global_org=False
+def org_import(runtime: CliRuntime, username_or_alias: str, org_name: str):
+    # Import the org from the SFDX keychain as an SfdxOrgConfig
+    # The `sfdx` key ensures we can reload using the right class.
+    org_config = SfdxOrgConfig(
+        {"username": username_or_alias, "sfdx": True},
+        org_name,
+        runtime.keychain,
+        global_org=False,
     )
-    scratch_org_config.config["created"] = True
 
-    info = scratch_org_config.sfdx_info
-    if not info.get("created_date"):
-        raise click.UsageError(
-            "cci org import only works for locally created "
-            "scratch orgs.\nUse `cci org connect` for other orgs."
-        )
-    scratch_org_config.config["days"] = calculate_org_days(info)
-    scratch_org_config.config["date_created"] = parse_api_datetime(info["created_date"])
+    # Determine if we received a locally-created scratch org
+    # or some other org (which we'll treat as persistent)
 
-    scratch_org_config.save()
-    click.echo(
-        "Imported scratch org: {org_id}, username: {username}".format(
-            **scratch_org_config.sfdx_info
+    info = org_config.sfdx_info
+    if info.get("created_date"):
+        # This is a locally-created scratch org.
+        # Re-import accordingly.
+        org_config = ScratchOrgConfig(
+            {"username": username_or_alias},
+            org_name,
+            runtime.keychain,
+            global_org=False,
         )
-    )
+        org_config._sfdx_info = info
+        # Set `created` so we don't try to rebuild it.
+        org_config.config["created"] = True
+
+        org_config.config["days"] = calculate_org_days(info)
+        org_config.config["date_created"] = parse_api_datetime(info["created_date"])
+
+        org_config.save()
+        click.echo(
+            "Imported scratch org: {org_id}, username: {username}".format(
+                **org_config.sfdx_info
+            )
+        )
+    else:
+        # This is either a persistent org or a scratch org imported into the
+        # sfdx keychain via OAuth login.
+
+        org_config.save()
+        click.echo(
+            "Imported org: {org_id}, username: {username}".format(
+                **org_config.sfdx_info
+            )
+        )
 
 
 def calculate_org_days(info):

--- a/cumulusci/cli/tests/test_org.py
+++ b/cumulusci/cli/tests/test_org.py
@@ -404,15 +404,15 @@ class TestOrgCommands:
         )
 
         out = []
-        with mock.patch("click.echo", out.append), pytest.raises(
-            click.UsageError, match="cci org connect"
-        ):
+        with mock.patch("click.echo", out.append):
             run_click_command(
                 org.org_import,
                 username_or_alias="test@test.org",
                 org_name="test",
                 runtime=runtime,
             )
+            runtime.keychain.set_org.assert_called_once()
+        assert "Imported org: access, username: test@test.org" in "".join(out)
 
     def test_calculate_org_days(self):
         info_1 = {

--- a/cumulusci/core/config/org_config.py
+++ b/cumulusci/core/config/org_config.py
@@ -163,6 +163,8 @@ class OrgConfig(BaseConfig):
 
     @property
     def salesforce_client(self):
+        """Return a simple_salesforce.Salesforce instance authorized to this org.
+        Does not perform a token refresh."""
         return Salesforce(
             instance=self.instance_url.replace("https://", ""),
             session_id=self.access_token,
@@ -188,6 +190,7 @@ class OrgConfig(BaseConfig):
 
     @property
     def start_url(self):
+        """The frontdoor URL that results in an instant login"""
         start_url = "%s/secur/frontdoor.jsp?sid=%s" % (
             self.instance_url,
             self.access_token,
@@ -226,6 +229,7 @@ class OrgConfig(BaseConfig):
         return False
 
     def _load_orginfo(self):
+        """Query the Organization sObject and populate local config values from the result."""
         self._org_sobject = self.salesforce_client.Organization.get(self.org_id)
 
         result = {
@@ -238,6 +242,7 @@ class OrgConfig(BaseConfig):
 
     @property
     def organization_sobject(self):
+        """Cached copy of Organization sObject. Does not perform API call."""
         return self._org_sobject
 
     def _fetch_community_info(self):

--- a/cumulusci/core/keychain/encrypted_file_project_keychain.py
+++ b/cumulusci/core/keychain/encrypted_file_project_keychain.py
@@ -13,6 +13,7 @@ from cryptography.hazmat.primitives.ciphers.algorithms import AES
 from cryptography.hazmat.primitives.ciphers.modes import CBC
 
 from cumulusci.core.config import OrgConfig, ScratchOrgConfig, ServiceConfig
+from cumulusci.core.config.sfdx_org_config import SfdxOrgConfig
 from cumulusci.core.exceptions import (
     ConfigError,
     CumulusCIException,
@@ -149,8 +150,11 @@ class EncryptedFileProjectKeychain(BaseProjectKeychain):
         return self._construct_config(config_class, args)
 
     def _construct_config(self, config_class, args):
-        if args[0].get("scratch"):
+        config = args[0]
+        if config.get("scratch"):
             config_class = scratch_org_factory
+        elif config.get("sfdx"):
+            config_class = SfdxOrgConfig
 
         return config_class(*args)
 


### PR DESCRIPTION
CumulusCI now supports importing persistent orgs from the SFDX keychain with the `cci org import` command.