### PR TITLE
fix: Make get permset licenses return active only

### DIFF
--- a/cumulusci/tasks/preflight/licenses.py
+++ b/cumulusci/tasks/preflight/licenses.py
@@ -15,11 +15,10 @@ class GetAvailableLicenses(BaseSalesforceApiTask):
 
 class GetAvailablePermissionSetLicenses(BaseSalesforceApiTask):
     def _run_task(self):
+        query = "SELECT PermissionSetLicenseKey FROM PermissionSetLicense WHERE Status = 'Active'"
         self.return_values = [
             result["PermissionSetLicenseKey"]
-            for result in self.sf.query(
-                "SELECT PermissionSetLicenseKey FROM PermissionSetLicense"
-            )["records"]
+            for result in self.sf.query(query)["records"]
         ]
         licenses = "\n".join(self.return_values)
         self.logger.info(f"Found permission set licenses:\n{licenses}")

--- a/cumulusci/tasks/preflight/tests/test_licenses.py
+++ b/cumulusci/tasks/preflight/tests/test_licenses.py
@@ -41,7 +41,7 @@ class TestLicensePreflights:
         task()
 
         task._init_api.return_value.query.assert_called_once_with(
-            "SELECT PermissionSetLicenseKey FROM PermissionSetLicense"
+            "SELECT PermissionSetLicenseKey FROM PermissionSetLicense WHERE Status = 'Active'"
         )
         assert task.return_values == ["TEST1", "TEST2"]
 


### PR DESCRIPTION
The get_available_permission_set_licenses task returns unavailable permset licenses because removed PSLs are still returned by SOQL. This commit adds a filter for Status to prevent this.
