### PR TITLE
Fix readthedocs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,9 +7,15 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-    os: ubuntu-20.04
+    os: ubuntu-22.04
     tools:
-        python: "3.9"
+        python: "3.12"
+    commands:
+        - asdf plugin add uv
+        - asdf install uv latest
+        - asdf global uv latest
+        - uv sync --only-group docs --frozen
+        - uv run -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -19,8 +25,3 @@ sphinx:
 formats:
     - pdf
     - epub
-
-# Optionally declare the Python requirements required to build your docs
-python:
-    install:
-        - requirements: requirements_dev.txt


### PR DESCRIPTION
- Rename readthedocs.yml to .readthedocs.yml, 
- update to Ubuntu 22.04 and Python 3.12, 
- add uv setup and Sphinx build commands.