### PR TITLE
DEVOPS-652 feat: extend create scratch org to accept snapshot as extra param that allow to create an org from a template

### DIFF
--- a/cumulusci/schema/cumulusci.jsonschema.json
+++ b/cumulusci/schema/cumulusci.jsonschema.json
@@ -435,6 +435,10 @@
                     "title": "Release",
                     "enum": ["preview", "previous"],
                     "type": "string"
+                },
+                "snapshot": {
+                    "title": "Snapshot",
+                    "type": "string"
                 }
             },
             "additionalProperties": false

--- a/cumulusci/utils/yaml/cumulusci_yml.py
+++ b/cumulusci/utils/yaml/cumulusci_yml.py
@@ -151,6 +151,7 @@ class ScratchOrg(CCIDictModel):
     setup_flow: str = None
     noancestors: bool = None
     release: Literal["preview", "previous"] = None
+    snapshot: str = None
 
 
 class Orgs(CCIDictModel):


### PR DESCRIPTION
## Overview

**Extend create scartch org to allow create scratch org from a salesforce snapshot**
- add 'snapshot' options to ScratchOrg schema
- when build args for create scratch org, leverage the snapshot is specified. 
- when snapshot is specified, remove 'feature' and 'edition' sessions from org_config file and used the new temp file for org creation.

