### PR TITLE
Datasets fixes

### DIFF
--- a/cumulusci/core/datasets.py
+++ b/cumulusci/core/datasets.py
@@ -130,7 +130,7 @@ class Dataset:
             else:
                 extraction_definition = self.extract_file
 
-                if not self.extract_file.exists():
+                if not self.extract_file.exists():  # pragma: no cover
                     self.extract_file.write_text(DEFAULT_EXTRACT_DATA)
             decls = ExtractRulesFile.parse_extract(extraction_definition)
 

--- a/cumulusci/core/datasets.py
+++ b/cumulusci/core/datasets.py
@@ -94,7 +94,6 @@ class Dataset:
         decls = ExtractRulesFile.parse_extract(StringIO(DEFAULT_EXTRACT_DATA))
 
         decls = list(decls.values())
-        self._save_load_mapping(decls)
 
     def _get_org_schema(self):
         return get_org_schema(
@@ -104,40 +103,62 @@ class Dataset:
             filters=[Filters.extractable, Filters.createable, Filters.populated],
         )
 
-    def _save_load_mapping(self, decls: T.Sequence[ExtractDeclaration]) -> None:
+    def _save_load_mapping(
+        self,
+        decls: T.Sequence[ExtractDeclaration],
+        opt_in_only: T.Sequence[str] = (),
+    ) -> None:
         assert isinstance(self.schema, Schema)
         mapping_data = create_load_mapping_file_from_extract_declarations(
-            decls, self.schema
+            decls, self.schema, opt_in_only
         )
         with self.mapping_file.open("w") as f:
             yaml.safe_dump(mapping_data, f, sort_keys=False)
 
     @contextmanager
-    def temp_extract_mapping(self, schema):
+    def temp_extract_mapping(
+        self,
+        schema,
+        extraction_definition: T.Optional[Path],
+        opt_in_only: T.Sequence[str],
+    ):
         with TemporaryDirectory() as t:
             t = Path(t)
-            if self.extract_file.exists():
-                f = self.extract_file
+            if extraction_definition:
+                assert extraction_definition.exists(), "Cannot find extract mapping {f}"
+                self.extract_file.write_text(extraction_definition.read_text())
             else:
-                f = StringIO(DEFAULT_EXTRACT_DATA)
-            decls = ExtractRulesFile.parse_extract(f)
+                extraction_definition = self.extract_file
+
+                if not self.extract_file.exists():
+                    self.extract_file.write_text(DEFAULT_EXTRACT_DATA)
+            decls = ExtractRulesFile.parse_extract(extraction_definition)
 
             extract_mapping = t / "extract.mapping.yml"
             with extract_mapping.open("w") as f:
                 yaml.safe_dump(
                     create_extract_mapping_file_from_declarations(
-                        list(decls.values()), schema
+                        list(decls.values()), schema, opt_in_only
                     ),
                     f,
                 )
             yield extract_mapping, decls
 
     def extract(
-        self, options: T.Optional[T.Dict] = None, logger: T.Optional[Logger] = None
+        self,
+        options: T.Optional[T.Dict] = None,
+        logger: T.Optional[Logger] = None,
+        extraction_definition: T.Optional[Path] = None,
+        opt_in_only: T.Sequence[str] = (),
     ):
         options = options or {}
         logger = logger or DEFAULT_LOGGER
-        with self.temp_extract_mapping(self.schema) as (extract_mapping, decls):
+        with self.temp_extract_mapping(
+            self.schema, extraction_definition, opt_in_only
+        ) as (
+            extract_mapping,
+            decls,
+        ):
             task = _make_task(
                 ExtractData,
                 project_config=self.project_config,
@@ -146,7 +167,7 @@ class Dataset:
                 mapping=str(extract_mapping),
             )
             task()
-        self._save_load_mapping(list(decls.values()))
+        self._save_load_mapping(list(decls.values()), opt_in_only)
         return task.return_values
 
     def _snowfakery_dataload(self, options: T.Dict, logger: Logger) -> T.Dict:
@@ -208,7 +229,11 @@ class Dataset:
                 objrepr[field] = is_selected
         return out
 
-    def update_schema_subset(self, objs: T.Dict[str, T.List[str]]):
+    def update_schema_subset(
+        self,
+        objs: T.Dict[str, T.List[str]],
+        opt_in_only: T.Sequence[str] = (),
+    ):
         # TODO: Test round-tripping through this carefully...especially
         #       for weird objects like WorkBadgeDefinitions
         objs_dict = {name: {"fields": fields} for name, fields in objs.items()}
@@ -219,7 +244,7 @@ class Dataset:
             SimplifiedExtractDeclaration(sf_object=name, fields=fields)
             for name, fields in objs.items()
         ]
-        self._save_load_mapping(decls)
+        self._save_load_mapping(decls, opt_in_only)
 
 
 def _make_task(task_class, project_config, org_config, **options):

--- a/cumulusci/core/tests/test_datasets_e2e.py
+++ b/cumulusci/core/tests/test_datasets_e2e.py
@@ -1,9 +1,12 @@
 import time
 from contextlib import contextmanager
+from pathlib import Path
 from shutil import rmtree
+from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 from cumulusci.core.datasets import Dataset
 from cumulusci.core.exceptions import BulkDataException
@@ -194,6 +197,53 @@ class TestDatasetsE2E:
             # Run an extract to the filesystem
             dataset.extract()
             timer.checkpoint("Extract")
+
+            if dataset.path.exists():
+                rmtree(dataset.path)
+
+    def test_datasets_read_explicit_extract_declaration(
+        self, sf, project_config, org_config, delete_data_from_org, ensure_accounts
+    ):
+        object_counts = {"Account": 6, "Contact": 1, "Opportunity": 5}
+        obj_describes = (
+            describe_for("Account"),
+            describe_for("Contact"),
+            describe_for("Opportunity"),
+        )
+        with patch.object(type(org_config), "is_person_accounts_enabled", False), patch(
+            "cumulusci.core.datasets.get_org_schema",
+            lambda _sf, org_config, **kwargs: _fake_get_org_schema(
+                org_config,
+                obj_describes,
+                object_counts,
+                included_objects=["Account", "Contact", "Opportunity"],
+                **kwargs,
+            ),
+        ), ensure_accounts(6), Dataset(
+            "bar", project_config, sf, org_config
+        ) as dataset:
+            if dataset.path.exists():
+                rmtree(dataset.path)
+
+            dataset.create()
+            with TemporaryDirectory() as t:
+                def_file = Path(t) / "test_extract_definition"
+                with open(def_file, "w") as f:
+                    yaml.safe_dump({"extract": {"Account": {"fields": "Name"}}}, f)
+
+                # Don't actually extract data.
+                with patch("cumulusci.tasks.bulkdata.ExtractData._run_task"):
+                    dataset.extract(extraction_definition=def_file)
+            with open(dataset.mapping_file) as p:
+                actual = yaml.safe_load(p)
+                expected = {
+                    "Insert Account": {
+                        "sf_object": "Account",
+                        "table": "Account",
+                        "fields": ["Name"],
+                    }
+                }
+                assert actual == expected, actual
 
             if dataset.path.exists():
                 rmtree(dataset.path)

--- a/cumulusci/salesforce_api/org_schema.py
+++ b/cumulusci/salesforce_api/org_schema.py
@@ -359,6 +359,9 @@ def get_org_schema(
 
     force_recache: True - replace cache. False (default) - use/update cache is available.
     logger - replace the standard logger "cumulusci.salesforce_api.org_schema"
+
+    This function take 5-20 seconds (or even more) depending on
+    the complexity of the org. Call it at most once per task!
     """
     assert not isinstance(patterns_to_ignore, str)
 

--- a/cumulusci/salesforce_api/org_schema_models.py
+++ b/cumulusci/salesforce_api/org_schema_models.py
@@ -211,7 +211,12 @@ class Field(OrgSchemaModelMixin, Base):
 
     @property
     def requiredOnCreate(self):
-        return not (self.nillable or self.defaultedOnCreate)
+        defaulted = (
+            self.defaultValue is not None  # has a real default value
+            or self.nillable  # None is a valid default value
+            or self.defaultedOnCreate  # defaulted some other way
+        )
+        return self.createable and not defaulted
 
 
 class FileMetadata(Base):

--- a/cumulusci/tasks/bulkdata/extract_dataset_utils/synthesize_extract_declarations.py
+++ b/cumulusci/tasks/bulkdata/extract_dataset_utils/synthesize_extract_declarations.py
@@ -32,7 +32,9 @@ class SimplifiedExtractDeclaration(ExtractDeclaration):
 
 
 def flatten_declarations(
-    declarations: T.Iterable[ExtractDeclaration], schema: Schema
+    declarations: T.Iterable[ExtractDeclaration],
+    schema: Schema,
+    opt_in_only: T.Sequence[str],
 ) -> T.List[SimplifiedExtractDeclaration]:
     """Convert short-form, abstract Extract declarations like this:
 
@@ -54,7 +56,9 @@ def flatten_declarations(
     from referenced tables recursively.
     """
     assert schema.includes_counts, "Schema object was not set up with `includes_counts`"
-    simplified_declarations = _simplify_sfobject_declarations(declarations, schema)
+    simplified_declarations = _simplify_sfobject_declarations(
+        declarations, schema, opt_in_only
+    )
 
     from .calculate_dependencies import extend_declarations_to_include_referenced_tables
 
@@ -66,7 +70,7 @@ def flatten_declarations(
 
 
 def _simplify_sfobject_declarations(
-    declarations, schema: Schema
+    declarations, schema: Schema, opt_in_only: T.Sequence[str]
 ) -> T.List[SimplifiedExtractDeclaration]:
     """Generate a new list of declarations such that all sf_object patterns
     (like OBJECTS(CUSTOM)) have been expanded into many declarations
@@ -79,7 +83,7 @@ def _simplify_sfobject_declarations(
         atomic_declarations, DEFAULT_DECLARATIONS
     )
     atomized_declarations = _merge_group_declarations_with_simple_declarations(
-        normalized_atomic_declarations, group_declarations, schema
+        normalized_atomic_declarations, group_declarations, schema, opt_in_only
     )
     simplifed_declarations = [
         _expand_field_definitions(decl, schema[decl.sf_object].fields)
@@ -93,6 +97,7 @@ def _merge_group_declarations_with_simple_declarations(
     simple_declarations: T.Iterable[ExtractDeclaration],
     group_declarations: T.Iterable[ExtractDeclaration],
     schema: Schema,
+    opt_in_only: T.Sequence[str],
 ) -> T.List[ExtractDeclaration]:
     """Expand group declarations to simple declarations and merge
     with existing simple declarations"""
@@ -106,9 +111,12 @@ def _merge_group_declarations_with_simple_declarations(
     ]
     for decl_set in simplified_declarations:
         for decl in decl_set:
-            if decl.sf_object not in specific_sobject_decl_names and not any(
+            already_specified = decl.sf_object in specific_sobject_decl_names
+            hard_banned = any(
                 re.match(pat, decl.sf_object, re.IGNORECASE) for pat in NOT_EXTRACTABLE
-            ):
+            )
+            opted_out = decl.sf_object in opt_in_only
+            if not (already_specified or hard_banned or opted_out):
                 simple_declarations.append(decl)
 
     return simple_declarations
@@ -171,7 +179,9 @@ def _expand_field_definitions(
 
     # add in all of the required fields
     declarations.extend(
-        field.name for field in schema_fields.values() if required(field)
+        field.name
+        for field in schema_fields.values()
+        if field.requiredOnCreate and field.name not in declarations
     )
     # get rid of OwnerId because we don't move users between orgs
     if "OwnerId" in declarations:

--- a/cumulusci/tasks/bulkdata/extract_dataset_utils/synthesize_extract_declarations.py
+++ b/cumulusci/tasks/bulkdata/extract_dataset_utils/synthesize_extract_declarations.py
@@ -34,7 +34,7 @@ class SimplifiedExtractDeclaration(ExtractDeclaration):
 def flatten_declarations(
     declarations: T.Iterable[ExtractDeclaration],
     schema: Schema,
-    opt_in_only: T.Sequence[str],
+    opt_in_only: T.Sequence[str] = (),
 ) -> T.List[SimplifiedExtractDeclaration]:
     """Convert short-form, abstract Extract declarations like this:
 

--- a/cumulusci/tasks/bulkdata/generate_mapping_utils/extract_mapping_file_generator.py
+++ b/cumulusci/tasks/bulkdata/generate_mapping_utils/extract_mapping_file_generator.py
@@ -30,12 +30,12 @@ def _mapping_decl_for_extract_decl(
 
 
 def create_extract_mapping_file_from_declarations(
-    decls: T.List[ExtractDeclaration], schema: Schema
+    decls: T.List[ExtractDeclaration], schema: Schema, opt_in_only: T.Sequence[str]
 ):
     """Create a mapping file sufficient for driving an extract process
     from an extract declarations file."""
     assert decls is not None
-    simplified_decls = flatten_declarations(decls, schema)
+    simplified_decls = flatten_declarations(decls, schema, opt_in_only)
     simplified_decls = classify_and_filter_lookups(simplified_decls, schema)
     mappings = [_mapping_decl_for_extract_decl(decl) for decl in simplified_decls]
     return dict(pair for pair in mappings if pair)

--- a/cumulusci/tasks/bulkdata/generate_mapping_utils/generate_mapping_from_declarations.py
+++ b/cumulusci/tasks/bulkdata/generate_mapping_utils/generate_mapping_from_declarations.py
@@ -22,9 +22,10 @@ class SimplifiedExtractDeclarationWithLookups(SimplifiedExtractDeclaration):
 def create_load_mapping_file_from_extract_declarations(
     decls: T.Sequence[ExtractDeclaration],
     schema: Schema,
+    opt_in_only: T.Sequence[str] = (),
 ) -> T.Dict[str, dict]:
     """Create a mapping file from Extract declarations"""
-    simplified_decls = flatten_declarations(decls, schema)
+    simplified_decls = flatten_declarations(decls, schema, opt_in_only)  # FIXME
     simplified_decls_w_lookups = classify_and_filter_lookups(simplified_decls, schema)
     intertable_dependencies = _discover_dependendencies(simplified_decls_w_lookups)
 

--- a/cumulusci/tasks/bulkdata/generate_mapping_utils/tests/test_generate_extract_mapping_from_declarations.py
+++ b/cumulusci/tasks/bulkdata/generate_mapping_utils/tests/test_generate_extract_mapping_from_declarations.py
@@ -28,7 +28,7 @@ class TestGenerateLoadMappingFromDeclarations:
             filters=[],
             include_counts=True,
         ) as schema:
-            mf = create_extract_mapping_file_from_declarations(declarations, schema)
+            mf = create_extract_mapping_file_from_declarations(declarations, schema, ())
             assert mf == {
                 "Extract Account": {
                     "sf_object": "Account",
@@ -55,7 +55,7 @@ class TestGenerateLoadMappingFromDeclarations:
             filters=[],
             include_counts=True,
         ) as schema:
-            mf = create_extract_mapping_file_from_declarations(declarations, schema)
+            mf = create_extract_mapping_file_from_declarations(declarations, schema, ())
             print(mf)
             assert mf == {
                 "Extract Account": {

--- a/cumulusci/tasks/sample_data/capture_sample_data.py
+++ b/cumulusci/tasks/sample_data/capture_sample_data.py
@@ -1,5 +1,8 @@
+from pathlib import Path
+
 from cumulusci.core.config.org_config import OrgConfig
 from cumulusci.core.datasets import Dataset
+from cumulusci.core.exceptions import TaskOptionsError
 from cumulusci.salesforce_api.org_schema import Filters, get_org_schema
 from cumulusci.tasks.salesforce.BaseSalesforceApiTask import BaseSalesforceApiTask
 
@@ -45,6 +48,21 @@ class CaptureSampleData(BaseSalesforceApiTask):
                 verb = "Created"
             else:
                 verb = "Updated"
-            self.return_values = dataset.extract({}, self.logger)
+            if extraction_definition := self.options.get("extraction_definition"):
+                extraction_definition = Path(extraction_definition)
+                if not extraction_definition.exists():
+                    raise TaskOptionsError(f"Cannot find {extraction_definition}")
+            opt_in_only = [f["name"] for f in self.tooling.describe()["sobjects"]]  # type: ignore
+            opt_in_only += [
+                "FeedItem",
+                "Translation",
+                "WebLinkLocalization",
+                "RecordTypeLocalization",
+                "RecordType",
+                "BrandTemplate",
+            ]
+            self.return_values = dataset.extract(
+                {}, self.logger, extraction_definition, opt_in_only
+            )
             self.logger.info(f"{verb} dataset '{name}' in 'datasets/{name}'")
             return self.return_values

--- a/cumulusci/tasks/sample_data/capture_sample_data.py
+++ b/cumulusci/tasks/sample_data/capture_sample_data.py
@@ -31,6 +31,10 @@ class CaptureSampleData(BaseSalesforceApiTask):
 
     def _run_task(self):
         name = self.options["dataset"]
+        if extraction_definition := self.options.get("extraction_definition"):
+            extraction_definition = Path(extraction_definition)
+            if not extraction_definition.exists():
+                raise TaskOptionsError(f"Cannot find {extraction_definition}")
         with get_org_schema(
             self.sf,
             self.org_config,
@@ -48,10 +52,6 @@ class CaptureSampleData(BaseSalesforceApiTask):
                 verb = "Created"
             else:
                 verb = "Updated"
-            if extraction_definition := self.options.get("extraction_definition"):
-                extraction_definition = Path(extraction_definition)
-                if not extraction_definition.exists():
-                    raise TaskOptionsError(f"Cannot find {extraction_definition}")
             opt_in_only = [f["name"] for f in self.tooling.describe()["sobjects"]]  # type: ignore
             opt_in_only += [
                 "FeedItem",


### PR DESCRIPTION
1. Tighten up the definition of "required field" and ensure it is consistent across the code base. (Field.requiredOnCreate)

2. Do not load sobjects which are also tooling objects. Tooling objects are generally loaded as metadata so loading them as data causes duplicate errors. The user can opt-in in their extract declaration if they want them.

3. Do not load sobjects which are known to cause problems unless the user opts-in. So far there are six such items.

4. Previously I had forgotten to respect the situation where a user supplied an extract declaration as an option. Fixed now.