### PR TITLE
Support Python 3.12

### DIFF
--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -41,10 +41,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [macos-latest, sfdc-ubuntu-latest, sfdc-windows-latest]
-                python-version: ["3.8", "3.9", "3.10", "3.11"]
-                exclude: # FIXME: Remove when lxml publishes a 311-windows wheel
-                    - os: sfdc-windows-latest
-                      python-version: "3.11"
+                python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python

--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -71,7 +71,7 @@ jobs:
             - name: Install sfdx
               run: |
                   mkdir sfdx
-                  wget -qO- https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz | tar xJ -C sfdx --strip-components 1
+                  wget -qO- https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-linux-x64.tar.xz | tar xJ -C sfdx --strip-components 1
                   echo $(realpath sfdx/bin) >> $GITHUB_PATH
             - name: Authenticate Dev Hub
               run: |

--- a/cumulusci/cli/tests/test_plan.py
+++ b/cumulusci/cli/tests/test_plan.py
@@ -70,7 +70,7 @@ class TestPlanList:
 
         run_click_command(plan.plan_list, runtime=runtime, print_json=False)
 
-        cli_table.called_once_with(
+        cli_table.assert_called_once_with(
             data=[
                 ["Name", "Title", "Slug", "Tier"],
                 ["plan 1", "Test Plan #1", "plan1_slug", "primary"],

--- a/cumulusci/core/keychain/tests/test_encrypted_file_project_keychain.py
+++ b/cumulusci/core/keychain/tests/test_encrypted_file_project_keychain.py
@@ -1173,7 +1173,9 @@ class TestCleanupOrgCacheDir:
             org_config.config["bad"] = 25j
 
             keychain.set_org(org_config, True)
-            assert dumps.called_once_with({"bad", 25j})
+            dumps.assert_called_once_with(
+                {"foo": "bar", "good": 25, "bad": 25j}, protocol=mock.ANY
+            )
 
     def test_set_and_get_service_with_dates__global(
         self, keychain, key, withdifferentformats

--- a/cumulusci/oauth/client.py
+++ b/cumulusci/oauth/client.py
@@ -197,14 +197,16 @@ class OAuth2Client(object):
                 raise
 
         if use_https:
-            if not Path("localhost.pem").is_file() or not Path("key.pem").is_file():
+            certfile = "localhost.pem"
+            keyfile = "key.pem"
+            if not Path(certfile).is_file() or not Path(keyfile).is_file():
                 create_key_and_self_signed_cert()
-            httpd.socket = ssl.wrap_socket(
+            # FIXME: Use ssl.PROTOCOL_TLS_SERVER after dropping 3.8 support
+            ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS)
+            ssl_context.load_cert_chain(certfile, keyfile)
+            httpd.socket = ssl_context.wrap_socket(
                 httpd.socket,
                 server_side=True,
-                certfile="localhost.pem",
-                keyfile="key.pem",
-                ssl_version=ssl.PROTOCOL_TLS,
             )
 
         httpd.timeout = self.httpd_timeout

--- a/cumulusci/oauth/tests/test_client.py
+++ b/cumulusci/oauth/tests/test_client.py
@@ -156,14 +156,15 @@ class TestOAuth2Client:
         # use https for callback
         client.client_config.redirect_uri = "https://localhost:8080/callback"
         # squash CERTIFICATE_VERIFY_FAILED from urllib
-        # https://stackoverflow.com/questions/49183801/ssl-certificate-verify-failed-with-urllib
-        ssl._create_default_https_context = ssl._create_unverified_context
+        # https://peps.python.org/pep-0476/
+        unverified_context = ssl._create_unverified_context()
 
         # call OAuth object on another thread - this spawns local httpd
         with httpd_thread(client) as oauth_client:
             # simulate callback from browser
             response = urllib.request.urlopen(
-                oauth_client.client_config.redirect_uri + "?code=123"
+                oauth_client.client_config.redirect_uri + "?code=123",
+                context=unverified_context,
             )
 
         assert oauth_client.response.json() == expected_response

--- a/cumulusci/tasks/bulkdata/tests/test_step.py
+++ b/cumulusci/tasks/bulkdata/tests/test_step.py
@@ -1247,7 +1247,7 @@ class TestGetOperationFunctions:
         )
         assert op == bulk_query.return_value
 
-        context.sf.restful.called_once_with("limits/recordCount?sObjects=Test")
+        context.sf.restful.assert_called_once_with("limits/recordCount?sObjects=Test")
 
     @mock.patch("cumulusci.tasks.bulkdata.step.BulkApiDmlOperation")
     @mock.patch("cumulusci.tasks.bulkdata.step.RestApiDmlOperation")

--- a/cumulusci/tasks/release_notes/tests/test_task.py
+++ b/cumulusci/tasks/release_notes/tests/test_task.py
@@ -287,8 +287,8 @@ class TestParentPullRequestNotes(GithubApiTestMixin):
         get_pr.return_value = [to_return, additional_pull_request]
         child_branch_name = task._get_child_branch_name_from_merge_commit()
         assert child_branch_name is None
-        assert task.logger.error.called_once_with(
-            "Received multiple pull request,s expected one, for commit sha: {}".format(
+        task.logger.error.assert_called_once_with(
+            "Received multiple pull requests, expected one, for commit sha: {}".format(
                 task.commit.sha
             )
         )
@@ -304,7 +304,7 @@ class TestParentPullRequestNotes(GithubApiTestMixin):
 
         generator.return_value = mock.Mock()
         task._run_task()
-        assert task.generator.aggregate_child_change_notes.called_once_with(
+        task.generator.aggregate_child_change_notes.assert_called_once_with(
             pull_request
         )
         assert not task.generator.update_unaggregated_pr_header.called

--- a/cumulusci/tasks/salesforce/tests/test_PackageUpload.py
+++ b/cumulusci/tasks/salesforce/tests/test_PackageUpload.py
@@ -309,7 +309,7 @@ class TestPackageUpload:
         task._make_package_upload_request()
 
         assert task._upload_start_time == upload_start_time
-        assert task.logger.info.called_once_with(
+        task.logger.info.assert_called_once_with(
             f"Created PackageUploadRequest {upload_id} for Package {package_id}"
         )
 
@@ -347,27 +347,26 @@ class TestPackageUpload:
 
         task._handle_apex_test_failures()
 
-        assert task.logger.error.called_once_with("Failed Apex Test")
+        task.logger.error.assert_called_once_with("Failed Apex Tests:")
         assert task._get_apex_test_results_from_upload.call_count == 1
         assert task._log_failures.call_count == 1
 
-    @mock.patch("cumulusci.tasks.salesforce.package_upload.CliTable")
+    @mock.patch("cumulusci.tasks.salesforce.package_upload.CliTable", autospec=True)
     def test_log_failures(self, table):
-        table.echo = mock.Mock()
 
         task = create_task(PackageUpload, {"name": "Test Release"})
 
         table_data = [1, 2, 3, 4]
-        task._get_table_data = mock.Mock(return_value="[1,2,3,4]")
+        task._get_table_data = mock.Mock(return_value=table_data)
 
         results = "Test Results"
         task._log_failures(results)
 
-        assert table.called_once_with(
+        table.assert_called_once_with(
             table_data,
             "Failed Apex Tests",
         )
-        assert table.echo.called_once()
+        table.return_value.echo.assert_called()
 
     def test_get_table_data(self):
         task = create_task(PackageUpload, {"name": "Test Release"})
@@ -515,7 +514,7 @@ class TestPackageUpload:
 
         task._log_package_upload_success()
 
-        assert task.logger.info.called_once_with(
+        task.logger.info.assert_called_once_with(
             f"Uploaded package version {version_number} with Id {version_id}"
         )
 

--- a/cumulusci/tests/test_main.py
+++ b/cumulusci/tests/test_main.py
@@ -6,4 +6,4 @@ def test_main():
         from cumulusci import __main__
 
         __main__
-    assert main.called_once
+    main.assert_called_once()

--- a/cumulusci/utils/tests/test_logging.py
+++ b/cumulusci/utils/tests/test_logging.py
@@ -29,7 +29,7 @@ class TestUtilLogging:
             sys.stdout.write(expected_stdout_text)
             sys.stderr.write(expected_stderr_text)
 
-        assert gist_logger.called_once()
+        gist_logger.assert_called_once()
         assert logger.debug.call_count == 3
         assert logger.debug.call_args_list[0][0][0] == "cci test\n"
         assert logger.debug.call_args_list[1][0][0] == expected_stdout_text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "click",


### PR DESCRIPTION
Changes needed to get 3.12 working:

### Replace deprecated ssl.wrap_socket in OAuth client

`ssl.wrap_socket()` has been discouraged since Python 3.2, deprecated since 3.7, and finally removed in 3.12. In this PR, the `ssl.wrap_socket` function has been removed and replaced with the recommended approach using `ssl.SSLContext`.  Previously, `ssl.wrap_socket` internally set up the SSL context, including loading certificates. Now, we're doing that explicitly with `ssl.SSLContext`. This is a substantive, but low-risk, change.

On the testing side, the previous workaround for suppressing the `CERTIFICATE_VERIFY_FAILED` error has been adapted to utilize the context creation method.

### Remove invalid assertions

`called_once` and `called_once_with` are [not valid assertions] on mock objects, meaning an instance of `mock.Mock` is returned. Because instances of `mock.Mock` evaluate to true, the assertion is equivalent to `assert True`. Those invalid assertions throw an `AttributeError` in Python 3.12, so this PR replaces them with valid assertions and updates some of the expected calls.

[not valid assertions]: https://discuss.python.org/t/include-prefix-called-in-list-of-forbidden-method-prefixes-for-mock-objects-in-unsafe-mode/22249/4