### PR TITLE
Force inclusion of pytest plugins in wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,8 @@ include = [
 [tool.hatch.build.targets.wheel]
 exclude = [
     "tests/",
+    "!/cumulusci/tests", # Snowfakery uses our pytest plugins
+    "!/cumulusci/tasks/bulkdata/tests",
     "*.sql",
     "*.zip"
 ]


### PR DESCRIPTION
Snowfakery depends on some of CumulusCI's pytest plugins for integration
tests. This adds about 175 kB to the size of the wheel.
