### PR TITLE
Pin Click to version 8.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "click>=8.1",
+    "click>=8.2.0",
     "cryptography",
     "python-dateutil",
     "Faker",

--- a/uv.lock
+++ b/uv.lock
@@ -138,7 +138,7 @@ name = "cffi"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload-time = "2024-09-04T20:45:21.852Z" }
 wheels = [
@@ -462,7 +462,7 @@ lint = [
 [package.metadata]
 requires-dist = [
     { name = "annoy", marker = "extra == 'select'" },
-    { name = "click", specifier = ">=8.1" },
+    { name = "click", specifier = ">=8.2.0" },
     { name = "cryptography" },
     { name = "defusedxml" },
     { name = "docutils", specifier = "<=0.21.2" },


### PR DESCRIPTION
Needed to cover the mix_stderr deprecation, since the behavior is
different in <8.2.0
