### PR TITLE
Fix skip_future_releases option

### DIFF
--- a/cumulusci/tasks/github/merge.py
+++ b/cumulusci/tasks/github/merge.py
@@ -49,9 +49,12 @@ class MergeBranch(BaseGithubTask):
             self.options[
                 "source_branch"
             ] = self.project_config.project__git__default_branch
-        self.options["skip_future_releases"] = process_bool_arg(
-            self.options.get("skip_future_releases") or True
-        )
+        if "skip_future_releases" not in self.options:
+            self.options["skip_future_releases"] = True
+        else:
+            self.options["skip_future_releases"] = process_bool_arg(
+                self.options.get("skip_future_releases")
+            )
         self.options["update_future_releases"] = process_bool_arg(
             self.options.get("update_future_releases") or False
         )


### PR DESCRIPTION
Fixes #3594

As written, skip_future_releases is always `True` for
`skip_future_releases: False` or `skip_future_releases: false` because
those get converted to booleans before being passed to
`process_bool_arg`. This was working as designed when run through the
CLI because the option doesn't go through the Pydantic model so it's a
`str`.
