### PR TITLE
Allow org_schema consumers to download a subset

### DIFF
--- a/cumulusci/salesforce_api/org_schema.py
+++ b/cumulusci/salesforce_api/org_schema.py
@@ -44,13 +44,6 @@ def unzip_database(gzipfile, outfile):
                 db.write(gzipped.read())
 
 
-class Everything:
-    """A set that contains everything"""
-
-    def __contains__(self, obj):
-        return True
-
-
 class Schema:
     """Represents an org's schema, cached from describe() calls"""
 

--- a/cumulusci/salesforce_api/org_schema.py
+++ b/cumulusci/salesforce_api/org_schema.py
@@ -1,4 +1,5 @@
 import gzip
+import typing as T
 from collections import defaultdict
 from contextlib import ExitStack, contextmanager
 from email.utils import parsedate
@@ -7,10 +8,12 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Dict, Iterable, List, NamedTuple, Optional, Tuple
 
+from simple_salesforce import Salesforce
 from sqlalchemy import MetaData, create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import create_session, exc, sessionmaker
 
+from cumulusci.core.config.org_config import OrgConfig
 from cumulusci.salesforce_api.org_schema_models import (
     Base,
     Field,
@@ -39,6 +42,13 @@ def unzip_database(gzipfile, outfile):
         with gzip.GzipFile(fileobj=fileobj) as gzipped:
             with open(outfile, "wb") as db:
                 db.write(gzipped.read())
+
+
+class Everything:
+    """A set that contains everything"""
+
+    def __contains__(self, obj):
+        return True
 
 
 class Schema:
@@ -105,12 +115,13 @@ class Schema:
     def __repr__(self):
         return f"<Schema {self.path} : {self.engine}>"
 
-    def populate_cache(self, sf, last_modified_date, logger=None):
+    def populate_cache(self, sf, last_modified_date, include=None, logger=None):
         """Populate a schema cache from the API, using last_modified_date
         to pull down only new schema"""
 
         sobjs = sf.describe()["sobjects"]
-        sobj_names = [obj["name"] for obj in sobjs]
+        include = set(include) if include is not None else Everything()
+        sobj_names = [obj["name"] for obj in sobjs if obj["name"] in include]
 
         responses = list(deep_describe(sf, last_modified_date, sobj_names, logger))
         changes = [
@@ -126,7 +137,9 @@ class Schema:
         self._populate_cache_from_describe(changes, last_modified_date)
 
     def _populate_cache_from_describe(
-        self, describe_objs: List[Tuple[dict, str]], last_modified_date
+        self,
+        describe_objs: List[Tuple[dict, str]],
+        last_modified_date,
     ):
         """Populate a schema cache from a list of describe objects."""
         engine = self.engine
@@ -220,7 +233,14 @@ class BufferedSession:
 
 
 @contextmanager
-def get_org_schema(sf, org_config, force_recache=False, logger=None):
+def get_org_schema(
+    sf: Salesforce,
+    org_config: OrgConfig,
+    include: T.Sequence[str] = None,
+    *,
+    force_recache=False,
+    logger=None,
+):
     """
     Get a read-only representation of an org's schema.
 
@@ -270,11 +290,7 @@ def get_org_schema(sf, org_config, force_recache=False, logger=None):
                 closer.callback(schema.close)
                 schema.from_cache = False
 
-            schema.populate_cache(
-                sf,
-                schema.last_modified_date or y2k,
-                logger,
-            )
+            schema.populate_cache(sf, schema.last_modified_date or y2k, include, logger)
             schema.block_writing()
             # save a gzipped copy for later
             zip_database(tempfile, schema_path)
@@ -309,6 +325,8 @@ def deep_describe(
                     "httpHeaders": {"If-Modified-Since": last_modified_date},
                 }
                 for obj in objs
+                # Platform bug!!!
+                if not obj.startswith("MacroInstruction")
             )
         )
 

--- a/cumulusci/salesforce_api/org_schema.py
+++ b/cumulusci/salesforce_api/org_schema.py
@@ -119,9 +119,11 @@ class Schema:
         """Populate a schema cache from the API, using last_modified_date
         to pull down only new schema"""
 
-        sobjs = sf.describe()["sobjects"]
-        include = set(include) if include is not None else Everything()
-        sobj_names = [obj["name"] for obj in sobjs if obj["name"] in include]
+        if include:
+            sobj_names = include
+        else:
+            sobjs = sf.describe()["sobjects"]
+            sobj_names = [obj["name"] for obj in sobjs]
 
         responses = list(deep_describe(sf, last_modified_date, sobj_names, logger))
         changes = [

--- a/cumulusci/salesforce_api/org_schema_models.py
+++ b/cumulusci/salesforce_api/org_schema_models.py
@@ -75,12 +75,6 @@ class OrgSchemaModelMixin:
         other_state.pop("_sa_instance_state", None)
         return my_state == other_state
 
-    def __contains__(self, attr):
-        return hasattr(self, attr)
-
-    def get(self, attr, default=None):
-        return getattr(self, attr, default)
-
 
 class SObject(OrgSchemaModelMixin, Base):
     __tablename__ = "sobjects"

--- a/cumulusci/salesforce_api/org_schema_models.py
+++ b/cumulusci/salesforce_api/org_schema_models.py
@@ -75,6 +75,12 @@ class OrgSchemaModelMixin:
         other_state.pop("_sa_instance_state", None)
         return my_state == other_state
 
+    def __contains__(self, attr):
+        return hasattr(self, attr)
+
+    def get(self, attr, default=None):
+        return getattr(self, attr, default)
+
 
 class SObject(OrgSchemaModelMixin, Base):
     __tablename__ = "sobjects"

--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -709,7 +709,9 @@ class LoadData(SqlAlchemyMixin, BaseSalesforceApiTask):
                 self.logger.warning(
                     f"Cannot get the list of custom tabs to set recently viewed status on them. Error: {e}"
                 )
-        with get_org_schema(self.sf, self.org_config) as org_schema:
+        with get_org_schema(
+            self.sf, self.org_config, object_names & custom_objects
+        ) as org_schema:
             for mapped_item in sorted(object_names):
                 if org_schema[mapped_item].mruEnabled:
                     try:

--- a/cumulusci/utils/http/multi_request.py
+++ b/cumulusci/utils/http/multi_request.py
@@ -68,7 +68,7 @@ def future_with_exception_handling(future, futures_to_requests):
         return HTTPRequestError(exception=e, request=futures_to_requests[future])
 
 
-def collate_results(result_iterable: T.Sequence) -> (T.Generator, T.Generator):
+def collate_results(result_iterable: T.Sequence) -> T.Tuple[T.Generator, T.Generator]:
     """Partition results into separate sequences of successes and errors."""
     return partition(lambda r: isinstance(r, HTTPRequestError), result_iterable)
 

--- a/cumulusci/utils/tests/cassettes/ManualEditTestDescribeOrg.test_minimal_schema.yaml
+++ b/cumulusci/utils/tests/cassettes/ManualEditTestDescribeOrg.test_minimal_schema.yaml
@@ -1,0 +1,36 @@
+interactions:
+    - include_file: GET_sobjects_Global_describe.yaml
+    - request:
+          body:
+              '{"compositeRequest": [{"referenceId": "refAccount", "method": "GET", "url":
+              "/services/data/vxx.0/sobjects/Account/describe", "httpHeaders": {"If-Modified-Since":
+              "Sat, 1 Jan 2000 00:00:01 GMT"}}, {"referenceId": "refOpportunity", "method":
+              "GET", "url": "/services/data/vxx.0/sobjects/Opportunity/describe", "httpHeaders":
+              {"If-Modified-Since": "Sat, 1 Jan 2000 00:00:01 GMT"}}]}'
+          headers:
+              Request-Headers:
+                  - Elided
+          method: POST
+          uri: https://orgname.my.salesforce.com/services/data/vxx.0/composite
+      response:
+          body:
+              string:
+                  '{"compositeResponse": [{"body": {"label": "Account", "labelPlural": "Accounts", "layoutable":
+                  true, "listviewable": null, "lookupLayoutable": null, "mergeable": true, "mruEnabled":
+                  true, "name": "Account", "fields":[]}, "httpHeaders": {"ETag": "\"2b806538\"",
+                  "Last-Modified": "Tue, 28 Jun 2022 03:46:54 GMT"}, "httpStatusCode": 200,
+                  "referenceId": "refAccount"}, {"body": {"fields": [], "name": "Opportunity",
+                  "namedLayoutInfos": [], "networkScopeFieldName": null, "queryable": true,
+                  "replicateable": true, "retrieveable": true, "searchLayoutable": true,
+                  "searchable": true, "sobjectDescribeOption": "FULL", "triggerable": true,
+                  "undeletable": true, "updateable": true}, "httpHeaders":
+                  {"ETag": "\"2b806538\"", "Last-Modified": "Tue, 28 Jun 2022 03:46:54 GMT"},
+                  "httpStatusCode": 200, "referenceId": "refOpportunity"}]}'
+          headers:
+              Content-Type:
+                  - application/json;charset=UTF-8
+              Others: Elided
+          status:
+              code: 200
+              message: OK
+version: 1

--- a/cumulusci/utils/tests/test_org_schema.py
+++ b/cumulusci/utils/tests/test_org_schema.py
@@ -290,6 +290,15 @@ class TestDescribeOrg:
             with get_org_schema(sf, org_config):
                 pass
 
+    def test_minimal_schema(self, sf, org_config, vcr):
+        with vcr.use_cassette(
+            "ManualEditTestDescribeOrg.test_minimal_schema.yaml",
+            record_mode="none",
+        ), get_org_schema(
+            sf, org_config, include=["Account", "Opportunity"], force_recache=True
+        ) as schema:
+            assert list(schema.keys()) == ["Account", "Opportunity"]
+
 
 @pytest.mark.vcr()  # too hard to make these VCR-compatible due to data volume
 @pytest.mark.slow()
@@ -311,6 +320,12 @@ class TestOrgSchemaIntegration:
         with get_org_schema(sf, org_config) as schema:
             self.validate_real_schema_data(schema)
             assert schema.from_cache
+
+    def test_minimal_schema(self, sf, org_config):
+        with get_org_schema(
+            sf, org_config, include=["Account", "Opportunity"], force_recache=True
+        ) as schema:
+            assert list(schema.keys()) == ["Account", "Opportunity"]
 
 
 class TestBufferedSession:


### PR DESCRIPTION
If a consumer of the org_schema cache needs only a few objects, they can now download info about just those few objects. If a later consumer needs others, it will fill out the database with what it needs (or everything).

Shaves 4 seconds off of `load` tasks, for example.

Some other benchmarks: 

1. empty org.

```
With Cleared cache, 1 obj 0.7929778099060059
Verify 1 obj fresh 0.5295290946960449
With Cleared cache, all objects 10.970187187194824
Verify 1 obj fresh on full cache 1.1063191890716553
Verify all objs fresh 4.084507942199707
```

2. Giant-metadata org first time (server cache is probably cold)
```
With Cleared cache, 1 obj 12.726238012313843
Verify 1 obj fresh 0.5373942852020264
With Cleared cache, all objects 508.0563840866089
Verify 1 obj fresh on full cache 2.6867473125457764
Verify all objs fresh 28.623379945755005
```

3. Giant-metadata org second time (server cache is warm)
```
With Cleared cache, 1 obj 1.9306612014770508
Verify 1 obj fresh 0.6272079944610596
With Cleared cache, all objects 61.49964499473572
Verify 1 obj fresh on full cache 2.4226250648498535
Verify all objs fresh 28.57364320755005
```
