### PR TITLE
Add Homebrew python upgrade error workaround to docs

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -37,6 +37,10 @@ After `pipx` installs, install CumulusCI:
 $ pipx install cumulusci
 ```
 
+```{note}
+Upgrading Homebrew's Python version can result in a `bad interpreter` error. To resolve this, run `pipx reinstall cumulusci`.
+```
+
 When finished, [verify your installation](verify-your-installation).
 
 ### On Linux


### PR DESCRIPTION
Homebrew users periodically experience `bad interpreter` errors after an upgrade. This PR documents the fix for users.

See also: pypa/pipx#886