### PR TITLE
Specify Python minor version in homebrew formula

### DIFF
--- a/utility/build-homebrew.sh
+++ b/utility/build-homebrew.sh
@@ -21,7 +21,9 @@ echo " "
 echo "=> Compiling pip requirements including hashes..."
 echo " "
 echo "cumulusci==$PACKAGE_VERSION" > "$REQS_IN_FILE"
-pip-compile "$REQS_IN_FILE" -o "$REQS_FILE" --generate-hashes
+# For a longish thread on why `allow-unsafe`, see https://github.com/pypa/pip/issues/6459
+# Here, we're adding it to collect setuptools-rust for the cryptography library.
+pip-compile "$REQS_IN_FILE" -o "$REQS_FILE" --generate-hashes --allow-unsafe
 
 echo " "
 echo "=> Writing Homebrew Formula to ${OUT_FILE}..."
@@ -34,8 +36,10 @@ class Cumulusci < Formula
   homepage "https://github.com/SFDO-Tooling/CumulusCI"
   url $PACKAGE_URL
   sha256 $PACKAGE_SHA
-  head "https://github.com/SFDO-Tooling/CumulusCI.git"
+  license "BSD-3-Clause"
+  head "https://github.com/SFDO-Tooling/CumulusCI.git", branch: "main"
 
+  depends_on "rust" => :build # cryptography -> setuptools-rust
   depends_on "python@3.9"
 
   def install
@@ -48,7 +52,8 @@ $(cat "$REQS_FILE")
 REQS
 
     File.write("requirements.txt", reqs)
-    system "python3", "-m", "pip", "install", "-r", "requirements.txt", "--require-hashes", "--no-deps", "--ignore-installed", "--prefix", libexec
+    ## Python@3.9 no longer includes python3 https://github.com/Homebrew/homebrew-core/pull/107517
+    system "python3.9", "-m", "pip", "install", "-r", "requirements.txt", "--require-hashes", "--no-deps", "--ignore-installed", "--prefix", libexec
 
     bin.install Dir["#{libexec}/bin/cci"]
     bin.install Dir["#{libexec}/bin/snowfakery"]

--- a/utility/build-homebrew.sh
+++ b/utility/build-homebrew.sh
@@ -39,7 +39,6 @@ class Cumulusci < Formula
   license "BSD-3-Clause"
   head "https://github.com/SFDO-Tooling/CumulusCI.git", branch: "main"
 
-  depends_on "rust" => :build # cryptography -> setuptools-rust
   depends_on "python@3.9"
 
   def install


### PR DESCRIPTION
Users were intermittently reporting that upgrades failed with some
variation of the following error:

```python-traceback
File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/site-packages/setuptools/build_meta.py", line 142, in run_setup
     exec(compile(code, __file__, 'exec'), locals())
   File "setup.py", line 14, in <module>
     from setuptools_rust import RustExtension
   File "/private/tmp/pip-build-env-gh8ot2a3/overlay/lib/python3.8/site-packages/setuptools_rust/__init__.py", line 1, in <module>
     from .build import build_rust
   File "/private/tmp/pip-build-env-gh8ot2a3/overlay/lib/python3.8/site-packages/setuptools_rust/build.py", line 23, in <module>
     from setuptools.command.build import build as CommandBuild  # type: ignore[import]
 ModuleNotFoundError: No module named 'setuptools.command.build'
```
This changeset includes two substantive changes to how the formula is
generated:

1. The major.minor version (`python3.9`of the python executable is used instead of `python3`). This prevents the installation from inadvertently using the system Python. This occurs because Homebrew only symlinks a `python3` executable for the latest version. See Homebrew/homebrew-core#107517.
3. Adds `--allow-unsafe` to the `pip-compile` step. This is a noop because we aren't pinning setuptools.