### PR TITLE
@W-17440435: Filter default records during INSERT for SELECT action

### DIFF
--- a/cumulusci/tasks/bulkdata/tests/test_step.py
+++ b/cumulusci/tasks/bulkdata/tests/test_step.py
@@ -25,6 +25,7 @@ from cumulusci.tasks.bulkdata.step import (
     assign_weights,
     download_file,
     extract_flattened_headers,
+    filter_records,
     flatten_record,
     get_dml_operation,
     get_query_operation,
@@ -3875,3 +3876,42 @@ def test_flatten_record(record, headers, expected):
 def test_assign_weights(priority_fields, fields, expected):
     result = assign_weights(priority_fields, fields)
     assert result == expected
+
+
+def test_filter_records():
+    fields = ["Name", "AccountNumber", "Industry"]
+    records = [
+        ["Sample Account for Entitlements", "123", "Technology"],
+        ["Acme Corp", "456", "Retail"],
+        ["Test Company", "789", "Finance"],
+    ]
+
+    # Test 1: Exclude specific record
+    where_condition = "Name != 'Sample Account for Entitlements'"
+    expected_output = [
+        ["Acme Corp", "456", "Retail"],
+        ["Test Company", "789", "Finance"],
+    ]
+    assert filter_records(fields, records, where_condition) == expected_output
+
+    # Test 2: Include only specific Industry
+    where_condition = "Industry == 'Retail'"
+    expected_output = [["Acme Corp", "456", "Retail"]]
+    assert filter_records(fields, records, where_condition) == expected_output
+
+    # Test 3: No match
+    where_condition = "AccountNumber == '999'"
+    expected_output = []
+    assert filter_records(fields, records, where_condition) == expected_output
+
+    # Test 4: Multiple conditions
+    where_condition = "Name == 'Acme Corp' and Industry == 'Retail'"
+    expected_output = [["Acme Corp", "456", "Retail"]]
+    assert filter_records(fields, records, where_condition) == expected_output
+
+    # Test 5: Empty input
+    fields = []
+    records = []
+    where_condition = "Name != 'Nonexistent'"
+    expected_output = []
+    assert filter_records(fields, records, where_condition) == expected_output


### PR DESCRIPTION
[W-17440435](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000026pOS4YAM/view)

Changes:  
- Added a pre-step to the `select_post_process` where any default records (defined in `hardcoded_default_declarations.py`) present in the local SQL are removed if no `user_filter` is provided.  

Reason for the condition: The default records are included during selection from the target org when a `user_filter` is provided. Therefore, default records should only be excluded from the local SQL when they are also excluded during the selection process, which occurs only when no `user_filter` is specified.