### PR TITLE
Mark MetaDeploy REST API tests

### DIFF
--- a/cumulusci/cli/tests/test_plan.py
+++ b/cumulusci/cli/tests/test_plan.py
@@ -9,6 +9,8 @@ from cumulusci.cli.runtime import CliRuntime
 from .. import plan
 from .utils import run_click_command
 
+pytestmark = pytest.mark.metadeploy
+
 
 @pytest.fixture
 def runtime():

--- a/cumulusci/core/metadeploy/tests/test_api.py
+++ b/cumulusci/core/metadeploy/tests/test_api.py
@@ -8,6 +8,7 @@ from cumulusci.core.config import ServiceConfig
 from cumulusci.core.exceptions import CumulusCIException
 from cumulusci.core.metadeploy.api import MetaDeployAPI, make_api_session
 
+pytestmark = pytest.mark.metadeploy
 DEFAULT_REST_URL: str = "https://metadeploy.example.com/api/rest"
 DEFAULT_TOKEN: str = "37b003aee9bdd744a6618e9fe12"
 

--- a/cumulusci/tasks/tests/test_metadeploy.py
+++ b/cumulusci/tasks/tests/test_metadeploy.py
@@ -17,6 +17,8 @@ from cumulusci.tasks.github.tests.util_github_api import GithubApiTestMixin
 from cumulusci.tasks.metadeploy import BaseMetaDeployTask, Publish
 from cumulusci.tests.util import create_project_config
 
+pytestmark = pytest.mark.metadeploy
+
 
 class TestBaseMetaDeployTask:
     maxDiff = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ exclude_lines = ["pragma: no cover", "@abstract", "@abc.abstract" ]
 [tool.pytest.ini_options]
 testpaths = "cumulusci"
 addopts =  "-p cumulusci.tests.pytest_plugins.pytest_typeguard -p cumulusci.tests.pytest_plugins.pytest_sf_vcr -p cumulusci.tests.pytest_plugins.pytest_sf_orgconnect"
+markers = [
+    "metadeploy: mark a test that interacts with the MetaDeploy REST API",
+]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Allows running the subset of MetaDeploy-related unit tests via:

```console
$ pytest -m metadeploy
```