### PR TITLE
Updated the PermissionSetLicenseKey to DeveloperName

### DIFF
--- a/cumulusci/tasks/preflight/licenses.py
+++ b/cumulusci/tasks/preflight/licenses.py
@@ -16,9 +16,9 @@ class GetAvailableLicenses(BaseSalesforceApiTask):
 class GetAvailablePermissionSetLicenses(BaseSalesforceApiTask):
     def _run_task(self):
         self.return_values = [
-            result["PermissionSetLicenseKey"]
+            result["DeveloperName"]
             for result in self.sf.query(
-                "SELECT PermissionSetLicenseKey FROM PermissionSetLicense"
+                "SELECT DeveloperName FROM PermissionSetLicense"
             )["records"]
         ]
         licenses = "\n".join(self.return_values)

--- a/cumulusci/tasks/preflight/tests/test_licenses.py
+++ b/cumulusci/tasks/preflight/tests/test_licenses.py
@@ -34,14 +34,14 @@ class TestLicensePreflights:
         task._init_api.return_value.query.return_value = {
             "totalSize": 2,
             "records": [
-                {"PermissionSetLicenseKey": "TEST1"},
-                {"PermissionSetLicenseKey": "TEST2"},
+                {"DeveloperName": "TEST1"},
+                {"DeveloperName": "TEST2"},
             ],
         }
         task()
 
         task._init_api.return_value.query.assert_called_once_with(
-            "SELECT PermissionSetLicenseKey FROM PermissionSetLicense"
+            "SELECT DeveloperName FROM PermissionSetLicense"
         )
         assert task.return_values == ["TEST1", "TEST2"]
 


### PR DESCRIPTION
The PermissionSetLicenseKey have the naming format as `SalesforceCPQ.CPQStandardPerm` and the actual developer name is `SalesforceCPQ_CPQStandardPerm` and to avoid errors .

Replaced with the developername