### PR TITLE
Add support for file scheme url dependencies.

### DIFF
--- a/cumulusci/utils/__init__.py
+++ b/cumulusci/utils/__init__.py
@@ -127,8 +127,12 @@ removeXmlElement = remove_xml_element_directory
 def download_extract_zip(url, target=None, subfolder=None, headers=None):
     if not headers:
         headers = {}
-    resp = requests.get(url, headers=headers)
-    zip_content = io.BytesIO(resp.content)
+    if url.startswith("file://"):
+        zip_content = url[7:]
+    else:
+        resp = requests.get(url, headers=headers)
+        zip_content = io.BytesIO(resp.content)
+
     zip_file = zipfile.ZipFile(zip_content)
     if subfolder:
         zip_file = zip_subfolder(zip_file, subfolder)


### PR DESCRIPTION
When the zip_url start with "file://", just use the zip file instead of doing a get request.  