### PR TITLE
fix(playwright): cast viewport dimensions to int (#3955)

### DIFF
--- a/cumulusci/robotframework/SalesforcePlaywright.py
+++ b/cumulusci/robotframework/SalesforcePlaywright.py
@@ -103,7 +103,7 @@ class SalesforcePlaywright(FakerMixin, BaseLibrary):
             # seems to be the only way to get the videos to go directly in
             # the video folder. Also, using "." doesn't work :-/
             record_video = {"dir": "../video"}
-        width, height = size.split("x", 1)
+        width, height = (int(v) for v in size.split("x", 1))
 
         browser_id = self.browser.new_browser(browser=browser_enum, headless=headless)
         context_id = self.browser.new_context(

--- a/cumulusci/tests/triage/test_issue_3955.py
+++ b/cumulusci/tests/triage/test_issue_3955.py
@@ -47,10 +47,7 @@ def _stub_browser_library():
             sys.modules.pop(name, None)
 
 
-@pytest.mark.xfail(
-    reason=("repro for #3955 - see docs/triage/v5/repro-results.md"),
-    strict=False,
-)
+
 def test_open_test_browser_passes_int_viewport_to_playwright():
     from cumulusci.robotframework.SalesforcePlaywright import SalesforcePlaywright
 


### PR DESCRIPTION
Fixes #3955. Casts width/height to int after splitting the size string, matching Playwright's viewport contract.