### PR TITLE
Correctly parse `--org-wide-defaults` option when passed via `cci`

### DIFF
--- a/cumulusci/tasks/metadata_etl/sharing.py
+++ b/cumulusci/tasks/metadata_etl/sharing.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 
 from cumulusci.core.exceptions import CumulusCIException, TaskOptionsError
@@ -27,6 +28,13 @@ class SetOrgWideDefaults(MetadataSingleEntityTransformTask, BaseSalesforceApiTas
     def _init_options(self, kwargs):
         self.task_config.options["api_names"] = "dummy"
         super()._init_options(kwargs)
+
+        # If this option is comming directly from the CLI
+        # then we need to appropriately parse the string
+        option_val = self.options["org_wide_defaults"]
+        if isinstance(option_val, str):
+            self.options["org_wide_defaults"] = json.loads(option_val)
+
         self.api_names = {
             self._inject_namespace(elem["api_name"])
             for elem in self.options["org_wide_defaults"]

--- a/cumulusci/tasks/metadata_etl/sharing.py
+++ b/cumulusci/tasks/metadata_etl/sharing.py
@@ -29,7 +29,7 @@ class SetOrgWideDefaults(MetadataSingleEntityTransformTask, BaseSalesforceApiTas
         self.task_config.options["api_names"] = "dummy"
         super()._init_options(kwargs)
 
-        # If this option is comming directly from the CLI
+        # If this option is coming directly from the CLI
         # then we need to appropriately parse the string
         option_val = self.options["org_wide_defaults"]
         if isinstance(option_val, str):

--- a/cumulusci/tasks/metadata_etl/tests/test_sharing.py
+++ b/cumulusci/tasks/metadata_etl/tests/test_sharing.py
@@ -74,6 +74,19 @@ class TestSetOrgWideDefaults:
         assert len(entry) == 1
         assert entry[0].text == "Read"
 
+    def test_set_owd__parse_owd_option_from_cli(self):
+        task = create_task(
+            SetOrgWideDefaults,
+            {
+                "managed": True,
+                "api_version": "47.0",
+                "api_names": "bar,foo",
+                "org_wide_defaults": '[{"api_name": "Account","internal_sharing_model": "Private", "external_sharing_model": "Private" }]',
+            },
+        )
+        task._init_options({})
+        assert isinstance(task.options["org_wide_defaults"], list)
+
     def test_sets_owd__missing_tags(self):
         task = create_task(
             SetOrgWideDefaults,


### PR DESCRIPTION
# Bug Fixes
- Fixed a bug where passing the `--org-wide-defaults` option on the `set-organization-wide-defaults` task wasn't being properly parsed when passed from the CLI.