### PR TITLE
Ensure that products have a slug before publishing translations

### DIFF
--- a/cumulusci/tasks/metadeploy.py
+++ b/cumulusci/tasks/metadeploy.py
@@ -103,6 +103,11 @@ class Publish(BaseMetaDeployTask):
             raise CumulusCIException(
                 f"No product found in MetaDeploy with repo URL {repo_url}"
             )
+        elif not product.get("slug"):  # pragma: no cover
+            raise CumulusCIException(
+                f"No slug found in MetaDeploy for product {product} from {repo_url}"
+            )
+
         if not self.dry_run:
             version = self._find_or_create_version(product)
             if self.labels_path and "slug" in product:
@@ -363,8 +368,9 @@ class Publish(BaseMetaDeployTask):
             self.logger.info(f"Updating labels in {labels_path}")
             labels_path.write_text(json.dumps(self.labels, indent=4))
 
-    def _publish_labels(self, slug):
+    def _publish_labels(self, slug: str):
         """Publish labels in all languages to MetaDeploy."""
+        assert isinstance(slug, str), f"Slug should be a string, not {slug}"
         for path in Path(self.labels_path).glob("*.json"):
             lang = path.stem.split("_")[-1].lower()
             if lang in ("en", "en-us"):


### PR DESCRIPTION
We have evidence that product translations are being published for products that don't have slugs.

Per David Glick, "a product should have at least one slug and if it’s None, something isn’t set up correctly."

If translations are published while the Product is in this weird state, you get weird translations:

```python
>>> Translation.objects.filter(context__startswith="None").first().context
'None:product'
>>> Translation.objects.filter(context__startswith="None").count()
184
>>> set(c.context for c in Translation.objects.filter(context__startswith="None"))
{'None:plan:ra_einstein_template', 'None:plan:install', 'None:steps', 'None:checks', 'None:product'}
```

We believe this to be the source of web interfaces that are mistranslated.

This code is intended to prevent all of that. 
