### PR TITLE
Use 3.8 typing syntax

### DIFF
--- a/cumulusci/core/config/scratch_org_config.py
+++ b/cumulusci/core/config/scratch_org_config.py
@@ -123,7 +123,7 @@ class ScratchOrgConfig(SfdxOrgConfig):
 
     def _build_org_create_args(self) -> List[str]:
         args = ["-f", self.config_file, "-w", "120"]
-        devhub_username: str | None = self._choose_devhub_username()
+        devhub_username: Optional[str] = self._choose_devhub_username()
         if devhub_username:
             args += ["--targetdevhubusername", devhub_username]
         if not self.namespaced:
@@ -141,8 +141,7 @@ class ScratchOrgConfig(SfdxOrgConfig):
             args += [f"adminEmail={self.email_address}"]
         if self.default:
             args += ["-s"]
-        instance = self.instance or os.environ.get("SFDX_SIGNUP_INSTANCE")
-        if instance:
+        if instance := self.instance or os.environ.get("SFDX_SIGNUP_INSTANCE"):
             args += [f"instance={instance}"]
         return args
 


### PR DESCRIPTION
Support for PEP 604 union types was added in 3.10[^1]:

```python-console
Python 3.8.16 (default, Dec  8 2022, 14:03:21)
[Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> mystr: str | None = None or str
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

(Also, :walrus:)

[^1]: Personally, I'd rather drop 3.8/3.9 instead 😏 
