### PR TITLE
Include net zero cloud tooling objects in metadata_map

### DIFF
--- a/cumulusci/tasks/metadata/metadata_map.yml
+++ b/cumulusci/tasks/metadata/metadata_map.yml
@@ -82,6 +82,10 @@ briefcaseDefinitions:
     - type: BriefcaseDefinition
       class: MetadataFilenameParser
       extension: briefcaseDefinition
+buildingEnergyIntensityConfigs:
+    - type: BldgEnrgyIntensityCnfg
+      class: MetadataFilenameParser
+      extension: buildingEnergyIntensityConfig
 businessProcessGroups:
     - type: BusinessProcessGroup
       class: MetadataFilenameParser
@@ -723,6 +727,10 @@ staticresources:
     - type: StaticResource
       class: MetadataFilenameParser
       extension: resource
+stationaryAssetEnvSourceConfigs:
+    - type: StnryAssetEnvSrcCnfg
+      class: MetadataFilenameParser
+      extension: stationaryAssetEnvSourceConfig
 synonymDictionaries:
     - type: SynonymDictionary
       class: MetadataFilenameParser
@@ -759,6 +767,10 @@ userCriteria:
     - type: UserCriteria
       class: MetadataFilenameParser
       extension: userCriteria
+vehicleAssetEmssnSourceConfigs:
+    - type: VehicleAssetEmssnSrcCnfg
+      class: MetadataFilenameParser
+      extension: vehicleAssetEmssnSourceConfig
 viewdefinitions:
     - type: ViewDefinition
       class: MetadataFilenameParser


### PR DESCRIPTION
# Changes
* CumulusCI now supports the following types from [Net Zero Cloud's Tooling API](https://developer.salesforce.com/docs/atlas.en-us.netzero_cloud_dev_guide.meta/netzero_cloud_dev_guide/netzero_cloud_tooling_api_parent.htm): `BldgEnrgyIntensityCnfg`, `StnryAssetEnvSrcCnfg`, `VehicleAssetEmssnSrcCnfg`.