### PR TITLE
fix: Use private runner names instead of labels

### DIFF
--- a/.github/workflows/chores.yml
+++ b/.github/workflows/chores.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     check_api_versions:
-        runs-on: sfdc-ubuntu-latest
+        runs-on: SFDO-Tooling-Ubuntu
         outputs:
             hub_version: ${{ steps.devhub-api-version.outputs.hub_version }}
             cci_version: ${{ steps.cci-api-version.outputs.cci_version }}
@@ -30,7 +30,7 @@ jobs:
                   version=$(yq '.project.package.api_version' cumulusci/cumulusci.yml)
                   echo "::set-output name=cci_version::$version"
     update_api_versions:
-        runs-on: sfdc-ubuntu-latest
+        runs-on: SFDO-Tooling-Ubuntu
         needs: check_api_versions
         if: ${{ needs.check_api_versions.outputs.hub_version != needs.check_api_versions.outputs.cci_version }}
         env:

--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -16,7 +16,7 @@ jobs:
     docs:
         name: Build Docs
         if: ${{ github.event_name == 'pull_request' }}
-        runs-on: sfdc-ubuntu-latest
+        runs-on: SFDO-Tooling-Ubuntu
         steps:
             - name: "Checkout"
               uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [macos-latest, sfdc-ubuntu-latest, sfdc-windows-latest]
+                os: [macos-latest, SFDO-Tooling-Ubuntu, SFDO-Tooling-Windows]
                 python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
                 exclude:
                     - os: macos-latest
@@ -63,7 +63,7 @@ jobs:
 
     robot_api:
         name: "Robot: No browser"
-        runs-on: sfdc-ubuntu-latest
+        runs-on: SFDO-Tooling-Ubuntu
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python 3.8

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -19,7 +19,7 @@ on:
 jobs:
     generate-changelog:
         name: Create a PR to update version and release notes
-        runs-on: sfdc-ubuntu-latest
+        runs-on: SFDO-Tooling-Ubuntu
         steps:
             - uses: actions/checkout@main
             - name: Set up Python 3.8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ concurrency: publishing
 jobs:
     publish-to-pypi:
         name: Publish new release to PyPI
-        runs-on: sfdc-ubuntu-latest
+        runs-on: SFDO-Tooling-Ubuntu
         steps:
             - uses: actions/checkout@main
             - name: Set up Python 3.8

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -34,7 +34,7 @@ env:
 jobs:
     test_artifacts:
         name: "Test Package Artifacts"
-        runs-on: sfdc-ubuntu-latest
+        runs-on: SFDO-Tooling-Ubuntu
         steps:
             - uses: actions/checkout@v3
             - name: Set up Python 3.8
@@ -67,7 +67,7 @@ jobs:
 
     test_release:
         name: "Test Release Flows"
-        runs-on: sfdc-ubuntu-latest
+        runs-on: SFDO-Tooling-Ubuntu
         concurrency: release
         steps:
             - uses: actions/checkout@v3

--- a/.github/workflows/slow_integration_tests.yml
+++ b/.github/workflows/slow_integration_tests.yml
@@ -22,7 +22,7 @@ env:
 jobs:
     org_backed_tests:
         name: "Org-connected Tests"
-        runs-on: sfdc-ubuntu-latest
+        runs-on: SFDO-Tooling-Ubuntu
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python 3.8
@@ -57,7 +57,7 @@ jobs:
                   cci org scratch_delete pytest
     robot_ui:
         name: "Robot: ${{ matrix.job-name }}"
-        runs-on: sfdc-ubuntu-latest
+        runs-on: SFDO-Tooling-Ubuntu
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
We missed the [announcement]:

> Customers will then no longer be able to use multiple labels or target
> non-name labels on larger runners after the 17th of June.

[announcement]: https://github.blog/changelog/2024-05-16-new-dates-for-actions-larger-runner-multi-label-deprecation/
