### PR TITLE
Publish MetaDeploy plans in a deterministic order

### DIFF
--- a/cumulusci/utils/yaml/cumulusci_yml.py
+++ b/cumulusci/utils/yaml/cumulusci_yml.py
@@ -20,7 +20,7 @@ from cumulusci.utils.yaml.safer_loader import load_yaml_data
 
 default_logger = getLogger(__name__)
 
-PLANS_VALIDATOR_ERROR_MESSAGE = "You can only defined one 'primary' Plan and one 'secondary' Plan. All other Plans must be defined as 'additional'. The default tier is 'primary'."
+PLANS_VALIDATOR_ERROR_MESSAGE = "You can only define one 'primary' Plan and one 'secondary' Plan. All other Plans must be defined as 'additional'. The default tier is 'primary'."
 
 
 #  type aliases


### PR DESCRIPTION
Plans are published in a deterministic order: sorted by tier, and then by the order they appear in the `cumulusci.yml` file.
Clarified error message that appears when a user tries to include more than one primary or more than one secondary Plan in their `cumulusci.yml` file.