### PR TITLE
Fixes(?) to _get_required_permission_types

### DIFF
--- a/cumulusci/tasks/bulkdata/mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/mapping_parser.py
@@ -305,10 +305,15 @@ class MappingStep(CCIDictModel):
         if operation is DataOperationType.QUERY:
             return ("queryable",)
         if (
-            operation is DataOperationType.INSERT
+            operation is DataOperationType.UPDATE
             and self.action is DataOperationType.UPDATE
         ):
             return ("updateable",)
+        if (
+            operation is DataOperationType.UPDATE
+            or self.action is DataOperationType.UPDATE
+        ):
+            return ("updateable", "createable")
         if operation in (
             DataOperationType.UPSERT,
             DataOperationType.ETL_UPSERT,


### PR DESCRIPTION
I'm quite unclear on this code and hesitant to change it, but I think it may hide a bug.

If you remove the mocks that force `_validate_field_dict` to return the "right" value, it will return the "wrong" value. It's unclear to me why we would need the mocks except to work around a bug. Removing the mocks surfaced the bug, so I tried to fix it. But I'm not sure of my fix. The relationship between "operation" and "action" is fuzzy.

@davidmreed 