### PR TITLE
chore: re-enable Dependabot version updates (uv + github-actions) @W-22187458

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,14 @@
 version: 2
 updates:
-    - package-ecosystem: pip
+    - package-ecosystem: uv
       directory: "/"
       schedule:
           interval: weekly
           day: tuesday
-      open-pull-requests-limit: 0
+      open-pull-requests-limit: 5
+    - package-ecosystem: github-actions
+      directory: "/"
+      schedule:
+          interval: weekly
+          day: tuesday
+      open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- Switch `package-ecosystem` from `pip` to `uv` to match the repo manager and `uv.lock`.
- Set `open-pull-requests-limit` to `5` (was `0`, so version updates were effectively off).
- Add `github-actions` ecosystem for Action version updates.

## Test plan

- [ ] Confirm Dependabot opens PRs on the next schedule after merge.