### PR TITLE
cumulusci.yml org modification is missing "scratch:" in the example.

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -633,8 +633,9 @@ For example, override the default number of days from 7 to 15 in the
 
 ```yaml
 orgs:
-    dev:
-        days: 15
+    scratch:
+        dev:
+            days: 15
 ```
 
 ## Configuration Scopes


### PR DESCRIPTION
cumulusci.yml org modification is missing "scratch:" in the example.