### PR TITLE
Remove PyFilesystem2 dependency @W-21244194

### DIFF
--- a/cumulusci/core/source/github.py
+++ b/cumulusci/core/source/github.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 
-import fs
 from github3.exceptions import NotFoundError
 
 from cumulusci.core.exceptions import DependencyResolutionError
@@ -129,7 +128,7 @@ class GitHubSource:
     def fetch(self):
         """Fetch the archive of the specified commit and construct its project config."""
         with self.project_config.open_cache(
-            fs.path.join("projects", self.repo_name, self.commit)
+            os.path.join("projects", self.repo_name, self.commit)
         ) as path:
             zf = download_extract_github(
                 self.gh, self.repo_owner, self.repo_name, ref=self.commit

--- a/cumulusci/utils/fileutils.py
+++ b/cumulusci/utils/fileutils.py
@@ -85,7 +85,7 @@ def load_from_source(source: DataInput) -> ContextManager[Tuple[IO[Text], Text]]
             yield f, path
     elif "://" in source:  # URL string-like
         url = source
-        resp = requests.get(url)
+        resp = requests.get(url, timeout=30)
         resp.raise_for_status()
         yield StringIO(resp.text), url
     else:  # path-string-like
@@ -261,7 +261,7 @@ class FSResource:
             p.mkdir(exist_ok=exist_ok)
 
     def __contains__(self, other):
-        return other in str(self.geturl())
+        return str(other) in str(self.getsyspath())
 
     @property
     def suffix(self):
@@ -274,10 +274,7 @@ class FSResource:
         return f"<FSResource {self.geturl()}>"
 
     def __str__(self):
-        rc = self.geturl()
-        if rc.startswith("file://"):
-            return rc[7:] if rc.startswith("file:///") else rc[6:]
-        return rc
+        return str(self.getsyspath())
 
     def __fspath__(self):
         return str(self.getsyspath())

--- a/cumulusci/utils/tests/test_fileutils.py
+++ b/cumulusci/utils/tests/test_fileutils.py
@@ -3,6 +3,7 @@ import os
 import sys
 import time
 import urllib.request
+from collections import namedtuple
 from io import BytesIO, UnsupportedOperation
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -10,7 +11,6 @@ from unittest import mock
 
 import pytest
 import responses
-from fs import errors, open_fs
 
 import cumulusci
 from cumulusci.utils import fileutils, temporary_dir, update_tree
@@ -151,7 +151,9 @@ class _TestFSResourceShared:
 
     def test_load_from_file_system(self):
         abspath = os.path.abspath(self.file)
-        fs = open_fs("/")
+        # Backwards compatibility: pass a dummy filesystem and ensure it is ignored
+        DummyFS = namedtuple("DummyFS", [])
+        fs = DummyFS()
         with open_fs_resource(abspath, fs) as f:
             assert abspath in str(f)
 
@@ -234,7 +236,7 @@ class TestFSResourceTempdir(_TestFSResourceShared):
             f.mkdir(parents=False, exist_ok=True)
             assert abspath.exists()
 
-            with pytest.raises(errors.DirectoryExists):
+            with pytest.raises(FileExistsError):
                 f.mkdir(parents=False, exist_ok=False)
             f.rmdir()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "cryptography",
     "python-dateutil",
     "Faker",
-    "fs",
     "github3.py",
     "jinja2",
     "keyring<=23.0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -45,15 +45,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/07/38/e321b0e05d8cc068a594279fb7c097efb1df66231c295d482d7ad51b6473/annoy-1.17.3.tar.gz", hash = "sha256:9cbfebefe0a5f843eba29c6be4c84d601f4f41ad4ded0486f1b88c3b07739c15", size = 647460, upload-time = "2023-06-14T16:37:34.152Z" }
 
 [[package]]
-name = "appdirs"
-version = "1.4.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", size = 13470, upload-time = "2020-05-11T07:59:51.037Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", size = 9566, upload-time = "2020-05-11T07:59:49.499Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -392,7 +383,6 @@ dependencies = [
     { name = "defusedxml" },
     { name = "docutils" },
     { name = "faker" },
-    { name = "fs" },
     { name = "github3-py" },
     { name = "jinja2" },
     { name = "keyring" },
@@ -465,7 +455,6 @@ requires-dist = [
     { name = "defusedxml" },
     { name = "docutils", specifier = "<=0.21.2" },
     { name = "faker" },
-    { name = "fs" },
     { name = "github3-py" },
     { name = "jinja2" },
     { name = "keyring", specifier = "<=23.0.1" },
@@ -622,20 +611,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9e/47/15b267dfe7e03dca4c4c06e7eadbd55ef4dfd368b13a0bab36d708b14366/flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b", size = 164777, upload-time = "2021-05-08T19:52:34.369Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/80/35a0716e5d5101e643404dabd20f07f5528a21f3ef4032d31a49c913237b/flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907", size = 73147, upload-time = "2021-05-08T19:52:32.476Z" },
-]
-
-[[package]]
-name = "fs"
-version = "2.4.16"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "appdirs" },
-    { name = "setuptools" },
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/a9/af5bfd5a92592c16cdae5c04f68187a309be8a146b528eac3c6e30edbad2/fs-2.4.16.tar.gz", hash = "sha256:ae97c7d51213f4b70b6a958292530289090de3a7e15841e108fbe144f069d313", size = 187441, upload-time = "2022-05-02T09:25:54.22Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/5c/a3d95dc1ec6cdeb032d789b552ecc76effa3557ea9186e1566df6aac18df/fs-2.4.16-py2.py3-none-any.whl", hash = "sha256:660064febbccda264ae0b6bace80a8d1be9e089e0a5eb2427b7d517f9a91545c", size = 135261, upload-time = "2022-05-02T09:25:52.363Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR removes `PyFilesystem2`. Importing `fs` emits a `pkg_resources` deprecation warning (see
[pyfilesystem2#597](https://github.com/PyFilesystem/pyfilesystem2/issues/597)). There are also open questions about the project’s maintenance status (see
[pyfilesystem2#571](https://github.com/PyFilesystem/pyfilesystem2/issues/571)). As far as I can tell, CumulusCI only relied on a small, local subset of functionality. That subset maps cleanly to Python’s standard library.

This PR introduces a local-only `FSResource` and `open_fs_resource` implemented with `pathlib`, `os`, and `shutil`. `file://` URLs are supported for absolute and relative paths, and non-file schemes are rejected. All `fs` imports were removed and tests updated to expect `FileExistsError` instead of `fs.errors.DirectoryExists`.