### PR TITLE
Include All Keys in standardValue XML for add_standard_value_set_entries Task from Entries Option with Backward Compatibility

### DIFF
--- a/cumulusci/tasks/metadata_etl/tests/test_value_sets.py
+++ b/cumulusci/tasks/metadata_etl/tests/test_value_sets.py
@@ -38,8 +38,8 @@ class TestAddValueSetEntries:
                 "api_version": "47.0",
                 "api_names": "bar,foo",
                 "entries": [
-                    {"fullName": "Test", "label": "Label"},
-                    {"fullName": "Test_2", "label": "Label 2"},
+                    {"fullName": "Test", "label": "Label", "group": "Schedule"},
+                    {"fullName": "Test_2", "label": "Label 2", "default": "true"},
                 ],
             },
         )
@@ -57,6 +57,9 @@ class TestAddValueSetEntries:
         assert len(entry) == 1
         label = entry[0].findall(f".//{MD}label")
         assert len(label) == 1
+        group = entry[0].findall(f".//{MD}group")
+        assert group[0].text == "Schedule"
+        assert len(group) == 1
         assert label[0].text == "Label"
         default = entry[0].findall(f".//{MD}default")
         assert len(default) == 1

--- a/cumulusci/tasks/metadata_etl/value_sets.py
+++ b/cumulusci/tasks/metadata_etl/value_sets.py
@@ -88,15 +88,19 @@ class AddValueSetEntries(MetadataSingleEntityTransformTask):
 
                 elem.append("default", text="false")
 
-                if api_name in ["OpportunityStage", "CaseStatus"]:
+                if api_name == "CaseStatus":
                     elem.append("closed", str(entry["closed"]).lower())
 
-                if api_name == "OpportunityStage":
+                elif api_name == "OpportunityStage":
                     elem.append("won", str(entry["won"]).lower())
+                    elem.append("closed", str(entry["closed"]).lower())
                     elem.append("probability", str(entry["probability"]))
                     elem.append("forecastCategory", entry["forecastCategory"])
 
-                if api_name == "LeadStatus":
-                    elem.append("converted", str(entry["converted"]).lower())
-
+                elif api_name == "LeadStatus":
+                    elem.append("converted", str(entry["converted"]).lower())             
+                else:
+                    for entry_key in entry:
+                        if entry_key not in ['fullName', 'label', 'default']:
+                            elem.append(entry_key, str(entry[entry_key]))
         return metadata

--- a/cumulusci/tasks/metadata_etl/value_sets.py
+++ b/cumulusci/tasks/metadata_etl/value_sets.py
@@ -98,9 +98,9 @@ class AddValueSetEntries(MetadataSingleEntityTransformTask):
                     elem.append("forecastCategory", entry["forecastCategory"])
 
                 elif api_name == "LeadStatus":
-                    elem.append("converted", str(entry["converted"]).lower())             
+                    elem.append("converted", str(entry["converted"]).lower())
                 else:
                     for entry_key in entry:
-                        if entry_key not in ['fullName', 'label', 'default']:
+                        if entry_key not in ["fullName", "label", "default"]:
                             elem.append(entry_key, str(entry[entry_key]))
         return metadata


### PR DESCRIPTION
```
  task: add_standard_value_set_entries
  options:
      api_names: CaseOrigin
      entries:
          - fullName: New Account
            label: New Account
          - fullName: Questionable Contact
            label: Questionable Contact
      ui_options:
          name: Add values to Case Origin picklist
```

For the add_standard_value_set_entries task, we noticed that only the fullname and label keys were being considered when generating the XML file for deployment, while other keys were being ignored. We've implemented a fix to ensure that all provided keys are now included in the standard value entry XML file.

For example ,

If the entries were given like this , 
```
entries:
   - fullName: testerunner
      label: testrunner
      groupingString: Scheduled
```     
Now, it generates an XML like this 
```
<standardValue>
    <fullName>testerunner</fullName>
    <label>testrunner</label>
    <default>false</default>
    <groupingString>Scheduled</groupingString>
</standardValue>
```

But, there were case by case scenarios added for "OpportunityStage","CaseStatus","LeadStatus" which were left untouched to maintain backward compatibility and default will be always set as False, even though we pass in the entries as true.

Related work item : [W-16541459](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001zQu1TYAS/view)
