### PR TITLE
Add support for CustomIndex metadata type

### DIFF
--- a/cumulusci/tasks/metadata/metadata_map.yml
+++ b/cumulusci/tasks/metadata/metadata_map.yml
@@ -174,6 +174,10 @@ customHelpMenuSections:
     - type: CustomHelpMenuSection
       class: MetadataFilenameParser
       extension: customHelpMenuSection
+customindex:
+    - type: CustomIndex
+      class: MetadataFilenameParser
+      extension: indx
 customMetadata:
     - type: CustomMetadata
       class: MetadataFilenameParser


### PR DESCRIPTION
Steps to reproduce with `dreamhouse-lwc`:
1. In a scratch org (`v55.0`), create a custom field with "External ID" checked
2. Run `cci task run retrieve_changes` against that org, retrieving a `CustomField` and `CustomIndex`.
3. Run `cci flow run dev_org --org`

Fixes #3381.