### PR TITLE
Validate MetaDeploy plans in cumulusci.yml

### DIFF
--- a/cumulusci/schema/cumulusci.jsonschema.json
+++ b/cumulusci/schema/cumulusci.jsonschema.json
@@ -523,6 +523,7 @@
                 },
                 "tier": {
                     "title": "Tier",
+                    "default": "primary",
                     "enum": ["primary", "secondary", "additional"],
                     "type": "string"
                 },

--- a/cumulusci/utils/yaml/cumulusci_yml.py
+++ b/cumulusci/utils/yaml/cumulusci_yml.py
@@ -10,7 +10,7 @@ from logging import getLogger
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Union
 
-from pydantic import Field, root_validator
+from pydantic import Field, root_validator, validator
 from pydantic.types import DirectoryPath
 from typing_extensions import Literal, TypedDict
 
@@ -115,7 +115,7 @@ class Git(CCIDictModel):
 class Plan(CCIDictModel):  # MetaDeploy plans
     title: str = None
     description: str = None
-    tier: Literal["primary", "secondary", "additional"] = None
+    tier: Literal["primary", "secondary", "additional"] = "primary"
     slug: str = None
     is_listed: bool = True
     steps: Dict[str, Step] = None
@@ -231,6 +231,16 @@ class CumulusCIRoot(CCIDictModel):
     minimum_cumulusci_version: str = None
     sources: Dict[str, Union[LocalFolderSourceModel, GitHubSourceModel]] = {}
     cli: CumulusCLIConfig = None
+
+    @validator("plans")
+    def validate_plan_tiers(cls, plans):
+        existing_tiers = [plan.tier for plan in plans.values()]
+        has_duplicate_tiers = any(
+            existing_tiers.count(tier) > 1 for tier in ("primary", "secondary")
+        )
+        if has_duplicate_tiers:
+            raise ValueError("Only one plan can be defined as 'primary' or 'secondary'")
+        return plans
 
 
 class CumulusCIFile(CCIDictModel):


### PR DESCRIPTION
Validate that MetaDeploy plans only specify a single primary and secondary plan.

Because `plan.tier` defaults to `primary` in the API, we set the same here, with the expectation that users that do not explicitly set `tier` will see these warnings before plan validation is enforced by `cci plan publish`.

Other callers can validate project_configs with:

```python
with pytest.raises(ValueError, match='Only one plan'):
    CumulusCIRoot.validate_plan_tiers(plans_with_multiple_primary)
```