### PR TITLE
Declare use real env marker

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -185,20 +185,24 @@ examples where they are used in context, or to see their definitions:
 
 Decorators for tests:
 
-> -   pytest.mark.slow(): a slow test that should only be executed when
->     requested with --run-slow-tests
-> -   pytest.mark.large_vcr(): a network-based test that generates VCR
->     cassettes too large for version control. Use --org to generate
->     them locally.
-> -   pytest.mark.needs_org(): a test that needs an org (or at least
->     access to the network) but should not attempt to store VCR
->     cassettes. Most tests that need network access do so because they
->     need to talk to an org, but you can also use this decorator to
->     give access to the network to talk to github or any other API.
-> -   pytest.mark.org_shape('qa', 'qa_org'): - switch the current
->     org to an org created with org template "qa" after running flow
->     "qa_org". As with all tests, clean up any changes you make,
->     because this org may be reused by other tests.
+-   pytest.mark.slow(): a slow test that should only be executed when
+    requested with --run-slow-tests
+-   pytest.mark.large_vcr(): a network-based test that generates VCR
+    cassettes too large for version control. Use --org to generate
+    them locally.
+-   pytest.mark.needs_org(): a test that needs an org (or at least
+    access to the network) but should not attempt to store VCR
+    cassettes. Most tests that need network access do so because they
+    need to talk to an org, but you can also use this decorator to
+    give access to the network to talk to github or any other API.
+-   pytest.mark.org_shape('qa', 'qa_org'): - switch the current
+    org to an org created with org template "qa" after running flow
+    "qa_org". As with all tests, clean up any changes you make,
+    because this org may be reused by other tests.
+
+A complete list is available with:
+
+> $ pytest --markers
 
 ### Randomized tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,8 +138,9 @@ exclude_lines = ["pragma: no cover", "@abstract", "@abc.abstract"]
 [tool.pytest.ini_options]
 testpaths = "cumulusci"
 addopts = "-p cumulusci.tests.pytest_plugins.pytest_typeguard -p cumulusci.tests.pytest_plugins.pytest_sf_vcr -p cumulusci.tests.pytest_plugins.pytest_sf_orgconnect"
-markers = [
+markers = [ # note that some are also defined in code. Search for addinivalue_line
     "metadeploy: mark a test that interacts with the MetaDeploy REST API",
+    "use_real_env: use real environment variables to get access to e.g. environment-defined services for integration tests",
 ]
 filterwarnings = [
     "error:ClassMovedWarning",


### PR DESCRIPTION
Declare the `use_real_env` marker and make some small fixes to the docs.