### PR TITLE
Fix crash with unusual Unicode characters in metadata on Windows running `update_package_xml`

### DIFF
--- a/cumulusci/tasks/metadata/package.py
+++ b/cumulusci/tasks/metadata/package.py
@@ -53,7 +53,9 @@ class PackageXmlGenerator(object):
         uninstall_class=None,
         types=None,
     ):
-        with open(__location__ + "/metadata_map.yml", "r") as f_metadata_map:
+        with open(
+            __location__ + "/metadata_map.yml", "r", encoding="utf-8"
+        ) as f_metadata_map:
             self.metadata_map = yaml.safe_load(f_metadata_map)
         self.directory = directory
         self.api_version = api_version
@@ -150,7 +152,7 @@ class BaseMetadataParser(object):
             __location__, "..", "..", "files", "delete_excludes.txt"
         )
         excludes = []
-        with open(filename, "r") as f:
+        with open(filename, "r", encoding="utf-8") as f:
             for line in f:
                 excludes.append(line.strip())
         return excludes
@@ -440,5 +442,5 @@ class UpdatePackageXml(BaseTask):
             "Generating {} from metadata in {}".format(output, self.options.get("path"))
         )
         package_xml = self.package_xml()
-        with open(self.options.get("output", output), mode="w") as f:
+        with open(self.options.get("output", output), mode="w", encoding="utf-8") as f:
             f.write(package_xml)

--- a/cumulusci/utils/xml/metadata_tree.py
+++ b/cumulusci/utils/xml/metadata_tree.py
@@ -37,7 +37,7 @@ def parse(source):
 
     """
     if hasattr(source, "open"):  # for pathlib.Path objects
-        with source.open() as stream:
+        with source.open(encoding="utf-8") as stream:
             doc = lxml_parse_file(stream)
     else:
         doc = lxml_parse_file(source)


### PR DESCRIPTION
Fix #3322 and hopefully a few more similar situations.