### PR TITLE
GitHub enterprise support : bypass retry ssl errors

### DIFF
--- a/cumulusci/core/github.py
+++ b/cumulusci/core/github.py
@@ -51,10 +51,27 @@ UNAUTHORIZED_WARNING = """
 Bad credentials. Verify that your personal access token is correct and that you are authorized to access this resource.
 """
 
+
+class GitHubRety(Retry):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def increment(self, *args, **kwargs):
+        # Check for connnection and fail on SSLerror
+        # SSLCertVerificationError
+        if "error" in kwargs:
+            error = kwargs["error"]
+            error_str = "CERTIFICATE_VERIFY_FAILED"
+            if error_str in str(error):
+                raise error
+        # finally call increment
+        return super().increment(*args, **kwargs)
+
+
 # Prepare request retry policy to be attached to github sessions.
 # 401 is a weird status code to retry, but sometimes it happens spuriously
 # and https://github.community/t5/GitHub-API-Development-and/Random-401-errors-after-using-freshly-generated-installation/m-p/22905 suggests retrying
-retries = Retry(status_forcelist=(401, 502, 503, 504), backoff_factor=0.3)
+retries = GitHubRety(status_forcelist=(401, 502, 503, 504), backoff_factor=0.3)
 adapter = HTTPAdapter(max_retries=retries)
 
 

--- a/cumulusci/core/tests/test_github.py
+++ b/cumulusci/core/tests/test_github.py
@@ -1,6 +1,7 @@
 import json
 import os
 from datetime import datetime
+from ssl import SSLCertVerificationError
 from unittest import mock
 
 import pytest
@@ -100,6 +101,26 @@ class TestGithub(GithubApiTestMixin):
             ),
         )
         return runtime.keychain
+
+    def test_github_api_retries__escape_hatch_SSL_error(self, mock_http_response):
+        gh = get_github_api("TestUser", "TestPass")
+        adapter = gh.session.get_adapter("http://")
+
+        assert 0.3 == adapter.max_retries.backoff_factor
+        assert 502 in adapter.max_retries.status_forcelist
+
+        with mock.patch(
+            "urllib3.connectionpool.HTTPConnectionPool._make_request"
+        ) as _make_request:
+            _make_request.side_effect = SSLCertVerificationError(
+                "SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain"
+            )
+
+            with pytest.raises(
+                ConnectionError,
+                match="(CERTIFICATE_VERIFY_FAILED)",
+            ):
+                gh.octocat("meow")
 
     def test_github_api_retries(self, mock_http_response):
         gh = get_github_api("TestUser", "TestPass")

--- a/cumulusci/core/tests/test_github.py
+++ b/cumulusci/core/tests/test_github.py
@@ -102,7 +102,7 @@ class TestGithub(GithubApiTestMixin):
         )
         return runtime.keychain
 
-    def test_github_api_retries__escape_hatch_SSL_error(self, mock_http_response):
+    def test_github_api_retries__escape_hatch_SSL_error(self):
         gh = get_github_api("TestUser", "TestPass")
         adapter = gh.session.get_adapter("http://")
 
@@ -121,6 +121,8 @@ class TestGithub(GithubApiTestMixin):
                 match="(CERTIFICATE_VERIFY_FAILED)",
             ):
                 gh.octocat("meow")
+
+            assert 1 == _make_request.call_count
 
     def test_github_api_retries(self, mock_http_response):
         gh = get_github_api("TestUser", "TestPass")


### PR DESCRIPTION
Under certain circumstances then authorizing to GitHub Enterprise servers a retry loop will run until retries are exhausted.
The retry loop can take about 4-5 minutes, and this change looks for known SSL verification issues to bypass the loop.