### PR TITLE
fix(managed-context): correct namespace context calculation for multi-package

### DIFF
--- a/cumulusci/core/config/org_config.py
+++ b/cumulusci/core/config/org_config.py
@@ -318,9 +318,15 @@ class OrgConfig(BaseConfig):
 
     @property
     def installed_packages(self):
-        """installed_packages is a dict mapping a namespace or package Id (033*) to the installed package
+        """installed_packages is a dict mapping a namespace, package name, or package Id (033*) to the installed package
         version(s) matching that identifier. All values are lists, because multiple second-generation
         packages may be installed with the same namespace.
+
+        Keys include:
+        - namespace: "mycompany"
+        - package name: "My Package Name"
+        - namespace@version: "mycompany@1.2.3"
+        - package ID: "033ABCDEF123456"
 
         To check if a required package is present, call `has_minimum_package_version()` with either the
         namespace or 033 Id of the desired package and its version, in 1.2.3 format.
@@ -329,7 +335,7 @@ class OrgConfig(BaseConfig):
         """
         if self._installed_packages is None:
             isp_result = self.salesforce_client.restful(
-                "tooling/query/?q=SELECT SubscriberPackage.Id, SubscriberPackage.NamespacePrefix, "
+                "tooling/query/?q=SELECT SubscriberPackage.Id, SubscriberPackage.Name, SubscriberPackage.NamespacePrefix, "
                 "SubscriberPackageVersionId FROM InstalledSubscriberPackage"
             )
             _installed_packages = defaultdict(list)
@@ -357,10 +363,14 @@ class OrgConfig(BaseConfig):
                     version += f"b{spv['BuildNumber']}"
                 version_info = VersionInfo(spv["Id"], StrictVersion(version))
                 namespace = sp["NamespacePrefix"]
+                package_name = sp["Name"]
                 _installed_packages[namespace].append(version_info)
                 namespace_version = f"{namespace}@{version}"
                 _installed_packages[namespace_version].append(version_info)
                 _installed_packages[sp["Id"]].append(version_info)
+                # Add package name as a key for specific package detection
+                if package_name:
+                    _installed_packages[package_name].append(version_info)
 
             self._installed_packages = _installed_packages
         return self._installed_packages

--- a/cumulusci/core/config/tests/test_config.py
+++ b/cumulusci/core/config/tests/test_config.py
@@ -1185,6 +1185,7 @@ class TestOrgConfig:
                 {
                     "SubscriberPackage": {
                         "Id": "03350000000DEz4AAG",
+                        "Name": "Volunteers for Salesforce",
                         "NamespacePrefix": "GW_Volunteers",
                     },
                     "SubscriberPackageVersionId": "04t1T00000070yqQAA",
@@ -1192,6 +1193,7 @@ class TestOrgConfig:
                 {
                     "SubscriberPackage": {
                         "Id": "03350000000DEz5AAG",
+                        "Name": "Volunteers for Salesforce",
                         "NamespacePrefix": "GW_Volunteers",
                     },
                     "SubscriberPackageVersionId": "04t000000000001AAA",
@@ -1199,6 +1201,7 @@ class TestOrgConfig:
                 {
                     "SubscriberPackage": {
                         "Id": "03350000000DEz7AAG",
+                        "Name": "Test Package",
                         "NamespacePrefix": "TESTY",
                     },
                     "SubscriberPackageVersionId": "04t000000000002AAA",
@@ -1206,6 +1209,7 @@ class TestOrgConfig:
                 {
                     "SubscriberPackage": {
                         "Id": "03350000000DEz4AAG",
+                        "Name": "Blah Package",
                         "NamespacePrefix": "blah",
                     },
                     "SubscriberPackageVersionId": "04t0000000BOGUSAAA",
@@ -1213,6 +1217,7 @@ class TestOrgConfig:
                 {
                     "SubscriberPackage": {
                         "Id": "03350000000DEz8AAG",
+                        "Name": "Error Package",
                         "NamespacePrefix": "error",
                     },
                     "SubscriberPackageVersionId": "04t0000000ERRORAAA",
@@ -1295,6 +1300,13 @@ class TestOrgConfig:
                 VersionInfo("04t000000000001AAA", StrictVersion("12.0.1"))
             ],
             "03350000000DEz7AAG": [
+                VersionInfo("04t000000000002AAA", StrictVersion("1.10.0b5"))
+            ],
+            "Volunteers for Salesforce": [
+                VersionInfo("04t1T00000070yqQAA", StrictVersion("3.119")),
+                VersionInfo("04t000000000001AAA", StrictVersion("12.0.1")),
+            ],
+            "Test Package": [
                 VersionInfo("04t000000000002AAA", StrictVersion("1.10.0b5"))
             ],
         }

--- a/cumulusci/core/utils.py
+++ b/cumulusci/core/utils.py
@@ -378,23 +378,24 @@ def determine_managed_mode(options, project_config, org_config):
     if "managed" in options:
         return process_bool_arg(options["managed"])
 
+    if "unmanaged" in options:
+        return not process_bool_arg(options.get("unmanaged", True))
+
     # Get package and namespace information
     package_name = getattr(project_config, 'project__package__name', None)
     namespace = (
         getattr(project_config, 'project__package__namespace', None)
         or options.get("namespace")
     )
-    installed_packages = getattr(org_config, 'installed_packages', {})
 
-    if "unmanaged" in options:
-        # Explicit unmanaged flag always takes precedence
-        return not process_bool_arg(options.get("unmanaged", True))
-    elif package_name and any(package_name in key for key in installed_packages.keys()):
-        # If this specific package is installed (or there is any installed package with a Name that contains package_name), we're in managed context
-        return True
-    elif bool(namespace) and namespace == getattr(org_config, 'namespace', None):
-        # We're in a namespaced org (packaging org) developing unmanaged code
+    if not package_name and not namespace:
         return False
-    else:
-        # Fall back to checking namespace in installed packages
-        return bool(namespace) and namespace in installed_packages
+
+    if bool(namespace) and namespace == getattr(org_config, 'namespace', None):
+        return False
+
+    installed_packages = getattr(org_config, 'installed_packages', {})
+    if package_name and any(package_name in key for key in installed_packages.keys()):
+        return True
+
+    return bool(namespace) and namespace in installed_packages

--- a/cumulusci/core/utils.py
+++ b/cumulusci/core/utils.py
@@ -362,3 +362,39 @@ def make_jsonable(x):
         return x
     except (TypeError, OverflowError):
         return str(x)
+
+
+def determine_managed_mode(options, project_config, org_config):
+    """Determine the managed mode based on options, project config, and org config.
+
+    Args:
+        options: Dict of task options that may contain 'managed' or 'unmanaged' flags
+        project_config: Project configuration object with package info
+        org_config: Org configuration object with installed packages and namespace info
+
+    Returns:
+        bool: True if in managed mode, False if in unmanaged mode
+    """
+    if "managed" in options:
+        return process_bool_arg(options["managed"])
+
+    # Get package and namespace information
+    package_name = getattr(project_config, 'project__package__name', None)
+    namespace = (
+        getattr(project_config, 'project__package__namespace', None)
+        or options.get("namespace")
+    )
+    installed_packages = getattr(org_config, 'installed_packages', {})
+
+    if "unmanaged" in options:
+        # Explicit unmanaged flag always takes precedence
+        return not process_bool_arg(options.get("unmanaged", True))
+    elif package_name and any(package_name in key for key in installed_packages.keys()):
+        # If this specific package is installed (or there is any installed package with a Name that contains package_name), we're in managed context
+        return True
+    elif bool(namespace) and namespace == getattr(org_config, 'namespace', None):
+        # We're in a namespaced org (packaging org) developing unmanaged code
+        return False
+    else:
+        # Fall back to checking namespace in installed packages
+        return bool(namespace) and namespace in installed_packages

--- a/cumulusci/tasks/apex/anon.py
+++ b/cumulusci/tasks/apex/anon.py
@@ -4,7 +4,7 @@ from cumulusci.core.exceptions import (
     SalesforceException,
     TaskOptionsError,
 )
-from cumulusci.core.utils import process_bool_arg
+from cumulusci.core.utils import determine_managed_mode, process_bool_arg
 from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 from cumulusci.utils import in_directory, inject_namespace
 from cumulusci.utils.http.requests_utils import safe_json_from_response
@@ -107,12 +107,9 @@ class AnonymousApexTask(BaseSalesforceApiTask):
     def _prepare_apex(self, apex):
         # Process namespace tokens
         namespace = self.project_config.project__package__namespace
-        if "managed" in self.options:
-            managed = process_bool_arg(self.options["managed"])
-        else:
-            managed = (
-                bool(namespace) and namespace in self.org_config.installed_packages
-            )
+        managed = determine_managed_mode(
+            self.options, self.project_config, self.org_config
+        )
         if "namespaced" in self.options:
             namespaced = process_bool_arg(self.options["namespaced"])
         else:

--- a/cumulusci/tasks/apex/testrunner.py
+++ b/cumulusci/tasks/apex/testrunner.py
@@ -10,7 +10,12 @@ from cumulusci.core.exceptions import (
     CumulusCIException,
     TaskOptionsError,
 )
-from cumulusci.core.utils import decode_to_unicode, process_bool_arg, process_list_arg
+from cumulusci.core.utils import (
+    decode_to_unicode,
+    determine_managed_mode,
+    process_bool_arg,
+    process_list_arg,
+)
 from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 from cumulusci.utils.http.requests_utils import safe_json_from_response
 
@@ -609,13 +614,9 @@ class RunApexTests(BaseSalesforceApiTask):
 
     def _init_task(self):
         super()._init_task()
-        if "managed" in self.options:
-            self.options["managed"] = process_bool_arg(self.options["managed"] or False)
-        else:
-            namespace = self.options.get("namespace")
-            self.options["managed"] = (
-                bool(namespace) and namespace in self.org_config.installed_packages
-            )
+        self.options["managed"] = determine_managed_mode(
+            self.options, self.project_config, self.org_config
+        )
 
     def _run_task(self):
         result = self._get_test_classes()

--- a/cumulusci/tasks/apex/tests/test_apex_tasks.py
+++ b/cumulusci/tasks/apex/tests/test_apex_tasks.py
@@ -68,6 +68,7 @@ class TestRunApexTests(MockLoggerMixin):
             },
             "test",
         )
+        self.org_config._installed_packages = {}
         self.base_tooling_url = "{}/services/data/v{}/tooling/".format(
             self.org_config.instance_url, self.api_version
         )

--- a/cumulusci/tasks/metadata_etl/base.py
+++ b/cumulusci/tasks/metadata_etl/base.py
@@ -7,7 +7,11 @@ from cumulusci.core.config import TaskConfig
 from cumulusci.core.enums import StrEnum
 from cumulusci.core.exceptions import CumulusCIException, TaskOptionsError
 from cumulusci.core.tasks import BaseSalesforceTask
-from cumulusci.core.utils import process_bool_arg, process_list_arg
+from cumulusci.core.utils import (
+    determine_managed_mode,
+    process_bool_arg,
+    process_list_arg,
+)
 from cumulusci.salesforce_api.metadata import ApiRetrieveUnpackaged
 from cumulusci.tasks.metadata.package import PackageXmlGenerator
 from cumulusci.utils import inject_namespace
@@ -66,19 +70,16 @@ class BaseMetadataETLTask(BaseSalesforceTask, metaclass=ABCMeta):
             self.options.get("namespace_inject")
             or self.project_config.project__package__namespace
         )
-        if "managed" in self.options:
-            self.options["managed"] = process_bool_arg(self.options["managed"] or False)
-        else:
-            self.options["managed"] = (
-                bool(namespace) and namespace in self.org_config.installed_packages
-            )
+        self.options["managed"] = determine_managed_mode(
+            self.options, self.project_config, self.org_config
+        )
         if "namespaced_org" in self.options:
             self.options["namespaced_org"] = process_bool_arg(
                 self.options["namespaced_org"] or False
             )
         else:
             self.options["namespaced_org"] = (
-                bool(namespace) and namespace == self.org_config.namespace
+                bool(namespace) and namespace == getattr(self.org_config, 'namespace', None)
             )
 
     def _inject_namespace(self, text):

--- a/cumulusci/tasks/salesforce/Deploy.py
+++ b/cumulusci/tasks/salesforce/Deploy.py
@@ -12,7 +12,11 @@ from cumulusci.core.source_transforms.transforms import (
     SourceTransform,
     SourceTransformList,
 )
-from cumulusci.core.utils import process_bool_arg, process_list_arg
+from cumulusci.core.utils import (
+    determine_managed_mode,
+    process_bool_arg,
+    process_list_arg,
+)
 from cumulusci.salesforce_api.metadata import ApiDeploy, ApiRetrieveUnpackaged
 from cumulusci.salesforce_api.package_zip import MetadataPackageZipBuilder
 from cumulusci.salesforce_api.rest_deploy import RestDeploy
@@ -154,9 +158,9 @@ class Deploy(BaseSalesforceMetadataApiTask):
         )
 
     def _has_namespaced_package(self, ns: Optional[str]) -> bool:
-        if "unmanaged" in self.options:
-            return not process_bool_arg(self.options.get("unmanaged", True))
-        return bool(ns) and ns in self.org_config.installed_packages
+        return determine_managed_mode(
+            self.options, self.project_config, self.org_config
+        )
 
     def _is_namespaced_org(self, ns: Optional[str]) -> bool:
         if "namespaced_org" in self.options:

--- a/cumulusci/tasks/salesforce/composite.py
+++ b/cumulusci/tasks/salesforce/composite.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from cumulusci.cli.ui import CliTable
 from cumulusci.core.exceptions import SalesforceException
-from cumulusci.core.utils import process_bool_arg, process_list_arg
+from cumulusci.core.utils import determine_managed_mode, process_list_arg
 from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 from cumulusci.utils import inject_namespace
 
@@ -83,12 +83,9 @@ Example Task Definition
         body = body.replace("%%%USERID%%%", user_id)
 
         namespace = self.project_config.project__package__namespace
-        if "managed" in self.options:
-            managed = process_bool_arg(self.options["managed"])
-        else:
-            managed = (
-                bool(namespace) and namespace in self.org_config.installed_packages
-            )
+        managed = determine_managed_mode(
+            self.options, self.project_config, self.org_config
+        )
 
         _, body = inject_namespace(
             "composite",

--- a/cumulusci/tasks/salesforce/custom_settings_wait.py
+++ b/cumulusci/tasks/salesforce/custom_settings_wait.py
@@ -3,7 +3,7 @@
 from simple_salesforce.exceptions import SalesforceError
 
 from cumulusci.core.exceptions import TaskOptionsError
-from cumulusci.core.utils import process_bool_arg
+from cumulusci.core.utils import determine_managed_mode, process_bool_arg
 from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 
 
@@ -93,12 +93,9 @@ class CustomSettingValueWait(BaseSalesforceApiTask):
     def _apply_namespace(self):
         # Process namespace tokens
         namespace = self.project_config.project__package__namespace
-        if "managed" in self.options:
-            managed = process_bool_arg(self.options["managed"])
-        else:
-            managed = (
-                bool(namespace) and namespace in self.org_config.installed_packages
-            )
+        managed = determine_managed_mode(
+            self.options, self.project_config, self.org_config
+        )
         if "namespaced" in self.options:
             namespaced = process_bool_arg(self.options["namespaced"])
         else:

--- a/cumulusci/tasks/salesforce/enable_prediction.py
+++ b/cumulusci/tasks/salesforce/enable_prediction.py
@@ -1,7 +1,11 @@
 from simple_salesforce.exceptions import SalesforceError
 
 from cumulusci.core.exceptions import CumulusCIException
-from cumulusci.core.utils import process_bool_arg, process_list_arg
+from cumulusci.core.utils import (
+    determine_managed_mode,
+    process_bool_arg,
+    process_list_arg,
+)
 from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 from cumulusci.utils import inject_namespace
 from cumulusci.utils.http.requests_utils import safe_json_from_response
@@ -37,12 +41,9 @@ class EnablePrediction(BaseSalesforceApiTask):
             or self.project_config.project__package__namespace
         )
         self.options["namespace_inject"] = namespace
-        if "managed" in self.options:
-            self.options["managed"] = process_bool_arg(self.options["managed"] or False)
-        else:
-            self.options["managed"] = (
-                bool(namespace) and namespace in self.org_config.installed_packages
-            )
+        self.options["managed"] = determine_managed_mode(
+            self.options, self.project_config, self.org_config
+        )
         if "namespaced_org" in self.options:
             self.options["namespaced_org"] = process_bool_arg(
                 self.options["namespaced_org"] or False

--- a/cumulusci/utils/__init__.py
+++ b/cumulusci/utils/__init__.py
@@ -264,6 +264,14 @@ def inject_namespace(
                 f'  {name}: Replaced {filename_token} with "{namespace_prefix}"'
             )
 
+        # Also replace ___NAMESPACED_ORG___ tokens in package.xml
+        prev_content = content
+        content = content.replace(namespaced_org_file_token, namespaced_org)
+        if logger and content != prev_content:
+            logger.info(
+                f'  {name}: Replaced {namespaced_org_file_token} with "{namespaced_org}"'
+            )
+
     prev_content = content
     content = content.replace(namespaced_org_token, namespaced_org)
     if logger and content != prev_content:
@@ -430,7 +438,7 @@ def get_option_usage_string(name, option):
     """
     usage_str = option.get("usage")
     if not usage_str:
-        usage_str = f"--{name} {name.replace('_','').upper()}"
+        usage_str = f"--{name} {name.replace('_', '').upper()}"
     return usage_str
 
 


### PR DESCRIPTION
## Summary

Cherry-pick of #3906 by @jorgesolebur with fixes for lint, test compatibility, and a backward-compat fix for task-level `namespace` option fallback.

- Centralizes managed-mode determination into `determine_managed_mode()` in `cumulusci/core/utils.py`
- Indexes `installed_packages` by package Name in addition to namespace and ID
- Fixes `___NAMESPACED_ORG___` token replacement in package.xml
- Adds backward-compatible fallback to `options["namespace"]` when project config namespace is unset

Closes #3906

## Test plan

- [x] All touched module tests pass locally (394 passed)
- [ ] CI required checks pass (Python 3.11-3.13)

Co-authored-by: Jorge Soler <jsolerburguera@salesforce.com>