### PR TITLE
Include `Territory2Model` in MD Types

### DIFF
--- a/cumulusci/tasks/bulkdata/step.py
+++ b/cumulusci/tasks/bulkdata/step.py
@@ -343,7 +343,7 @@ class BulkApiDmlOperation(BaseDmlOperation, BulkJobMixin):
             self.api_options.get("batch_size") or DEFAULT_BULK_BATCH_SIZE
         )
         self.csv_buff = io.StringIO(newline="")
-        self.csv_writer = csv.writer(self.csv_buff)
+        self.csv_writer = csv.writer(self.csv_buff, quoting=csv.QUOTE_ALL)
 
     def start(self):
         self.job_id = self.bulk.create_job(

--- a/cumulusci/tasks/bulkdata/tests/test_step.py
+++ b/cumulusci/tasks/bulkdata/tests/test_step.py
@@ -488,15 +488,15 @@ class TestBulkApiDmlOperation:
         )
 
         serialized = step._serialize_csv_record(step.fields)
-        assert serialized == b"Id,FirstName,LastName\r\n"
+        assert serialized == b'"Id","FirstName","LastName"\r\n'
 
         record = ["1", "Bob", "Ross"]
         serialized = step._serialize_csv_record(record)
-        assert serialized == b"1,Bob,Ross\r\n"
+        assert serialized == b'"1","Bob","Ross"\r\n'
 
         record = ["col1", "multiline\ncol2"]
         serialized = step._serialize_csv_record(record)
-        assert serialized == b'col1,"multiline\ncol2"\r\n'
+        assert serialized == b'"col1","multiline\ncol2"\r\n'
 
     def test_batch(self):
         context = mock.Mock()
@@ -514,13 +514,13 @@ class TestBulkApiDmlOperation:
 
         assert len(results) == 2
         assert list(results[0]) == [
-            "LastName\r\n".encode("utf-8"),
-            "Test\r\n".encode("utf-8"),
-            "Test2\r\n".encode("utf-8"),
+            '"LastName"\r\n'.encode("utf-8"),
+            '"Test"\r\n'.encode("utf-8"),
+            '"Test2"\r\n'.encode("utf-8"),
         ]
         assert list(results[1]) == [
-            "LastName\r\n".encode("utf-8"),
-            "Test3\r\n".encode("utf-8"),
+            '"LastName"\r\n'.encode("utf-8"),
+            '"Test3"\r\n'.encode("utf-8"),
         ]
 
     def test_batch__character_limit(self):
@@ -548,13 +548,13 @@ class TestBulkApiDmlOperation:
 
         assert len(results) == 2
         assert list(results[0]) == [
-            "LastName\r\n".encode("utf-8"),
-            "Test\r\n".encode("utf-8"),
-            "Test2\r\n".encode("utf-8"),
+            '"LastName"\r\n'.encode("utf-8"),
+            '"Test"\r\n'.encode("utf-8"),
+            '"Test2"\r\n'.encode("utf-8"),
         ]
         assert list(results[1]) == [
-            "LastName\r\n".encode("utf-8"),
-            "Test3\r\n".encode("utf-8"),
+            '"LastName"\r\n'.encode("utf-8"),
+            '"Test3"\r\n'.encode("utf-8"),
         ]
 
     @mock.patch("cumulusci.tasks.bulkdata.step.download_file")

--- a/cumulusci/tasks/bulkdata/update_data.py
+++ b/cumulusci/tasks/bulkdata/update_data.py
@@ -166,7 +166,7 @@ class UpdateData(BaseSalesforceApiTask):
         with TemporaryDirectory() as t:
             csvfile = Path(t) / "input.csv"
             with csvfile.open("w") as f:
-                writer = csv.writer(f)
+                writer = csv.writer(f, quoting=csv.QUOTE_ALL)
                 snowfakery_fieldnames = ["Oid"] + fields[1:]
                 writer.writerow(snowfakery_fieldnames)
                 writer.writerows(qs.get_results())

--- a/cumulusci/tasks/datadictionary.py
+++ b/cumulusci/tasks/datadictionary.py
@@ -597,7 +597,7 @@ class GenerateDataDictionary(BaseGithubTask):
 
     def _write_object_results(self, file_handle):
         """Write to the given handle an output CSV containing the data dictionary for sObjects."""
-        writer = csv.writer(file_handle)
+        writer = csv.writer(file_handle, quoting=csv.QUOTE_ALL)
 
         writer.writerow(
             [
@@ -645,7 +645,7 @@ class GenerateDataDictionary(BaseGithubTask):
 
     def _write_field_results(self, file_handle):
         """Write to the given handle an output CSV containing the data dictionary for fields."""
-        writer = csv.writer(file_handle)
+        writer = csv.writer(file_handle, quoting=csv.QUOTE_ALL)
 
         writer.writerow(
             [

--- a/cumulusci/tasks/metadata/metadata_map.yml
+++ b/cumulusci/tasks/metadata/metadata_map.yml
@@ -743,6 +743,10 @@ tabs:
     - type: CustomTab
       class: MetadataFilenameParser
       extension: tab
+terriroty2Models:
+    - type: Territory2Model
+      class: MetadataFilenameParser
+      extension: territory2Model
 testSuites:
     - type: ApexTestSuite
       class: MetadataFilenameParser

--- a/cumulusci/tasks/metadata/metadata_map.yml
+++ b/cumulusci/tasks/metadata/metadata_map.yml
@@ -743,6 +743,10 @@ tabs:
     - type: CustomTab
       class: MetadataFilenameParser
       extension: tab
+territory2Models:
+    - type: Territory2Model
+      class: MetadataFilenameParser
+      extension: territory2Model
 testSuites:
     - type: ApexTestSuite
       class: MetadataFilenameParser

--- a/cumulusci/tasks/metadata/metadata_map.yml
+++ b/cumulusci/tasks/metadata/metadata_map.yml
@@ -743,10 +743,6 @@ tabs:
     - type: CustomTab
       class: MetadataFilenameParser
       extension: tab
-terriroty2Models:
-    - type: Territory2Model
-      class: MetadataFilenameParser
-      extension: territory2Model
 testSuites:
     - type: ApexTestSuite
       class: MetadataFilenameParser

--- a/cumulusci/tasks/push/pushfails.py
+++ b/cumulusci/tasks/push/pushfails.py
@@ -106,7 +106,7 @@ class ReportPushFailures(BaseSalesforceApiTask):
         ignore_errors = self.options["ignore_errors"]
         file_name = self.options["result_file"]
         with open(file_name, "w", encoding="utf-8") as f:
-            w = csv.writer(f)
+            w = csv.writer(f, quoting=csv.QUOTE_ALL)
             w.writerow(self.headers)
             for result in job_records:
                 error = result["Error"]

--- a/cumulusci/tasks/robotframework/libdoc.py
+++ b/cumulusci/tasks/robotframework/libdoc.py
@@ -134,7 +134,7 @@ class RobotLibDoc(BaseTask):
             if self.options["output"].endswith(".csv"):
                 data = self._convert_to_tuples(kwfiles)
                 with open(self.options["output"], "w", newline="") as f:
-                    csv_writer = csv.writer(f)
+                    csv_writer = csv.writer(f, quoting=csv.QUOTE_ALL)
                     csv_writer.writerows(data)
 
             else:

--- a/cumulusci/tasks/tests/test_datadictionary.py
+++ b/cumulusci/tasks/tests/test_datadictionary.py
@@ -66,7 +66,7 @@ class TestGenerateDataDictionary:
 
         assert (
             result
-            == "Object Label,Object API Name,Object Description,Version Introduced,Version Deleted\r\nTest,test__Test__c,Description,Test 1.1,Test 1.2\r\n"
+            == '"Object Label","Object API Name","Object Description","Version Introduced","Version Deleted"\r\n"Test","test__Test__c","Description","Test 1.1","Test 1.2"\r\n'
         )
 
     def test_write_field_results(self):
@@ -152,10 +152,15 @@ class TestGenerateDataDictionary:
         result = f.read()
 
         assert result == (
-            "Object Label,Object API Name,Field Label,Field API Name,Type,Picklist Values,Help Text,Field Description,Version Introduced,Version Picklist Values Last Changed,Version Help Text Last Changed,Version Deleted\r\n"
-            "Account,Account,Desc,test__Desc__c,Text,,,,Test 1.2,,,\r\n"
-            "Test Object,test__Test__c,Type,test__Type__c,Picklist,Foo; Bar; New Value,New Help,Description,Test 1.1,Test 1.2,Test 1.2,\r\n"
-            "Test Object,test__Test__c,Account,test__Account__c,Lookup to Account,,Help,Description,Test 1.1,,,Test 1.2\r\n"
+            '"Object Label","Object API Name","Field Label","Field API Name",'
+            '"Type","Picklist Values","Help Text","Field Description","Version Introduced",'
+            '"Version Picklist Values Last Changed","Version Help Text Last Changed",'
+            '"Version Deleted"\r\n"Account","Account","Desc","test__Desc__c","Text",'
+            '"","","","Test 1.2","","",""\r\n"Test Object","test__Test__c","Type",'
+            '"test__Type__c","Picklist","Foo; Bar; New Value","New Help","Description",'
+            '"Test 1.1","Test 1.2","Test 1.2",""\r\n"Test Object","test__Test__c",'
+            '"Account","test__Account__c","Lookup to Account","","Help","Description",'
+            '"Test 1.1","","","Test 1.2"\r\n'
         )
 
     def test_write_field_results__omit_sobjects(self):
@@ -236,9 +241,13 @@ class TestGenerateDataDictionary:
         result = f.read()
 
         assert result == (
-            "Object Label,Object API Name,Field Label,Field API Name,Type,Picklist Values,Help Text,Field Description,Version Introduced,Version Picklist Values Last Changed,Version Help Text Last Changed,Version Deleted\r\n"
-            "Test Object,test__Test__c,Type,test__Type__c,Picklist,Foo; Bar; New Value,New Help,Description,Test 1.1,Test 1.2,Test 1.2,\r\n"
-            "Test Object,test__Test__c,Account,test__Account__c,Lookup to Account,,Help,Description,Test 1.1,,,Test 1.2\r\n"
+            '"Object Label","Object API Name","Field Label","Field API Name","Type",'
+            '"Picklist Values","Help Text","Field Description","Version Introduced",'
+            '"Version Picklist Values Last Changed","Version Help Text Last Changed",'
+            '"Version Deleted"\r\n"Test Object","test__Test__c","Type","test__Type__c",'
+            '"Picklist","Foo; Bar; New Value","New Help","Description","Test 1.1","Test 1.2",'
+            '"Test 1.2",""\r\n"Test Object","test__Test__c","Account","test__Account__c",'
+            '"Lookup to Account","","Help","Description","Test 1.1","","","Test 1.2"\r\n'
         )
 
     def test_should_process_object(self):
@@ -1270,14 +1279,14 @@ class TestGenerateDataDictionary:
         m.return_value.write.assert_has_calls(
             [
                 call(
-                    "Object Label,Object API Name,Object Description,Version Introduced,Version Deleted\r\n"
+                    '"Object Label","Object API Name","Object Description","Version Introduced","Version Deleted"\r\n'
                 ),
-                call("Test,test__Test__c,Description,Project 1.1,\r\n"),
+                call('"Test","test__Test__c","Description","Project 1.1",""\r\n'),
                 call(
-                    "Object Label,Object API Name,Field Label,Field API Name,Type,Picklist Values,Help Text,Field Description,Version Introduced,Version Picklist Values Last Changed,Version Help Text Last Changed,Version Deleted\r\n"
+                    '"Object Label","Object API Name","Field Label","Field API Name","Type","Picklist Values","Help Text","Field Description","Version Introduced","Version Picklist Values Last Changed","Version Help Text Last Changed","Version Deleted"\r\n'
                 ),
                 call(
-                    "Test,test__Test__c,Type,test__Type__c,Text (255),,Type of field.,,Project 1.1,,,\r\n"
+                    '"Test","test__Test__c","Type","test__Type__c","Text (255)","","Type of field.","","Project 1.1","","",""\r\n'
                 ),
             ],
             any_order=True,
@@ -1359,17 +1368,17 @@ class TestGenerateDataDictionary:
         m.return_value.write.assert_has_calls(
             [
                 call(
-                    "Object Label,Object API Name,Object Description,Version Introduced,Version Deleted\r\n"
+                    '"Object Label","Object API Name","Object Description","Version Introduced","Version Deleted"\r\n'
                 ),
-                call("Test,test__Test__c,Description,Project 1.1,\r\n"),
+                call('"Test","test__Test__c","Description","Project 1.1",""\r\n'),
                 call(
-                    "Object Label,Object API Name,Field Label,Field API Name,Type,Picklist Values,Help Text,Field Description,Version Introduced,Version Picklist Values Last Changed,Version Help Text Last Changed,Version Deleted\r\n"
-                ),
-                call(
-                    "Test,test__Test__c,Type,test__Type__c,Text (255),,Type of field.,,Project 1.1,,,\r\n"
+                    '"Object Label","Object API Name","Field Label","Field API Name","Type","Picklist Values","Help Text","Field Description","Version Introduced","Version Picklist Values Last Changed","Version Help Text Last Changed","Version Deleted"\r\n'
                 ),
                 call(
-                    "Test,test__Test__c,Description,test__Description__c,Text (255),,Description of field.,,Project Prerelease,,,\r\n"
+                    '"Test","test__Test__c","Type","test__Type__c","Text (255)","","Type of field.","","Project 1.1","","",""\r\n'
+                ),
+                call(
+                    '"Test","test__Test__c","Description","test__Description__c","Text (255)","","Description of field.","","Project Prerelease","","",""\r\n'
                 ),
             ],
             any_order=True,


### PR DESCRIPTION
## Changes
* We now support the `Territory2Model` metadata type.