### PR TITLE
Use parent_tree in CommitDir  to fix timeouts with large repositories

### DIFF
--- a/cumulusci/tasks/github/util.py
+++ b/cumulusci/tasks/github/util.py
@@ -1,8 +1,11 @@
 import base64
 import hashlib
-import io
 import logging
 import os
+from pathlib import Path
+from typing import Optional, Tuple
+
+from github3.git import Commit, Tree
 
 from cumulusci.core.exceptions import GithubException
 
@@ -57,10 +60,11 @@ class CommitDir(object):
         self.new_tree_list = [item for item in self.new_tree_list if item]
         self._add_new_files_to_tree(self.new_tree_list)
 
-        if tree_unchanged := self._summarize_changes(self.new_tree_list):
+        if not self.new_tree_list:
             self.logger.warning("No changes found, aborting commit")
             return self.parent_commit
 
+        self._summarize_changes(self.tree, self.new_tree_list)
         new_tree = self._create_tree(self.new_tree_list)
         new_commit = self._create_commit(commit_message, new_tree)
         self._update_head(new_commit)
@@ -71,88 +75,98 @@ class CommitDir(object):
         self.head = self.repo.ref(f"heads/{branch}")
 
         # get commit pointed to by HEAD
-        self.parent_commit = self.repo.git_commit(self.head.object.sha)
+        self.parent_commit: Commit = self.repo.git_commit(self.head.object.sha)
 
         # get tree of commit as dict
-        self.tree = self.repo.tree(self.parent_commit.tree.sha, recursive=True)
+        orig_tree: Tree = self.repo.tree(self.parent_commit.tree.sha, recursive=True)
         self.tree = [
-            self._git_hash_to_dict(git_hash)
-            for git_hash in self.tree.tree
-            if git_hash.type != "tree"
+            git_hash.as_dict() for git_hash in orig_tree.tree if git_hash.type != "tree"
         ]
 
-    def _git_hash_to_dict(self, git_hash):
-        return {
-            "sha": git_hash.sha,
-            "mode": git_hash.mode,
-            "path": git_hash.path,
-            "size": git_hash.size,
-            "type": git_hash.type,
-        }
-
-    def _create_new_tree_item(self, item):
+    def _create_new_tree_item(self, item: dict) -> Optional[dict]:
+        """Given an Git tree element, returns None if it is unchanged, or
+        a new element if it has been deleted or updated.
+        """
         if not item["path"].startswith(self.repo_dir):
             # outside target dir in repo - keep in tree
             self.logger.debug(f'Unchanged (outside target path): {item["path"]}')
-            return item
+            return None
 
-        local_file, content = self._read_item_content(item)
+        local_path, content = self._find_and_read_item(item)
         new_item = item.copy()
         if content is None:
-            # delete blob from tree
+            # delete blob from tree by setting 'sha' to null
             self.logger.debug(f"Delete: {item['path']}")
-            return content
+            new_item["sha"] = None
         elif self._item_changed(item, content):
-            self.logger.debug(f"Update: {local_file}")
-            blob_sha = self._create_blob(content, local_file)
-            new_item["sha"] = blob_sha
+            # we need to delete the sha key because GH returns an error if
+            # both 'sha' and 'contents' are passed.
+            self.logger.debug(f"Update: {local_path}")
+            new_item.pop("sha", None)
+            new_item.update(self._get_content_or_sha(content, self.dry_run))
         else:
             self.logger.debug(f'Unchanged: {item["path"]}')
+            return None
         return new_item
 
     def _add_new_files_to_tree(self, new_tree_list):
         new_tree_target_subpaths = [
             self._get_item_sub_path(item)
-            for item in new_tree_list
+            for item in self.tree
             if item["path"].startswith(self.repo_dir)
         ]
 
-        for root, dirs, files in os.walk(self.local_dir):
+        for root, _, files in os.walk(self.local_dir):
             for filename in files:
                 if not filename.startswith("."):
                     local_file = os.path.join(root, filename)
                     local_file_subpath = local_file[(len(self.local_dir) + 1) :]
                     if local_file_subpath not in new_tree_target_subpaths:
-                        with io.open(local_file, "rb") as f:
-                            content = f.read()
                         repo_path = f"{self.repo_dir}/" if self.repo_dir else ""
                         new_item = {
                             "path": f'{repo_path}{local_file_subpath.replace(os.sep, "/")}',
-                            "mode": "100644",
+                            "mode": "100644",  # FIXME: This is wrong
                             "type": "blob",
-                            "sha": self._create_blob(content, local_file),
                         }
-
+                        new_item.update(
+                            self._get_content_or_sha(
+                                Path(local_file).read_bytes(), self.dry_run
+                            )
+                        )
                         new_tree_list.append(new_item)
 
-    def _summarize_changes(self, new_tree_list):
+    def _summarize_changes(self, old_tree_list, new_tree_list):
         self.logger.info("Summary of changes:")
-        new_shas = [item["sha"] for item in new_tree_list]
-        new_paths = [item["path"] for item in new_tree_list]
-        old_paths = [item["path"] for item in self.tree]
-        old_tree_list = []
-        for item in self.tree:
-            if item["type"] == "tree":
-                continue
-            old_tree_list.append(item)
-            if item["path"] not in new_paths:
-                self.logger.warning(f'Delete:\t{item["path"]}')
-            elif item["sha"] not in new_shas:
-                self.logger.info(f'Update:\t{item["path"]}')
-        for item in new_tree_list:
-            if item["path"] not in old_paths:
-                self.logger.info(f'Add:\t{item["path"]}')
-        return new_tree_list == old_tree_list
+        old_paths = [item["path"] for item in old_tree_list]
+
+        def join_paths(paths):
+            return "\n".join(f"\t{path}" for path in paths)
+
+        deleted_paths = join_paths(
+            [item["path"] for item in new_tree_list if item.get("sha", "") is None]
+        )
+        if deleted_paths:
+            self.logger.warning(f"Deleted:\n{deleted_paths}")
+
+        new_paths = join_paths(
+            [
+                item["path"]
+                for item in new_tree_list
+                if "content" in item and item["path"] not in old_paths
+            ]
+        )
+        if new_paths:
+            self.logger.info(f"Added:\n{new_paths}")
+
+        updated_paths = join_paths(
+            [
+                item["path"]
+                for item in new_tree_list
+                if "content" in item and item["path"] in old_paths
+            ]
+        )
+        if updated_paths:
+            self.logger.info(f"Updated:\n{updated_paths}")
 
     def _create_tree(self, new_tree_list):
         new_tree = None
@@ -160,7 +174,9 @@ class CommitDir(object):
             self.logger.info("[dry_run] Skipping creation of new tree")
         else:
             self.logger.info("Creating new tree")
-            new_tree = self.repo.create_tree(new_tree_list, None)
+            new_tree = self.repo.create_tree(
+                new_tree_list, base_tree=self.parent_commit.tree.sha
+            )
             if not new_tree:
                 raise GithubException("Failed to create tree")
         return new_tree
@@ -200,35 +216,36 @@ class CommitDir(object):
         len_path = (len(self.repo_dir) + 1) if self.repo_dir else 0
         return item["path"][len_path:]
 
-    def _read_item_content(self, item):
+    def _find_and_read_item(self, item) -> Tuple[Path, Optional[bytes]]:
         item_subpath = self._get_item_sub_path(item)
-        local_file = os.path.join(self.local_dir, item_subpath)
-        if not os.path.isfile(local_file):
-            return local_file, None
-        with io.open(local_file, "rb") as f:
-            content = f.read()
-        return local_file, content
+        pth = Path(self.local_dir, item_subpath)
+        contents = pth.read_bytes() if pth.exists() else None
+        return pth, contents
 
-    def _item_changed(self, item, content):
+    def _item_changed(self, item: dict, content: bytes) -> bool:
         header = b"blob " + str(len(content)).encode() + b"\0"
         return hashlib.sha1(header + content).hexdigest() != item["sha"]
 
-    def _create_blob(self, content, local_file):
-        if self.dry_run:
-            self.logger.info(
-                f"[dry_run] Skipping creation of blob for new file: {local_file}"
-            )
+    def _get_content_or_sha(self, content, dry_run) -> dict:
+        """Given file contents as bytes, returns a dict with file contents.
 
-            blob_sha = None
-        else:
-            self.logger.info(f"Creating blob for new file: {local_file}")
-            try:
-                content = content.decode("utf-8")
-                blob_sha = self.repo.create_blob(content, "utf-8")
-            except UnicodeDecodeError:
-                content = base64.b64encode(content)
-                blob_sha = self.repo.create_blob(content.decode("utf-8"), "base64")
-            if not blob_sha:
-                raise GithubException("Failed to create blob")
+        If the contents are text: {'contents': contents as str}
+        If the contents are binary: {'sha': hash of the uploaded blob}
+        """
+        if dry_run:
+            self.logger.info("[dry_run] Skipping creation of blob for new file")
+            return {"content": None}
+        try:
+            content = content.decode("utf-8")
+            return {"content": content}
+        except UnicodeDecodeError:
+            return self._create_blob(content)
+
+    def _create_blob(self, contents: bytes) -> dict:
+        self.logger.info("Creating blob for binary file")
+        content: bytes = base64.b64encode(contents)
+        blob_sha: str = self.repo.create_blob(content.decode("utf-8"), "base64")
+        if not blob_sha:
+            raise GithubException("Failed to create blob")
         self.logger.debug(f"Blob created: {blob_sha}")
-        return blob_sha
+        return {"sha": blob_sha}


### PR DESCRIPTION
Users have reported 502 errors (i.e., timeouts) when using CommitDir to create a commit when the repository is above a certain size. Because CommitDir uses GitHub's [Git Database API] directly to create blob and tree objects before authoring a commit, it made too many calls and triggered rate limiting. For very large repositories (e.g., NPSP), even very small changes will throw an exception because CommitDir constructs the entire Tree and creates a blob for each file that is new or modified.

This PR resolves this issue with two changes:

1. CommitDir now creates a smaller tree object by omitting unchanged files. By using the `parent_tree` property in the `create_tree` request, we only need to include the blobs that are new, modified, or deleted, meaning the overall tree is much smaller.
2. CommitDir no longer calls the `blob` endpoint for each new or modified file before constructing the new tree. Github will accept property `contents` with the text contents of a file, so only binary files need to create a blob first. This saves a number of API calls and avoids triggering secondary rate limits.

[Git Database API]: https://docs.github.com/en/rest/git

Fixes SFDO-Tooling/Metecho#1303