### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -342,8 +342,8 @@ CumulusCI makes it easy to create, connect, and manage orgs. The
 `cci org` top-level command helps you work with orgs.
 
 To learn about working with orgs in detail, read
-(scratch-orgs) and
-(connected-orgs).
+[](scratch-orgs) and
+[](connected-orgs).
 
 (manage-services)=
 


### PR DESCRIPTION
[W-14157597](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001asUQrYAM/view)

Fixed broken links in [documentation](https://cumulusci.readthedocs.io/en/stable/cli.html#access-and-manage-orgs)
**Line:** To learn about working with orgs in detail, read (scratch-orgs) and (connected-orgs).