### PR TITLE
Remove default declaration for select rows query

### DIFF
--- a/cumulusci/tasks/bulkdata/select_utils.py
+++ b/cumulusci/tasks/bulkdata/select_utils.py
@@ -7,9 +7,6 @@ from enum import Enum
 from pydantic import Field, root_validator, validator
 
 from cumulusci.core.enums import StrEnum
-from cumulusci.tasks.bulkdata.extract_dataset_utils.hardcoded_default_declarations import (
-    DEFAULT_DECLARATIONS,
-)
 from cumulusci.tasks.bulkdata.utils import CaseInsensitiveDict
 from cumulusci.utils import get_cci_upgrade_command
 from cumulusci.utils.yaml.model_parser import CCIDictModel
@@ -188,10 +185,6 @@ def standard_generate_query(
             filter_clause=user_filter, limit_clause=limit, offset_clause=offset
         )
     else:
-        # Get the WHERE clause from DEFAULT_DECLARATIONS if available
-        declaration = DEFAULT_DECLARATIONS.get(sobject)
-        if declaration:
-            query += f" WHERE {declaration.where}"
         query += f" LIMIT {limit}" if limit else ""
         query += f" OFFSET {offset}" if offset else ""
     return query, ["Id"]
@@ -281,10 +274,6 @@ def similarity_generate_query(
             filter_clause=user_filter, limit_clause=limit, offset_clause=offset
         )
     else:
-        # Get the WHERE clause from DEFAULT_DECLARATIONS if available
-        declaration = DEFAULT_DECLARATIONS.get(sobject)
-        if declaration:
-            query += f" WHERE {declaration.where}"
         query += f" LIMIT {limit}" if limit else ""
         query += f" OFFSET {offset}" if offset else ""
 

--- a/cumulusci/tasks/bulkdata/tests/cassettes/TestSelect.test_select_random_strategy.yaml
+++ b/cumulusci/tasks/bulkdata/tests/cassettes/TestSelect.test_select_random_strategy.yaml
@@ -48,7 +48,7 @@ interactions:
              
     - request:
           method: GET
-          uri: https://orgname.my.salesforce.com/services/data/v62.0/query/?q=SELECT%20Id,%20Name,%20Description,%20Phone,%20AccountNumber%20FROM%20Account%20WHERE%20Name%20!=%20'Sample%20Account%20for%20Entitlements'
+          uri: https://orgname.my.salesforce.com/services/data/v62.0/query/?q=SELECT%20Id,%20Name,%20Description,%20Phone,%20AccountNumber%20FROM%20Account
           body: null
           headers: *id004
       response:
@@ -125,7 +125,7 @@ interactions:
 
     - request:
           method: GET
-          uri: https://orgname.my.salesforce.com/services/data/v62.0/query/?q=SELECT%20Id%20FROM%20Account%20WHERE%20Name%20!=%20'Sample%20Account%20for%20Entitlements'%20LIMIT%205
+          uri: https://orgname.my.salesforce.com/services/data/v62.0/query/?q=SELECT%20Id%20FROM%20Account%20LIMIT%205
           body: null
           headers: *id004
       response:

--- a/cumulusci/tasks/bulkdata/tests/cassettes/TestSelect.test_select_similarity_strategy.yaml
+++ b/cumulusci/tasks/bulkdata/tests/cassettes/TestSelect.test_select_similarity_strategy.yaml
@@ -48,7 +48,7 @@ interactions:
              
     - request:
           method: GET
-          uri: https://orgname.my.salesforce.com/services/data/v62.0/query/?q=SELECT%20Id,%20Name,%20Description,%20Phone,%20AccountNumber%20FROM%20Account%20WHERE%20Name%20!=%20'Sample%20Account%20for%20Entitlements'
+          uri: https://orgname.my.salesforce.com/services/data/v62.0/query/?q=SELECT%20Id,%20Name,%20Description,%20Phone,%20AccountNumber%20FROM%20Account
           body: null
           headers: *id004
       response:

--- a/cumulusci/tasks/bulkdata/tests/cassettes/TestSelect.test_select_standard_strategy.yaml
+++ b/cumulusci/tasks/bulkdata/tests/cassettes/TestSelect.test_select_standard_strategy.yaml
@@ -48,7 +48,7 @@ interactions:
              
     - request:
           method: GET
-          uri: https://orgname.my.salesforce.com/services/data/v62.0/query/?q=SELECT%20Id,%20Name,%20Description,%20Phone,%20AccountNumber%20FROM%20Account%20WHERE%20Name%20!=%20'Sample%20Account%20for%20Entitlements'
+          uri: https://orgname.my.salesforce.com/services/data/v62.0/query/?q=SELECT%20Id,%20Name,%20Description,%20Phone,%20AccountNumber%20FROM%20Account
           body: null
           headers: *id004
       response:
@@ -125,7 +125,7 @@ interactions:
 
     - request:
           method: GET
-          uri: https://orgname.my.salesforce.com/services/data/v62.0/query/?q=SELECT%20Id%20FROM%20Account%20WHERE%20Name%20!=%20'Sample%20Account%20for%20Entitlements'%20LIMIT%205
+          uri: https://orgname.my.salesforce.com/services/data/v62.0/query/?q=SELECT%20Id%20FROM%20Account%20LIMIT%205
           body: null
           headers: *id004
       response:

--- a/cumulusci/tasks/bulkdata/tests/test_select_utils.py
+++ b/cumulusci/tasks/bulkdata/tests/test_select_utils.py
@@ -24,23 +24,7 @@ except ImportError:
     PANDAS_AVAILABLE = False
 
 
-# Test Cases for standard_generate_query
-def test_standard_generate_query_with_default_record_declaration():
-    select_operator = SelectOperationExecutor(SelectStrategy.STANDARD)
-    sobject = "Account"  # Assuming Account has a declaration in DEFAULT_DECLARATIONS
-    limit = 5
-    offset = 2
-    query, fields = select_operator.select_generate_query(
-        sobject=sobject, fields=[], user_filter="", limit=limit, offset=offset
-    )
-
-    assert "WHERE" in query  # Ensure WHERE clause is included
-    assert f"LIMIT {limit}" in query
-    assert f"OFFSET {offset}" in query
-    assert fields == ["Id"]
-
-
-def test_standard_generate_query_without_default_record_declaration():
+def test_standard_generate_query_without_filter():
     select_operator = SelectOperationExecutor(SelectStrategy.STANDARD)
     sobject = "Contact"  # Assuming no declaration for this object
     limit = 3
@@ -49,7 +33,6 @@ def test_standard_generate_query_without_default_record_declaration():
         sobject=sobject, fields=[], user_filter="", limit=limit, offset=offset
     )
 
-    assert "WHERE" not in query  # No WHERE clause should be present
     assert f"LIMIT {limit}" in query
     assert "OFFSET" not in query
     assert fields == ["Id"]
@@ -72,23 +55,7 @@ def test_standard_generate_query_with_user_filter():
     assert fields == ["Id"]
 
 
-# Test Cases for random generate query
-def test_random_generate_query_with_default_record_declaration():
-    select_operator = SelectOperationExecutor(SelectStrategy.RANDOM)
-    sobject = "Account"  # Assuming Account has a declaration in DEFAULT_DECLARATIONS
-    limit = 5
-    offset = 2
-    query, fields = select_operator.select_generate_query(
-        sobject=sobject, fields=[], user_filter="", limit=limit, offset=offset
-    )
-
-    assert "WHERE" in query  # Ensure WHERE clause is included
-    assert f"LIMIT {limit}" in query
-    assert f"OFFSET {offset}" in query
-    assert fields == ["Id"]
-
-
-def test_random_generate_query_without_default_record_declaration():
+def test_random_generate_query():
     select_operator = SelectOperationExecutor(SelectStrategy.RANDOM)
     sobject = "Contact"  # Assuming no declaration for this object
     limit = 3
@@ -97,7 +64,6 @@ def test_random_generate_query_without_default_record_declaration():
         sobject=sobject, fields=[], user_filter="", limit=limit, offset=offset
     )
 
-    assert "WHERE" not in query  # No WHERE clause should be present
     assert f"LIMIT {limit}" in query
     assert "OFFSET" not in query
     assert fields == ["Id"]
@@ -209,23 +175,7 @@ def test_random_post_process_with_no_records():
     assert error_message == f"No records found for {sobject} in the target org."
 
 
-# Test Cases for Similarity Generate Query
-def test_similarity_generate_query_with_default_record_declaration():
-    select_operator = SelectOperationExecutor(SelectStrategy.SIMILARITY)
-    sobject = "Account"  # Assuming Account has a declaration in DEFAULT_DECLARATIONS
-    limit = 5
-    offset = 2
-    query, fields = select_operator.select_generate_query(
-        sobject, ["Name"], [], limit, offset
-    )
-
-    assert "WHERE" in query  # Ensure WHERE clause is included
-    assert fields == ["Id", "Name"]
-    assert f"LIMIT {limit}" in query
-    assert f"OFFSET {offset}" in query
-
-
-def test_similarity_generate_query_without_default_record_declaration():
+def test_similarity_generate_query_no_nesting():
     select_operator = SelectOperationExecutor(SelectStrategy.SIMILARITY)
     sobject = "Contact"  # Assuming no declaration for this object
     limit = 3
@@ -234,7 +184,6 @@ def test_similarity_generate_query_without_default_record_declaration():
         sobject, ["Name"], [], limit, offset
     )
 
-    assert "WHERE" not in query  # No WHERE clause should be present
     assert fields == ["Id", "Name"]
     assert f"LIMIT {limit}" in query
     assert "OFFSET" not in query

--- a/docs/env-var-reference.md
+++ b/docs/env-var-reference.md
@@ -70,3 +70,7 @@ org, e.g. a Dev Hub. Set with SFDX_CLIENT_ID.
 ## `SFDX_ORG_CREATE_ARGS`
 
 Extra arguments passed to `sf org create scratch`.
+
+To provide additional arguments, use the following format. For instance, to set the release to "preview", the environment variable would be: "--release=preview"
+
+To specify multiple options, you can include them together, like: "--edition=developer --release=preview"


### PR DESCRIPTION
Default records were not being selected earlier. This bug is now fixed.