### PR TITLE
Keychain cleanups

### DIFF
--- a/cumulusci/core/keychain/tests/conftest.py
+++ b/cumulusci/core/keychain/tests/conftest.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from cumulusci.core.config import (
@@ -15,9 +17,9 @@ def project_config():
     project_config = BaseProjectConfig(universal_config, config={"no_yaml": True})
     project_config.config["services"] = {
         "connected_app": {"attributes": {"test": {"required": True}}},
-        "github": {"attributes": {"name": {"required": True}, "password": {}}},
+        "github": {"attributes": {"name4tests": {"required": True}, "pw4tests": {}}},
         "github_enterprise": {
-            "attributes": {"name": {"required": True}, "password": {}}
+            "attributes": {"name4tests": {"required": True}, "pw4tests": {}}
         },
         "not_configured": {"attributes": {"foo": {"required": True}}},
         "devhub": {"attributes": {"foo": {"required": True}}},
@@ -28,6 +30,12 @@ def project_config():
     }
     project_config.project__name = "TestProject"
     return project_config
+
+
+@pytest.fixture(autouse=True)
+def clear_environment():
+    with mock.patch("os.environ", {}):
+        yield
 
 
 @pytest.fixture
@@ -47,4 +55,4 @@ def key():
 
 @pytest.fixture
 def service_config():
-    return ServiceConfig({"name": "bar@baz.biz", "password": "test123"})
+    return ServiceConfig({"name4tests": "bar@baz.biz", "password": "test123"})

--- a/cumulusci/core/keychain/tests/test_base_project_keychain.py
+++ b/cumulusci/core/keychain/tests/test_base_project_keychain.py
@@ -220,10 +220,10 @@ class TestBaseProjectKeychain:
         assert keychain.get_default_org() == (None, None)
 
     def test_validate_service_attributes(self, keychain):
-        # config is missing the "name" attribute
+        # config is missing the "name4tests" attribute
         service_config = ServiceConfig({"password": "test123"})
         error_message = re.escape(
-            "Missing required attribute(s) for github service: ['name']"
+            "Missing required attribute(s) for github service: ['name4tests']"
         )
         with pytest.raises(
             ServiceNotValid,

--- a/cumulusci/core/keychain/tests/test_encrypted_file_project_keychain.py
+++ b/cumulusci/core/keychain/tests/test_encrypted_file_project_keychain.py
@@ -304,7 +304,9 @@ class TestEncryptedFileProjectKeychain:
         github_service_path = Path(f"{keychain.global_config_dir}/services/github")
         self._write_file(
             Path(github_service_path / "alias.service"),
-            keychain._get_config_bytes(BaseConfig({"name": "foo"})).decode("utf-8"),
+            keychain._get_config_bytes(BaseConfig({"name4tests": "foo"})).decode(
+                "utf-8"
+            ),
         )
 
         # keychain.config["services"] = {}
@@ -316,14 +318,14 @@ class TestEncryptedFileProjectKeychain:
         ):
             keychain._load_service_files()
         github_service = keychain.get_service("github", "alias")
-        assert "foo" in github_service.config["name"]
+        assert "foo" in github_service.config["name4tests"]
 
     def test_load_services__from_env(self, keychain):
         service_config_one = ServiceConfig(
-            {"name": "foo1", "password": "1234", "token": "1234"}
+            {"name4tests": "foo1", "pw4tests": "1234", "token": "1234"}
         )
         service_config_two = ServiceConfig(
-            {"name": "foo2", "password": "5678", "token": "5678"}
+            {"name4tests": "foo2", "pw4tests": "5678", "token": "5678"}
         )
         with EnvironmentVarGuard() as env:
             env.set(
@@ -349,7 +351,7 @@ class TestEncryptedFileProjectKeychain:
         keychain.logger = mock.Mock()
         service_prefix = EncryptedFileProjectKeychain.env_service_var_prefix
         service_config = ServiceConfig(
-            {"name": "foo", "password": "1234", "token": "1234"}
+            {"name4tests": "foo", "pw4tests": "1234", "token": "1234"}
         )
         with EnvironmentVarGuard() as env:
             env.set(f"{service_prefix}github", json.dumps(service_config.config))
@@ -440,30 +442,40 @@ class TestEncryptedFileProjectKeychain:
             )
 
     def test_set_service__first_should_be_default(self, keychain):
-        keychain.set_service("github", "foo_github", ServiceConfig({"name": "foo"}))
-        keychain.set_service("github", "bar_github", ServiceConfig({"name": "bar"}))
+        keychain.set_service(
+            "github", "foo_github", ServiceConfig({"name4tests": "foo"})
+        )
+        keychain.set_service(
+            "github", "bar_github", ServiceConfig({"name4tests": "bar"})
+        )
 
         github_service = keychain.get_service("github")
-        assert _simplify_config(github_service.config) == {"name": "foo"}
+        assert _simplify_config(github_service.config) == {"name4tests": "foo"}
 
     def test_set_default_service(self, keychain, withdifferentformats):
-        keychain.set_service("github", "foo_github", ServiceConfig({"name": "foo"}))
-        keychain.set_service("github", "bar_github", ServiceConfig({"name": "bar"}))
+        keychain.set_service(
+            "github", "foo_github", ServiceConfig({"name4tests": "foo"})
+        )
+        keychain.set_service(
+            "github", "bar_github", ServiceConfig({"name4tests": "bar"})
+        )
 
         github_service = keychain.get_service("github")
-        assert _simplify_config(github_service.config) == {"name": "foo"}
+        assert _simplify_config(github_service.config) == {"name4tests": "foo"}
         # now set default to bar
         keychain.set_default_service("github", "bar_github")
         github_service = keychain.get_service("github")
-        assert _simplify_config(github_service.config) == {"name": "bar"}
+        assert _simplify_config(github_service.config) == {"name4tests": "bar"}
 
     def test_set_default_service__service_alredy_default(
         self, keychain, withdifferentformats
     ):
-        keychain.set_service("github", "foo_github", ServiceConfig({"name": "foo"}))
+        keychain.set_service(
+            "github", "foo_github", ServiceConfig({"name4tests": "foo"})
+        )
         github_service = keychain.get_service("github")
         assert github_service.config == {
-            "name": "foo",
+            "name4tests": "foo",
             "serialization_format": withdifferentformats,
         }
 
@@ -471,7 +483,7 @@ class TestEncryptedFileProjectKeychain:
 
         github_service = keychain.get_service("github")
         assert github_service.config == {
-            "name": "foo",
+            "name4tests": "foo",
             "serialization_format": withdifferentformats,
         }
 
@@ -480,7 +492,9 @@ class TestEncryptedFileProjectKeychain:
             keychain.set_default_service("fooey", "alias")
 
     def test_set_default_service__no_such_alias(self, keychain):
-        keychain.set_service("github", "foo_github", ServiceConfig({"name": "foo"}))
+        keychain.set_service(
+            "github", "foo_github", ServiceConfig({"name4tests": "foo"})
+        )
         with pytest.raises(ServiceNotConfigured):
             keychain.set_default_service("github", "wrong_alias")
 
@@ -1133,7 +1147,7 @@ class TestCleanupOrgCacheDir:
         self, keychain, key, withdifferentformats
     ):
         service_config = ServiceConfig(
-            {"name": "foo1", "password": "1234", "token": "1234"}
+            {"name4tests": "foo1", "pw4tests": "1234", "token": "1234"}
         )
 
         keychain.key = key
@@ -1167,7 +1181,10 @@ class TestCleanupOrgCacheDir:
             del keychain.config["orgs"]
             keychain._load_orgs()
             assert keychain.get_org("test_migration").password == "Kltpzyxm"
-            assert keychain.get_org("test_migration").serialization_format == "pickle"
+            assert (
+                keychain.get_org("test_migration").lookup("serialization_format")
+                == "pickle"
+            )
 
         with mock.patch(
             "cumulusci.core.keychain.serialization.SHOULD_SAVE_AS_JSON", True
@@ -1177,4 +1194,7 @@ class TestCleanupOrgCacheDir:
             del keychain.config["orgs"]
             keychain._load_orgs()
             assert keychain.get_org("test_migration").password == "Kltpzyxm"
-            assert keychain.get_org("test_migration").serialization_format == "json"
+            assert (
+                keychain.get_org("test_migration").lookup("serialization_format")
+                == "json"
+            )


### PR DESCRIPTION
1. Change names to be more grepable.
2. Keep environment out.
3. Quiet some logs.