### PR TITLE
Suppress third-party warnings and error on `ClassMovedWarning`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,12 @@ addopts =  "-p cumulusci.tests.pytest_plugins.pytest_typeguard -p cumulusci.test
 markers = [
     "metadeploy: mark a test that interacts with the MetaDeploy REST API",
 ]
+filterwarnings = [
+    "error:ClassMovedWarning",
+    "ignore::DeprecationWarning:.*.rflint",
+    "ignore::DeprecationWarning:.*.selenium",
+    "ignore::SyntaxWarning:.*.selenium",
+]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
1. We don't need to know about every `invalid escape sequence` in every library.
2. We added `ClassMovedWarning` in #3250, but we only throw an error in the integration tests, so we add it here.