### PR TITLE
Remove references to brew

### DIFF
--- a/cumulusci/tests/test_utils.py
+++ b/cumulusci/tests/test_utils.py
@@ -584,15 +584,15 @@ Options\n------------------------------------------\n\n
             pass
         assert 4 == logger.info.call_count
 
-    def test_util__sets_homebrew_upgrade_cmd(self):
+    def test_util__sets_homebrew_deprecation_msg(self):
         utils.CUMULUSCI_PATH = "/usr/local/Cellar/cumulusci/2.1.2"
         upgrade_cmd = utils.get_cci_upgrade_command()
-        assert utils.BREW_UPDATE_CMD == upgrade_cmd
+        assert utils.BREW_DEPRECATION_MSG == upgrade_cmd
 
-    def test_util__sets_linuxbrew_upgrade_cmd(self):
+    def test_util__sets_linuxbrew_deprecation_msg(self):
         utils.CUMULUSCI_PATH = "/home/linuxbrew/.linuxbrew/cumulusci/2.1.2"
         upgrade_cmd = utils.get_cci_upgrade_command()
-        assert utils.BREW_UPDATE_CMD == upgrade_cmd
+        assert utils.BREW_DEPRECATION_MSG == upgrade_cmd
 
     def test_util__sets_pip_upgrade_cmd(self):
         utils.CUMULUSCI_PATH = "/usr/local/pip-path/cumulusci/2.1.2"

--- a/cumulusci/utils/__init__.py
+++ b/cumulusci/utils/__init__.py
@@ -30,7 +30,12 @@ META_XML_CLEAN_DIRS = ("classes/", "triggers/", "pages/", "aura/", "components/"
 API_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
 DATETIME_LEN = len("2018-08-07T16:00:56.000")
 
-BREW_UPDATE_CMD = "brew upgrade cumulusci"
+BREW_DEPRECATION_MSG = (
+    "It looks like you have installed CumulusCI using brew."
+    "This method of installation is no longer supported."
+    "Please use the following to install CumulusCI with pipx:\n"
+    "brew uninstall cumulusci\nbrew install pipx\npipx ensurepath\npipx install cumulusci"
+)
 PIP_UPDATE_CMD = "pip install --upgrade cumulusci"
 PIPX_UPDATE_CMD = "pipx upgrade cumulusci"
 
@@ -592,15 +597,12 @@ def random_alphanumeric_underscore(length):
 
 
 def get_cci_upgrade_command():
-    commands_by_path = {
-        "cellar": BREW_UPDATE_CMD,
-        "linuxbrew": BREW_UPDATE_CMD,
-        "pipx": PIPX_UPDATE_CMD,
-    }
-    for path, cmd in commands_by_path.items():
+    deprecated_install_paths = ["cellar", "linuxbrew"]
+    for path in deprecated_install_paths:
         if path in CUMULUSCI_PATH.lower():
-            return cmd
-    return PIP_UPDATE_CMD
+            return BREW_DEPRECATION_MSG
+
+    return PIPX_UPDATE_CMD if "pipx" in CUMULUSCI_PATH.lower() else PIP_UPDATE_CMD
 
 
 def convert_to_snake_case(content):


### PR DESCRIPTION
* Replacing brew update messaging with a deprecation

## Critical Changes
* CumulusCI will no longer be supporting installations via `brew`. See [our docs](https://cumulusci.readthedocs.io/en/latest/get-started.html#install-cumulusci) for the officially supported install method via `pipx`.