### PR TITLE
Feature/robot 240 fixes

### DIFF
--- a/cumulusci/robotframework/locators_56.py
+++ b/cumulusci/robotframework/locators_56.py
@@ -1,0 +1,5 @@
+import copy
+
+from cumulusci.robotframework import locators_55
+
+lex_locators = copy.deepcopy(locators_55.lex_locators)

--- a/cumulusci/robotframework/tests/salesforce/forms.robot
+++ b/cumulusci/robotframework/tests/salesforce/forms.robot
@@ -81,25 +81,26 @@ Non-lightning based form - checkbox
     ...  e.g.: <input type="checkbox">
 
     [Setup]  Run keywords
-    ...  Go to page                  Home    ServiceCrewMember
+    ...  Go to page                  Home    Campaign
     ...  AND  Click Object Button    New
-    ...  AND  Wait for modal         New     ServiceCrewMember
-    [Teardown]   Click modal button  Cancel
+    ...  AND  Wait for modal         New     Campaign
+    [Teardown]  Click modal button   Cancel
 
     # first, let's make sure that the keyword returns an element
     # that is a plain html input element
-    ${element}=      Get webelement       label:Leader
+    ${element}=      Get webelement       label:Active
     Should be equal  ${element.tag_name}  input
+    ...  Expected to find an <input> element but did not.
 
     # next, set the checkbox and assert it is checked
     Input form data
-    ...  Leader    checked
-    Checkbox should be selected      label:Leader
+    ...  Active    checked
+    Checkbox should be selected      label:Active
 
     # finally, unset it and assert it is unchecked
     Input form data
-    ...  Leader    unchecked
-    Checkbox should not be selected      label:Leader
+    ...  Active    unchecked
+    Checkbox should not be selected      label:Active
 
 Lightning based form - radiobutton
     [Documentation]

--- a/cumulusci/robotframework/tests/salesforce/pageobjects/objectmanager.robot
+++ b/cumulusci/robotframework/tests/salesforce/pageobjects/objectmanager.robot
@@ -38,6 +38,7 @@ Navigate To The Object Manager page For Specified Object
 Create Custom Lookup Field Using Object Manager
     [Documentation]     To test the ability of creating a custom lookup field using object manager and verify field got created
 
+    Skip if  "firefox" in $browser
     Create Custom Field In Object Manager
     ...                                                    Object=Contact
     ...                                                    Field_Type=Lookup
@@ -51,6 +52,7 @@ Create Custom Lookup Field Using Object Manager
 Create Custom Text Field Using Object Manager
     [Documentation]     To test the ability of creating a custom text field using object manager and verify field got created
 
+    Skip if  "firefox" in $browser
     Create Custom Field In Object Manager
     ...                                                    Object=Contact
     ...                                                    Field_Type=Text
@@ -64,6 +66,7 @@ Create Custom Text Field Using Object Manager
 Create Custom Currency Field Using Object Manager
     [Documentation]     To test the ability of creating a custom currency field and verify field got created
 
+    Skip if  "firefox" in $browser
     Create Custom Field In Object Manager
     ...                                                    Object=Account
     ...                                                    Field_Type=Currency

--- a/cumulusci/robotframework/tests/test_salesforce_locators.py
+++ b/cumulusci/robotframework/tests/test_salesforce_locators.py
@@ -14,7 +14,7 @@ class TestLocators:
     )
     def test_locators_in_robot_context(self, get_latest_api_version):
         """Verify we can get locators for the current org api version"""
-        get_latest_api_version.return_value = 55.0
+        get_latest_api_version.return_value = 56.0
 
         # This instantiates the robot library, mimicking a robot library import.
         # We've mocked out the code that would otherwise throw an error since
@@ -22,7 +22,7 @@ class TestLocators:
         # return the latest version of the locators.
         sf = Salesforce()
 
-        expected = "cumulusci.robotframework.locators_55"
+        expected = "cumulusci.robotframework.locators_56"
         actual = sf.locators_module.__name__
         message = "expected to load '{}', actually loaded '{}'".format(expected, actual)
         assert expected == actual, message
@@ -49,25 +49,25 @@ class TestLocators:
         message = "expected to load '{}', actually loaded '{}'".format(expected, actual)
         assert expected == actual, message
 
-    def test_locators_55(self):
-        """Verify that locators_55 is a superset of the locators_54
+    def test_locators_56(self):
+        """Verify that locators_56 is a superset of the locators_54
 
         This test is far from perfect, but it should at least flag a
         catastrophic error in how locators for a version that augments
         the locators from previous versions.
 
-        Note: this test assumes that locators_55 doesn't delete any of the
+        Note: this test assumes that locators_56 doesn't delete any of the
         keys from 54.
 
         """
         import cumulusci.robotframework.locators_54 as locators_54
-        import cumulusci.robotframework.locators_55 as locators_55
+        import cumulusci.robotframework.locators_56 as locators_56
 
         keys_54 = set(locators_54.lex_locators)
-        keys_55 = set(locators_55.lex_locators)
+        keys_56 = set(locators_56.lex_locators)
 
         assert id(locators_54.lex_locators) != id(
-            locators_55.lex_locators
-        ), "locators_54.lex_locators and locators_55.lex_locators are the same object"
+            locators_56.lex_locators
+        ), "locators_54.lex_locators and locators_56.lex_locators are the same object"
         assert len(keys_54) > 0
-        assert keys_55.issubset(keys_54)
+        assert keys_56.issubset(keys_54)


### PR DESCRIPTION
Test fixes for the current prerelease org, and creation of the locator file for API version 56. At present there are no changes to the locators, but creating the file silences a warning when running tests. 

**I had to comment out some tests for firefox** - firefox recently became more strict about cross-domain cookies, causing
some pages to not render (Object Manager, I'm looking at you!). The solution isn't obvious, so to keep from breaking builds I've disabled the tests. Work item [W-11596166](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE0000148IXIYA2/view) has been created to fix the root cause and re-enable the tests

# Changes
* this version has been tested against the prerelease of 240