### PR TITLE
Add a real email for bot commits

### DIFF
--- a/.github/workflows/chores.yml
+++ b/.github/workflows/chores.yml
@@ -48,8 +48,8 @@ jobs:
                   ' cumulusci/cumulusci.yml
             - name: Commit changes
               run: |
-                  git config user.name github-actions
-                  git config user.email github-actions@github.com
+                  git config user.name github-actions[bot]
+                  git config user.email 41898282+github-actions[bot]@users.noreply.github.com
                   git switch -c "update-sfdc-api-v$VERSION"
                   git add cumulusci/cumulusci.yml
                   git commit -m "Automated update to sfdc API version $VERSION"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -58,8 +58,8 @@ jobs:
                   npx prettier --write docs/history.md
             - name: Commit changes
               run: |
-                  git config user.name github-actions
-                  git config user.email github-actions@github.com
+                  git config user.name github-actions[bot]
+                  git config user.email 41898282+github-actions[bot]@users.noreply.github.com
                   git switch -c "release-$(hatch version)"
                   git add docs/history.md cumulusci/__about__.py
                   git commit -m "Update changelog (automated)"


### PR DESCRIPTION
Fixes the :cla_missing: errors on bot-authored commits.
