### PR TITLE
Fix the check_sobjects_available task to take the api_version from Cumulusci.yml

### DIFF
--- a/cumulusci/tasks/preflight/sobjects.py
+++ b/cumulusci/tasks/preflight/sobjects.py
@@ -17,9 +17,9 @@ class CheckSObjectsAvailable(BaseSalesforceApiTask):
                   action: error
                   message: "Enhanced Notes are not turned on."
     """
-    api_version = "48.0"
 
     def _run_task(self):
+
         self.return_values = {entry["name"] for entry in self.sf.describe()["sobjects"]}
 
         self.logger.info(


### PR DESCRIPTION
Fixed the issue where the `check_sobjects_available ` takes api_version as "48.0" and lists the sobjects available as per '48' version. So, it doesn't check for the latest sobjects as per the cumulusci.yml.

Now, removing the hardcoded value automatically picks the version from cumulusci.yml