### PR TITLE
Include readme fragments in source distribution 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,8 @@ include = [
 include = [
     "/cumulusci",
     "/requirements/*", # Needed by tox
+    "README.md", # needed by hatch-fancy-pypi-readme
+    "docs/history.md" # ditto
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
If not included the sdist will not be installable, and will fail with:

```
hatch_fancy_pypi_readme.exceptions.ConfigurationError:
["Fragment file 'README.md' not found.", "Fragment file 'docs/history.md' not found."]
```