### PR TITLE
Fix Python 3.8 unit tests on macOS

### DIFF
--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -42,6 +42,12 @@ jobs:
             matrix:
                 os: [macos-latest, sfdc-ubuntu-latest, sfdc-windows-latest]
                 python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+                exclude:
+                    - os: macos-latest
+                      python-version: 3.8
+                include:
+                    - os: macos-13
+                      python-version: 3.8
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python


### PR DESCRIPTION
Importing `lxml` in Python 3.8 now throws an `ImportError` on macOS:

```python-traceback
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/_pytest/config/__init__.py", line 743, in import_plugin
    __import__(importspec)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/_pytest/assertion/rewrite.py", line 171, in exec_module
    exec(co, module.__dict__)
  File "/Users/runner/work/CumulusCI/CumulusCI/cumulusci/tests/pytest_plugins/pytest_sf_orgconnect.py", line 9, in <module>
    from cumulusci.cli.org import org_remove, org_scratch, org_scratch_delete
  File "/Users/runner/work/CumulusCI/CumulusCI/cumulusci/cli/org.py", line 12, in <module>
    from cumulusci.core.config import OrgConfig, ScratchOrgConfig
  File "/Users/runner/work/CumulusCI/CumulusCI/cumulusci/core/config/__init__.py", line 8, in <module>
    from cumulusci.core.utils import import_global
  File "/Users/runner/work/CumulusCI/CumulusCI/cumulusci/core/utils.py", line 21, in <module>
    from cumulusci.utils.options import parse_list_of_pairs_dict_arg
  File "/Users/runner/work/CumulusCI/CumulusCI/cumulusci/utils/__init__.py", line 20, in <module>
    from .xml import (  # noqa
  File "/Users/runner/work/CumulusCI/CumulusCI/cumulusci/utils/xml/__init__.py", line 5, in <module>
    from lxml import etree as lxml_etree
ImportError: dlopen(/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/lxml/etree.cpython-38-darwin.so, 0x0002): symbol not found in flat namespace '_exsltDateXpathCtxtRegister'
```

According to the discussion on actions/setup-python#696, `macos-latest` runners are now on `AArch64`, while `macos-13` is still on `x86`. This PR switches the 3.8 runner to `macos-13` as a workaround.