### PR TITLE
chore: add uv to bug-report install-method dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -64,6 +64,7 @@ body:
           label: CumulusCI installation method
           description: How did you install CumulusCI?
           options:
+              - uv
               - brew
               - pip
               - pipx


### PR DESCRIPTION
## Summary

- Add `uv` to the install-method dropdown in `.github/ISSUE_TEMPLATE/bug_report.yml`.
- `uv` is listed first as the recommended path for v5 development.
- Existing options (`brew`, `pip`, `pipx`) are preserved for older installs.

## Test plan

- [x] YAML loads via `yaml.safe_load`.
- [x] `cci error gist` is unaffected (`cumulusci/cli/error.py` has no install-method coupling).
- [ ] Reviewer renders the form and confirms `uv` appears in the dropdown.

Refs spec docs/superpowers/specs/2026-05-08-github-hygiene-and-rulesets-design.md.