### PR TITLE
Issue-3938 rest_deploy should throw errors just like SOAP deploy does

### DIFF
--- a/cumulusci/salesforce_api/rest_deploy.py
+++ b/cumulusci/salesforce_api/rest_deploy.py
@@ -9,6 +9,11 @@ from typing import List, Union
 
 import requests
 
+from cumulusci.salesforce_api.exceptions import (
+    MetadataApiError,
+    MetadataComponentFailure,
+)
+
 PARENT_DIR_NAME = "metadata"
 
 
@@ -120,7 +125,7 @@ class RestDeploy:
                         error_message = self._construct_error_message(failure)
                         self.task.logger.error(error_message)
                         error_log += error_message + "\n"
-                    raise MetadataComponentFailure(error_log, response)       
+                    raise MetadataComponentFailure(error_log, response)
                 return
             time.sleep(5)
 
@@ -143,7 +148,7 @@ class RestDeploy:
 
     # Construct an error message from deployment failure details
     def _construct_error_message(self, failure):
-        error_message = f"{str.upper(failure['problemType'])} in file {failure['fileName'][len(PARENT_DIR_NAME)+len('/'):]}: {failure['problem']}"
+        error_message = f"{str.upper(failure['problemType'])} in file {failure['fileName'][len(PARENT_DIR_NAME) + len('/'):]}: {failure['problem']}"
 
         if failure["lineNumber"] and failure["columnNumber"]:
             error_message += (

--- a/cumulusci/salesforce_api/rest_deploy.py
+++ b/cumulusci/salesforce_api/rest_deploy.py
@@ -83,6 +83,7 @@ class RestDeploy:
             self.task.logger.error(
                 f"Deployment request failed with status code {response.status_code}"
             )
+            raise MetadataApiError(f"Deployment request failed with status code {response.status_code}", response)
 
     # Set the purge_on_delete attribute based on org type
     def _set_purge_on_delete(self, purge_on_delete):
@@ -112,10 +113,14 @@ class RestDeploy:
             if response_json["deployResult"]["status"] not in ["InProgress", "Pending"]:
                 # Handle the case when status has Failed
                 if response_json["deployResult"]["status"] == "Failed":
+                    error_log = ''
                     for failure in response_json["deployResult"]["details"][
                         "componentFailures"
                     ]:
-                        self.task.logger.error(self._construct_error_message(failure))
+                        error_message = self._construct_error_message(failure)
+                        self.task.logger.error(error_message)
+                        error_log += error_message + "\n"
+                    raise MetadataComponentFailure(error_log, response)       
                 return
             time.sleep(5)
 

--- a/cumulusci/salesforce_api/tests/test_rest_deploy.py
+++ b/cumulusci/salesforce_api/tests/test_rest_deploy.py
@@ -4,6 +4,12 @@ import unittest
 import zipfile
 from unittest.mock import MagicMock, Mock, call, patch
 
+import pytest
+
+from cumulusci.salesforce_api.exceptions import (
+    MetadataApiError,
+    MetadataComponentFailure,
+)
 from cumulusci.salesforce_api.rest_deploy import RestDeploy
 from cumulusci.tests.util import CURRENT_SF_API_VERSION
 
@@ -90,15 +96,14 @@ class TestRestDeploy(unittest.TestCase):
         deployer = RestDeploy(
             self.mock_task, self.mock_zip, False, False, "NoTestRun", []
         )
-        deployer()
+        with pytest.raises(MetadataApiError) as excinfo:
+            deployer()
 
-        # Assertions to verify log messages
+        assert "500" in str(excinfo.value)
         assert (
             call("Deployment request failed with status code 500")
             in self.mock_logger.error.call_args_list
         )
-
-        # Assertions to verify API Calls
         mock_post.assert_called_once()
 
     # Test for deployment success but deploy status failure
@@ -142,9 +147,11 @@ class TestRestDeploy(unittest.TestCase):
         deployer = RestDeploy(
             self.mock_task, self.mock_zip, False, False, "NoTestRun", []
         )
-        deployer()
+        with pytest.raises(MetadataComponentFailure) as excinfo:
+            deployer()
 
-        # Assertions to verify log messages
+        assert "someproblem1" in str(excinfo.value)
+        assert "someproblem2" in str(excinfo.value)
         assert (
             call("Deployment request successful")
             in self.mock_logger.info.call_args_list
@@ -160,20 +167,17 @@ class TestRestDeploy(unittest.TestCase):
             in self.mock_logger.error.call_args_list
         )
 
-        # Assertions to verify API Calls
-        expected_get_calls = [
-            call(
-                f"https://example.com/services/data/v{CURRENT_SF_API_VERSION}/metadata/deployRequest/dummy_id?includeDetails=true",
-                headers={"Authorization": "Bearer dummy_token"},
-            ),
-            call(
-                f"https://example.com/services/data/v{CURRENT_SF_API_VERSION}/metadata/deployRequest/dummy_id?includeDetails=true",
-                headers={"Authorization": "Bearer dummy_token"},
-            ),
-        ]
-
         mock_post.assert_called_once()
-        mock_get.assert_has_calls(expected_get_calls, any_order=True)
+        mock_get.assert_has_calls(
+            [
+                call(
+                    f"https://example.com/services/data/v{CURRENT_SF_API_VERSION}/metadata/deployRequest/dummy_id?includeDetails=true",
+                    headers={"Authorization": "Bearer dummy_token"},
+                ),
+            ]
+            * 2,
+            any_order=True,
+        )
 
     # Test case for a deployment with a pending status
     @patch("requests.post")


### PR DESCRIPTION
If cumulusCI Deploy task is using REST to do the metadata deploy, errors happen silently and the task reports success. This is different from when using SOAP, which will raise an exception.

Add exception raising to the Rest_deploy handler.