### PR TITLE
updated return_values for task get_assigned_permission_sets

### DIFF
--- a/cumulusci/tasks/preflight/permsets.py
+++ b/cumulusci/tasks/preflight/permsets.py
@@ -5,16 +5,16 @@ class GetPermissionSetAssignments(BaseSalesforceApiTask):
     def _run_task(self):
         query = f"SELECT PermissionSet.Name,PermissionSetGroupId FROM PermissionSetAssignment WHERE AssigneeId = '{self.org_config.user_id}'"
 
-        self.permsets = []
+        self.return_values = []
         for result in self.sf.query_all(query)["records"]:
-            if result["PermissionSet"]["Name"] not in self.permsets:
-                self.permsets.append(result["PermissionSet"]["Name"])
+            if result["PermissionSet"]["Name"] not in self.return_values:
+                self.return_values.append(result["PermissionSet"]["Name"])
 
             if result["PermissionSetGroupId"] is not None:
                 psg_query = f"SELECT PermissionSet.Name from PermissionSetGroupComponent where PermissionSetGroupId = '{result['PermissionSetGroupId']}'"
                 for psg_result in self.sf.query_all(psg_query)["records"]:
-                    if psg_result["PermissionSet"]["Name"] not in self.permsets:
-                        self.permsets.append(psg_result["PermissionSet"]["Name"])
+                    if psg_result["PermissionSet"]["Name"] not in self.return_values:
+                        self.return_values.append(psg_result["PermissionSet"]["Name"])
 
-        permsets_str = "\n".join(self.permsets)
+        permsets_str = "\n".join(self.return_values)
         self.logger.info(f"Found permission sets assigned:\n{permsets_str}")

--- a/cumulusci/tasks/preflight/tests/test_permset_preflights.py
+++ b/cumulusci/tasks/preflight/tests/test_permset_preflights.py
@@ -43,9 +43,8 @@ class TestPermsetPreflights:
             },
         ]
         task()
-
         task._init_api.return_value.query_all.assert_called()
-        assert task.permsets == [
+        assert task.return_values == [
             "DocumentChecklist",
             "EinsteinAnalyticsPlusAdmin",
             "CustomerExperienceAnalyticsAdmin",


### PR DESCRIPTION
[W-14910021](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001j2AULYA2/view)

Retrieved list of assigned permission sets are assigned for the `task.return_values` to ensure the preflight check conditions are checked properly