### PR TITLE
@W-15258380/ Updating the login URL's

### DIFF
--- a/cumulusci/oauth/salesforce.py
+++ b/cumulusci/oauth/salesforce.py
@@ -22,9 +22,17 @@ PROD_LOGIN_URL = os.environ.get("SF_PROD_LOGIN_URL") or "https://login.salesforc
 
 
 def update_login_urls():
+    """
+    Updating to setup the environment variables dynamically
+    """
     global PROD_LOGIN_URL, SANDBOX_LOGIN_URL
-    PROD_LOGIN_URL = os.environ.get("SF_PROD_LOGIN_URL") or "https://login.salesforce.com"
-    SANDBOX_LOGIN_URL = os.environ.get("SF_SANDBOX_LOGIN_URL") or "https://test.salesforce.com"
+    PROD_LOGIN_URL = (
+        os.environ.get("SF_PROD_LOGIN_URL") or "https://login.salesforce.com"
+    )
+    SANDBOX_LOGIN_URL = (
+        os.environ.get("SF_SANDBOX_LOGIN_URL") or "https://test.salesforce.com"
+    )
+
 
 def jwt_session(
     client_id, private_key, username, url=None, auth_url=None, is_sandbox=False

--- a/cumulusci/oauth/salesforce.py
+++ b/cumulusci/oauth/salesforce.py
@@ -21,6 +21,11 @@ SANDBOX_LOGIN_URL = (
 PROD_LOGIN_URL = os.environ.get("SF_PROD_LOGIN_URL") or "https://login.salesforce.com"
 
 
+def update_login_urls():
+    global PROD_LOGIN_URL, SANDBOX_LOGIN_URL
+    PROD_LOGIN_URL = os.environ.get("SF_PROD_LOGIN_URL") or "https://login.salesforce.com"
+    SANDBOX_LOGIN_URL = os.environ.get("SF_SANDBOX_LOGIN_URL") or "https://test.salesforce.com"
+
 def jwt_session(
     client_id, private_key, username, url=None, auth_url=None, is_sandbox=False
 ):
@@ -31,6 +36,7 @@ def jwt_session(
     :param username: Username to authenticate as
     :param url: Org's instance_url
     """
+    update_login_urls()
     if auth_url:
         aud = (
             SANDBOX_LOGIN_URL

--- a/cumulusci/oauth/tests/test_salesforce.py
+++ b/cumulusci/oauth/tests/test_salesforce.py
@@ -1,3 +1,4 @@
+import os
 from unittest import mock
 
 import pytest
@@ -28,10 +29,12 @@ def test_jwt_session(encode):
 @mock.patch("cumulusci.oauth.salesforce.jwt.encode")
 def test_jwt_session__enhanced_domains_enabled(encode):
     # raise an assertion error if the registered url was not accessed
+    os.environ["SF_PROD_LOGIN_URL"] = "https://login.test1.salesforce.com"
+    os.environ["SF_SANDBOX_LOGIN_URL"] = "https://test.test1.salesforce.com"
     with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
         rsps.add(
             responses.POST,
-            "https://test.salesforce.com/services/oauth2/token",
+            "https://test.test1.salesforce.com/services/oauth2/token",
             body='{"message":"well done mate!"}',
             status=200,
         )


### PR DESCRIPTION
Work item : [link](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001mHTY8YAO/view)


Setting the PROD_LOGIN_URL and SANDBOX_LOGIN_URL doesn't update them dynamically. This causing issue while calling the jwt_session for the test environment 