### PR TITLE
enhancement: support spanning fields in update_data

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -37,3 +37,4 @@ For example:
 * Ed Rivas (jerivas)
 * Gustavo Tandeciarz (dcinzona)
 * Ben French (BenjaminFrench)
+* Jonny Power (JonnyPower) on behalf of Traction Rec

--- a/cumulusci/tasks/bulkdata/step.py
+++ b/cumulusci/tasks/bulkdata/step.py
@@ -8,6 +8,7 @@ from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 from typing import Any, Dict, List, NamedTuple, Optional
 
+import pydash
 import requests
 
 from cumulusci.core.enums import StrEnum
@@ -277,7 +278,10 @@ class RestApiQueryOperation(BaseQueryOperation):
 
     def get_results(self):
         def convert(rec):
-            return [str(rec[f]) if rec[f] is not None else "" for f in self.fields]
+            return [
+                str(pydash.get(rec, f)) if rec[f] is not None else ""
+                for f in self.fields
+            ]
 
         while True:
             yield from (convert(rec) for rec in self.response["records"])

--- a/cumulusci/tasks/bulkdata/update_data.py
+++ b/cumulusci/tasks/bulkdata/update_data.py
@@ -66,7 +66,7 @@ class UpdateData(BaseSalesforceApiTask):
         self.sobject = self.options["object"]
 
         def identifier(f):
-            return isinstance(f, str) and f.isidentifier()
+            return isinstance(f, str) and re.match("^[a-zA-Z0-9_\\.]+$", f)
 
         if not identifier(self.sobject):
             raise TaskOptionsError(

--- a/datasets/update_spanning.recipe.yml
+++ b/datasets/update_spanning.recipe.yml
@@ -1,0 +1,7 @@
+# cci task run update_data --recipe datasets/update_spanning.recipe.yml
+#                          --object Contact --fields Account.Name --org qa
+
+# doesn't use randomized data because we want to use VCR.
+- object: Contact
+  fields:
+      FirstName: ${{input.Account.Name}}


### PR DESCRIPTION
- inbuilt isidentifier() method on string does not support strings including `.`
- Salesforce API will accept spanning fields in API query, but will return child objects / dicts
- Using pydash to navigate the dict by keys split by `.`


Draft to seek feedback early, as I don't write a lot of python and threw this together quickly.