### PR TITLE
Message for the not_found error

### DIFF
--- a/cumulusci/core/config/scratch_org_config.py
+++ b/cumulusci/core/config/scratch_org_config.py
@@ -81,6 +81,18 @@ class ScratchOrgConfig(SfdxOrgConfig):
 
         def raise_error() -> NoReturn:
             message = f"{FAILED_TO_CREATE_SCRATCH_ORG}: \n{stdout}\n{stderr}"
+            try:
+                Output = json.loads(stdout)
+                if (
+                    Output.get("message") == "The requested resource does not exist"
+                    and Output.get("name") == "NOT_FOUND"
+                ):
+                    raise ScratchOrgException(
+                        "Check the API Version or endpoint you are interacting"
+                    )
+            except json.decoder.JSONDecodeError:
+                raise ScratchOrgException(message)
+
             raise ScratchOrgException(message)
 
         result = {}  # for type checker.
@@ -88,6 +100,7 @@ class ScratchOrgConfig(SfdxOrgConfig):
             raise_error()
         try:
             result = json.loads(stdout)
+
         except json.decoder.JSONDecodeError:
             raise_error()
 

--- a/cumulusci/core/config/tests/test_config_expensive.py
+++ b/cumulusci/core/config/tests/test_config_expensive.py
@@ -606,6 +606,29 @@ class TestScratchOrgConfig:
         assert config.config["created"]
         assert config.scratch_org_type == "workspace"
 
+    def test_check_apiversion_error(self, Command):
+        out = b"""{
+            "context": "Create",
+            "commandName": "Create",
+            "message": "The requested resource does not exist",
+            "name": "NOT_FOUND"
+            }"""
+
+        Command.return_value = mock.Mock(
+            stdout=io.BytesIO(out), stderr=io.BytesIO(b""), returncode=1
+        )
+        config = ScratchOrgConfig(
+            {"config_file": "tmp.json", "email_address": "test@example.com"}, "test"
+        )
+        with temporary_dir():
+            with open("tmp.json", "w") as f:
+                f.write("{}")
+            with pytest.raises(
+                SfdxOrgException,
+                match="Check the API Version or endpoint you are interacting",
+            ):
+                config.create_org()
+
     def test_create_org_no_config_file(self, Command):
         config = ScratchOrgConfig({}, "test")
         with pytest.raises(ScratchOrgException, match="missing a config_file"):


### PR DESCRIPTION
Hi @davidmreed 

Please review the PR for the changes made to add a descriptive message for the not_found error while creating  a new scratch org.