### PR TITLE
fix: re-enable telemetry, make CCI usage identifiable

### DIFF
--- a/cumulusci/core/sfdx.py
+++ b/cumulusci/core/sfdx.py
@@ -52,7 +52,7 @@ def sfdx(
         stdout=sarge.Capture(buffer_size=-1) if capture_output else None,
         stderr=sarge.Capture(buffer_size=-1) if capture_output else None,
         shell=True,
-        env={**env, "SFDX_DISABLE_TELEMETRY": "true"},
+        env={**env, "SFDX_TOOL": "CCI"},
     )
     p.run()
     if capture_output:


### PR DESCRIPTION
1. CLI team would like to not be missing all the CCI usage of the CLI when monitoring performance and making deprecation decisions
2. setting `SFDX_TOOL` makes it obvious which executions come from CCI.  Useful for debugging/adoption