### PR TITLE
Stricter check on what counts as a dataset

### DIFF
--- a/cumulusci/tasks/sample_data/load_sample_data.py
+++ b/cumulusci/tasks/sample_data/load_sample_data.py
@@ -42,7 +42,7 @@ class LoadSampleData(BaseSalesforceApiTask):
             self.org_config,
             schema,
         ) as dataset:
-            self.return_values = dataset.load(self.options, self.logger)
+            self.return_values = dataset.load(self.options, self.logger) or {}
         return self.return_values
 
     def _find_dataset(self) -> Optional[str]:
@@ -61,7 +61,9 @@ class LoadSampleData(BaseSalesforceApiTask):
         config_name = self.org_config.lookup("config_name")
         if config_name:
             config_dsf = dataset_for_name(config_name)
-            if config_dsf.exists():
+            if config_dsf.exists() and (
+                config_dsf.data_file.exists() or config_dsf.snowfakery_recipe.exists()
+            ):
                 return config_name
             else:
                 checked_folders.append(config_dsf.path)


### PR DESCRIPTION
Fix an error where a project had a /datasets/qa/ subdirectory which was not intended to be a real dataset. It was always the intent that such directories would be ignored but that code was not ported from `load.py` to `load_sample_data.py`.