### PR TITLE
Improve test coverage for oid_as_pk

### DIFF
--- a/cumulusci/tasks/bulkdata/mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/mapping_parser.py
@@ -238,9 +238,11 @@ class MappingStep(CCIDictModel):
     @validator("oid_as_pk")
     @classmethod
     def oid_as_pk_is_deprecated(cls, v):
-        raise ValueError(
-            "oid_as_pk is no longer supported. Include the Id field if desired."
-        )
+        if v:
+            raise ValueError(
+                "oid_as_pk is no longer supported. Include the Id field if desired."
+            )
+        return v
 
     @validator("fields_", pre=True)
     @classmethod

--- a/cumulusci/tasks/bulkdata/tests/test_mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/tests/test_mapping_parser.py
@@ -1174,6 +1174,34 @@ class TestMappingLookup:
         assert mapping["Insert Accounts"].action.value == "insert"
         assert mapping["Insert Accounts"].batch_size == 50
 
+    def test_oid_as_pk__raises(self):
+        with pytest.raises(ValueError):
+            parse_from_yaml(
+                StringIO(
+                    (
+                        """Insert Accounts:
+                            sf_object: account
+                            oid_as_pk: True
+                            fields:
+                                - name"""
+                    )
+                )
+            )
+
+    def test_oid_as_pk__false(self):
+        mapping = parse_from_yaml(
+            StringIO(
+                (
+                    """Insert Accounts:
+                            sf_object: account
+                            oid_as_pk: False
+                            fields:
+                                - name"""
+                )
+            )
+        )
+        assert not mapping["Insert Accounts"].oid_as_pk
+
 
 class TestUpsertKeyValidations:
     def test_upsert_key_wrong_type(self):


### PR DESCRIPTION
Improve test coverage for the deprecated `oid_as_pk` mapping file argument.