### PR TITLE
ci: trigger feature tests on push to dev to unblock auto-publish

### DIFF
--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -7,11 +7,12 @@ on:
     push:
         branches:
             - main
+            - dev
 
 jobs:
     lint:
         name: Lint
-        if: ${{ contains(fromJSON('["workflow_dispatch", "pull_request"]'), github.event_name) }}
+        if: ${{ contains(fromJSON('["workflow_dispatch", "pull_request", "push"]'), github.event_name) }}
         uses: SFDO-Tooling/.github/.github/workflows/pre-commit.yml@main
     docs:
         name: Build Docs


### PR DESCRIPTION
## Summary

- Add `dev` to `feature_test.yml` push.branches.
- Add `push` to the lint job's `if` condition.

This unblocks the dev auto-publish workflow that has been failing for 4 consecutive runs with GH006 ("7 of 7 required status checks are expected").

## Test plan

- [ ] CI passes on this PR (all 9 contexts including 3.14 jobs)
- [ ] Squash-merge to dev
- [ ] Observe \`Publish and release CumulusCI\` workflow run on dev: bot version bump commits and pushes successfully
- [ ] Verify \`cumulusci==5.0.0.devN\` lands on PyPI

Spec: docs/superpowers/specs/2026-04-27-cci-dev-auto-publish-unblock-design.md