### PR TITLE
Temporarily pin SQLAlchemy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "selenium<4",
     "simple-salesforce==1.11.4",
     "snowfakery",
-    "SQLAlchemy",
+    "SQLAlchemy<2",
     "xmltodict",
 ]
 


### PR DESCRIPTION
Postpone SQLAlchemy 2.0 migration until we get the WI included in a future sprint.