### PR TITLE
New Option `resolve_sfdx_package_dirs` for dx_convert_from Task

### DIFF
--- a/cumulusci/tasks/dx_convert_from.py
+++ b/cumulusci/tasks/dx_convert_from.py
@@ -25,9 +25,9 @@ class DxConvertFrom(SFDXBaseTask):
         self.options["command"] = f"force:source:convert -d {self.options['src_dir']}"
 
         if self.options["resolve_sfdx_package_dirs"]:
-            package_directories = self._resolve_sfdx_package_dirs()
-            if package_directories:
-                self.options["command"] += f" --sourcepath {package_directories}"
+            path_string = self._resolve_sfdx_package_dirs()
+            if path_string:
+                self.options["command"] += f" --sourcepath {path_string}"
 
     def _run_task(self):
         src_dir = Path(self.options["src_dir"])
@@ -36,7 +36,7 @@ class DxConvertFrom(SFDXBaseTask):
         super()._run_task()
 
     def _resolve_sfdx_package_dirs(self):
-        return ",".join(
+        path_string = ",./".join(
             [
                 node["path"]
                 for node in self.project_config.sfdx_project_config.get(
@@ -44,3 +44,6 @@ class DxConvertFrom(SFDXBaseTask):
                 )
             ]
         )
+        if path_string:
+            return f"./{path_string}"
+        return ""

--- a/cumulusci/tasks/dx_convert_from.py
+++ b/cumulusci/tasks/dx_convert_from.py
@@ -5,8 +5,13 @@ from cumulusci.tasks.sfdx import SFDXBaseTask
 
 
 class DxConvertFrom(SFDXBaseTask):
+    """Call the sfdx cli to convert sfdx source format to mdapi format"""
+
     task_options = {
         "extra": {"description": "Append additional options to the command"},
+        "resolve_sfdx_package_dirs": {
+            "description": "If True, will resolve package directory paths in sfdx-project.json and append them to the source:convert command via --sourcepath. If you need to use --sourcepath, use the extra option to pass the --sourcepath argument instead of this option",
+        },
         "src_dir": {
             "description": "The path to the src directory where converted contents will be stored. Defaults to src/",
             "required": True,
@@ -16,11 +21,26 @@ class DxConvertFrom(SFDXBaseTask):
     def _init_options(self, kwargs):
         super()._init_options(kwargs)
 
-        # append command  -d option to sfdx} force:source:convert
+        # append command  -d option to sfdx force:source:convert
         self.options["command"] = f"force:source:convert -d {self.options['src_dir']}"
+
+        if self.options["resolve_sfdx_package_dirs"]:
+            package_directories = self._resolve_sfdx_package_dirs()
+            if package_directories:
+                self.options["command"] += f" --sourcepath {package_directories}"
 
     def _run_task(self):
         src_dir = Path(self.options["src_dir"])
         if src_dir.exists():
             shutil.rmtree(src_dir)
         super()._run_task()
+
+    def _resolve_sfdx_package_dirs(self):
+        return ",".join(
+            [
+                node["path"]
+                for node in self.project_config.sfdx_project_config.get(
+                    "packageDirectories", []
+                )
+            ]
+        )

--- a/cumulusci/tasks/tests/test_dx_convert_from.py
+++ b/cumulusci/tasks/tests/test_dx_convert_from.py
@@ -16,8 +16,9 @@ from cumulusci.utils import temporary_dir
 def sfdx_project_config():
     dx_project_config = {
         "packageDirectories": [
-            {"default": True, "path": "main/default"},
+            {"default": True, "path": "force-app"},
             {"path": "libs/helper"},
+            {"path": "libs/mdapiservice"},
         ]
     }
     with mock.patch.object(
@@ -69,7 +70,7 @@ def test_dx_convert_from(sarge, sarge_process, dx_convert_task):
 
         assert not src_dir.exists()
         sarge.Command.assert_called_once_with(
-            "sfdx force:source:convert -d src --sourcepath main/default,libs/helper",
+            "sfdx force:source:convert -d src --sourcepath ./force-app,./libs/helper,./libs/mdapiservice",
             cwd=".",
             env=ANY,
             shell=True,

--- a/cumulusci/tasks/tests/test_dx_convert_from.py
+++ b/cumulusci/tasks/tests/test_dx_convert_from.py
@@ -13,7 +13,23 @@ from cumulusci.utils import temporary_dir
 
 
 @pytest.fixture
-def project_config():
+def sfdx_project_config():
+    dx_project_config = {
+        "packageDirectories": [
+            {"default": True, "path": "main/default"},
+            {"path": "libs/helper"},
+        ]
+    }
+    with mock.patch.object(
+        BaseProjectConfig,
+        "sfdx_project_config",
+        new_callable=mock.PropertyMock(return_value=dx_project_config),
+    ) as sfdx_project_config:
+        yield sfdx_project_config
+
+
+@pytest.fixture
+def project_config(sfdx_project_config):
     universal_config = UniversalConfig()
     project_config = BaseProjectConfig(universal_config, config={"no_yaml": True})
     project_config.project__name = "TestProject"
@@ -22,7 +38,9 @@ def project_config():
 
 @pytest.fixture
 def task_config():
-    return TaskConfig({"options": {"src_dir": "src"}})
+    return TaskConfig(
+        {"options": {"src_dir": "src", "resolve_sfdx_package_dirs": True}}
+    )
 
 
 @pytest.fixture
@@ -41,7 +59,7 @@ def dx_convert_task(project_config, task_config):
 
 @mock.patch("cumulusci.tasks.command.sarge")
 def test_dx_convert_from(sarge, sarge_process, dx_convert_task):
-    """Ensure that we clear out the `src/`"""
+    """Ensure that we clear out the `src/` dir and that sfdx packageDirectories were resolved"""
     with temporary_dir():
         src_dir = Path("src")
         src_dir.mkdir(exist_ok=True)
@@ -51,7 +69,7 @@ def test_dx_convert_from(sarge, sarge_process, dx_convert_task):
 
         assert not src_dir.exists()
         sarge.Command.assert_called_once_with(
-            "sfdx force:source:convert -d src",
+            "sfdx force:source:convert -d src --sourcepath main/default,libs/helper",
             cwd=".",
             env=ANY,
             shell=True,


### PR DESCRIPTION
Addresses #3543 

`dx_convert_from` has a new option `resolve_sfdx_package_dirs`

Usage Example:

Given a `sfdx-project.json` with several package directories
```
{
  "packageDirectories": [
    {
      "path": "my-app",
      "default": true
    },
    {
      "path": "libs/helper"
    }
  ],
  "namespace": "",
  "sfdcLoginUrl": "https://login.salesforce.com",
  "sourceApiVersion": "56.0"
}
```

```
cci task run dx_convert_from --resolve_sfdx_package_dirs True
```

Will result in the following dx command:

```
sfdx force:source:convert -d src --sourcepath ./my-app,./libs/helper
```

 