### PR TITLE
Include nearly everything in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,9 +116,6 @@ include = [
 
 [tool.hatch.build.targets.wheel]
 exclude = [
-    "tests/",
-    "!/cumulusci/tests", # Snowfakery uses our pytest plugins
-    "!/cumulusci/tasks/bulkdata/tests",
     "*.sql",
     "*.zip"
 ]


### PR DESCRIPTION
Removing tests from the wheel broke the `cci project init` command.
There may be other hidden dependencies and the tradeoffs in playing
whack-a-mole with issues caused by hidden dependencies on test code have
outweighed the savings in bandwidth and artifact size.
