### PR TITLE
Re-order release notes config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,6 +7,9 @@ changelog:
         authors:
             - app/github-actions
     categories:
+        - title: Issues Fixed 🩴
+          labels:
+              - bug
         - title: Critical Changes 🛠
           labels:
               - critical-change
@@ -14,6 +17,3 @@ changelog:
           labels:
               - enhancement
               - "*"
-        - title: Issues Fixed 🩴
-          labels:
-              - bug


### PR DESCRIPTION
We think the wildcard is clobbering the last entry.