### PR TITLE
Fix `metadeploy_publish` error caused by supported_orgs case-sensitivity

### DIFF
--- a/cumulusci/tasks/metadeploy.py
+++ b/cumulusci/tasks/metadeploy.py
@@ -259,11 +259,11 @@ class Publish(BaseMetaDeployTask):
         corresponds `supported_orgs` field on the Plan model in MetaDeploy
         """
         if not providers or providers == ["user"]:
-            org_providers = "persistent"
+            org_providers = "Persistent"
         elif "user" in providers and "devhub" in providers:
-            org_providers = "both"
+            org_providers = "Both"
         elif providers == ["devhub"]:
-            org_providers = "scratch"
+            org_providers = "Scratch"
 
         return org_providers
 

--- a/cumulusci/tasks/tests/test_metadeploy.py
+++ b/cumulusci/tasks/tests/test_metadeploy.py
@@ -271,7 +271,7 @@ class TestPublish(GithubApiTestMixin):
         task()
 
         body = json.loads(responses.calls[-2].request.body)
-        assert body["supported_orgs"] == "both"
+        assert body["supported_orgs"] == "Both"
 
         steps = body["steps"]
         self.maxDiff = None
@@ -530,9 +530,9 @@ class TestPublish(GithubApiTestMixin):
         assert steps == []
 
     providers = [
-        (["user"], "persistent"),
-        (["devhub"], "scratch"),
-        (["user", "devhub"], "both"),
+        (["user"], "Persistent"),
+        (["devhub"], "Scratch"),
+        (["user", "devhub"], "Both"),
     ]
 
     @pytest.mark.parametrize("org_providers,metadeploy_equivalent", providers)


### PR DESCRIPTION
When running metadeploy_publish, users received an error from the REST
API:
```
Error: b'{"supported_orgs":["\\"persistent\\" is not a valid choice."]}'
```

because the Plan.supported_orgs field in MDP is case-sensitive. We
switch to title case on client-side in this PR.