### PR TITLE
Feature/metadata api support

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -36,3 +36,4 @@ For example:
 
 * Ed Rivas (jerivas)
 * Gustavo Tandeciarz (dcinzona)
+* Kai Amundsen (yippie)

--- a/cumulusci/tasks/salesforce/BaseSalesforceApiTask.py
+++ b/cumulusci/tasks/salesforce/BaseSalesforceApiTask.py
@@ -14,6 +14,7 @@ class BaseSalesforceApiTask(BaseSalesforceTask):
         self.sf = self._init_api()
         self.bulk = self._init_bulk()
         self.tooling = self._init_api("tooling")
+        self.mdapi = self._init_api().mdapi
         self._init_class()
 
     def _init_api(self, base_url=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "salesforce-bulk",
     "sarge",
     "selenium<4",
-    "simple-salesforce==1.11.4",
+    "simple-salesforce==1.12.3",
     "snowfakery",
     "SQLAlchemy",
     "xmltodict",

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -277,7 +277,7 @@ selenium==3.141.0
     # via
     #   cumulusci (pyproject.toml)
     #   robotframework-seleniumlibrary
-simple-salesforce==1.11.4
+simple-salesforce==1.12.3
     # via
     #   cumulusci (pyproject.toml)
     #   salesforce-bulk

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -148,7 +148,7 @@ selenium==3.141.0
     # via
     #   cumulusci (pyproject.toml)
     #   robotframework-seleniumlibrary
-simple-salesforce==1.11.4
+simple-salesforce==1.12.3
     # via
     #   cumulusci (pyproject.toml)
     #   salesforce-bulk


### PR DESCRIPTION
simple-salesforce dependency in cci is very old (from 2019) Since then they have added a very handy and extensive mdapi feature.

## Changes
- bump simple-salesforce version from 1.11.4 to 1.12.3 (latest)
- added new self.mdapi to BaseSalesforceApiTask which has the new simple-salesforce mdapi connection