### PR TITLE
Mask invalid oauth token

### DIFF
--- a/cumulusci/oauth/client.py
+++ b/cumulusci/oauth/client.py
@@ -354,7 +354,7 @@ def get_device_oauth_token(
     from the auth server.
     @returns a dict including the access token.
     {
-        "access_token": "gho_16C7e42F292c6912E7710c838347Ae178B4a",
+        "access_token": "gho_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
         "token_type": "bearer",
         "scope": "user"
     }


### PR DESCRIPTION
Apparently this triggered a security scan. Replaces the string with 'x'
and removes a character to fool the regex.
