### PR TITLE
ci: Add Python 3.14 to CI and pin support to <=3.13

### DIFF
--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -22,11 +22,11 @@ jobs:
               uses: actions/checkout@v4
               with:
                   fetch-depth: 1
-            - name: Set up Python 3.11
+            - name: Set up Python 3.13
               id: py
               uses: actions/setup-python@v5
               with:
-                  python-version: 3.11
+                  python-version: 3.13
             - name: Set up uv
               uses: SFDO-Tooling/setup-uv@v8.0.0-sfdo.1
               with:
@@ -42,11 +42,12 @@ jobs:
     unit_tests:
         name: "Unit tests: ${{ matrix.os }}-${{ matrix.python-version }}"
         runs-on: ${{ matrix.os }}
+        continue-on-error: ${{ matrix.python-version == '3.14' }}
         strategy:
             fail-fast: false
             matrix:
                 os: [macos-latest, SFDO-Tooling-Ubuntu, SFDO-Tooling-Windows]
-                python-version: ["3.11", "3.12", "3.13"]
+                python-version: ["3.11", "3.12", "3.13", "3.14"]
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python
@@ -66,11 +67,12 @@ jobs:
     unit_tests_opt_deps:
         name: "Unit tests with optional dependencies: ${{ matrix.os }}-${{ matrix.python-version }}"
         runs-on: ${{ matrix.os }}
+        continue-on-error: ${{ matrix.python-version == '3.14' }}
         strategy:
             fail-fast: false
             matrix:
                 os: [macos-latest, SFDO-Tooling-Ubuntu, SFDO-Tooling-Windows]
-                python-version: ["3.11", "3.12", "3.13"]
+                python-version: ["3.11", "3.12", "3.13", "3.14"]
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python
@@ -92,17 +94,17 @@ jobs:
         runs-on: SFDO-Tooling-Ubuntu
         steps:
             - uses: actions/checkout@v4
-            - name: Set up Python 3.11
+            - name: Set up Python 3.13
               uses: actions/setup-python@v5
               with:
-                  python-version: 3.11
+                  python-version: 3.13
             - name: Set up uv
               uses: SFDO-Tooling/setup-uv@v8.0.0-sfdo.1
               with:
                   version: "0.8.4"
                   enable-cache: true
             - name: Install dependencies
-              run: uv sync -p 3.11
+              run: uv sync -p 3.13
             - name: Install sfdx
               run: |
                   mkdir sfdx

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -22,10 +22,10 @@ jobs:
         runs-on: SFDO-Tooling-Ubuntu
         steps:
             - uses: actions/checkout@v4
-            - name: Set up Python 3.11
+            - name: Set up Python 3.13
               uses: actions/setup-python@v5
               with:
-                  python-version: 3.11
+                  python-version: 3.13
                   cache: pip
             - name: Install build tool
               run: python -m pip install hatch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
         runs-on: SFDO-Tooling-Ubuntu
         steps:
             - uses: actions/checkout@v4
-            - name: Set up Python 3.11
+            - name: Set up Python 3.13
               uses: actions/setup-python@v5
               with:
-                  python-version: 3.11
+                  python-version: 3.13
                   cache: pip
             - name: Install build tools
               run: python -m pip install hatch tomli tomli-w

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -11,10 +11,10 @@ jobs:
         runs-on: SFDO-Tooling-Ubuntu
         steps:
             - uses: actions/checkout@v4
-            - name: Set up Python 3.11
+            - name: Set up Python 3.13
               uses: actions/setup-python@v5
               with:
-                  python-version: 3.11
+                  python-version: 3.13
                   cache: pip
                   cache-dependency-path: "pyproject.toml"
             - name: Install build tools

--- a/.github/workflows/release_test_sfdx.yml
+++ b/.github/workflows/release_test_sfdx.yml
@@ -41,10 +41,10 @@ jobs:
         concurrency: release
         steps:
             - uses: actions/checkout@v4
-            - name: Set up Python 3.11
+            - name: Set up Python 3.13
               uses: actions/setup-python@v5
               with:
-                  python-version: 3.11
+                  python-version: 3.13
             - name: Set up uv
               uses: SFDO-Tooling/setup-uv@v8.0.0-sfdo.1
               with:

--- a/.github/workflows/slow_integration_tests.yml
+++ b/.github/workflows/slow_integration_tests.yml
@@ -25,17 +25,17 @@ jobs:
         runs-on: SFDO-Tooling-Ubuntu
         steps:
             - uses: actions/checkout@v4
-            - name: Set up Python 3.11
+            - name: Set up Python 3.13
               uses: actions/setup-python@v5
               with:
-                  python-version: 3.11
+                  python-version: 3.13
             - name: Set up uv
               uses: SFDO-Tooling/setup-uv@v8.0.0-sfdo.1
               with:
                   version: "0.8.4"
                   enable-cache: true
             - name: Install dependencies
-              run: uv sync -p 3.11
+              run: uv sync -p 3.13
             - name: Install Salesforce CLI
               run: |
                   mkdir sfdx
@@ -74,17 +74,17 @@ jobs:
                     #   org-shape: "prerelease"
         steps:
             - uses: actions/checkout@v4
-            - name: Set up Python 3.11
+            - name: Set up Python 3.13
               uses: actions/setup-python@v5
               with:
-                  python-version: 3.11
+                  python-version: 3.13
             - name: Set up uv
               uses: SFDO-Tooling/setup-uv@v8.0.0-sfdo.1
               with:
                   version: "0.8.4"
                   enable-cache: true
             - name: Install Python dependencies
-              run: uv sync -p 3.11
+              run: uv sync -p 3.13
             - name: Install Salesforce CLI
               run: |
                   mkdir sfdx

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -7,4 +7,4 @@ jobs:
     update_python_dependencies:
         uses: SFDO-Tooling/.github/.github/workflows/update_python_dependencies.yml@main
         with:
-            python-version: 3.11
+            python-version: 3.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "cumulusci"
 dynamic = ["readme", "version"]
 description = "Build and release tools for Salesforce developers"
 license = { text = "BSD 3-Clause License" }
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14"
 authors = [
     { name = "Salesforce.org", email = "sfdo-mrbelvedere@salesforce.com" },
 ]


### PR DESCRIPTION
  This PR adds Python 3.14 to our CI test matrix as an informational/non-blocking test while pinning official package support to Python `<=3.13`. This provides early-warning detection of Python 3.14 compatibility issues without blocking development.

CumulusCI currently uses the Pydantic v1 compatibility layer (via `pydantic>=2.0,<3`), which does not support Python 3.14. A full migration to native Pydantic v2 APIs is not feasible at this time. To prevent users from encountering runtime errors when installing on Python 3.14, we need to restrict package installation while still monitoring compatibility for future planning.