### PR TITLE
The `capture_sample_data` task now looks for a `datasetname.load.yml` file to influence how it generates its .mapping file

### DIFF
--- a/cumulusci/core/datasets.py
+++ b/cumulusci/core/datasets.py
@@ -123,6 +123,7 @@ class Dataset:
             decls, self.schema, opt_in_only, loading_rules
         )
         with self.mapping_file.open("w") as f:
+            f.write(EDIT_MAPPING_WARNING)
             yaml.safe_dump(mapping_data, f, sort_keys=False)
 
     @contextmanager
@@ -186,6 +187,8 @@ class Dataset:
     def _parse_loading_rules_file(
         self, loading_rules_file: T.Optional[Path]
     ) -> T.List[SObjectRuleDeclaration]:
+        """Parse a loading rules file if provided, else try to parse
+        <datasets/dataset/dataset.load.yml>"""
         if loading_rules_file:
             assert loading_rules_file.exists()
         else:
@@ -225,7 +228,8 @@ class Dataset:
             self._snowfakery_dataload(options, logger)
         else:  # pragma: no cover
             raise exc.BulkDataException(
-                f"Dataset has no SQL ({self.data_file}) or recipe ({self.snowfakery_recipe})"
+                f"Dataset has no SQL ({self.data_file}) "
+                "or recipe ({self.snowfakery_recipe})"
             )
 
     def _sql_dataload(self, options: T.Dict):
@@ -287,4 +291,13 @@ DEFAULT_EXTRACT_DATA = """
 extract:
     OBJECTS(ALL):
         fields: FIELDS(ALL)
+"""
+
+EDIT_MAPPING_WARNING = """# Editing this file is usually not recommended because it will
+# be overwritten the next time you re-capture this data.
+#
+# You can change this file's contents permanently by creating a
+# .load.yml file and re-capturing:
+#
+#  https://cumulusci.readthedocs.io/en/stable/data.html#extracting-and-loading-sample-datasets
 """

--- a/cumulusci/salesforce_api/filterable_objects.py
+++ b/cumulusci/salesforce_api/filterable_objects.py
@@ -1,3 +1,17 @@
+# discovered by trial and error. Usually extended with a list of
+# tooling objects. i.e. any object which is both a tooling object
+# and also a "regular" sobject will be skipped.
+OPT_IN_ONLY = [
+    "ApexClass",
+    "ApexTrigger",
+    "FeedItem",
+    "Translation",
+    "WebLinkLocalization",
+    "RecordTypeLocalization",
+    "RecordType",
+    "BrandTemplate",
+]
+
 NOT_COUNTABLE = (
     "ContentDocumentLink",  # ContentDocumentLink requires a filter by a single Id on ContentDocumentId or LinkedEntityId
     "ContentFolderItem",  # Implementation restriction: ContentFolderItem requires a filter by Id or ParentContentFolderId

--- a/cumulusci/tasks/bulkdata/generate_mapping_utils/dependency_map.py
+++ b/cumulusci/tasks/bulkdata/generate_mapping_utils/dependency_map.py
@@ -77,6 +77,7 @@ def _sort_by_dependencies(
             for table in table_names
             if _table_is_free(table, dependencies, sorted_tables, priority)
         ]
+        print("LF", leaf_tables)
         sorted_tables.extend(leaf_tables)
         table_names = [table for table in table_names if table not in sorted_tables]
 

--- a/cumulusci/tasks/bulkdata/generate_mapping_utils/dependency_map.py
+++ b/cumulusci/tasks/bulkdata/generate_mapping_utils/dependency_map.py
@@ -77,7 +77,6 @@ def _sort_by_dependencies(
             for table in table_names
             if _table_is_free(table, dependencies, sorted_tables, priority)
         ]
-        print("LF", leaf_tables)
         sorted_tables.extend(leaf_tables)
         table_names = [table for table in table_names if table not in sorted_tables]
 

--- a/cumulusci/tasks/bulkdata/generate_mapping_utils/generate_mapping_from_declarations.py
+++ b/cumulusci/tasks/bulkdata/generate_mapping_utils/generate_mapping_from_declarations.py
@@ -1,6 +1,8 @@
 import typing as T
 from itertools import chain
 
+from snowfakery.cci_mapping_files.declaration_parser import SObjectRuleDeclaration
+
 from cumulusci.salesforce_api.org_schema import Schema
 from cumulusci.tasks.bulkdata.mapping_parser import MappingStep
 from cumulusci.utils.collections import OrderedSet
@@ -23,6 +25,7 @@ def create_load_mapping_file_from_extract_declarations(
     decls: T.Sequence[ExtractDeclaration],
     schema: Schema,
     opt_in_only: T.Sequence[str] = (),
+    loading_rules: T.Sequence[SObjectRuleDeclaration] = (),
 ) -> T.Dict[str, dict]:
     """Create a mapping file from Extract declarations"""
     simplified_decls = flatten_declarations(decls, schema, opt_in_only)  # FIXME
@@ -39,7 +42,9 @@ def create_load_mapping_file_from_extract_declarations(
 
     mapping_steps = [_mapping_step(decl) for decl in simplified_decls_w_lookups]
 
-    mappings = generate_load_mapping_file(mapping_steps, intertable_dependencies, [])
+    mappings = generate_load_mapping_file(
+        mapping_steps, intertable_dependencies, loading_rules
+    )
     return mappings
 
 

--- a/cumulusci/tasks/bulkdata/generate_mapping_utils/load_mapping_file_generator.py
+++ b/cumulusci/tasks/bulkdata/generate_mapping_utils/load_mapping_file_generator.py
@@ -29,13 +29,13 @@ from .mapping_generator_post_processes import add_after_statements
 def generate_load_mapping_file(
     mapping_steps: T.Sequence[MappingStep],
     intertable_dependencies: OrderedSetType[SObjDependency],
-    load_declarations: T.List[SObjectRuleDeclaration] = None,
+    load_declarations: T.Sequence[SObjectRuleDeclaration] = (),
 ) -> T.Dict[str, dict]:
     """Generate a mapping file in optimal order with forward references etc.
 
     Input is a set of a tables, dependencies between them and load declarations"""
 
-    load_declarations = load_declarations or []
+    load_declarations = list(load_declarations) or []
     declared_dependencies = collect_user_specified_dependencies(load_declarations)
     table_names = OrderedSet(mapping.sf_object for mapping in mapping_steps)
     depmap = DependencyMap(

--- a/cumulusci/tasks/bulkdata/mapping_parser.py
+++ b/cumulusci/tasks/bulkdata/mapping_parser.py
@@ -548,9 +548,16 @@ class MappingStep(CCIDictModel):
             by_alias=by_alias, exclude_defaults=exclude_defaults, **kwargs
         )
         if fields := out.get("fields"):
+            # Convert dicts of {"Name": "Name", "Role": "Role"}
+            # (an old-fashioned syntax)
+            # into a more modern ["Name", "Role"] -type format.
             keys = list(fields.keys())
             if keys == list(fields.values()):
                 out["fields"] = keys
+
+        # flatten enum to string
+        if isinstance(out.get("api"), DataApi):
+            out["api"] = out["api"].value
         return out
 
 

--- a/cumulusci/tasks/sample_data/capture_sample_data.py
+++ b/cumulusci/tasks/sample_data/capture_sample_data.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from cumulusci.core.config.org_config import OrgConfig
 from cumulusci.core.datasets import Dataset
 from cumulusci.core.exceptions import TaskOptionsError
+from cumulusci.salesforce_api.filterable_objects import OPT_IN_ONLY
 from cumulusci.salesforce_api.org_schema import Filters, get_org_schema
 from cumulusci.tasks.salesforce.BaseSalesforceApiTask import BaseSalesforceApiTask
 
@@ -67,14 +68,7 @@ class CaptureSampleData(BaseSalesforceApiTask):
             else:
                 verb = "Updated"
             opt_in_only = [f["name"] for f in self.tooling.describe()["sobjects"]]  # type: ignore
-            opt_in_only += [
-                "FeedItem",
-                "Translation",
-                "WebLinkLocalization",
-                "RecordTypeLocalization",
-                "RecordType",
-                "BrandTemplate",
-            ]
+            opt_in_only += OPT_IN_ONLY
 
             self.return_values = dataset.extract(
                 {}, self.logger, extraction_definition, opt_in_only, loading_rules

--- a/cumulusci/tasks/sample_data/test_capture_sample_data.py
+++ b/cumulusci/tasks/sample_data/test_capture_sample_data.py
@@ -75,12 +75,17 @@ class TestCaptureDatasets:
             with open(extraction_definition, "w") as f:
                 f.write("")  # Doesn't matter. We won't parse it
 
+            loading_rules = Path(t) / "test_load_definition"
+            with open(loading_rules, "w") as f:
+                f.write("[]")  # Doesn't matter. We won't parse it
+
             Dataset().__enter__().path.exists.return_value = False
             task = create_task(
                 CaptureSampleData,
                 {
                     "dataset": "mydataset",
                     "extraction_definition": extraction_definition,
+                    "loading_rules": loading_rules,
                 },
             )
             task()
@@ -91,7 +96,7 @@ class TestCaptureDatasets:
             Dataset().__enter__().create.assert_called_with()
             # and extracted
             Dataset().__enter__().extract.assert_called_with(
-                {}, task.logger, extraction_definition, mock.ANY, None
+                {}, task.logger, extraction_definition, mock.ANY, loading_rules
             )
 
     @mock.patch("cumulusci.tasks.sample_data.capture_sample_data.Dataset")

--- a/cumulusci/tasks/sample_data/test_capture_sample_data.py
+++ b/cumulusci/tasks/sample_data/test_capture_sample_data.py
@@ -60,7 +60,7 @@ class TestCaptureDatasets:
             Dataset.assert_any_call("default", mock.ANY, mock.ANY, org_config, mock.ANY)
             # and extracted
             Dataset().__enter__().extract.assert_called_with(
-                {}, task.logger, None, mock.ANY
+                {}, task.logger, None, mock.ANY, None
             )
 
     @mock.patch("cumulusci.tasks.sample_data.capture_sample_data.Dataset")
@@ -91,7 +91,7 @@ class TestCaptureDatasets:
             Dataset().__enter__().create.assert_called_with()
             # and extracted
             Dataset().__enter__().extract.assert_called_with(
-                {}, task.logger, extraction_definition, mock.ANY
+                {}, task.logger, extraction_definition, mock.ANY, None
             )
 
     @mock.patch("cumulusci.tasks.sample_data.capture_sample_data.Dataset")

--- a/docs/data.md
+++ b/docs/data.md
@@ -68,6 +68,19 @@ in a highly automated situation. It is designed to be
 used interactively, and you can control its behavior
 with an [Extract Declaration](data/extract_declarations.md) file.
 
+The extract process generates a mapping YAML file which will be used for subsequent
+loads. It has the name `datasets/<datasetname>/<datasetname>.mapping.yml`.
+It is possible to edit this file, but this may not be the best choice.
+Changes to the file can be overwritten when you capture data a second time.
+Rather than editing the file, it is preferable to create a Loading Rules
+file and then re-create the mapping file by capturing sample data again.
+
+A Loading Rules file is a file named
+`datasets/<datasetname>/<datasetname>.load.yml` which can specify instructions
+like which API to use and in which order to load objects. This file is in
+the [Loading Rules](data/loading_rules.md) format. If you create such a file
+and then re-capture sample data, the mapping file will be updated to match.
+
 ### Multiple Sample Datasets
 
 If you want different datasets for different scratch org types
@@ -919,52 +932,14 @@ Would be equivalent to `--run-until-records-loaded 700:Account` because one need
 ### Controlling the Loading Process
 
 CumulusCI's data loader has many knobs and switches that you might want
-to adjust during your load. It supports a ".load.yml" file format
+to adjust during your load. It supports a
+[".load.yml"](data/loading_rules.md) file format
 which allows you to manipulate these load settings. The simplest way to
 use this file format is to make a file in the same directory as your
 recipe with a filename that is derived from the recipe's by replacing
 everything after the first "." with ".load.yml". For example, if
 your recipe is called "babka.recipe.yml" then your load file would be
 "babka.load.yml".
-
-Inside of that file you put a list of declarations in the following
-format:
-
-```yaml
-- sf_object: Account
-  api: bulk
-  bulk_mode: parallel
-```
-
-Which would specifically load accounts using the bulk API's parallel
-mode.
-
-The specific keys that you can associate with an object are:
-
--   api: "smart", "rest" or "bulk"
--   batch_size: a number
--   bulk_mode: "serial" or "parallel"
--   load_after: the name of another sobject to wait for before loading
-
-"api", "batch_size" and "bulk_mode" have the same meanings that
-they do in mapping.yml as described in [API Selection](api-selection).
-
-For example, one could force Accounts and Opportunities to load after
-Contacts:
-
-```yaml
-- sf_object: Account
-  load_after: Contact
-
-- sf_object: Opportunity
-  load_after: Contact
-```
-
-If you wish to share a loading file between multiple recipes, you can
-refer to it with the `--loading_rules` option. That will override the
-default filename (`<recipename>.load.yml`). If you want both, or any
-combination of multiple files, you can do that by listing them with
-commas between the filenames.
 
 ### Batch Sizes
 

--- a/docs/data/loading_rules.md
+++ b/docs/data/loading_rules.md
@@ -1,0 +1,50 @@
+# Loading Rules
+
+CumulusCI's data loader has many knobs and switches that you might want
+to adjust during your load. It supports a ".load.yml" file format
+which allows you to manipulate these load settings. The simplest way to
+use this file format is to make a file in the same directory as your
+recipe or dataset with a filename that is derived from the recipe's by replacing
+everything after the first "." with ".load.yml". For example, if
+your recipe is called "babka.recipe.yml" then your load file would be
+"babka.load.yml". Similarly if you have a dataset called
+`datasets/ds/ds.dataset.sql` then you could create `datasets/ds/ds.load.yml`.
+
+Inside of that file you put a list of declarations in the following
+format:
+
+```yaml
+- sf_object: Account
+  api: bulk
+  bulk_mode: parallel
+```
+
+Which would specifically load accounts using the bulk API's parallel
+mode.
+
+The specific keys that you can associate with an object are:
+
+-   api: "smart", "rest" or "bulk"
+-   batch_size: a number
+-   bulk_mode: "serial" or "parallel"
+-   load_after: the name of another sobject to wait for before loading
+
+"api", "batch_size" and "bulk_mode" have the same meanings that
+they do in mapping.yml as described in [API Selection](api-selection).
+
+For example, one could force Accounts and Opportunities to load after
+Contacts:
+
+```yaml
+- sf_object: Account
+  load_after: Contact
+
+- sf_object: Opportunity
+  load_after: Contact
+```
+
+If you wish to share a loading file between multiple recipes or
+datasets, you can refer to it with the `--loading_rules` option.
+That will override the default filename (`<recipename>.load.yml`).
+If you want both, or any combination of multiple files, you can do
+that by listing them with commas between the filenames.


### PR DESCRIPTION
CumulusCI has a feature called a ".[load.yml](https://cumulusci.readthedocs.io/en/stable/data.html#controlling-the-loading-process)" file which is used when generating mapping files in the context of loading Snowfakery recipes. This allows you to, for example, control the API used, change the load order, etc. Basically it allows you to override default loading behaviours.

Our new `capture_sample_data` task also generates mapping files, and therefore could benefit from the same kinds of overrides. It was always anticipated that the `load.yml` would also be relevant in this context, but it was not implemented until now.

This was a problem when an internal team needed to change the load order of two objects. Now users can do that.