### PR TITLE
Make `delete_data` task freezable

### DIFF
--- a/cumulusci/tasks/bulkdata/step.py
+++ b/cumulusci/tasks/bulkdata/step.py
@@ -35,7 +35,7 @@ class DataOperationType(Enum):
     SMART_UPSERT = "smart_upsert"  # currently undocumented
 
 
-class DataApi(Enum):
+class DataApi(str, Enum):
     """Enum defining requested Salesforce data API for an operation."""
 
     BULK = "bulk"

--- a/cumulusci/tasks/bulkdata/tests/test_upsert.py
+++ b/cumulusci/tasks/bulkdata/tests/test_upsert.py
@@ -232,9 +232,7 @@ class TestUpsert:
             relevant_debug_statement = look_for_operation_creation_debug_statement(
                 task.logger.debug.mock_calls
             )
-            assert relevant_debug_statement == str(
-                DataApi.REST
-            ), relevant_debug_statement
+            assert relevant_debug_statement == DataApi.REST, relevant_debug_statement
 
     def _mock_bulk(self, domain):
         responses.add(
@@ -421,9 +419,7 @@ class TestUpsert:
             relevant_debug_statement = look_for_operation_creation_debug_statement(
                 task.logger.debug.mock_calls
             )
-            assert relevant_debug_statement == str(
-                DataApi.BULK
-            ), relevant_debug_statement
+            assert relevant_debug_statement == DataApi.BULK, relevant_debug_statement
 
     def _test_two_upserts_and_check_results__complex(
         self, api, create_task, cumulusci_test_repo_root, sf


### PR DESCRIPTION
Repro:

Create a plan that references the delete_data task

```yaml
plans:
  unfreezable:
    steps:
      1:
        task: delete_data
        options:
          objects:
            - Contact
```

Expected: Task can be frozen

Actual: TypeError: Object of type DataApi is not JSON serializable

