### PR TITLE
Move to PEP-517-ish setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,45 @@
+[metadata]
+name = cumulusci
+version = attr: cumulusci.__version__
+description = Build and release tools for Salesforce developers
+license = BSD-3-Clause
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = Salesforce.org
+author_email = sfdo-mrbelvedere@salesforce.com
+url = https://github.com/SFDO-Tooling/CumulusCI
+project_urls =
+    Documentation=http://cumulusci.readthedocs.io/
+    Source=https://github.com/SFDO-Tooling/CumulusCI
+    Issues=https://github.com/SFDO-Tooling/CumulusCI/issues
+    Changelog=https://cumulusci.readthedocs.io/en/stable/history.html
+keywords = cumulusci
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    License :: OSI Approved :: BSD License
+    Natural Language :: English
+    Operating System :: MacOS :: MacOS X
+    Operating System :: POSIX :: Linux
+    Operating System :: Microsoft :: Windows
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+
+[options]
+include_package_data = True
+install_requires = file: requirements/prod.txt
+zip_safe = False
+python_requires = >=3.8
+package_dir =
+    cumulusci = cumulusci
+
+[options.entry_points]
+console_scripts =
+    cci = cumulusci.cli.cci:main
+    snowfakery = snowfakery.cli:main
+
 [build]
 build-base = pybuild
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os.path
-import re
 from pkgutil import walk_packages
 
 from setuptools import setup
@@ -16,59 +14,7 @@ def find_packages(path=["."], prefix=""):
             yield name
 
 
-with open(os.path.join("cumulusci", "version.txt"), "r") as version_file:
-    version = version_file.read().strip()
-
-with open("README.rst", "rb") as readme_file:
-    readme = readme_file.read().decode("utf-8")
-
-with open("HISTORY.rst", "rb") as history_file:
-    history = history_file.read().decode("utf-8")
-
-with open("requirements/prod.txt") as requirements_file:
-    requirements = []
-    for req in requirements_file.read().splitlines():
-        # skip comments and hash lines
-        if re.match(r"\s*#", req) or re.match(r"\s*--hash", req):
-            continue
-        else:
-            req = req.split(" ")[0]
-            # Work around normalized name of github3.py distribution
-            req = req.replace("github3-py", "github3.py")
-            requirements.append(req)
-
 setup(
-    name="cumulusci",
-    version=version,
-    description="Build and release tools for Salesforce developers",
-    long_description=readme + "\n\n" + history,
-    long_description_content_type="text/x-rst",
-    author="Salesforce.org",
-    author_email="jlantz@salesforce.com",
-    url="https://github.com/SFDO-Tooling/CumulusCI",
     packages=list(find_packages(["cumulusci"], "cumulusci")),
-    package_dir={"cumulusci": "cumulusci"},
-    entry_points={
-        "console_scripts": [
-            "cci=cumulusci.cli.cci:main",
-            "snowfakery=snowfakery.cli:main",
-        ]
-    },
-    include_package_data=True,
-    install_requires=requirements,
-    license="BSD license",
-    zip_safe=False,
-    keywords="cumulusci",
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: BSD License",
-        "Natural Language :: English",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-    ],
     test_suite="cumulusci.core.tests",
-    python_requires=">=3.8",
 )


### PR DESCRIPTION
Need to maintain setup.py for editable installs.

Substantive changes:
- _Update package author metadata_
- Added classifiers
- Added project_urls
- No longer concatenate README and HISTORY for long_description

Probably worth investigating alternate build systems if we ever get the chance