### PR TITLE
Update pyright configuration for 1.1.339

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,8 @@ known_first_party = "cumulusci"
 known_third_party = "robot"
 
 [tool.pyright]
-reportMissingImports = "warning"
+reportMissingImports = "none"
+typeCheckingMode = "basic"
 exclude = ["**/test_*", "**/tests/**"]
 # Add files to this list as you make them compatible.
 include = [
@@ -234,7 +235,6 @@ include = [
     'cumulusci/tasks/robotframework/__init__.py',
     'cumulusci/tasks/robotframework/debugger/__init__.py',
     'cumulusci/tasks/robotframework/debugger/model.py',
-    'cumulusci/tasks/robotframework/lint.py',
     'cumulusci/tasks/salesforce/BaseRetrieveMetadata.py',
     'cumulusci/tasks/salesforce/BaseSalesforceTask.py',
     'cumulusci/tasks/salesforce/GetInstalledPackages.py',


### PR DESCRIPTION
Pyright changed the default typechecking level from 'basic' to 'standard' in v1.1.339. We don't have time to fix these right now, so this commit explicitly declares our `typeCheckingMode` to 'basic' until we do.

Also, our pre-commit configuration for pyright needs to be improved. First, pyright can't see find our imports because pre-commit installs hooks in their own environments. We could:

1. Fix our local pre-commit hook so it uses the global environment,
2. Install our dependencies into the hook environment,
3. Ignore missing imports until we do (1) or (2).

This commit chooses (3).

Second, using a local hook for Pyright results in inconsistencies in the version used across different environments (local development vs CI). Although an official hook is not available, 'python-pyright' was considered. However, it presents similar challenges in module detection.

