### PR TITLE
W-12077732: Pass in install class and uninstall class names from cli

### DIFF
--- a/cumulusci/tasks/metadata/package.py
+++ b/cumulusci/tasks/metadata/package.py
@@ -548,6 +548,12 @@ class UpdatePackageXml(BaseTask):
         "delete": {
             "description": "If True, generate a package.xml for use as a destructiveChanges.xml file for deleting metadata"
         },
+        "install_class": {
+            "description": "Specify post install class file to be used. Defaults to what is set in project config"
+        },
+        "uninstall_class": {
+            "description": "Specify post uninstall class file to be used. Defaults to what is set in project config"
+        },
     }
 
     def _init_options(self, kwargs):
@@ -568,8 +574,12 @@ class UpdatePackageXml(BaseTask):
             package_name=package_name,
             managed=self.options.get("managed", False),
             delete=self.options.get("delete", False),
-            install_class=self.project_config.project__package__install_class,
-            uninstall_class=self.project_config.project__package__uninstall_class,
+            install_class=self.options.get(
+                "install_class", self.project_config.project__package__install_class
+            ),
+            uninstall_class=self.options.get(
+                "uninstall_class", self.project_config.project__package__uninstall_class
+            ),
         )
 
     def _run_task(self):

--- a/cumulusci/tasks/metadata/tests/package_metadata/namespaced_report_folder/package_install_uninstall.xml
+++ b/cumulusci/tasks/metadata/tests/package_metadata/namespaced_report_folder/package_install_uninstall.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Test Package</fullName>
+    <postInstallClass>MyPostInstallClass</postInstallClass>
+    <uninstallClass>MyPostUninstallClass</uninstallClass>
+    <types>
+        <members>namespace__TestFolder/TestReport</members>
+        <name>Report</name>
+    </types>
+    <version>36.0</version>
+</Package>

--- a/cumulusci/tasks/metadata/tests/test_package.py
+++ b/cumulusci/tasks/metadata/tests/test_package.py
@@ -365,3 +365,36 @@ class TestUpdatePackageXml:
             with open(output_path, "r") as f:
                 result = f.read()
             assert expected == result
+
+
+class TestUpdatePackageXmlInstallUninstallClass:
+    def test_run_task(self):
+        src_path = os.path.join(
+            __location__, "package_metadata", "namespaced_report_folder"
+        )
+        with open(os.path.join(src_path, "package_install_uninstall.xml"), "r") as f:
+            expected = f.read()
+        with temporary_dir() as path:
+            output_path = os.path.join(path, "package.xml")
+            project_config = BaseProjectConfig(
+                UniversalConfig(),
+                {
+                    "project": {
+                        "package": {
+                            "name": "Test Package",
+                            "api_version": "36.0",
+                            "install_class": "MyPostInstallClass",
+                            "uninstall_class": "MyPostUninstallClass",
+                        }
+                    }
+                },
+            )
+            task_config = TaskConfig(
+                {"options": {"path": src_path, "output": output_path, "managed": True}}
+            )
+            org_config = OrgConfig({}, "test")
+            task = UpdatePackageXml(project_config, task_config, org_config)
+            task()
+            with open(output_path, "r") as f:
+                result = f.read()
+            assert expected == result


### PR DESCRIPTION
Validation Runs

Passing **install_class** on cli
```
cci task run update_package_xml --path ../via_core --managed True --install_class MyInstallClass
<?xml version="1.0" encoding="UTF-8"?>
<Package xmlns="http://soap.sforce.com/2006/04/metadata">
    <fullName>CumulusCI</fullName>
    <postInstallClass>MyInstallClass</postInstallClass>
    <version>55.0</version>
</Package>
```
Passing **install_class** and **uninstall_class**
```
cci task run update_package_xml --path ../via_core --managed True --install_class MyInstallClass --uninstall_class MyUnInstallClass
<?xml version="1.0" encoding="UTF-8"?>
<Package xmlns="http://soap.sforce.com/2006/04/metadata">
    <fullName>CumulusCI</fullName>
    <postInstallClass>MyInstallClass</postInstallClass>
    <uninstallClass>MyUnInstallClass</uninstallClass>
    <version>55.0</version>
</Package>
```

With **cumulusci.yaml configs** added
```
project:
    name: CumulusCI
    package:
        name: CumulusCI
        install_class: "FromCumulusCIYamlProjectConfig_MyInstallClass"
        uninstall_class: "FromCumulusCIYamlProjectConfig_UnInstallClass"
```

```
cci task run update_package_xml --path ../via_core --managed True                                                                  
<?xml version="1.0" encoding="UTF-8"?>
<Package xmlns="http://soap.sforce.com/2006/04/metadata">
    <fullName>CumulusCI</fullName>
    <postInstallClass>FromCumulusCIYamlProjectConfig_MyInstallClass</postInstallClass>
    <uninstallClass>FromCumulusCIYamlProjectConfig_UnInstallClass</uninstallClass>
    <version>55.0</version>
</Package>
```
Keeping the project config, and adding cli params overrides what is set in the project config
```
cci task run update_package_xml --path ../via_core --managed True --install_class MyInstallClass --uninstall_class MyUnInstallClass
<?xml version="1.0" encoding="UTF-8"?>
<Package xmlns="http://soap.sforce.com/2006/04/metadata">
    <fullName>CumulusCI</fullName>
    <postInstallClass>MyInstallClass</postInstallClass>
    <uninstallClass>MyUnInstallClass</uninstallClass>
    <version>55.0</version>
</Package>
```


With **nothing** set in cumulusci.yaml or passsed in via cli. Default Behavior
```
cci task run update_package_xml --path ../via_core --managed True                                                                  
<?xml version="1.0" encoding="UTF-8"?>
<Package xmlns="http://soap.sforce.com/2006/04/metadata">
    <fullName>CumulusCI</fullName>
    <version>55.0</version>
</Package>
```

pytest results
```
pytest cumulusci/tasks/metadata/tests/test_package.py
================================================================================= test session starts ==================================================================================
platform darwin -- Python 3.10.4, pytest-7.0.1, pluggy-1.0.0
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /Users/jkunjoonju/v/src/cumulus-work/CumulusCI, configfile: pyproject.toml
plugins: random-order-1.0.4, vcr-1.0.2, Faker-15.0.0, typeguard-2.13.3, cov-4.0.0
collected 31 items                                                                                                                                                                     

cumulusci/tasks/metadata/tests/test_package.py ...............................                                                                                                   [100%]

================================================================================== 31 passed in 0.70s ==================================================================================
```