### PR TITLE
 @W-15946941: New task added to display files in the salesforce org 

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -224,10 +224,6 @@ tasks:
         class_path: cumulusci.tasks.marketing_cloud.deploy.MarketingCloudDeployTask
         description: Deploys a package zip file to a Marketing Cloud Tenant via the Marketing Cloud Package Manager API.
         group: Marketing Cloud
-    display_files:
-        description: Display documents that has been uploaded to a library in Salesforce CRM Content or Salesforce Files.
-        class_path: cumulusci.tasks.salesforce.salesforce_files.DisplayFiles
-        group: Salesforce Metadata
     marketing_cloud_create_subscriber_attribute:
         class_path: cumulusci.tasks.marketing_cloud.api.CreateSubscriberAttribute
         description: Creates a Subscriber Attribute via the Marketing Cloud SOAP API.
@@ -415,6 +411,10 @@ tasks:
         description: Prints the Community Templates available to the current org
         class_path: cumulusci.tasks.salesforce.ListCommunityTemplates
         group: Salesforce Communities
+    list_files:
+        description: Display documents that has been uploaded to a library in Salesforce CRM Content or Salesforce Files.
+        class_path: cumulusci.tasks.salesforce.salesforce_files.ListFiles
+        group: Salesforce Metadata
     list_metadata_types:
         description: Prints the metadata types in a project
         class_path: cumulusci.tasks.util.ListMetadataTypes

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -224,6 +224,10 @@ tasks:
         class_path: cumulusci.tasks.marketing_cloud.deploy.MarketingCloudDeployTask
         description: Deploys a package zip file to a Marketing Cloud Tenant via the Marketing Cloud Package Manager API.
         group: Marketing Cloud
+    display_files:
+        description: Display documents that has been uploaded to a library in Salesforce CRM Content or Salesforce Files.
+        class_path: cumulusci.tasks.salesforce.salesforce_files.DisplayFiles
+        group: Salesforce Metadata
     marketing_cloud_create_subscriber_attribute:
         class_path: cumulusci.tasks.marketing_cloud.api.CreateSubscriberAttribute
         description: Creates a Subscriber Attribute via the Marketing Cloud SOAP API.

--- a/cumulusci/tasks/salesforce/salesforce_files.py
+++ b/cumulusci/tasks/salesforce/salesforce_files.py
@@ -1,0 +1,30 @@
+from cumulusci.tasks.salesforce import BaseSalesforceApiTask
+
+
+class DisplayFiles(BaseSalesforceApiTask):
+    task_docs = """
+    Lists the available documents that has been uploaded to a library in Salesforce CRM Content or Salesforce Files
+    """
+
+    def _run_task(self):
+        self.return_values = [
+            {
+                "Id": result["Id"],
+                "Title": result["Title"],
+                "FileType": result["FileType"],
+            }
+            for result in self.sf.query(
+                "SELECT Title, Id, FileType FROM ContentDocument"
+            )["records"]
+        ]
+        self.logger.info(f"Found {len(self.return_values)} files")
+        if len(self.return_values) > 0:
+            self.logger.info(f"{'Id':<20} {'Title':<50} {'FileType':<10}")
+
+            # Print each row of the table
+            for file_desc in self.return_values:
+                self.logger.info(
+                    f"{file_desc['Id']:<20} {file_desc['Title']:<50} {file_desc['FileType']:<10}"
+                )
+
+        return self.return_values

--- a/cumulusci/tasks/salesforce/salesforce_files.py
+++ b/cumulusci/tasks/salesforce/salesforce_files.py
@@ -19,7 +19,7 @@ class DisplayFiles(BaseSalesforceApiTask):
         ]
         self.logger.info(f"Found {len(self.return_values)} files")
         if len(self.return_values) > 0:
-            self.logger.info(f"{'Id':<20} {'Title':<50} {'FileType':<10}")
+            self.logger.info(f"{'Id':<20} {'FileName':<50} {'FileType':<10}")
 
             # Print each row of the table
             for file_desc in self.return_values:

--- a/cumulusci/tasks/salesforce/salesforce_files.py
+++ b/cumulusci/tasks/salesforce/salesforce_files.py
@@ -10,7 +10,7 @@ class DisplayFiles(BaseSalesforceApiTask):
         self.return_values = [
             {
                 "Id": result["Id"],
-                "Title": result["Title"],
+                "FileName": result["Title"],
                 "FileType": result["FileType"],
             }
             for result in self.sf.query(
@@ -24,7 +24,7 @@ class DisplayFiles(BaseSalesforceApiTask):
             # Print each row of the table
             for file_desc in self.return_values:
                 self.logger.info(
-                    f"{file_desc['Id']:<20} {file_desc['Title']:<50} {file_desc['FileType']:<10}"
+                    f"{file_desc['Id']:<20} {file_desc['FileName']:<50} {file_desc['FileType']:<10}"
                 )
 
         return self.return_values

--- a/cumulusci/tasks/salesforce/salesforce_files.py
+++ b/cumulusci/tasks/salesforce/salesforce_files.py
@@ -1,7 +1,7 @@
 from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 
 
-class DisplayFiles(BaseSalesforceApiTask):
+class ListFiles(BaseSalesforceApiTask):
     task_docs = """
     Lists the available documents that has been uploaded to a library in Salesforce CRM Content or Salesforce Files
     """

--- a/cumulusci/tasks/salesforce/sourcetracking.py
+++ b/cumulusci/tasks/salesforce/sourcetracking.py
@@ -350,7 +350,7 @@ def retrieve_components(
             with open(os.path.join(target, "package.xml"), "w", encoding="utf-8") as f:
                 f.write(package_xml)
         if capture_output:
-            return p.stdout_text.read()
+            return p.stdout_text.read(), p.stderr_text.read()
         else:
             return None
 

--- a/cumulusci/tasks/salesforce/sourcetracking.py
+++ b/cumulusci/tasks/salesforce/sourcetracking.py
@@ -350,7 +350,7 @@ def retrieve_components(
             with open(os.path.join(target, "package.xml"), "w", encoding="utf-8") as f:
                 f.write(package_xml)
         if capture_output:
-            return p.stdout_text.read(), p.stderr_text.read()
+            return p.stdout_text.read()
         else:
             return None
 

--- a/cumulusci/tasks/salesforce/tests/test_salesforce_files.py
+++ b/cumulusci/tasks/salesforce/tests/test_salesforce_files.py
@@ -21,6 +21,6 @@ class TestDisplayFiles:
             "SELECT Title, Id, FileType FROM ContentDocument"
         )
         assert task.return_values == [
-            {"Id": "0PS000000000000", "Title": "TEST1", "FileType": "TXT"},
-            {"Id": "0PS000000000001", "Title": "TEST2", "FileType": "TXT"},
+            {"Id": "0PS000000000000", "FileName": "TEST1", "FileType": "TXT"},
+            {"Id": "0PS000000000001", "FileName": "TEST2", "FileType": "TXT"},
         ]

--- a/cumulusci/tasks/salesforce/tests/test_salesforce_files.py
+++ b/cumulusci/tasks/salesforce/tests/test_salesforce_files.py
@@ -1,12 +1,12 @@
 from unittest.mock import Mock
 
-from cumulusci.tasks.salesforce.salesforce_files import DisplayFiles
+from cumulusci.tasks.salesforce.salesforce_files import ListFiles
 from cumulusci.tasks.salesforce.tests.util import create_task
 
 
 class TestDisplayFiles:
     def test_display_files(self):
-        task = create_task(DisplayFiles, {})
+        task = create_task(ListFiles, {})
         task._init_api = Mock()
         task._init_api.return_value.query.return_value = {
             "totalSize": 2,

--- a/cumulusci/tasks/salesforce/tests/test_salesforce_files.py
+++ b/cumulusci/tasks/salesforce/tests/test_salesforce_files.py
@@ -1,0 +1,26 @@
+from unittest.mock import Mock
+
+from cumulusci.tasks.salesforce.salesforce_files import DisplayFiles
+from cumulusci.tasks.salesforce.tests.util import create_task
+
+
+class TestDisplayFiles:
+    def test_display_files(self):
+        task = create_task(DisplayFiles, {})
+        task._init_api = Mock()
+        task._init_api.return_value.query.return_value = {
+            "totalSize": 2,
+            "records": [
+                {"Title": "TEST1", "Id": "0PS000000000000", "FileType": "TXT"},
+                {"Title": "TEST2", "Id": "0PS000000000001", "FileType": "TXT"},
+            ],
+        }
+        task()
+
+        task._init_api.return_value.query.assert_called_once_with(
+            "SELECT Title, Id, FileType FROM ContentDocument"
+        )
+        assert task.return_values == [
+            {"Id": "0PS000000000000", "Title": "TEST1", "FileType": "TXT"},
+            {"Id": "0PS000000000001", "Title": "TEST2", "FileType": "TXT"},
+        ]


### PR DESCRIPTION
Files uploaded via the app launcher in the orgs are currently not included in the metadata listings.

To address this, the "display_files" task has been introduced to list these files efficiently. 

- This task gives the list of files in a tabular format querying the `ContentDocument`, fetching the fields Id, Filetype, and Filename, as filenames alone are not unique identifiers. 
- Upon uploading a new file, a fresh entry is generated in the `ContentDocument` entity, establishing it as the latest version in the `ContentVersion` entity. Subsequent uploads of new versions of already tracked documents are noted in the ContentVersion entity, without creating additional ContentDocument records. 
- Retrieving the latest version involves filtering the ContentVersion entity by setting IsLatest to true and employing the file's ContentDocumentId as the filter criterion. 