### PR TITLE
Ensure that top-level 'tasks' directory is read for custom tasks

### DIFF
--- a/cumulusci/core/config/project_config.py
+++ b/cumulusci/core/config/project_config.py
@@ -673,8 +673,9 @@ class BaseProjectConfig(BaseTaskFlowConfig, ProjectConfigPropertiesMixin):
             self.logger.debug(f"Adding {directory} to tasks.__path__")
             tasks.__path__.append(directory)
         if get_debug_mode():
+            spec = getattr(self.source, "spec", ".")
             self.logger.debug(
-                f"After importing {self.source.spec}:  tasks.__path__ {tasks.__path__}"
+                f"After importing {spec}:  tasks.__path__ {tasks.__path__}"
             )
 
     def construct_subproject_config(self, **kwargs) -> "BaseProjectConfig":

--- a/cumulusci/core/runtime.py
+++ b/cumulusci/core/runtime.py
@@ -83,6 +83,7 @@ class BaseCumulusCI:
         self.project_config = self.project_config_cls(
             self.universal_config, *args, **kwargs
         )
+        self.project_config._add_tasks_directory_to_python_path()
 
     def _load_keychain(self):
         if self.keychain is not None:

--- a/cumulusci/core/utils.py
+++ b/cumulusci/core/utils.py
@@ -25,7 +25,6 @@ def import_global(path: str):
     components = path.split(".")
     module = components[:-1]
     module = ".".join(module)
-    mod = __import__(module, fromlist=[str(components[-1])])
 
     if get_debug_mode():
         import sys
@@ -35,6 +34,8 @@ def import_global(path: str):
         logger.info(f"Looking in sys.path {sys.path}")
         if components[0] == "tasks":
             logger.info(f"With tasks.__path__ {sys.modules['tasks'].__path__}")
+
+    mod = __import__(module, fromlist=[str(components[-1])])
     return getattr(mod, str(components[-1]))
 
 


### PR DESCRIPTION
"tasks" directories for sub-projects were added but not for the "main project" directory.

Now they are.

All of the opt-in, opt-out tests should ensure that I have not changed the strictness of the opt-in code execution feature.

If a project used a directory not called "tasks", it should not have been affected by this regression.

Metecho and MetaDeploy should pick up this code through their use of `BaseCumulusCI` .

Should open another PR with a test that would have caught the regression, but I'll get to that Monday.