### PR TITLE
Add MetaDeploy data models

### DIFF
--- a/cumulusci/core/metadeploy/api.py
+++ b/cumulusci/core/metadeploy/api.py
@@ -1,5 +1,4 @@
 """Calls to the MetaDeploy REST API."""
-
 import functools
 from typing import Optional, Union
 

--- a/cumulusci/core/metadeploy/api.py
+++ b/cumulusci/core/metadeploy/api.py
@@ -2,11 +2,19 @@
 import functools
 from typing import Optional, Union
 
+from pydantic.error_wrappers import ValidationError
 from requests.models import Response
 from requests.sessions import Session
 
 from cumulusci.core.config import ServiceConfig
 from cumulusci.core.exceptions import CumulusCIException
+from cumulusci.core.metadeploy.models import (
+    MetaDeployPlan,
+    PlanTemplate,
+    Product,
+    Slug,
+    Version,
+)
 from cumulusci.utils.http.requests_utils import safe_json_from_response
 
 
@@ -55,26 +63,40 @@ class MetaDeployAPI:
                 "ends in /rest, and that your authentication token is valid."
             ) from None
 
-    def create_plan(self, plan: dict) -> dict:
-        return self._create("/plans", plan)
+    def create_plan(self, plan: MetaDeployPlan) -> MetaDeployPlan:
+        return MetaDeployPlan.parse_obj(
+            self._create("/plans", json=plan.dict(exclude_none=True))
+        )
 
-    def create_plan_template(self, template: dict) -> dict:
-        return self._create("/plantemplates", json=template)
+    def create_plan_template(self, template: PlanTemplate) -> PlanTemplate:
+        return PlanTemplate.parse_obj(
+            self._create("/plantemplates", json=template.dict())
+        )
 
-    def create_plan_slug(self, slug: dict) -> dict:
-        return self._create("/planslug", json=slug)
+    def create_plan_slug(self, slug: Slug) -> Slug:
+        return Slug.parse_obj(
+            self._create("/planslug", json=slug.dict(include={"slug", "parent"}))
+        )
 
-    def create_version(self, version: dict) -> dict:
-        return self._create("/versions", json=version)
+    def create_version(self, version: dict) -> Version:
+        return Version.parse_obj(self._create("/versions", json=version))
 
-    def find_product(self, repo_url: str) -> Optional[dict]:
-        return self._find("/products", {"repo_url": repo_url})
+    def find_product(self, repo_url: str) -> Product:
+        try:
+            product_json = self._find("/products", {"repo_url": repo_url})
+            return Product.parse_obj(product_json)
+        except ValidationError:
+            raise CumulusCIException(
+                f"No product found in MetaDeploy with repo URL {repo_url}"
+            ) from None
 
-    def find_plan_template(self, query: dict) -> Optional[dict]:
-        return self._find("/plantemplates", query)
+    def find_plan_template(self, query: dict) -> Optional[PlanTemplate]:
+        if template_json := self._find("/plantemplates", query):
+            return PlanTemplate.parse_obj(template_json)
 
-    def find_version(self, query: dict) -> Optional[dict]:
-        return self._find("/versions", query)
+    def find_version(self, query: dict) -> Optional[Version]:
+        if version_json := self._find("/versions", query):
+            return Version.parse_obj(version_json)
 
     def update_version(self, pk: Union[int, str]) -> dict:
         response: Response = self.session.patch(
@@ -85,3 +107,25 @@ class MetaDeployAPI:
     def update_lang_translation(self, lang: str, labels: dict) -> dict:
         response: Response = self.session.patch(f"/translations/{lang}", json=labels)
         return safe_json_from_response(response)
+
+    def find_or_create_plan_template(
+        self, product_id: str, plan_template_maybe: PlanTemplate, slug: str
+    ) -> PlanTemplate:
+        query: dict = {"product": product_id, "name": plan_template_maybe.name}
+        existing_plan_template: Optional[PlanTemplate] = self.find_plan_template(query)
+
+        if existing_plan_template:
+            return existing_plan_template
+
+        plan_template = self.create_plan_template(plan_template_maybe)
+        _ = self.create_plan_slug(
+            Slug.parse_obj({"slug": slug, "parent": plan_template.url})
+        )
+        return plan_template
+
+    def find_or_create_version(
+        self, product_id: str, version_maybe: Version
+    ) -> Version:
+        query: dict = {"product": product_id, "label": version_maybe.label}
+        existing_version: Optional[Version] = self.find_version(query)
+        return existing_version or self.create_version(version_maybe.dict())

--- a/cumulusci/core/metadeploy/labels.py
+++ b/cumulusci/core/metadeploy/labels.py
@@ -1,0 +1,135 @@
+"""
+Functions for creating/modifying MetaDeploy translation labels.
+"""
+import contextlib
+import json
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Mapping, Union
+
+LabelMap = Mapping[str, Mapping[str, str]]
+
+INSTALL_VERSION_RE = re.compile(r"^Install .*\d$")
+METADEPLOY_DIR: str = "metadeploy"
+METADEPLOY_LABELS: LabelMap = {
+    "checks": {"message": "shown if validation fails"},
+    "plan": {
+        "title": "title of installation plan",
+        "preflight_message": "shown before user starts installation (markdown)",
+        "preflight_message_additional": "shown before user starts installation (markdown)",
+        "post_install_message": "shown after successful installation (markdown)",
+        "post_install_message_additional": "shown after successful installation (markdown)",
+        "error_message": "shown after failed installation (markdown)",
+    },
+    "product": {
+        "title": "name of product",
+        "short_description": "tagline of product",
+        "description": "shown on product detail page (markdown)",
+        "click_through_agreement": "legal text shown in modal dialog",
+        "error_message": "shown after failed installation (markdown)",
+    },
+    "steps": {
+        "name": "title of installation step",
+        "description": "description of installation step",
+    },
+}
+
+
+def read_default_labels(labels_path: Union[Path, str] = METADEPLOY_DIR) -> dict:
+    """Load existing English labels from disk."""
+    labels: dict = defaultdict(dict)
+    with contextlib.suppress(FileNotFoundError):
+        labels_file: Path = Path(labels_path, "labels_en.json")
+        labels.update(json.loads(labels_file.read_text()))
+    return labels
+
+
+def read_label_files(labels_path: Union[Path, str], slug: str) -> Dict[str, dict]:
+    """
+    Load all tranlations from disk, returning prefixed labels keyed by language.
+
+    Keyword Arguments:
+    labels_path -- Path containing files to read
+    slug        -- Prepended to each label's key
+    """
+    prefixed_labels = {}
+    for path in Path(labels_path).glob("*.json"):
+        lang = path.stem.split("_")[-1].lower()
+        if lang in ("en", "en-us"):
+            continue
+        orig_labels = json.loads(path.read_text())
+        prefixed_labels[lang] = {
+            f"{slug}:{context}": labels for context, labels in orig_labels.items()
+        }
+    return prefixed_labels
+
+
+def save_default_labels(labels_path: Union[Path, str], labels_to_save: dict):
+    """Save updates to English labels."""
+    with contextlib.suppress(FileNotFoundError):
+        labels_file: Path = Path(labels_path, "labels_en.json")
+        labels_file.write_text(json.dumps(labels_to_save, indent=4))
+
+
+def update_plan_labels(plan_name: str, plan, labels_to_update):
+    """Add specified fields from plan to a label category."""
+    labels_to_update[f"plan:{plan_name}"].update(
+        {
+            name: {"message": plan[name], "description": description}
+            for name, description in METADEPLOY_LABELS["plan"].items()
+            if name in plan
+        }
+    )
+    update_check_labels(plan, labels_to_update)
+
+
+def update_product_labels(product, labels_to_update):
+    """
+    Mutates labels_to_update to add specified fields from obj to a label category.
+    """
+    if updates := {
+        name: {"message": product[name], "description": description}
+        for name, description in METADEPLOY_LABELS["product"].items()
+        if name in product
+    }:
+        labels_to_update["product"].update(updates)
+
+
+def update_step_labels(steps, labels_to_update):
+    """Mutates labels_to_update
+    Keyword Arguments:
+    """
+    for step in steps:
+        # avoid separate labels for installing each package
+        name = (
+            "Install {product} {version}"
+            if INSTALL_VERSION_RE.match(step["name"])
+            else step["name"]
+        )
+        labels_to_update["steps"][name] = {
+            "message": name,
+            "description": METADEPLOY_LABELS["steps"]["name"],
+        }
+        if step.get("description"):
+            description = step.get("description")
+            labels_to_update["steps"][description] = {
+                "message": description,
+                "description": METADEPLOY_LABELS["steps"]["descripton"],
+            }
+        update_check_labels(step["task_config"], labels_to_update)
+
+
+def update_check_labels(plan_or_step, labels_to_update):
+    checks = plan_or_step.get("checks", [])
+    updates = [
+        {
+            "message": check.get("message"),
+            "description": METADEPLOY_LABELS["checks"]["message"],
+        }
+        for check in checks
+        if check.get("message")
+    ]
+    for label in updates:
+        msg = label["message"]
+        labels_to_update["checks"][msg] = label

--- a/cumulusci/core/metadeploy/labels.py
+++ b/cumulusci/core/metadeploy/labels.py
@@ -69,7 +69,7 @@ def save_default_labels(labels_path: Union[Path, str], labels_to_save: dict):
     """Save updates to English labels."""
     with contextlib.suppress(FileNotFoundError):
         labels_file: Path = Path(labels_path, "labels_en.json")
-        labels_file.write_text(json.dumps(labels_to_save, indent=4))
+        labels_file.write_text(f"{json.dumps(labels_to_save, indent=4)}\n")
 
 
 def update_plan_labels(plan_name: str, plan, labels_to_update):

--- a/cumulusci/core/metadeploy/models.py
+++ b/cumulusci/core/metadeploy/models.py
@@ -1,0 +1,178 @@
+"""MetaDeploy domain models"""
+
+import enum
+from typing import Dict, List, Literal, Mapping, Optional
+
+from pydantic import BaseModel, root_validator, validator
+from pydantic.fields import Field
+from pydantic.networks import AnyUrl
+from pydantic.types import NonNegativeInt
+
+from cumulusci.core.metadeploy.labels import (
+    INSTALL_VERSION_RE,
+    METADEPLOY_DIR,
+    METADEPLOY_LABELS,
+)
+
+
+def labels_to_field_descriptions(labels: Mapping[str, str]) -> Dict[str, dict]:
+    """Convert a LabelMap to pydantic field descriptions"""
+    return {
+        field: {"description": description} for field, description in labels.items()
+    }
+
+
+class SupportedOrgs(str, enum.Enum):
+    BOTH = "Both"
+    PERSISTENT = "Persistent"
+    SCRATCH = "Scratch"
+
+
+class MetaDeployModel(BaseModel):
+    id: Optional[str]
+    url: Optional[AnyUrl]
+
+
+class FrozenModel(BaseModel):
+    class Config:
+        allow_mutation = False
+
+
+class PreflightCheck(BaseModel):
+    when: Optional[str] = None
+    action: Optional[str] = None
+    message: Optional[str] = None
+
+    class Config:
+        fields = {"message": {"description": "shown if validation fails"}}
+
+
+class FrozenSpec(FrozenModel):
+    github: AnyUrl
+    commit: str
+    description: str
+
+
+class FrozenTaskConfig(FrozenModel):
+    options: dict
+    checks: List[PreflightCheck] = []
+
+
+class FrozenStep(FrozenModel):
+    is_recommended: bool = True
+    is_required: bool = True
+    kind: Literal["data", "managed", "metadata", "onetime", "other"] = "other"
+    description: Optional[str] = None
+    name: str
+    path: str
+    source: Optional[FrozenSpec]
+    step_num: str
+    task_class: str
+    task_config: FrozenTaskConfig
+    url: Optional[AnyUrl] = None
+
+
+class PublisherOptions(FrozenModel):
+    tag: Optional[str] = None
+    commit: Optional[str] = None
+    plan: Optional[str] = None
+    dry_run: bool = False
+    publish: bool = False
+    labels_path: str = METADEPLOY_DIR
+
+    @root_validator
+    def check_tag_or_commit(cls, values):
+        if not values.get("tag") and not values.get("commit"):
+            raise ValueError("You must specify either the tag or commit option.")
+        return values
+
+    @validator("publish")
+    def check_publish(cls, publish, values):
+        return not values["dry_run"] and publish
+
+
+class Product(MetaDeployModel):
+    title: str
+    short_description: str
+    description: str
+    click_through_agreement: str
+    error_message: str
+    slug: str
+    color: Optional[str]
+    image: Optional[str]
+    icon_url: Optional[str]
+    slds_icon_category: Optional[
+        Literal["", "action", "custom", "doctype", "standard", "utility"]
+    ]
+    slds_icon_name: Optional[str]
+    repo_url: Optional[str]
+    is_listed: Optional[str]
+    order_key: Optional[str]
+    layout: Optional[Literal["Default", "Card"]]
+    visible_to: Optional[str]
+    category: Optional[str]
+
+
+class Slug(MetaDeployModel):
+    parent: AnyUrl
+    is_active: Optional[bool] = None
+    slug: str = Field(..., max_length=50)
+
+
+class Version(MetaDeployModel):
+    id: Optional[str] = None
+    url: Optional[str] = None
+    label: str
+    is_production: bool = False
+    is_listed: bool = False
+    commit_ish: str
+    product: AnyUrl
+
+
+class PlanTemplate(MetaDeployModel):
+    preflight_message: str = ""
+    post_install_message: str = ""
+    error_message: str = ""
+    name: Optional[str] = Field(None, max_length=100)
+    product: AnyUrl
+    regression_test_opt_out: bool = False
+    preflight_checks: List[PreflightCheck] = Field([], alias="checks")
+
+
+class MetaDeployPlan(MetaDeployModel):
+    id: Optional[str] = None
+    commit_ish: Optional[str] = None
+    is_listed: bool = True
+    order_key: Optional[NonNegativeInt] = None
+    plan_template: Optional[AnyUrl] = None
+    post_install_message: str = Field("", exclude=True)
+    preflight_checks: List[PreflightCheck] = Field([], alias="checks")
+    preflight_message: str = Field("", exclude=True)
+    slug: Optional[str]
+    steps: List[FrozenStep] = []
+    supported_orgs: SupportedOrgs = SupportedOrgs.PERSISTENT
+    tier: Literal["primary", "secondary", "additional"]
+    title: str
+    url: Optional[AnyUrl] = None
+    version: AnyUrl
+    visible_to: Optional[str]
+
+    class Config:
+        fields = labels_to_field_descriptions(METADEPLOY_LABELS["plan"])
+
+    @validator("supported_orgs", pre=True)
+    def map_supported_orgs(cls, input):
+        """Given a list of plan.allowed_org_providers return the value that
+        corresponds to the `supported_orgs` field on the MetaDeploy Plan
+        """
+        if not input:
+            return SupportedOrgs.PERSISTENT
+        try:
+            return SupportedOrgs(input)
+        except ValueError:
+            lookup: Mapping[frozenset, str] = {
+                frozenset(["user"]): SupportedOrgs.PERSISTENT,
+                frozenset(["devhub"]): SupportedOrgs.SCRATCH,
+                frozenset(["devhub", "user"]): SupportedOrgs.BOTH,
+            }
+            return lookup[frozenset(input)]

--- a/cumulusci/core/metadeploy/tests/conftest.py
+++ b/cumulusci/core/metadeploy/tests/conftest.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python3
 import pytest
 
-from cumulusci.core.metadeploy.models import PlanTemplate, Product, Version
+from cumulusci.core.metadeploy.models import (
+    MetaDeployPlan,
+    PlanTemplate,
+    Product,
+    Version,
+)
 
 
 @pytest.fixture
@@ -83,3 +88,8 @@ def version_model(version_dict):
 @pytest.fixture
 def plantemplate_model(plantemplate_dict):
     return PlanTemplate.parse_obj(plantemplate_dict)
+
+
+@pytest.fixture
+def plan_model(simple_plan_dict):
+    return MetaDeployPlan.parse_obj(simple_plan_dict)

--- a/cumulusci/core/metadeploy/tests/conftest.py
+++ b/cumulusci/core/metadeploy/tests/conftest.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+import pytest
+
+from cumulusci.core.metadeploy.models import PlanTemplate, Product, Version
+
+
+@pytest.fixture
+def product_dict():
+    return {
+        "id": "abcdef",
+        "url": "https://EXISTING_PRODUCT",
+        "title": "Education Data Architecture (EDA)",
+        "short_description": "The Foundation for the Connected Campus",
+        "description": "## Welcome to the EDA installer!",
+        "click_through_agreement": "Ladies and Gentlemen of the jury, I'm just a Caveman.",
+        "error_message": "",
+        "slug": "existing",
+    }
+
+
+@pytest.fixture
+def version_dict():
+    return {
+        "url": "http://EXISTING_VERSION",
+        "id": "OkAgPpL",
+        "label": "1.0",
+        "created_at": "2022-06-30T21:15:15.390046Z",
+        "is_production": True,
+        "commit_ish": "release/1.0",
+        "is_listed": True,
+        "product": "http://localhost:8080/admin/rest/products/abcdef",
+    }
+
+
+@pytest.fixture
+def plantemplate_dict():
+    return {
+        "url": "http://localhost:8080/admin/rest/plantemplates/1",
+        "id": "1",
+        "preflight_message": "Preflight message consists of generic product message and step pre-check info — run in one operation before the install begins. Preflight includes the name of what is being installed. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s.",
+        "post_install_message": "Success! You installed it.",
+        "error_message": "",
+        "name": "Full Install for Product With Useful Data, Version 0.2.0",
+        "regression_test_opt_out": False,
+        "product": "http://localhost:8080/admin/rest/products/GLN6Ppx",
+    }
+
+
+@pytest.fixture
+def simple_plan_dict():
+    return {
+        "url": "http://localhost:8080/admin/rest/plans/GLN6Ppx",
+        "id": "GLN6Ppx",
+        "steps": [],
+        "title": "Full Install",
+        "preflight_message_additional": "",
+        "post_install_message_additional": "",
+        "commit_ish": None,
+        "order_key": 0,
+        "tier": "primary",
+        "is_listed": True,
+        "preflight_checks": [],
+        "supported_orgs": "Persistent",
+        "org_config_name": "release",
+        "scratch_org_duration_override": None,
+        "created_at": "2022-06-30T21:15:11.629638Z",
+        "visible_to": None,
+        "plan_template": "http://localhost:8080/admin/rest/plantemplates/1",
+        "version": "http://localhost:8080/admin/rest/versions/GLN6Ppx",
+    }
+
+
+@pytest.fixture
+def product_model(product_dict):
+    return Product.parse_obj(product_dict)
+
+
+@pytest.fixture
+def version_model(version_dict):
+    return Version.parse_obj(version_dict)
+
+
+@pytest.fixture
+def plantemplate_model(plantemplate_dict):
+    return PlanTemplate.parse_obj(plantemplate_dict)

--- a/cumulusci/core/metadeploy/tests/test_labels.py
+++ b/cumulusci/core/metadeploy/tests/test_labels.py
@@ -11,11 +11,9 @@ from cumulusci.core.metadeploy.labels import (
     read_default_labels,
     read_label_files,
     save_default_labels,
-    update_check_labels,
-    update_plan_labels,
-    update_product_labels,
     update_step_labels,
 )
+from cumulusci.core.metadeploy.models import FrozenStep
 
 pytestmark = pytest.mark.metadeploy
 
@@ -61,94 +59,66 @@ def test_save_labels(tmp_path):
     save_default_labels(label_path, METADEPLOY_LABELS)
 
     result = label_file.read_text()
-    assert expected == result
-
-
-def test_update_product_label():
-    prod = {
-        "title": "Foo",
-        "short_description": "Integrated multi-platform functionality.",
-    }
-    labels_to_update = defaultdict(dict)
-    expected_dict = deepcopy(labels_to_update)
-    expected_dict["product"] = {
-        "short_description": {
-            "description": METADEPLOY_LABELS["product"]["short_description"],
-            "message": "Integrated multi-platform functionality.",
-        },
-        "title": {
-            "description": METADEPLOY_LABELS["product"]["title"],
-            "message": "Foo",
-        },
-    }
-    update_product_labels(prod, labels_to_update)
-    assert expected_dict == labels_to_update
-
-
-def test_update_plan_labels():
-    plan = {
-        "title": "Test Install",
-        "error_message": "Your failure is complete.",
-        "checks": [{"message": "check_msg"}, {"message": ""}],
-    }
-    labels_to_update = defaultdict(dict)
-    expected_dict = deepcopy(labels_to_update)
-    expected_dict.update(
-        {
-            "plan:slug": {
-                "title": {
-                    "message": "Test Install",
-                    "description": METADEPLOY_LABELS["plan"]["title"],
-                },
-                "error_message": {
-                    "message": "Your failure is complete.",
-                    "description": METADEPLOY_LABELS["plan"]["error_message"],
-                },
-            },
-            "checks": {
-                "check_msg": {
-                    "message": "check_msg",
-                    "description": METADEPLOY_LABELS["checks"]["message"],
-                }
-            },
-        }
-    )
-    update_plan_labels("slug", plan, labels_to_update)
-    assert expected_dict == labels_to_update
+    assert expected == result.strip()  # delete trailing newline
 
 
 def test_update_step_labels():
     steps = [
-        {
-            "name": "Install Test Product 1.0",
-            "task_config": {
-                "checks": [],
-            },
-        },
-        {
-            "name": "Update Admin Profile",
-            "task_config": {
-                "checks": [],
-            },
-        },
-        {
-            "name": "util_sleep",
-            "task_config": {
-                "checks": [
-                    {"when": "False", "action": "error", "message": "Check failed 😭"}
-                ]
-            },
-        },
+        FrozenStep.parse_obj(
+            {
+                "is_recommended": True,
+                "is_required": True,
+                "kind": "managed",
+                "message": None,
+                "description": None,
+                "name": "Install Test Product 1.0",
+                "path": "install_prod.install_managed",
+                "source": None,
+                "step_num": "1/2",
+                "task_class": "cumulusci.tasks.salesforce.InstallPackageVersion",
+                "task_config": {
+                    "options": {
+                        "version": "1.0",
+                        "namespace": "ns",
+                        "interactive": False,
+                        "base_package_url_format": "{}",
+                    },
+                    "checks": [],
+                },
+                "url": None,
+            }
+        ),
+        FrozenStep.parse_obj(
+            {
+                "is_recommended": True,
+                "is_required": True,
+                "kind": "other",
+                "message": None,
+                "name": "util_sleep",
+                "path": "util_sleep",
+                "step_num": "2",
+                "source": None,
+                "task_class": "cumulusci.tasks.util.Sleep",
+                "task_config": {
+                    "options": {"seconds": 5},
+                    "checks": [
+                        {
+                            "when": "False",
+                            "action": "error",
+                            "message": "Check failed 😭",
+                        },
+                        {"when": "False", "action": "error", "message": None},
+                    ],
+                },
+                "url": None,
+            }
+        ),
     ]
     labels_to_update = defaultdict(dict)
     expected_dict = deepcopy(labels_to_update)
     expected_dict["steps"] = {
         "Install {product} {version}": {
             "message": "Install {product} {version}",
-            "description": METADEPLOY_LABELS["steps"]["name"],
-        },
-        "Update Admin Profile": {
-            "message": "Update Admin Profile",
             "description": METADEPLOY_LABELS["steps"]["name"],
         },
         "util_sleep": {
@@ -163,26 +133,4 @@ def test_update_step_labels():
         }
     }
     update_step_labels(steps, labels_to_update)
-    assert expected_dict == labels_to_update
-
-
-def test_update_check_labels():
-    plan_or_step = {"checks": [{"message": "check_msg"}, {"message": ""}]}
-    labels_to_update = defaultdict(dict)
-    labels_to_update["plan"] = {
-        "title": "TITLE",
-        "preflight_message": "PREFLIGHT_MESSAGE",
-        "preflight_message_additional": "PREFLIGHT_MESSAGE_ADDITIONAL",
-        "post_install_message": "POST_INSTALL_MESSAGE",
-        "post_install_message_additional": "POST_INSTALL_MESSAGE_ADDITIONAL",
-        "error_message": "ERROR_MESSAGE",
-    }
-    expected_dict = deepcopy(labels_to_update)
-    expected_dict["checks"] = {
-        "check_msg": {
-            "message": "check_msg",
-            "description": METADEPLOY_LABELS["checks"]["message"],
-        }
-    }
-    update_check_labels(plan_or_step, labels_to_update)
     assert expected_dict == labels_to_update

--- a/cumulusci/core/metadeploy/tests/test_labels.py
+++ b/cumulusci/core/metadeploy/tests/test_labels.py
@@ -1,0 +1,188 @@
+import json
+from collections import defaultdict
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from cumulusci.core.metadeploy.labels import (
+    METADEPLOY_DIR,
+    METADEPLOY_LABELS,
+    read_default_labels,
+    read_label_files,
+    save_default_labels,
+    update_check_labels,
+    update_plan_labels,
+    update_product_labels,
+    update_step_labels,
+)
+
+pytestmark = pytest.mark.metadeploy
+
+
+def test_read_default_labels(tmp_path):
+    label_path: Path = tmp_path / METADEPLOY_DIR
+    label_path.mkdir(parents=True)
+    label_file: Path = label_path / "labels_en.json"
+    label_file.write_text(json.dumps(METADEPLOY_LABELS))
+
+    result: dict = read_default_labels(labels_path=label_path)
+    assert METADEPLOY_LABELS == result, "should match input"
+    assert {} == result["missing_category"], "should be a default dict"
+
+
+def test_read_default_labels_missing():
+    result: dict = read_default_labels(labels_path="missing_dir")
+    assert {} == result, "should be empty dict"
+    assert {} == result["missing_category"], "should be a default dict"
+
+
+def test_read_label_files(tmp_path):
+    label_path: Path = tmp_path / METADEPLOY_DIR
+    en_label_file: Path = label_path / "labels_en.json"
+    fr_label_file: Path = label_path / "labels_fr.json"
+    label_path.mkdir(parents=True)
+    label = {"message": "message", "label": "label"}
+    en_label_file.write_text(json.dumps(label))
+    fr_label_file.write_text(json.dumps(label))
+
+    expected_dict = {"fr": {"slug:message": "message", "slug:label": "label"}}
+
+    result: dict = read_label_files(label_path, "slug")
+    assert expected_dict == result
+
+
+def test_save_labels(tmp_path):
+    label_path: Path = tmp_path / METADEPLOY_DIR
+    label_path.mkdir(parents=True)
+    label_file: Path = label_path / "labels_en.json"
+    expected = json.dumps(METADEPLOY_LABELS, indent=4)
+
+    save_default_labels(label_path, METADEPLOY_LABELS)
+
+    result = label_file.read_text()
+    assert expected == result
+
+
+def test_update_product_label():
+    prod = {
+        "title": "Foo",
+        "short_description": "Integrated multi-platform functionality.",
+    }
+    labels_to_update = defaultdict(dict)
+    expected_dict = deepcopy(labels_to_update)
+    expected_dict["product"] = {
+        "short_description": {
+            "description": METADEPLOY_LABELS["product"]["short_description"],
+            "message": "Integrated multi-platform functionality.",
+        },
+        "title": {
+            "description": METADEPLOY_LABELS["product"]["title"],
+            "message": "Foo",
+        },
+    }
+    update_product_labels(prod, labels_to_update)
+    assert expected_dict == labels_to_update
+
+
+def test_update_plan_labels():
+    plan = {
+        "title": "Test Install",
+        "error_message": "Your failure is complete.",
+        "checks": [{"message": "check_msg"}, {"message": ""}],
+    }
+    labels_to_update = defaultdict(dict)
+    expected_dict = deepcopy(labels_to_update)
+    expected_dict.update(
+        {
+            "plan:slug": {
+                "title": {
+                    "message": "Test Install",
+                    "description": METADEPLOY_LABELS["plan"]["title"],
+                },
+                "error_message": {
+                    "message": "Your failure is complete.",
+                    "description": METADEPLOY_LABELS["plan"]["error_message"],
+                },
+            },
+            "checks": {
+                "check_msg": {
+                    "message": "check_msg",
+                    "description": METADEPLOY_LABELS["checks"]["message"],
+                }
+            },
+        }
+    )
+    update_plan_labels("slug", plan, labels_to_update)
+    assert expected_dict == labels_to_update
+
+
+def test_update_step_labels():
+    steps = [
+        {
+            "name": "Install Test Product 1.0",
+            "task_config": {
+                "checks": [],
+            },
+        },
+        {
+            "name": "Update Admin Profile",
+            "task_config": {
+                "checks": [],
+            },
+        },
+        {
+            "name": "util_sleep",
+            "task_config": {
+                "checks": [
+                    {"when": "False", "action": "error", "message": "Check failed 😭"}
+                ]
+            },
+        },
+    ]
+    labels_to_update = defaultdict(dict)
+    expected_dict = deepcopy(labels_to_update)
+    expected_dict["steps"] = {
+        "Install {product} {version}": {
+            "message": "Install {product} {version}",
+            "description": METADEPLOY_LABELS["steps"]["name"],
+        },
+        "Update Admin Profile": {
+            "message": "Update Admin Profile",
+            "description": METADEPLOY_LABELS["steps"]["name"],
+        },
+        "util_sleep": {
+            "message": "util_sleep",
+            "description": METADEPLOY_LABELS["steps"]["name"],
+        },
+    }
+    expected_dict["checks"] = {
+        "Check failed 😭": {
+            "message": "Check failed 😭",
+            "description": METADEPLOY_LABELS["checks"]["message"],
+        }
+    }
+    update_step_labels(steps, labels_to_update)
+    assert expected_dict == labels_to_update
+
+
+def test_update_check_labels():
+    plan_or_step = {"checks": [{"message": "check_msg"}, {"message": ""}]}
+    labels_to_update = defaultdict(dict)
+    labels_to_update["plan"] = {
+        "title": "TITLE",
+        "preflight_message": "PREFLIGHT_MESSAGE",
+        "preflight_message_additional": "PREFLIGHT_MESSAGE_ADDITIONAL",
+        "post_install_message": "POST_INSTALL_MESSAGE",
+        "post_install_message_additional": "POST_INSTALL_MESSAGE_ADDITIONAL",
+        "error_message": "ERROR_MESSAGE",
+    }
+    expected_dict = deepcopy(labels_to_update)
+    expected_dict["checks"] = {
+        "check_msg": {
+            "message": "check_msg",
+            "description": METADEPLOY_LABELS["checks"]["message"],
+        }
+    }
+    update_check_labels(plan_or_step, labels_to_update)
+    assert expected_dict == labels_to_update

--- a/cumulusci/core/metadeploy/tests/test_models.py
+++ b/cumulusci/core/metadeploy/tests/test_models.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import pytest
 from pydantic import ValidationError
 
@@ -51,3 +53,160 @@ def test_publisher_options_no_publish_on_dry_run():
         plan="slug", dry_run=True, publish=True, tag="v2.0"
     )
     assert not opts.publish
+
+
+def test_product_get_labels(product_model):
+    expected: Dict[str, dict] = {
+        "short_description": {
+            "description": METADEPLOY_LABELS["product"]["short_description"],
+            "message": product_model.short_description,
+        },
+        "title": {
+            "description": METADEPLOY_LABELS["product"]["title"],
+            "message": product_model.title,
+        },
+        "description": {
+            "description": METADEPLOY_LABELS["product"]["description"],
+            "message": product_model.description,
+        },
+        "click_through_agreement": {
+            "description": METADEPLOY_LABELS["product"]["click_through_agreement"],
+            "message": product_model.click_through_agreement,
+        },
+        "error_message": {
+            "description": METADEPLOY_LABELS["product"]["error_message"],
+            "message": product_model.error_message,
+        },
+    }
+    actual = product_model.get_labels()
+    assert expected == actual
+
+
+def test_preflight_get_labels():
+    empty_check: PreflightCheck = PreflightCheck(
+        when="when 'foo' in tasks.get_stuff()", action="skip"
+    )
+    assert not empty_check.get_labels()
+
+    msg = "Scary warning message"
+    check: PreflightCheck = PreflightCheck(
+        when="when 'foo' in tasks.get_stuff()",
+        action="warn",
+        message=msg,
+    )
+    expected = {
+        msg: {
+            "message": msg,
+            "description": METADEPLOY_LABELS["checks"]["message"],
+        }
+    }
+    assert expected == check.get_labels()
+
+
+def test_plan_labels(plan_model):
+    plan_model.slug = "slug"
+    print(plan_model)
+    expected_dict = {
+        "plan:slug": {
+            "title": {
+                "message": plan_model.title,
+                "description": METADEPLOY_LABELS["plan"]["title"],
+            },
+            "post_install_message": {
+                "message": plan_model.post_install_message,
+                "description": "shown after successful installation (markdown)",
+            },
+            "preflight_message": {
+                "message": plan_model.preflight_message,
+                "description": "shown before user starts installation (markdown)",
+            },
+        },
+    }
+    labels = plan_model.get_labels()
+    assert expected_dict == labels
+
+    plan_model.preflight_checks = [
+        PreflightCheck(
+            when="when 'foo' in tasks.get_stuff()",
+            action="warn",
+            message="check_msg",
+        )
+    ]
+    expected_dict["checks"] = {
+        "check_msg": {
+            "message": "check_msg",
+            "description": METADEPLOY_LABELS["checks"]["message"],
+        }
+    }
+    labels_with_checks = plan_model.get_labels()
+    assert expected_dict == labels_with_checks
+
+
+def test_update_step_labels():
+    step: FrozenStep = FrozenStep.parse_obj(
+        {
+            "is_recommended": True,
+            "is_required": True,
+            "kind": "other",
+            "message": None,
+            "name": "util_sleep",
+            "path": "util_sleep",
+            "step_num": "2",
+            "source": None,
+            "task_class": "cumulusci.tasks.util.Sleep",
+            "task_config": {
+                "options": {"seconds": 5},
+                "checks": [
+                    {"when": "False", "action": "warn", "message": "check_msg"},
+                    {"when": "False", "action": "error", "message": None},
+                ],
+            },
+            "url": None,
+        }
+    )
+    expected_dict = {
+        "util_sleep": {
+            "message": "util_sleep",
+            "description": METADEPLOY_LABELS["steps"]["name"],
+        }
+    }
+    labels = step.get_labels()
+    assert expected_dict == labels
+
+
+def test_update_step_labels_regex():
+    step: FrozenStep = FrozenStep.parse_obj(
+        {
+            "is_recommended": True,
+            "is_required": True,
+            "kind": "managed",
+            "message": None,
+            "description": "Step description",
+            "name": "Install Test Product 1.0",
+            "path": "install_prod.install_managed",
+            "source": None,
+            "step_num": "1/2",
+            "task_class": "cumulusci.tasks.salesforce.InstallPackageVersion",
+            "task_config": {
+                "options": {
+                    "version": "1.0",
+                    "namespace": "ns",
+                    "interactive": False,
+                    "base_package_url_format": "{}",
+                },
+                "checks": [],
+            },
+        }
+    )
+    expected_dict = {
+        "Install {product} {version}": {
+            "message": "Install {product} {version}",
+            "description": METADEPLOY_LABELS["steps"]["name"],
+        },
+        "Step description": {
+            "message": "Step description",
+            "description": METADEPLOY_LABELS["steps"]["description"],
+        },
+    }
+    labels = step.get_labels()
+    assert expected_dict == labels

--- a/cumulusci/core/metadeploy/tests/test_models.py
+++ b/cumulusci/core/metadeploy/tests/test_models.py
@@ -1,0 +1,53 @@
+import pytest
+from pydantic import ValidationError
+
+from cumulusci.core.metadeploy.labels import METADEPLOY_LABELS
+from cumulusci.core.metadeploy.models import (
+    FrozenStep,
+    MetaDeployPlan,
+    PreflightCheck,
+    PublisherOptions,
+    SupportedOrgs,
+)
+
+pytestmark = pytest.mark.metadeploy
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    zip(
+        [
+            ["user", "devhub"],
+            ["user"],
+            ["devhub"],
+        ],
+        list(SupportedOrgs),
+    ),
+)
+def test_supported_orgs_validation_map(input, expected, simple_plan_dict):
+    del simple_plan_dict["supported_orgs"]
+    result = MetaDeployPlan(supported_orgs=input, **simple_plan_dict)
+    assert expected == result.supported_orgs
+
+
+def test_supported_orgs_validation_empty(simple_plan_dict):
+    del simple_plan_dict["supported_orgs"]
+    persistent = MetaDeployPlan(supported_orgs=None, **simple_plan_dict)
+    assert persistent.supported_orgs == SupportedOrgs.PERSISTENT
+
+    empty = MetaDeployPlan(supported_orgs=[], **simple_plan_dict)
+    assert empty.supported_orgs == SupportedOrgs.PERSISTENT
+
+
+def test_publisher_options_tag_validation():
+    with pytest.raises(
+        ValidationError, match="You must specify either the tag or commit option."
+    ):
+        PublisherOptions(plan="slug", dry_run=True, publish=True)
+
+
+def test_publisher_options_no_publish_on_dry_run():
+    opts: PublisherOptions = PublisherOptions(
+        plan="slug", dry_run=True, publish=True, tag="v2.0"
+    )
+    assert not opts.publish

--- a/cumulusci/core/metadeploy/tests/test_plans.py
+++ b/cumulusci/core/metadeploy/tests/test_plans.py
@@ -1,0 +1,95 @@
+import pytest
+
+from cumulusci.core.config import ServiceConfig
+from cumulusci.core.metadeploy.plans import get_frozen_steps
+from cumulusci.tests.util import create_project_config
+
+pytestmark = pytest.mark.metadeploy
+
+
+def test_freeze_steps():
+    project_config = create_project_config()
+    project_config.config["flows"] = {
+        "customer_org": {
+            "steps": {
+                1: {
+                    "task": "install_managed",
+                    "options": {
+                        "version": "1.0",
+                        "namespace": "ns",
+                        "name": "Test Product",
+                    },
+                },
+            }
+        }
+    }
+    plan_config = {
+        "title": "Test Install",
+        "slug": "install",
+        "tier": "primary",
+        "steps": {
+            1: {"flow": "customer_org"},
+            2: {
+                "task": "util_sleep",
+                "checks": [{"when": "False", "action": "error"}],
+            },
+        },
+        "checks": [{"when": "False", "action": "error"}],
+        "allowed_org_providers": ["user", "devhub"],
+    }
+    steps = get_frozen_steps(project_config, plan_config)
+    assert [
+        {
+            "is_required": True,
+            "kind": "managed",
+            "name": "Install Test Product 1.0",
+            "path": "customer_org.install_managed",
+            "source": None,
+            "step_num": "1/1",
+            "task_class": "cumulusci.tasks.salesforce.InstallPackageVersion",
+            "task_config": {
+                "checks": [],
+                "options": {
+                    "version": "1.0",
+                    "namespace": "ns",
+                    "interactive": False,
+                    "base_package_url_format": "{}",
+                },
+            },
+        },
+        {
+            "is_required": True,
+            "kind": "other",
+            "name": "util_sleep",
+            "path": "util_sleep",
+            "step_num": "2",
+            "source": None,
+            "task_class": "cumulusci.tasks.util.Sleep",
+            "task_config": {
+                "options": {"seconds": 5},
+                "checks": [{"when": "False", "action": "error"}],
+            },
+        },
+    ] == steps
+
+
+def test_freeze_steps__skip():
+    project_config = create_project_config()
+    project_config.keychain.set_service(
+        "metadeploy",
+        "test_alias",
+        ServiceConfig({"url": "https://metadeploy", "token": "TOKEN"}),
+    )
+    project_config.keychain.set_service(
+        "github",
+        "test_alias",
+        ServiceConfig({"username": "foo", "token": "bar", "email": "foo@example.com"}),
+    )
+    plan_config = {
+        "title": "Test Install",
+        "slug": "install",
+        "tier": "primary",
+        "steps": {1: {"task": "None"}},
+    }
+    steps = get_frozen_steps(project_config, plan_config)
+    assert steps == []

--- a/cumulusci/tasks/tests/test_metadeploy.py
+++ b/cumulusci/tasks/tests/test_metadeploy.py
@@ -403,10 +403,18 @@ class TestPublish(GithubApiTestMixin):
         labels = json.loads(en_labels_path.read_text())
         assert labels == {
             "plan:install": {
+                "post_install_message": {
+                    "message": "",
+                    "description": "shown after successful installation (markdown)",
+                },
+                "preflight_message": {
+                    "message": "",
+                    "description": "shown before user starts installation (markdown)",
+                },
                 "title": {
                     "message": "Test Install",
                     "description": "title of installation plan",
-                }
+                },
             },
             "steps": {
                 "Install {product} {version}": {
@@ -423,6 +431,29 @@ class TestPublish(GithubApiTestMixin):
                 },
             },
             "test": {"title": {}},
+            "checks": {},
+            "product": {
+                "title": {
+                    "message": "Education Data Architecture (EDA)",
+                    "description": "name of product",
+                },
+                "short_description": {
+                    "message": "The Foundation for the Connected Campus",
+                    "description": "tagline of product",
+                },
+                "description": {
+                    "message": "## Welcome to the EDA installer!",
+                    "description": "shown on product detail page (markdown)",
+                },
+                "click_through_agreement": {
+                    "message": "Ladies and Gentlemen of the jury, I'm just a Caveman.",
+                    "description": "legal text shown in modal dialog",
+                },
+                "error_message": {
+                    "message": "",
+                    "description": "shown after failed installation (markdown)",
+                },
+            },
         }
         shutil.rmtree(labels_path)
 


### PR DESCRIPTION
This PR adds:

- Pydantic models to represent entities consumed or
returned by the MetaDeploy (MDP) REST API. These were not autogenerated from the API schema, however, because of the logic needed to handle mapping enums/choices from CumulusCI to MDP, as well as the generation of translation labels.

- a submodule containing functions for processing translation labels. Direct translation of the existing logic from the `metadeploy_publish` task, with those tests left in place as integration tests.