### PR TITLE
fix(schema): correct namespaced field type from string to boolean

### DIFF
--- a/cumulusci/schema/cumulusci.jsonschema.json
+++ b/cumulusci/schema/cumulusci.jsonschema.json
@@ -421,7 +421,7 @@
                 },
                 "namespaced": {
                     "title": "Namespaced",
-                    "type": "string"
+                    "type": "boolean"
                 },
                 "setup_flow": {
                     "title": "Setup Flow",

--- a/cumulusci/utils/yaml/cumulusci_yml.py
+++ b/cumulusci/utils/yaml/cumulusci_yml.py
@@ -147,7 +147,7 @@ class Project(CCIDictModel):
 class ScratchOrg(CCIDictModel):
     config_file: Path = None
     days: int = None
-    namespaced: str = None
+    namespaced: bool = None
     setup_flow: str = None
     noancestors: bool = None
     release: Literal["preview", "previous"] = None


### PR DESCRIPTION
Update cumulusci.jsonschema.json to fix the data type for the 'namespaced' field from string to boolean, which better reflects its intended usage.

Fixes #3910 