### PR TITLE
feat: add support for custom base url filtering

### DIFF
--- a/cumulusci/core/config/org_config.py
+++ b/cumulusci/core/config/org_config.py
@@ -26,7 +26,6 @@ SKIP_REFRESH = os.environ.get("CUMULUSCI_DISABLE_REFRESH")
 SANDBOX_MYDOMAIN_RE = re.compile(r"\.cs\d+\.my\.(.*)salesforce\.com")
 MYDOMAIN_RE = re.compile(r"\.my\.(.*)salesforce\.com")
 
-
 VersionInfo = namedtuple("VersionInfo", ["id", "number"])
 
 
@@ -155,10 +154,20 @@ class OrgConfig(BaseConfig):
     @property
     def lightning_base_url(self):
         instance_url = self.instance_url.rstrip("/")
+        if "SF_CUSTOM_URL_RE" in os.environ and "SF_CUSTOM_URL_BASE" in os.environ:
+            checkCustom = True
+            SF_CUSTOM_URL_RE = re.compile(r"%s" % os.environ.get("SF_CUSTOM_URL_RE"))
+        else:
+            checkCustom = False
+
         if SANDBOX_MYDOMAIN_RE.search(instance_url):
             return SANDBOX_MYDOMAIN_RE.sub(r".lightning.\1force.com", instance_url)
         elif MYDOMAIN_RE.search(instance_url):
             return MYDOMAIN_RE.sub(r".lightning.\1force.com", instance_url)
+        elif checkCustom and SF_CUSTOM_URL_RE.search(instance_url):
+            return SF_CUSTOM_URL_RE.sub(
+                r"%s" % os.environ.get("SF_CUSTOM_URL_BASE"), instance_url
+            )
         else:
             return self.instance_url.split(".")[0] + ".lightning.force.com"
 

--- a/cumulusci/core/config/tests/test_config.py
+++ b/cumulusci/core/config/tests/test_config.py
@@ -1035,6 +1035,22 @@ class TestOrgConfig:
         config = OrgConfig({"instance_url": "https://foo.my.salesforce.com"}, "test")
         assert config.lightning_base_url == "https://foo.lightning.force.com"
 
+    def test_lightning_base_url__env_provided(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "SF_CUSTOM_URL_RE": "\\.test\\.url\\.dev:6101",
+                "SF_CUSTOM_URL_BASE": ".api.url.dev",
+            },
+        ):
+            config = OrgConfig(
+                {
+                    "instance_url": "https://special.custom.test.url.dev:6101",
+                },
+                "test",
+            )
+            assert config.lightning_base_url == "https://special.custom.api.url.dev"
+
     @responses.activate
     def test_get_salesforce_version(self):
         responses.add(


### PR DESCRIPTION
# Background

When cumulusCI goes to execute a command against a specific org, it generates some config of the org. Part of the config is a `lightningBaseUrl`. The `lightningBaseUrl` composition tries to standardize the base url by setting the base url to `*.lightning.force.com`.

There are a few edge cases where the instance we're interacting with is using a wholly custom url format so a `.lightning.force.com` url isn't going to be accurate. In those cases, the `.lightning.force.com` url will cause robot actions to fail when trying to interact with the instance.

# Resolution

In this PR, I introduce two env vars:
- `SF_CUSTOM_URL_RE` - The shape of the url to match 
- `SF_CUSTOM_URL_BASE` - How to set the base url when the above matches

The config inflation will check if an org's url matches these env vars before defaulting to the `.lightning.force.com` base url. 

