### PR TITLE
fix(utils): #3852 ensure sarge Capture.flush exists on Py 3.13+

### DIFF
--- a/cumulusci/utils/__init__.py
+++ b/cumulusci/utils/__init__.py
@@ -16,6 +16,14 @@ from typing import Union
 import requests
 import sarge
 
+if not hasattr(sarge.Capture, "flush"):
+    # sarge==0.1.7.post1 ships Capture without flush(); on Python 3.13+ the
+    # interpreter-shutdown logging path calls flush() on captured streams and
+    # surfaces a cosmetic AttributeError after refresh_oauth_token. Upstream
+    # has the fix on master but no release. Defensive, idempotent shim.
+    # See SFDO-Tooling/CumulusCI#3852.
+    sarge.Capture.flush = lambda self: None
+
 from cumulusci.core.exceptions import CumulusCIException
 from .xml import (  # noqa
     elementtree_parse_file,

--- a/cumulusci/utils/tests/test_sarge_patch.py
+++ b/cumulusci/utils/tests/test_sarge_patch.py
@@ -1,0 +1,34 @@
+"""Regression test for SFDO-Tooling/CumulusCI#3852.
+
+``sarge==0.1.7.post1`` (the version pinned via ``pyproject.toml``) ships a
+``sarge.Capture`` class with no ``flush()`` method. On Python 3.13+ the
+interpreter-shutdown logging path calls ``.flush()`` on the captured stream
+objects CumulusCI hands to logging handlers, which surfaces a cosmetic
+``AttributeError: 'Capture' object has no attribute 'flush'`` after
+``refresh_oauth_token`` runs.
+
+The upstream sarge fix (``def flush(self): pass``) is unreleased, so
+``cumulusci.utils`` installs a defensive shim at import time. This test
+guards that shim.
+"""
+
+import sarge
+
+import cumulusci.utils  # noqa: F401 -- importing applies the Capture.flush shim
+
+
+def test_sarge_capture_has_flush_after_importing_cumulusci_utils():
+    assert hasattr(sarge.Capture, "flush"), (
+        "sarge.Capture is missing flush(); CumulusCI must patch it to avoid "
+        "AttributeError during interpreter-shutdown logging on Python 3.13+ "
+        "(see SFDO-Tooling/CumulusCI#3852)."
+    )
+    assert callable(sarge.Capture.flush)
+
+
+def test_sarge_capture_instance_flush_is_a_no_op():
+    capture = sarge.Capture()
+    try:
+        assert capture.flush() is None
+    finally:
+        capture.close()


### PR DESCRIPTION
## Summary

Fixes #3852.

`sarge.Capture` lost its `flush()` method under newer Python/pipe semantics, surfacing as a noisy `AttributeError` on shutdown when CumulusCI captures subprocess output. This adds a one-shot monkey-patch at `cumulusci/utils/__init__.py` import time: if `sarge.Capture` has no `flush` attribute, install a no-op `flush()` so callers that probe the attribute do not crash. No functional change to sarge behavior.

## Test plan

- [ ] `cumulusci/utils/tests/test_sarge_patch.py::test_sarge_capture_has_flush_after_import` passes.
- [ ] xfail marker on `cumulusci/tests/triage/test_issue_3852.py` removed in the GREEN commit; test now passes.
- [ ] `uv run pytest cumulusci/utils/tests/ -q` clean.

## Provenance

Reproduced and characterized in the v5 triage evidence pack (PR #3979). See `docs/triage/v5/repro-results.md` (`### #3852`) for the full narrative.