### PR TITLE
Include default SFDX gitignore files

### DIFF
--- a/cumulusci/files/templates/project/dot-gitignore
+++ b/cumulusci/files/templates/project/dot-gitignore
@@ -1,6 +1,5 @@
-# Salesforce / SFDX / CCI
+# CCI
 .cci
-.sfdx
 /src.orig
 {% if source_format == "sfdx" %}
 /src
@@ -16,6 +15,42 @@ __pycache__
 # Robot Framework results
 robot/{{ project_name }}/results/
 
+{# START SFDX TEMPLATE #}
+# Salesforce cache
+.sf/
+.sfdx/
+.localdevserver/
+deploy-options.json
+
+# LWC VSCode autocomplete
+**/lwc/jsconfig.json
+
+# LWC Jest coverage reports
+coverage/
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Dependency directories
+node_modules/
+
+# Eslint cache
+.eslintcache
+
+# MacOS system files
+.DS_Store
+
+# Windows system files
+Thumbs.db
+ehthumbs.db
+[Dd]esktop.ini
+$RECYCLE.BIN/
+{# END SFDX TEMPLATE #}
+
 # Editors
 *.sublime-project
 *.sublime-workspace
@@ -23,7 +58,3 @@ robot/{{ project_name }}/results/
 .idea
 .project
 .settings
-
-# Misc
-.DS_Store
-


### PR DESCRIPTION
We previously didn't include the `.sf` directory in our gitignore
template, which resulted in git tracking it. Because `.sf` includes the
git_dir used in source tracking this resulted in a large number of
changes that users did not expect.

Because our copy of the gitignore is pretty old, it didn't include any
of the entries included in the skeleton generated by `sfdx
force:project:create`.

We now inline the contents of the upstream template [source] in our own.

[source]: https://github.com/forcedotcom/salesforcedx-templates/blob/main/packages/templates/src/templates/project/gitignore