### PR TITLE
Add better error handling for empty or invalid org and service env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ pabot_results/
 large_cassettes/
 github_release_notes.html
 tmp
+pytestdebug.log

--- a/cumulusci/core/exceptions.py
+++ b/cumulusci/core/exceptions.py
@@ -62,6 +62,12 @@ class ServiceNotConfigured(CumulusCIUsageError):
     pass
 
 
+class ServiceCannotBeLoaded(CumulusCIUsageError):
+    """Raised when a service cannot be decrypted or unpickled"""
+
+    pass
+
+
 class ServiceNotValid(CumulusCIUsageError):
     """Raised when no service configuration could be found by a given name in the project configuration"""
 

--- a/cumulusci/core/keychain/encrypted_file_project_keychain.py
+++ b/cumulusci/core/keychain/encrypted_file_project_keychain.py
@@ -21,6 +21,7 @@ from cumulusci.core.exceptions import (
     KeychainKeyNotFound,
     OrgCannotBeLoaded,
     OrgNotFound,
+    ServiceCannotBeLoaded,
     ServiceNotConfigured,
 )
 from cumulusci.core.keychain import BaseProjectKeychain
@@ -229,7 +230,14 @@ class EncryptedFileProjectKeychain(BaseProjectKeychain):
                 self._load_org_from_environment(env_var_name, value)
 
     def _load_org_from_environment(self, env_var_name, value):
-        org_config = json.loads(value)
+        if not value:
+            raise OrgCannotBeLoaded(
+                f"Org env var {env_var_name} cannot be loaded because it is empty. Either set {env_var_name} to a json string or unset it from the environment."
+            )
+        try:
+            org_config = json.loads(value)
+        except Exception as e:
+            raise OrgCannotBeLoaded(f"Could not parse {env_var_name} as JSON")
         org_name = env_var_name[len(self.env_org_var_prefix) :].lower()
         if org_config.get("scratch"):
             org_config = scratch_org_factory(
@@ -657,6 +665,14 @@ class EncryptedFileProjectKeychain(BaseProjectKeychain):
     def _load_service_from_environment(self, env_var_name, value):
         """Given a valid name/value pair, load the
         service from the environment on to the keychain"""
+        if not value:
+            raise ServiceCannotBeLoaded(
+                f"Service env var {env_var_name} cannot be loaded because it is empty. Either set {env_var_name} to a json string or unset it from the environmet."
+            )
+        try:
+            service_config = json.loads(value)
+        except Exception as e:
+            raise ServiceCannotBeLoaded(f"Could not parse {env_var_name} as JSON")
         service_config = ServiceConfig(json.loads(value))
         service_type, service_name = self._get_env_service_type_and_name(env_var_name)
         self.set_service(service_type, service_name, service_config, save=False)

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -552,6 +552,10 @@ tasks:
         class_path: cumulusci.tasks.metadata_etl.SetDuplicateRuleStatus
         options:
             namespace_inject: $project_config.project__package__namespace
+    set_object_settings:
+        description: Enable and disable object level settings on standard and custom objects
+        class_path: cumulusci.tasks.metadata_etl.SetObjectSettings
+        group: Metadata Transformations
     set_organization_wide_defaults:
         group: Metadata Transformations
         description: Sets the Organization-Wide Defaults for specific sObjects, and waits for sharing recalculation to complete.

--- a/cumulusci/tasks/metadata_etl/__init__.py
+++ b/cumulusci/tasks/metadata_etl/__init__.py
@@ -8,6 +8,7 @@ from cumulusci.tasks.metadata_etl.base import (
 )
 from cumulusci.tasks.metadata_etl.duplicate_rules import SetDuplicateRuleStatus
 from cumulusci.tasks.metadata_etl.layouts import AddRelatedLists
+from cumulusci.tasks.metadata_etl.objects import SetObjectSettings
 from cumulusci.tasks.metadata_etl.permissions import AddPermissionSetPermissions
 from cumulusci.tasks.metadata_etl.value_sets import AddValueSetEntries
 from cumulusci.tasks.metadata_etl.sharing import SetOrgWideDefaults
@@ -20,6 +21,7 @@ flake8 = (
     AddRelatedLists,
     AddPermissionSetPermissions,
     AddValueSetEntries,
+    SetObjectSettings,
     SetOrgWideDefaults,
     MetadataOperation,
     SetDuplicateRuleStatus,

--- a/cumulusci/tasks/metadata_etl/objects.py
+++ b/cumulusci/tasks/metadata_etl/objects.py
@@ -1,0 +1,65 @@
+from cumulusci.core.exceptions import TaskOptionsError
+from cumulusci.core.utils import process_list_arg
+from cumulusci.tasks.metadata_etl import MetadataSingleEntityTransformTask
+from cumulusci.utils.xml.metadata_tree import MetadataElement
+
+OBJ_SETTINGS = [
+    "Activities",
+    "BulkApi",
+    "Feeds",
+    "History",
+    "Licensing",
+    "Reports",
+    "Search",
+    "Sharing",
+    "StreamingApi",
+]
+OBJ_SETTINGS_STR = ", ".join(OBJ_SETTINGS)
+
+
+class SetObjectSettings(MetadataSingleEntityTransformTask):
+    entity = "CustomObject"
+    task_options = {
+        "enable": {
+            "description": f"Array of object settings to enable. Uses the setting name.  Available values: {OBJ_SETTINGS_STR}"
+        },
+        "disable": {
+            "description": f"Array of object settings to disable. Uses the setting name.  Available values: {OBJ_SETTINGS_STR}"
+        },
+        # Only include api_names option since namespace injection isn't supported
+        **{"api_names": MetadataSingleEntityTransformTask.task_options["api_names"]},
+    }
+
+    def _init_options(self, kwargs):
+        super()._init_options(kwargs)
+        if not self.options.get("enable") and not self.options.get("disable"):
+            raise TaskOptionsError(
+                "You must provide values for either 'enable' or 'disable'"
+            )
+        self.options["enable"] = self._process_settings(self.options.get("enable"))
+        self.options["disable"] = self._process_settings(self.options.get("disable"))
+
+    def _process_settings(self, settings):
+        settings = process_list_arg(settings)
+        if settings is None:
+            settings = []
+        invalid = []
+        for setting in settings:
+            if setting not in OBJ_SETTINGS:
+                invalid.append(setting)
+        if invalid:
+            raise TaskOptionsError(
+                "Invalid settings: {}.  Valid settings are: ".format(
+                    ", ".join(invalid), OBJ_SETTINGS_STR
+                )
+            )
+        return settings
+
+    def _transform_entity(self, metadata: MetadataElement, api_name: str):
+        for setting in self.options["enable"]:
+            elem = metadata.find("enable" + setting)
+            elem.text = "true"
+        for setting in self.options["disable"]:
+            elem = metadata.find("enable" + setting)
+            elem.text = "false"
+        return metadata

--- a/cumulusci/tasks/metadata_etl/tests/test_objects.py
+++ b/cumulusci/tasks/metadata_etl/tests/test_objects.py
@@ -1,0 +1,207 @@
+from datetime import datetime
+from unittest import mock
+
+import pytest
+
+from cumulusci.core.exceptions import CumulusCIException, TaskOptionsError
+from cumulusci.tasks.metadata_etl import SetObjectSettings
+from cumulusci.tasks.salesforce.tests.util import create_task
+from cumulusci.utils.xml import metadata_tree
+
+MD = "{%s}" % metadata_tree.METADATA_NAMESPACE
+
+CUSTOMOBJECT_SETTINGS_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <sharingModel>Read</sharingModel>
+    <externalSharingModel>Read</externalSharingModel>
+    <label>Test</label>
+    <pluralLabel>Tests</pluralLabel>
+    <nameField>
+        <label>Test Name</label>
+        <trackHistory>false</trackHistory>
+        <type>Text</type>
+    </nameField>
+    <deploymentStatus>Deployed</deploymentStatus>
+    <enableActivities>true</enableActivities>
+    <enableBulkApi>true</enableBulkApi>
+    <enableFeeds>false</enableFeeds>
+    <enableHistory>false</enableHistory>
+</CustomObject>"""
+
+
+class TestSetObjectSettings:
+    def test_options__require_enable_or_disable(self):
+        with pytest.raises(TaskOptionsError) as e:
+            task = create_task(
+                SetObjectSettings,
+                {
+                    "api_names": "Test__c",
+                },
+            )
+        assert (
+            e.value.args[0]
+            == "You must provide values for either 'enable' or 'disable'"
+        )
+
+    def test_options__invalid_setting(self):
+        with pytest.raises(TaskOptionsError) as e:
+            task = create_task(
+                SetObjectSettings,
+                {
+                    "api_names": "Test__c",
+                    "enable": ["Foo"],
+                },
+            )
+        assert e.value.args[0].startswith("Invalid settings: Foo.")
+
+    def test_options__invalid_settings(self):
+        with pytest.raises(TaskOptionsError) as e:
+            task = create_task(
+                SetObjectSettings,
+                {
+                    "api_names": "Test__c",
+                    "enable": ["Foo", "Bar"],
+                },
+            )
+        assert e.value.args[0].startswith("Invalid settings: Foo, Bar.")
+
+    def test_enable__single(self):
+        task = create_task(
+            SetObjectSettings,
+            {
+                "api_names": "Test__c",
+                "enable": ["Feeds"],
+            },
+        )
+        tree = metadata_tree.fromstring(CUSTOMOBJECT_SETTINGS_XML)
+
+        result = task._transform_entity(tree, "Test__c")
+
+        entry = result._element.findall(f".//{MD}enableFeeds")
+        assert len(entry) == 1
+        assert entry[0].text == "true"
+
+        entry = result._element.findall(f".//{MD}enableHistory")
+        assert len(entry) == 1
+        assert entry[0].text == "false"
+
+    def test_enable__no_change(self):
+        task = create_task(
+            SetObjectSettings,
+            {
+                "api_names": "Test__c",
+                "enable": ["Activities"],
+            },
+        )
+        tree = metadata_tree.fromstring(CUSTOMOBJECT_SETTINGS_XML)
+
+        result = task._transform_entity(tree, "Test__c")
+
+        entry = result._element.findall(f".//{MD}enableActivities")
+        assert len(entry) == 1
+        assert entry[0].text == "true"
+
+    def test_enable__multiple(self):
+        task = create_task(
+            SetObjectSettings,
+            {
+                "api_names": "Test__c",
+                "enable": ["Feeds", "History"],
+            },
+        )
+        tree = metadata_tree.fromstring(CUSTOMOBJECT_SETTINGS_XML)
+
+        result = task._transform_entity(tree, "Test__c")
+
+        entry = result._element.findall(f".//{MD}enableFeeds")
+        assert len(entry) == 1
+        assert entry[0].text == "true"
+
+        entry = result._element.findall(f".//{MD}enableHistory")
+        assert len(entry) == 1
+        assert entry[0].text == "true"
+
+    def test_disable__single(self):
+        task = create_task(
+            SetObjectSettings,
+            {
+                "api_names": "Test__c",
+                "disable": ["Activities"],
+            },
+        )
+        tree = metadata_tree.fromstring(CUSTOMOBJECT_SETTINGS_XML)
+
+        result = task._transform_entity(tree, "Test__c")
+
+        entry = result._element.findall(f".//{MD}enableActivities")
+        assert len(entry) == 1
+        assert entry[0].text == "false"
+
+        entry = result._element.findall(f".//{MD}enableBulkApi")
+        assert len(entry) == 1
+        assert entry[0].text == "true"
+
+    def test_disable__no_change(self):
+        task = create_task(
+            SetObjectSettings,
+            {
+                "api_names": "Test__c",
+                "disable": ["Feeds"],
+            },
+        )
+        tree = metadata_tree.fromstring(CUSTOMOBJECT_SETTINGS_XML)
+
+        result = task._transform_entity(tree, "Test__c")
+
+        entry = result._element.findall(f".//{MD}enableFeeds")
+        assert len(entry) == 1
+        assert entry[0].text == "false"
+
+    def test_disable__multiple(self):
+        task = create_task(
+            SetObjectSettings,
+            {
+                "api_names": "Test__c",
+                "disable": ["Activities", "BulkApi"],
+            },
+        )
+        tree = metadata_tree.fromstring(CUSTOMOBJECT_SETTINGS_XML)
+
+        result = task._transform_entity(tree, "Test__c")
+
+        entry = result._element.findall(f".//{MD}enableActivities")
+        assert len(entry) == 1
+        assert entry[0].text == "false"
+
+        entry = result._element.findall(f".//{MD}enableBulkApi")
+        assert len(entry) == 1
+        assert entry[0].text == "false"
+
+    def test_enable_and_disable(self):
+        task = create_task(
+            SetObjectSettings,
+            {
+                "api_names": "Test__c",
+                "enable": ["Feeds", "History"],
+                "disable": ["Activities", "BulkApi"],
+            },
+        )
+        tree = metadata_tree.fromstring(CUSTOMOBJECT_SETTINGS_XML)
+
+        result = task._transform_entity(tree, "Test__c")
+
+        entry = result._element.findall(f".//{MD}enableActivities")
+        assert len(entry) == 1
+        assert entry[0].text == "false"
+
+        entry = result._element.findall(f".//{MD}enableBulkApi")
+        assert len(entry) == 1
+        assert entry[0].text == "false"
+
+        entry = result._element.findall(f".//{MD}enableFeeds")
+        assert len(entry) == 1
+        assert entry[0].text == "true"
+
+        entry = result._element.findall(f".//{MD}enableHistory")
+        assert len(entry) == 1
+        assert entry[0].text == "true"


### PR DESCRIPTION
Adds extra error handling and a new exception, ServiceCannotBeLoaded, to match the exception already there for org load issues.  Should have 100% test coverage.

# Issues Closed
* Fixes #3340 