### PR TITLE
fix: Don't pass fullName for Unlocked packages

### DIFF
--- a/cumulusci/tasks/create_package_version.py
+++ b/cumulusci/tasks/create_package_version.py
@@ -211,7 +211,9 @@ class CreatePackageVersion(BaseSalesforceApiTask):
         package_zip_builder = None
         with convert_sfdx_source(
             self.project_config.default_package_path,
-            self.package_config.package_name,
+            None
+            if self.package_config.package_type == PackageTypeEnum.unlocked
+            else self.package_config.package_name,
             self.logger,
         ) as path:
             package_zip_builder = MetadataPackageZipBuilder(


### PR DESCRIPTION
This PR fixes an issue where the creation of a beta version of an unlocked package was failing during the `create_package_version` task with a misleading error message about a 1GP dependency.

The workaround is to match the behavior of the [@salesforce/packaging](https://github.com/forcedotcom/packaging/tree/830d45bd52b80b09b7a5f96b9664961eee3ce7f1) typescript library: when the package type is 'unlocked', 'None' is passed instead of the package name. 

Fixes #3633
