### PR TITLE
Fix dependency parsing errors caused by `collision_check` option

### DIFF
--- a/cumulusci/core/dependencies/dependencies.py
+++ b/cumulusci/core/dependencies/dependencies.py
@@ -544,6 +544,7 @@ class UnmanagedDependency(StaticDependency, abc.ABC):
     subfolder: Optional[str] = None
     namespace_inject: Optional[str] = None
     namespace_strip: Optional[str] = None
+    collision_check: Optional[bool] = None
 
     def _get_unmanaged(self, org: OrgConfig):
         if self.unmanaged is None:

--- a/cumulusci/core/dependencies/tests/test_dependencies.py
+++ b/cumulusci/core/dependencies/tests/test_dependencies.py
@@ -903,3 +903,13 @@ class TestParseDependency:
             }
         )
         assert isinstance(u, UnmanagedZipURLDependency)
+
+        u = parse_dependency(
+            {
+                "github": "https://github.com/Test/TestRepo",
+                "ref": "aaaaaaaa",
+                "collision_check": False,
+                "namespace_inject": "ns",
+            }
+        )
+        assert isinstance(u, UnmanagedGitHubRefDependency)


### PR DESCRIPTION
A new option, `collision_check`, was added to the `deploy` task. The new option wasn't added to `core/dependencies.py`, so attempting to deserialize resulted in a DependencyParseError in MetaDeploy.