### PR TITLE
Allow manually triggering lint workflow

### DIFF
--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
     lint:
         name: Lint
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ contains(fromJSON('["workflow_dispatch", "pull_request"]'), github.event_name) }}
         uses: SFDO-Tooling/.github/.github/workflows/pre-commit.yml@main
     docs:
         name: Build Docs


### PR DESCRIPTION
Needed until we update the shared workflow to run on pull requests
from forked repositories.