### PR TITLE
Fix for Delete Session Records

### DIFF
--- a/cumulusci/robotframework/SalesforceAPI.py
+++ b/cumulusci/robotframework/SalesforceAPI.py
@@ -11,9 +11,10 @@ STATUS_KEY = ("status",)
 class SalesforceAPI(BaseLibrary):
     """Keywords for interacting with Salesforce API"""
 
+    _session_records = []
+
     def __init__(self):
         super().__init__()
-        self._session_records = []
 
     def delete_session_records(self):
         """Deletes records that were created while running this test case.


### PR DESCRIPTION
Move _session_records outside __init__ to maintain records for Suite Teardown. Otherwise once the Suite Teardown is hit it will continue to cause the _session_records list to be cleared.