### PR TITLE
Exclude label from release notes generator

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,9 +7,6 @@ changelog:
         authors:
             - app/github-actions
     categories:
-        - title: Issues Fixed 🩴
-          labels:
-              - bug
         - title: Critical Changes 🛠
           labels:
               - critical-change
@@ -17,3 +14,9 @@ changelog:
           labels:
               - enhancement
               - "*"
+          exclude:
+              labels:
+                  - bug
+        - title: Issues Fixed 🩴
+          labels:
+              - bug


### PR DESCRIPTION
I'm pretty sure this changed silently, but this is the [documented] way to
do it.

[documented]: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configurations
