### PR TITLE
Retrieve pre-flight checks

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -1,10 +1,6 @@
 cumulusci:
     keychain: cumulusci.core.keychain.EncryptedFileProjectKeychain
 tasks:
-    preflight_checks:
-        group: Salesforce Preflight Checks
-        class_path: cumulusci.tasks.preflight.checks.RetrievePreflightChecks
-        description: Retrieves preflight checks passed and throws an error if failed
     activate_flow:
         group: Metadata Transformations
         description: Activates Flows identified by a given list of Developer Names
@@ -129,6 +125,10 @@ tasks:
             settings_type: EnhancedNotesSettings
             settings_field: IsEnhancedNotesEnabled
             value: True
+    preflight_checks:
+        group: Salesforce Preflight Checks
+        class_path: cumulusci.tasks.preflight.checks.RetrievePreflightChecks
+        description: Retrieves preflight checks passed and throws an error if failed
     custom_settings_value_wait:
         description: Waits for a specific field value on the specified custom settings object and field
         class_path: cumulusci.tasks.salesforce.custom_settings_wait.CustomSettingValueWait

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -1,6 +1,10 @@
 cumulusci:
     keychain: cumulusci.core.keychain.EncryptedFileProjectKeychain
 tasks:
+    preflight_checks:
+        group: Salesforce Preflight Checks
+        class_path: cumulusci.tasks.preflight.checks.RetrievePreflightChecks
+        description: Retrieves preflight checks passed and throws an error if failed
     activate_flow:
         group: Metadata Transformations
         description: Activates Flows identified by a given list of Developer Names

--- a/cumulusci/tasks/preflight/checks.py
+++ b/cumulusci/tasks/preflight/checks.py
@@ -1,0 +1,125 @@
+from cumulusci.core.config import TaskConfig
+from cumulusci.tasks.preflight.licenses import (
+    GetAvailableLicenses,
+    GetAvailablePermissionSetLicenses,
+    GetAvailablePermissionSets,
+    GetPermissionLicenseSetAssignments,
+)
+from cumulusci.tasks.preflight.packages import GetInstalledPackages
+from cumulusci.tasks.preflight.permsets import GetPermissionSetAssignments
+from cumulusci.tasks.preflight.recordtypes import CheckSObjectRecordTypes
+from cumulusci.tasks.preflight.settings import CheckMyDomainActive, CheckSettingsValue
+from cumulusci.tasks.preflight.sobjects import (
+    CheckSObjectOWDs,
+    CheckSObjectPerms,
+    CheckSObjectsAvailable,
+)
+from cumulusci.tasks.salesforce import BaseSalesforceApiTask, DescribeMetadataTypes
+
+
+class RetrievePreflightChecks(BaseSalesforceApiTask):
+    task_options = {
+        "object_permissions": {
+            "description": "The object permissions to check. Each key should be an sObject API name, whose value is a map of describe keys, "
+            "such as `queryable` and `createable`, to their desired values (True or False). The output is True if all sObjects and permissions "
+            "are present and matching the specification. See the task documentation for examples."
+        },
+        "treat_missing_setting_as_failure": {
+            "description": "If True, treat a missing Settings entity as a preflight failure, instead of raising an exception. Defaults to False.",
+        },
+        "setting_checks": {
+            "description": "To check whether the setting entity has the given field or not "
+        },
+        "object_org_wide_defaults": {
+            "description": "The Organization-Wide Defaults to check, "
+            "organized as a list with each element containing the keys api_name, "
+            "internal_sharing_model, and external_sharing_model. NOTE: you must have "
+            "External Sharing Model turned on in Sharing Settings to use the latter feature. "
+            "Checking External Sharing Model when it is turned off will fail the preflight.",
+        },
+    }
+
+    def _init_task(self):
+        super()._init_task()
+
+    def _run_task(self):
+
+        classes = [
+            CheckMyDomainActive,
+            GetAvailableLicenses,
+            GetAvailablePermissionSetLicenses,
+            GetPermissionLicenseSetAssignments,
+            GetAvailablePermissionSets,
+            GetInstalledPackages,
+            GetPermissionSetAssignments,
+            CheckSObjectRecordTypes,
+            CheckSObjectsAvailable,
+            DescribeMetadataTypes,
+        ]
+
+        self.return_values = {
+            cls.__name__: cls(
+                org_config=self.org_config,
+                project_config=self.project_config,
+                task_config=self.task_config,
+            )()
+            for cls in classes
+        }
+
+        if "object_permissions" in self.options:
+            task_config = TaskConfig(
+                {"options": {"permissions": self.options["object_permissions"]}}
+            )
+            self.return_values["CheckSObjectPerms"] = CheckSObjectPerms(
+                org_config=self.org_config,
+                project_config=self.project_config,
+                task_config=task_config,
+            )()
+        if "object_org_wide_defaults" in self.options:
+            task_config = TaskConfig(
+                {
+                    "options": {
+                        "org_wide_defaults": self.options["object_org_wide_defaults"]
+                    }
+                }
+            )
+
+            self.return_values["CheckSObjectOWDs"] = CheckSObjectOWDs(
+                org_config=self.org_config,
+                project_config=self.project_config,
+                task_config=task_config,
+            )()
+
+        if "treat_missing_setting_as_failure" not in self.options:
+            self.options["treat_missing_setting_as_failure"] = False
+
+        if "setting_checks" in self.options:
+            self.return_values["CheckSettingsValue"] = True
+            self.setting_checks = {
+                (entry["settings_type"], entry["settings_field"], entry["value"])
+                for entry in self.options["setting_checks"]
+            }
+
+            for type, field, value in self.setting_checks:
+                task_config = task_config = TaskConfig(
+                    {
+                        "options": {
+                            "settings_type": type,
+                            "settings_field": field,
+                            "value": value,
+                            "treat_missing_as_failure": self.options[
+                                "treat_missing_setting_as_failure"
+                            ],
+                        }
+                    }
+                )
+                self.return_values["CheckSettingsValue"] = (
+                    self.return_values["CheckSettingsValue"]
+                    and CheckSettingsValue(
+                        org_config=self.org_config,
+                        project_config=self.project_config,
+                        task_config=task_config,
+                    )()
+                )
+                if not self.return_values["CheckSettingsValue"]:
+                    break

--- a/cumulusci/tasks/preflight/tests/test_checks.py
+++ b/cumulusci/tasks/preflight/tests/test_checks.py
@@ -1,0 +1,77 @@
+from unittest.mock import Mock
+
+from cumulusci.tasks.preflight.checks import RetrievePreflightChecks
+from cumulusci.tasks.preflight.licenses import (
+    GetAvailableLicenses,
+    GetAvailablePermissionSetLicenses,
+    GetAvailablePermissionSets,
+    GetPermissionLicenseSetAssignments,
+)
+from cumulusci.tasks.preflight.packages import GetInstalledPackages
+from cumulusci.tasks.preflight.permsets import GetPermissionSetAssignments
+from cumulusci.tasks.preflight.recordtypes import CheckSObjectRecordTypes
+from cumulusci.tasks.preflight.settings import CheckMyDomainActive, CheckSettingsValue
+from cumulusci.tasks.preflight.sobjects import (
+    CheckSObjectOWDs,
+    CheckSObjectPerms,
+    CheckSObjectsAvailable,
+)
+from cumulusci.tasks.salesforce import DescribeMetadataTypes
+from cumulusci.tasks.salesforce.tests.util import create_task
+
+
+class TestRetrievePreflightChecks:
+    def test_preflight_checks(self):
+        task = create_task(
+            RetrievePreflightChecks,
+            {
+                "object_org_wide_defaults": [
+                    {"api_name": "Account", "internal_sharing_model": "Private"},
+                    {"api_name": "Contact", "internal_sharing_model": "ReadWrite"},
+                ],
+                "setting_checks": [
+                    {
+                        "settings_type": "ChatterSettings",
+                        "settings_field": "settings_field",
+                        "value": True,
+                    },
+                    {
+                        "settings_type": "ChatterSettings",
+                        "settings_field": "Foo",
+                        "value": True,
+                    },
+                ],
+                "object_permissions": {
+                    "Account": {"createable": True, "updateable": False},
+                    "Contact": {"createable": False},
+                },
+            },
+        )
+
+        classes = [
+            CheckMyDomainActive,
+            GetAvailableLicenses,
+            GetAvailablePermissionSetLicenses,
+            GetPermissionLicenseSetAssignments,
+            GetAvailablePermissionSets,
+            GetInstalledPackages,
+            GetPermissionSetAssignments,
+            CheckSObjectRecordTypes,
+            CheckSObjectsAvailable,
+            DescribeMetadataTypes,
+        ]
+
+        for cls in classes:
+            cls._run_task = Mock()
+
+        CheckSObjectOWDs._run_task = Mock()
+        CheckSettingsValue._run_task = Mock()
+        CheckSObjectPerms._run_task = Mock()
+
+        task()
+        for cls in classes:
+            cls._run_task.assert_called_once()
+
+        CheckSObjectOWDs._run_task.assert_called_once()
+        CheckSettingsValue._run_task.assert_called_once()
+        CheckSObjectPerms._run_task.assert_called_once()

--- a/cumulusci/tasks/salesforce/DescribeMetadataTypes.py
+++ b/cumulusci/tasks/salesforce/DescribeMetadataTypes.py
@@ -22,5 +22,5 @@ class DescribeMetadataTypes(BaseRetrieveMetadata):
 
     def _run_task(self):
         api_object = self._get_api()
-        metadata_list = api_object()
-        self.logger.info("Metadata Types supported by org:\n" + str(metadata_list))
+        self.return_values = api_object()
+        self.logger.info("Metadata Types supported by org:\n" + str(self.return_values))


### PR DESCRIPTION
[W-14540405](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001f2ZmgYAE/view)

Existing preflight checks are retrieved. That is sobjects, permissions, licenses and are stored in return_values and the object permissions and other are checked and the result is stored, throws an error if failed. 