### PR TITLE
Extend modal close wait with custom timeout

### DIFF
--- a/cumulusci/robotframework/Salesforce.py
+++ b/cumulusci/robotframework/Salesforce.py
@@ -632,10 +632,10 @@ class Salesforce(FakerMixin, BaseLibrary):
         )
 
     @capture_screenshot_on_error
-    def wait_until_modal_is_closed(self):
+    def wait_until_modal_is_closed(self, timeout=15):
         """Wait for modal to close"""
         self.selenium.wait_until_page_does_not_contain_element(
-            lex_locators["modal"]["is_open"], timeout=15
+            lex_locators["modal"]["is_open"], timeout
         )
 
     @capture_screenshot_on_error


### PR DESCRIPTION
Enhanced flexibility in `wait_until_modal_is_closed` method by adding an optional timeout parameter. This allows custom waiting periods for slower environments or particularly time-consuming operations, improving test reliability. Default timeout remains unchanged at 15 seconds.