### PR TITLE
Fix for mismatch between fields

### DIFF
--- a/cumulusci/tasks/bulkdata/load.py
+++ b/cumulusci/tasks/bulkdata/load.py
@@ -448,10 +448,10 @@ class LoadData(SqlAlchemyMixin, BaseSalesforceApiTask):
             AddMappingFiltersToQuery,
             AddUpsertsToQuery,
         ]
-        transformers = [cls(mapping, self.metadata, model) for cls in classes]
-        transformers.append(
+        transformers = [
             AddLookupsToQuery(mapping, self.metadata, model, self._old_format)
-        )
+        ]
+        transformers.extend([cls(mapping, self.metadata, model) for cls in classes])
 
         if mapping.sf_object == "Contact" and self._can_load_person_accounts(mapping):
             transformers.append(AddPersonAccountsToQuery(mapping, self.metadata, model))


### PR DESCRIPTION
Fixed `INVALID_CROSS_REFERENCE` error while inserting lookups and record types simultaneously. This error appeared after [PR: Polymorphic Lookup Data Extraction](https://github.com/SFDO-Tooling/CumulusCI/pull/3741). This error occurred due to mismatch in the order of fields between the step and query during generation of the json for the request. 