### PR TITLE
Fix Github url parse error for some scenarios

### DIFF
--- a/cumulusci/utils/git.py
+++ b/cumulusci/utils/git.py
@@ -72,6 +72,7 @@ def parse_repo_url(url: str) -> Tuple[str, str, str]:
         Returns (owner, name, host)
     """
     url_parts = re.split("/|@|:", url.rstrip("/"))
+    url_parts = list(filter(None, url_parts))
 
     name = url_parts[-1]
     if name.endswith(".git"):

--- a/cumulusci/utils/tests/test_git.py
+++ b/cumulusci/utils/tests/test_git.py
@@ -44,6 +44,7 @@ def test_construct_release_branch_name():
         ),
         ("https://github.com/owner/repo_name/", "owner", "repo_name", "github.com"),
         ("https://github.com/owner/repo_name.git", "owner", "repo_name", "github.com"),
+        ("https://user@github.com/owner/repo.git", "owner", "repo_name", "github.com"),
         (
             "https://git.ent.example.com/org/private_repo.git",
             "org",
@@ -51,6 +52,7 @@ def test_construct_release_branch_name():
             "git.ent.example.com",
         ),
         ("git@github.com:owner/repo_name.git", "owner", "repo_name", "github.com"),
+        ("git@github.com:/owner/repo_name.git", "owner", "repo_name", "github.com"),
         ("git@github.com:owner/repo_name", "owner", "repo_name", "github.com"),
         (
             "git@api.github.com/owner/repo_name/",


### PR DESCRIPTION
Fix Github parse issue during some scenarios as mentioned below
1. https://user@github.com/owner/repo.git
2. git@github.com:/SalesforceFoundation/Subledger.git