### PR TITLE
Include `Territory2` related md types

### DIFF
--- a/cumulusci/tasks/metadata/metadata_map.yml
+++ b/cumulusci/tasks/metadata/metadata_map.yml
@@ -743,6 +743,10 @@ tabs:
     - type: CustomTab
       class: MetadataFilenameParser
       extension: tab
+territory2Models:
+    - type: Territory2Model
+      class: MetadataFienameParser
+      extension: territory2Model
 testSuites:
     - type: ApexTestSuite
       class: MetadataFilenameParser

--- a/cumulusci/tasks/metadata/metadata_map.yml
+++ b/cumulusci/tasks/metadata/metadata_map.yml
@@ -654,6 +654,10 @@ roles:
     - type: Role
       class: MetadataFilenameParser
       extension: role
+rules:
+    - type: Territory2Rule
+      class: MetadataFilenameParser
+      extension: territory2Rule
 s3DataConnectors:
     - type: DataConnectorS3
       class: MetadataFilenameParser
@@ -743,10 +747,18 @@ tabs:
     - type: CustomTab
       class: MetadataFilenameParser
       extension: tab
+territories:
+    - type: Territory2
+      class: MetadataFilenameParser
+      extension: territory2
 territory2Models:
     - type: Territory2Model
-      class: MetadataFienameParser
+      class: MetadataFilenameParser
       extension: territory2Model
+territory2Types:
+    - type: Territory2Type
+      class: MetadataFilenameParser
+      extension: territory2Types
 testSuites:
     - type: ApexTestSuite
       class: MetadataFilenameParser


### PR DESCRIPTION
## Changes
* We now support the `Territory2`, `Territory2Model`, `Territory2Type`, and `Territory2Rule` MetaData types.