### PR TITLE
Run flow with option for project custom attributes

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -36,3 +36,4 @@ For example:
 
 * Ed Rivas (jerivas)
 * Gustavo Tandeciarz (dcinzona)
+* Rupert Barrow (rupertbarrow)

--- a/cumulusci/cli/flow.py
+++ b/cumulusci/cli/flow.py
@@ -137,6 +137,12 @@ def flow_info(runtime, flow_name):
     help="Pass task specific options for the task as '-o taskname__option value'.  You can specify more than one option by using -o more than once.",
 )
 @click.option(
+    "-op",
+    nargs=2,
+    multiple=True,
+    help="Pass project custom attributes as '-o project__custom__myattribute value'.  You can specify more than one attribute by using -op more than once.",
+)
+@click.option(
     "--no-prompt",
     is_flag=True,
     help="Disables all prompts.  Set for non-interactive mode use such as calling from scripts or CI systems",
@@ -159,6 +165,15 @@ def flow_run(runtime, flow_name, org, delete_org, debug, o, no_prompt):
             else:
                 raise click.UsageError(
                     "-o option for flows should contain __ to split task name from option name."
+                )
+    if op:
+        for key, value in o:
+            if "__" in key:
+                projectword, customword, project_custom_attribute = key.split("__")
+                runtime.project_config["custom"][project_custom_attribute] = value
+            else:
+                raise click.UsageError(
+                    "-op option for flows should contain __ to split project__custom__attribute parts."
                 )
 
     # Create the flow and handle initialization exceptions

--- a/docs/org_config-reference.md
+++ b/docs/org_config-reference.md
@@ -1,0 +1,30 @@
+# org_config Object Reference
+
+The `org_config` object can be used in the `cumulusci.yml` file to read a large number number of attributes of the Salesforce org currently used. For example, in a [custom flow step](https://cumulusci.readthedocs.io/en/stable/config.html#add-a-flow-step), you can use a `when`clause to adapt the behavior of the new step to the type of org (scratch org or not) by referencing the `org_config.scratch` attribute.
+
+## org_config Object Attributes
+
+-   `scratch` : true indicates the org is a scratch org. False indicates it is a persistent org
+-   `is_person_accounts_enabled` : `true` or `false`
+-   `installed_packages` : comma-separated list of package names
+-   `org_id` : orgid of the Salesforce org
+-   `namespace` : namespace of the org
+-   `namespaced` : `true` if the org has a namespace
+-   `instance_url` : eg https://crazy-demo.scratch.my.salesforce.com
+-   `access_token` : access token currently used to authenticate with Salesforce
+-   `username` : username of the current Salesforce user
+-   `user_id` : user id of the current Salesforce user
+-   `is_multiple_currencies_enabled`: `true` or `false`
+-   `is_advanced_currency_management_enabled` : `true` or `false`
+-   `org_type` : eg "Enterprise Edition" or "Developer Edition"
+-   `is_sandbox` : `true` if the org is a sandbox
+-   `organization_sobject` : whole Organization SObject (see the [Salesforce documentation for the Organization SObject](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_organization.htm))
+
+Also :
+
+-   `name`
+-   `start_url`
+-   `sfdx_alias`
+-   `config_file`
+-   `lightning_base_url`
+-   `latest_api_version`

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -8,5 +8,5 @@ maxdepth: 1
 cheat-sheet
 tasks
 flows
-env_var_reference
+env-var-reference
 ```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -9,4 +9,5 @@ cheat-sheet
 tasks
 flows
 env-var-reference
+org_config-reference
 ```


### PR DESCRIPTION
This adds the "-op" option to the "cci flow run" command, to pass a project__custom__attribute value.
For example : 
```
cci flow run myflow -o project__custom__destination US
```

It may be preferable to use a different option than "-op", but I thought that "-p" would be confusing because often used to pass a path.