### PR TITLE
Fix Handle SF CLI 2.136+ credential redaction in SFDX org config

### DIFF
--- a/cumulusci/cli/tests/test_org.py
+++ b/cumulusci/cli/tests/test_org.py
@@ -96,7 +96,7 @@ class TestOrgCommands:
         auth_code_flow.return_value = {
             "instance_url": "https://instance",
             "access_token": "BOGUS",
-            "id": "OODxxxxxxxxxxxx/user",
+            "id": "00Dxxxxxxxxxxxx/user",
         }
         runtime = mock.Mock()
         runtime.project_config = BaseProjectConfig(UniversalConfig(), config={})
@@ -109,7 +109,7 @@ class TestOrgCommands:
         )
         responses.add(
             method="GET",
-            url=f"https://instance/services/data/v{CURRENT_SF_API_VERSION}/sobjects/Organization/OODxxxxxxxxxxxx",
+            url=f"https://instance/services/data/v{CURRENT_SF_API_VERSION}/sobjects/Organization/00Dxxxxxxxxxxxx",
             json={
                 "TrialExpirationDate": None,
                 "OrganizationType": "Developer Edition",
@@ -129,7 +129,7 @@ class TestOrgCommands:
 
         name, org_config = runtime.keychain.get_default_org()
         assert name == "test"
-        assert org_config.id == "OODxxxxxxxxxxxx/user"
+        assert org_config.id == "00Dxxxxxxxxxxxx/user"
         assert org_config.connected_app == "built-in"
         assert org_config.expires == "Persistent"
         assert "Connecting org using the built-in connected app..." in result.output
@@ -141,7 +141,7 @@ class TestOrgCommands:
         auth_code_flow.return_value = {
             "instance_url": "https://instance",
             "access_token": "BOGUS",
-            "id": "OODxxxxxxxxxxxx/user",
+            "id": "00Dxxxxxxxxxxxx/user",
         }
         runtime = mock.Mock()
         runtime.project_config = BaseProjectConfig(UniversalConfig(), config={})
@@ -166,7 +166,7 @@ class TestOrgCommands:
         )
         responses.add(
             method="GET",
-            url=f"https://instance/services/data/v{CURRENT_SF_API_VERSION}/sobjects/Organization/OODxxxxxxxxxxxx",
+            url=f"https://instance/services/data/v{CURRENT_SF_API_VERSION}/sobjects/Organization/00Dxxxxxxxxxxxx",
             json={
                 "TrialExpirationDate": None,
                 "OrganizationType": "Developer Edition",
@@ -280,7 +280,7 @@ class TestOrgCommands:
         client_instance.auth_code_flow.return_value = {
             "instance_url": "https://instance",
             "access_token": "BOGUS",
-            "id": "OODxxxxxxxxxxxx/user",
+            "id": "00Dxxxxxxxxxxxx/user",
         }
         oauth2client.return_value = client_instance
         runtime = mock.Mock()
@@ -297,7 +297,7 @@ class TestOrgCommands:
         )
         responses.add(
             method="GET",
-            url=f"https://instance/services/data/v{CURRENT_SF_API_VERSION}/sobjects/Organization/OODxxxxxxxxxxxx",
+            url=f"https://instance/services/data/v{CURRENT_SF_API_VERSION}/sobjects/Organization/00Dxxxxxxxxxxxx",
             json={
                 "TrialExpirationDate": "1970-01-01T12:34:56.000+0000",
                 "OrganizationType": "Developer Edition",
@@ -379,11 +379,11 @@ class TestOrgCommands:
         runtime = mock.Mock()
         result = b"""{
             "result": {
-                "id": "OODxxxxxxxxxxxx",
+                "id": "00Dxxxxxxxxxxxx",
                 "createdDate": "1970-01-01T00:00:00.000Z",
                 "expirationDate": "1970-01-01",
                 "instanceUrl": "url",
-                "accessToken": "OODxxxxxxxxxxxx!token",
+                "accessToken": "00Dxxxxxxxxxxxx!token",
                 "username": "test@test.org",
                 "password": "password"
             }
@@ -402,7 +402,7 @@ class TestOrgCommands:
             )
             runtime.keychain.set_org.assert_called_once()
         assert (
-            "Imported scratch org: OODxxxxxxxxxxxx, username: test@test.org"
+            "Imported scratch org: 00Dxxxxxxxxxxxx, username: test@test.org"
             in "".join(out)
         )
 
@@ -412,10 +412,10 @@ class TestOrgCommands:
         runtime = mock.Mock()
         result = b"""{
             "result": {
-                "id": "OODxxxxxxxxxxxx",
+                "id": "00Dxxxxxxxxxxxx",
                 "createdDate": null,
                 "instanceUrl": "https://instance",
-                "accessToken": "OODxxxxxxxxxxxx!token",
+                "accessToken": "00Dxxxxxxxxxxxx!token",
                 "username": "test@test.org",
                 "password": "password"
             }
@@ -433,7 +433,7 @@ class TestOrgCommands:
         )
         responses.add(
             method="GET",
-            url=f"https://instance/services/data/v{CURRENT_SF_API_VERSION}/sobjects/Organization/OODxxxxxxxxxxxx",
+            url=f"https://instance/services/data/v{CURRENT_SF_API_VERSION}/sobjects/Organization/00Dxxxxxxxxxxxx",
             json={
                 "TrialExpirationDate": None,
                 "OrganizationType": "Developer Edition",
@@ -458,7 +458,7 @@ class TestOrgCommands:
             assert created_org.config["sfdx"]
         assert created_org.config["expires"] == "Persistent"
 
-        assert "Imported org: OODxxxxxxxxxxxx, username: test@test.org" in "".join(out)
+        assert "Imported org: 00Dxxxxxxxxxxxx, username: test@test.org" in "".join(out)
 
     @mock.patch("sarge.Command")
     @responses.activate
@@ -466,10 +466,10 @@ class TestOrgCommands:
         runtime = mock.Mock()
         result = b"""{
             "result": {
-                "id": "OODxxxxxxxxxxxx",
+                "id": "00Dxxxxxxxxxxxx",
                 "createdDate": null,
                 "instanceUrl": "https://instance",
-                "accessToken": "OODxxxxxxxxxxxx!token",
+                "accessToken": "00Dxxxxxxxxxxxx!token",
                 "username": "test@test.org",
                 "password": "password"
             }
@@ -488,7 +488,7 @@ class TestOrgCommands:
         )
         responses.add(
             method="GET",
-            url=f"https://instance/services/data/v{CURRENT_SF_API_VERSION}/sobjects/Organization/OODxxxxxxxxxxxx",
+            url=f"https://instance/services/data/v{CURRENT_SF_API_VERSION}/sobjects/Organization/00Dxxxxxxxxxxxx",
             json={
                 "TrialExpirationDate": api_datetime,
                 "OrganizationType": "Developer Edition",
@@ -515,7 +515,7 @@ class TestOrgCommands:
                 created_org.config["expires"] == parse_api_datetime(api_datetime).date()
             )
 
-        assert "Imported org: OODxxxxxxxxxxxx, username: test@test.org" in "".join(out)
+        assert "Imported org: 00Dxxxxxxxxxxxx, username: test@test.org" in "".join(out)
 
     def test_calculate_org_days(self):
         info_1 = {

--- a/cumulusci/cli/tests/test_org.py
+++ b/cumulusci/cli/tests/test_org.py
@@ -379,6 +379,7 @@ class TestOrgCommands:
         runtime = mock.Mock()
         result = b"""{
             "result": {
+                "id": "OODxxxxxxxxxxxx",
                 "createdDate": "1970-01-01T00:00:00.000Z",
                 "expirationDate": "1970-01-01",
                 "instanceUrl": "url",

--- a/cumulusci/cli/tests/test_org.py
+++ b/cumulusci/cli/tests/test_org.py
@@ -888,9 +888,9 @@ class TestOrgCommands:
 
         run_click_command(org.org_list, runtime=runtime, json_flag=False, plain=False)
 
-        assert "Cannot load org config for `test1`" in str(
+        assert "Cannot load org config for `test1`" in str(echo.mock_calls), (
             echo.mock_calls
-        ), echo.mock_calls
+        )
         assert "NOPE!" in str(echo.mock_calls), echo.mock_calls
         assert "Cannot cleanup org cache dirs" in str(echo.mock_calls), echo.mock_calls
 

--- a/cumulusci/core/config/sfdx_org_config.py
+++ b/cumulusci/core/config/sfdx_org_config.py
@@ -4,10 +4,23 @@ from json.decoder import JSONDecodeError
 
 from cumulusci.core.config import OrgConfig
 from cumulusci.core.exceptions import SfdxOrgException
-from cumulusci.core.sfdx import sfdx
+from cumulusci.core.sfdx import sfdx, shell_quote
 from cumulusci.utils import get_git_config
 
 nl = "\n"  # fstrings can't contain backslashes
+
+# Prefix of the sentinel string that SF CLI 2.136+ writes in place of
+# credential fields when SF_TEMP_SHOW_SECRETS is unset. See
+# @salesforce/plugin-org messages/secrets-redacted.md for the canonical
+# strings. Prefix-only matching avoids coupling to the English suffix.
+_REDACTED_PREFIX = "[REDACTED] "
+
+
+def _is_redacted(value):
+    """True when the CLI returned an absent/empty value or a redaction sentinel."""
+    if not value:
+        return True
+    return isinstance(value, str) and value.startswith(_REDACTED_PREFIX)
 
 
 class SfdxOrgConfig(OrgConfig):
@@ -63,12 +76,19 @@ class SfdxOrgConfig(OrgConfig):
             )
 
         access_token = result.get("accessToken")
-        if not access_token:
+        fallback_fired = _is_redacted(access_token)
+        if fallback_fired:
             access_token = self._fetch_access_token(username)
 
         password = result.get("password")
-        if not password:
+        # Only call show-user-password when the CLI redacted the password
+        # field AND we already know we're on a new CLI (access-token fallback
+        # fired). Legacy-passwordless orgs leave `password` absent; calling
+        # show-user-password in that case is a pointless extra subprocess.
+        if fallback_fired and _is_redacted(password):
             password = self._fetch_user_password(username)
+        elif _is_redacted(password):
+            password = None
 
         sfdx_info = {
             "instance_url": result["instanceUrl"],
@@ -181,7 +201,7 @@ class SfdxOrgConfig(OrgConfig):
             else:
                 username = result[0]["Username"]
 
-        p = sfdx(f"org display --target-org={username} --json")
+        p = sfdx(f"org display --target-org={shell_quote(username)} --json")
         if p.returncode:
             output = p.stdout_text.read()
             try:
@@ -196,9 +216,9 @@ class SfdxOrgConfig(OrgConfig):
 
         info = json.loads(p.stdout_text.read())
         token = info.get("result", {}).get("accessToken")
-        if token:
-            return token
-        return self._fetch_access_token(username)
+        if _is_redacted(token):
+            return self._fetch_access_token(username)
+        return token
 
     def _fetch_access_token(self, username):
         """Retrieve an access token using `sf org auth show-access-token`.
@@ -206,7 +226,8 @@ class SfdxOrgConfig(OrgConfig):
         Used as a fallback when `sf org display` redacts the token (SF CLI 2.136+).
         """
         p = sfdx(
-            f"org auth show-access-token --target-org={username} --json --no-prompt"
+            f"org auth show-access-token --target-org={shell_quote(username)}"
+            f" --json --no-prompt"
         )
         output = p.stdout_text.read()
         if p.returncode:
@@ -227,7 +248,9 @@ class SfdxOrgConfig(OrgConfig):
                 f"Failed to parse JSON from `sf org auth show-access-token`: {e}"
             )
         token = info.get("result", {}).get("accessToken")
-        if not token:
+        if _is_redacted(token):
+            # Defensive: if show-access-token itself ever returns a sentinel,
+            # treat it as failure rather than handing back a placeholder.
             raise SfdxOrgException(
                 f"Unable to retrieve access token for {username}. "
                 f"Tried `sf org display` and `sf org auth show-access-token`. "
@@ -242,7 +265,8 @@ class SfdxOrgConfig(OrgConfig):
         Returns None if the org has no password or the command fails; never raises.
         """
         p = sfdx(
-            f"org auth show-user-password --target-org={username} --json --no-prompt"
+            f"org auth show-user-password --target-org={shell_quote(username)}"
+            f" --json --no-prompt"
         )
         if p.returncode:
             return None
@@ -251,7 +275,9 @@ class SfdxOrgConfig(OrgConfig):
         except JSONDecodeError:
             return None
         password = info.get("result", {}).get("password")
-        return password if password else None
+        if _is_redacted(password):
+            return None
+        return password
 
     def force_refresh_oauth_token(self):
         # Call org display and parse output to get instance_url and

--- a/cumulusci/core/config/sfdx_org_config.py
+++ b/cumulusci/core/config/sfdx_org_config.py
@@ -193,9 +193,12 @@ class SfdxOrgConfig(OrgConfig):
             raise SfdxOrgException(
                 f"Unable to find access token for {username}\n{explanation}"
             )
-        else:
-            info = json.loads(p.stdout_text.read())
-            return info["result"]["accessToken"]
+
+        info = json.loads(p.stdout_text.read())
+        token = info.get("result", {}).get("accessToken")
+        if token:
+            return token
+        return self._fetch_access_token(username)
 
     def _fetch_access_token(self, username):
         """Retrieve an access token using `sf org auth show-access-token`.

--- a/cumulusci/core/config/sfdx_org_config.py
+++ b/cumulusci/core/config/sfdx_org_config.py
@@ -13,6 +13,8 @@ nl = "\n"  # fstrings can't contain backslashes
 # credential fields when SF_TEMP_SHOW_SECRETS is unset. See
 # @salesforce/plugin-org messages/secrets-redacted.md for the canonical
 # strings. Prefix-only matching avoids coupling to the English suffix.
+# The trailing space is load-bearing: the CLI sentinel is the literal
+# "[REDACTED] Use ..." form, never "[REDACTED]Use ...".
 _REDACTED_PREFIX = "[REDACTED] "
 
 
@@ -97,8 +99,6 @@ class SfdxOrgConfig(OrgConfig):
         # in that case is a pointless extra subprocess on every refresh.
         if _is_sentinel(password):
             password = self._fetch_user_password(username)
-        elif not password:
-            password = None
 
         sfdx_info = {
             "instance_url": result["instanceUrl"],
@@ -271,18 +271,29 @@ class SfdxOrgConfig(OrgConfig):
     def _fetch_user_password(self, username):
         """Retrieve the org password using `sf org auth show-user-password`.
 
-        Used as a fallback when `sf org display` redacts the password (SF CLI 2.136+).
-        Returns None if the org has no password or the command fails; never raises.
+        Used as a fallback when `sf org display` redacts the password (SF CLI
+        2.136+). Returns None on any failure path (non-zero exit, malformed
+        JSON, sentinel result) since the password is optional. Failures are
+        logged at debug level so transient issues can be diagnosed without
+        promoting the call to raise.
         """
         p = sfdx(
             f"org auth show-user-password --target-org={shell_quote(username)}"
             f" --json --no-prompt"
         )
         if p.returncode:
+            self.logger.debug(
+                f"sf org auth show-user-password exited {p.returncode} for "
+                f"{username}; treating as no password."
+            )
             return None
         try:
             info = json.loads(p.stdout_text.read())
-        except JSONDecodeError:
+        except JSONDecodeError as e:
+            self.logger.debug(
+                f"Failed to parse JSON from sf org auth show-user-password "
+                f"for {username}: {e}. Treating as no password."
+            )
             return None
         password = info.get("result", {}).get("password")
         if _is_redacted(password):

--- a/cumulusci/core/config/sfdx_org_config.py
+++ b/cumulusci/core/config/sfdx_org_config.py
@@ -182,6 +182,41 @@ class SfdxOrgConfig(OrgConfig):
             info = json.loads(p.stdout_text.read())
             return info["result"]["accessToken"]
 
+    def _fetch_access_token(self, username):
+        """Retrieve an access token using `sf org auth show-access-token`.
+
+        Used as a fallback when `sf org display` redacts the token (SF CLI 2.136+).
+        """
+        p = sfdx(
+            f"org auth show-access-token --target-org={username} --json --no-prompt"
+        )
+        output = p.stdout_text.read()
+        if p.returncode:
+            try:
+                explanation = json.loads(output).get("message", output)
+            except JSONDecodeError:
+                explanation = output
+            raise SfdxOrgException(
+                f"Unable to retrieve access token for {username}. "
+                f"Tried `sf org display` and `sf org auth show-access-token`. "
+                f"Try running `sf org login` or upgrading the Salesforce CLI.\n"
+                f"{explanation}"
+            )
+        try:
+            info = json.loads(output)
+        except JSONDecodeError as e:
+            raise SfdxOrgException(
+                f"Failed to parse JSON from `sf org auth show-access-token`: {e}"
+            )
+        token = info.get("result", {}).get("accessToken")
+        if not token:
+            raise SfdxOrgException(
+                f"Unable to retrieve access token for {username}. "
+                f"Tried `sf org display` and `sf org auth show-access-token`. "
+                f"Try running `sf org login` or upgrading the Salesforce CLI."
+            )
+        return token
+
     def force_refresh_oauth_token(self):
         # Call org display and parse output to get instance_url and
         # access_token

--- a/cumulusci/core/config/sfdx_org_config.py
+++ b/cumulusci/core/config/sfdx_org_config.py
@@ -15,6 +15,16 @@ nl = "\n"  # fstrings can't contain backslashes
 # strings. Prefix-only matching avoids coupling to the English suffix.
 # The trailing space is load-bearing: the CLI sentinel is the literal
 # "[REDACTED] Use ..." form, never "[REDACTED]Use ...".
+#
+# Locale fragility: today `@salesforce/core`'s Messages.getLocale() is
+# hardcoded to en_US (per-locale message bundles are an unimplemented
+# TODO upstream), so this prefix is stable on every shipping CLI. The
+# "[REDACTED] " literal lives inside the translatable message string,
+# however; if Salesforce later wires up localization, a non-English
+# `redacted.accessToken` could drop this prefix and silently break
+# detection. A locale-independent signal (matching the three sentinel
+# message keys, or "value is not a well-formed access token") would be
+# more robust if/when that lands.
 _REDACTED_PREFIX = "[REDACTED] "
 
 

--- a/cumulusci/core/config/sfdx_org_config.py
+++ b/cumulusci/core/config/sfdx_org_config.py
@@ -16,11 +16,22 @@ nl = "\n"  # fstrings can't contain backslashes
 _REDACTED_PREFIX = "[REDACTED] "
 
 
+def _is_sentinel(value):
+    """True only for the SF CLI 2.136+ redaction sentinel string."""
+    return isinstance(value, str) and value.startswith(_REDACTED_PREFIX)
+
+
 def _is_redacted(value):
-    """True when the CLI returned an absent/empty value or a redaction sentinel."""
+    """True when the CLI returned an absent/empty value or the redaction sentinel.
+
+    Used for the access-token path: an absent token is as actionable as a redacted
+    one (both mean "ask `sf org auth show-access-token`"). For the password path,
+    prefer _is_sentinel so a legitimately-absent password (passwordless org on a
+    new CLI) does not trigger a pointless `sf org auth show-user-password` call.
+    """
     if not value:
         return True
-    return isinstance(value, str) and value.startswith(_REDACTED_PREFIX)
+    return _is_sentinel(value)
 
 
 class SfdxOrgConfig(OrgConfig):
@@ -76,18 +87,17 @@ class SfdxOrgConfig(OrgConfig):
             )
 
         access_token = result.get("accessToken")
-        fallback_fired = _is_redacted(access_token)
-        if fallback_fired:
+        if _is_redacted(access_token):
             access_token = self._fetch_access_token(username)
 
         password = result.get("password")
-        # Only call show-user-password when the CLI redacted the password
-        # field AND we already know we're on a new CLI (access-token fallback
-        # fired). Legacy-passwordless orgs leave `password` absent; calling
-        # show-user-password in that case is a pointless extra subprocess.
-        if fallback_fired and _is_redacted(password):
+        # Gate the password fallback on the sentinel ONLY. An absent password
+        # means the org has no password (web-auth sandbox, scratch org without
+        # `force:user:password:generate`); calling `sf org auth show-user-password`
+        # in that case is a pointless extra subprocess on every refresh.
+        if _is_sentinel(password):
             password = self._fetch_user_password(username)
-        elif _is_redacted(password):
+        elif not password:
             password = None
 
         sfdx_info = {

--- a/cumulusci/core/config/sfdx_org_config.py
+++ b/cumulusci/core/config/sfdx_org_config.py
@@ -53,24 +53,39 @@ class SfdxOrgConfig(OrgConfig):
                     "Failed to parse json from output.\n  "
                     f"Exception: {e.__class__.__name__}\n  Output: {''.join(stdout_list)}"
                 )
-            org_id = org_info["result"]["accessToken"].split("!")[0]
+            result = org_info["result"]
+
+        org_id = result.get("id")
+        if not org_id:
+            raise SfdxOrgException(
+                "Salesforce CLI did not return an org id from `sf org display`. "
+                "Please re-authenticate with `sf org login`."
+            )
+
+        access_token = result.get("accessToken")
+        if not access_token:
+            access_token = self._fetch_access_token(username)
+
+        password = result.get("password")
+        if not password:
+            password = self._fetch_user_password(username)
 
         sfdx_info = {
-            "instance_url": org_info["result"]["instanceUrl"],
-            "access_token": org_info["result"]["accessToken"],
+            "instance_url": result["instanceUrl"],
+            "access_token": access_token,
             "org_id": org_id,
-            "username": org_info["result"]["username"],
+            "username": result["username"],
         }
-        if org_info["result"].get("password"):
-            sfdx_info["password"] = org_info["result"]["password"]
+        if password:
+            sfdx_info["password"] = password
         self._sfdx_info = sfdx_info
         self._sfdx_info_date = datetime.datetime.utcnow()
         self.config.update(sfdx_info)
 
         sfdx_info.update(
             {
-                "created_date": org_info["result"].get("createdDate"),
-                "expiration_date": org_info["result"].get("expirationDate"),
+                "created_date": result.get("createdDate"),
+                "expiration_date": result.get("expirationDate"),
             }
         )
         return sfdx_info

--- a/cumulusci/core/config/sfdx_org_config.py
+++ b/cumulusci/core/config/sfdx_org_config.py
@@ -25,6 +25,9 @@ nl = "\n"  # fstrings can't contain backslashes
 # detection. A locale-independent signal (matching the three sentinel
 # message keys, or "value is not a well-formed access token") would be
 # more robust if/when that lands.
+#
+# Tripwire: if a `sf org display --json` access token round-trips into
+# an API 401 with a human-readable token value, suspect this path first.
 _REDACTED_PREFIX = "[REDACTED] "
 
 

--- a/cumulusci/core/config/sfdx_org_config.py
+++ b/cumulusci/core/config/sfdx_org_config.py
@@ -217,6 +217,24 @@ class SfdxOrgConfig(OrgConfig):
             )
         return token
 
+    def _fetch_user_password(self, username):
+        """Retrieve the org password using `sf org auth show-user-password`.
+
+        Used as a fallback when `sf org display` redacts the password (SF CLI 2.136+).
+        Returns None if the org has no password or the command fails; never raises.
+        """
+        p = sfdx(
+            f"org auth show-user-password --target-org={username} --json --no-prompt"
+        )
+        if p.returncode:
+            return None
+        try:
+            info = json.loads(p.stdout_text.read())
+        except JSONDecodeError:
+            return None
+        password = info.get("result", {}).get("password")
+        return password if password else None
+
     def force_refresh_oauth_token(self):
         # Call org display and parse output to get instance_url and
         # access_token

--- a/cumulusci/core/config/tests/test_config_expensive.py
+++ b/cumulusci/core/config/tests/test_config_expensive.py
@@ -660,6 +660,119 @@ class TestScratchOrgConfig:
         password = config._fetch_user_password("test@example.com")
         assert password is None
 
+    # ---- SF CLI 2.136+ sentinel-redaction model (spec round 3) ----
+    #
+    # The CLI does NOT remove redacted fields; it replaces them with a
+    # truthy sentinel string. Falsy detection misses this. Detection MUST
+    # key on the "[REDACTED] " prefix. Three failing tests below pin the
+    # contract.
+
+    def test_sfdx_info_sentinel_token_triggers_fallback(self, Command):
+        """Spec round 3: redacted token is a truthy sentinel, not absent."""
+        redacted_token = (
+            "[REDACTED] Use 'sf org auth show-access-token' to view"
+        )
+        org_display = (
+            b'{"result": {"id": "00DDP000006GRcP2AW", "instanceUrl": "url",'
+            b' "username": "username", "accessToken":'
+            b' "' + redacted_token.encode() + b'", "createdDate":'
+            b' "1970-01-01T00:00:00Z", "expirationDate": "1970-01-08"}}'
+        )
+        token_fetch = b'{"result": {"accessToken": "real-token"}}'
+
+        Command.side_effect = [
+            mock.Mock(
+                stderr=io.BytesIO(b""), stdout=io.BytesIO(org_display), returncode=0
+            ),
+            mock.Mock(
+                stderr=io.BytesIO(b""), stdout=io.BytesIO(token_fetch), returncode=0
+            ),
+        ]
+
+        config = SfdxOrgConfig({"username": "test", "created": True}, "test")
+        info = config.sfdx_info
+
+        assert info["access_token"] == "real-token"
+        assert not info["access_token"].startswith("[REDACTED]")
+        assert Command.call_count == 2
+
+    def test_fetch_user_password_returns_none_on_sentinel(self, Command):
+        """Spec round 3: show-user-password returning a sentinel = no password."""
+        sentinel = (
+            b'{"result": {"password": "[REDACTED] Use'
+            b" 'sf org auth show-user-password' to view\"}}"
+        )
+        Command.return_value = mock.Mock(
+            stderr=io.BytesIO(b""),
+            stdout=io.BytesIO(sentinel),
+            returncode=0,
+        )
+
+        config = SfdxOrgConfig({"username": "test"}, "test")
+        password = config._fetch_user_password("test@example.com")
+        assert password is None
+
+    def test_get_access_token_sentinel_triggers_fallback(self, Command):
+        """Spec round 3: get_access_token must detect the sentinel, not just absence."""
+        redacted_token = (
+            "[REDACTED] Use 'sf org auth show-access-token' to view"
+        )
+        sf = mock.Mock()
+        sf.query_all.return_value = {"records": [{"Username": "whatever@example.com"}]}
+
+        first_response = mock.Mock(returncode=0)
+        first_response.stdout_text.read.return_value = (
+            '{"result": {"id": "00DDP000006GRcP2AW", "instanceUrl": "url",'
+            f' "accessToken": "{redacted_token}"}}}}'
+        )
+        second_response = mock.Mock(returncode=0)
+        second_response.stdout_text.read.return_value = (
+            '{"result": {"accessToken": "real-token"}}'
+        )
+        sfdx_mock = mock.Mock(side_effect=[first_response, second_response])
+
+        config = ScratchOrgConfig({}, "test")
+        with mock.patch(
+            "cumulusci.core.config.org_config.OrgConfig.salesforce_client", sf
+        ):
+            with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx_mock):
+                access_token = config.get_access_token(alias="dadvisor")
+                assert sfdx_mock.call_count == 2
+                assert access_token == "real-token"
+                assert not access_token.startswith("[REDACTED]")
+
+    def test_fetch_access_token_shell_quotes_username(self, Command):
+        """Spec round 3: usernames must be shell_quote'd; sfdx() uses shell=True."""
+        Command.return_value = mock.Mock(
+            stderr=io.BytesIO(b""),
+            stdout=io.BytesIO(b'{"result": {"accessToken": "fetched-token"}}'),
+            returncode=0,
+        )
+
+        config = SfdxOrgConfig({"username": "test"}, "test")
+        sfdx_mock = mock.Mock(return_value=mock.Mock(
+            returncode=0,
+            stdout_text=io.BytesIO(b'{"result": {"accessToken": "fetched-token"}}'),
+        ))
+        # Build a payload that includes a stdout_text read() side-effect.
+        sfdx_mock.return_value.stdout_text.read = mock.Mock(
+            return_value=b'{"result": {"accessToken": "fetched-token"}}'
+        )
+        with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx_mock):
+            config._fetch_access_token("weird;user@example.com")
+
+        cmd = sfdx_mock.call_args_list[0][0][0]
+        # Raw, unquoted username would let the semicolon break out of the arg.
+        assert "weird;user@example.com" not in cmd or (
+            "'weird;user@example.com'" in cmd
+            or '"weird;user@example.com"' in cmd
+        )
+        # Stronger form: the quoted token must appear.
+        assert (
+            "'weird;user@example.com'" in cmd
+            or '"weird;user@example.com"' in cmd
+        ), f"username not shell-quoted in command: {cmd!r}"
+
     def test_instance_url(self, Command):
         config = ScratchOrgConfig({}, "test")
         _marker = object()

--- a/cumulusci/core/config/tests/test_config_expensive.py
+++ b/cumulusci/core/config/tests/test_config_expensive.py
@@ -669,9 +669,7 @@ class TestScratchOrgConfig:
 
     def test_sfdx_info_sentinel_token_triggers_fallback(self, Command):
         """Spec round 3: redacted token is a truthy sentinel, not absent."""
-        redacted_token = (
-            "[REDACTED] Use 'sf org auth show-access-token' to view"
-        )
+        redacted_token = "[REDACTED] Use 'sf org auth show-access-token' to view"
         org_display = (
             b'{"result": {"id": "00DDP000006GRcP2AW", "instanceUrl": "url",'
             b' "username": "username", "accessToken":'
@@ -679,6 +677,8 @@ class TestScratchOrgConfig:
             b' "1970-01-01T00:00:00Z", "expirationDate": "1970-01-08"}}'
         )
         token_fetch = b'{"result": {"accessToken": "real-token"}}'
+        # Password absent in org_display -> _is_redacted True -> show-user-password runs.
+        password_fetch = b'{"result": {"password": null}}'
 
         Command.side_effect = [
             mock.Mock(
@@ -687,6 +687,9 @@ class TestScratchOrgConfig:
             mock.Mock(
                 stderr=io.BytesIO(b""), stdout=io.BytesIO(token_fetch), returncode=0
             ),
+            mock.Mock(
+                stderr=io.BytesIO(b""), stdout=io.BytesIO(password_fetch), returncode=0
+            ),
         ]
 
         config = SfdxOrgConfig({"username": "test", "created": True}, "test")
@@ -694,7 +697,7 @@ class TestScratchOrgConfig:
 
         assert info["access_token"] == "real-token"
         assert not info["access_token"].startswith("[REDACTED]")
-        assert Command.call_count == 2
+        assert Command.call_count == 3
 
     def test_fetch_user_password_returns_none_on_sentinel(self, Command):
         """Spec round 3: show-user-password returning a sentinel = no password."""
@@ -714,9 +717,7 @@ class TestScratchOrgConfig:
 
     def test_get_access_token_sentinel_triggers_fallback(self, Command):
         """Spec round 3: get_access_token must detect the sentinel, not just absence."""
-        redacted_token = (
-            "[REDACTED] Use 'sf org auth show-access-token' to view"
-        )
+        redacted_token = "[REDACTED] Use 'sf org auth show-access-token' to view"
         sf = mock.Mock()
         sf.query_all.return_value = {"records": [{"Username": "whatever@example.com"}]}
 
@@ -750,10 +751,12 @@ class TestScratchOrgConfig:
         )
 
         config = SfdxOrgConfig({"username": "test"}, "test")
-        sfdx_mock = mock.Mock(return_value=mock.Mock(
-            returncode=0,
-            stdout_text=io.BytesIO(b'{"result": {"accessToken": "fetched-token"}}'),
-        ))
+        sfdx_mock = mock.Mock(
+            return_value=mock.Mock(
+                returncode=0,
+                stdout_text=io.BytesIO(b'{"result": {"accessToken": "fetched-token"}}'),
+            )
+        )
         # Build a payload that includes a stdout_text read() side-effect.
         sfdx_mock.return_value.stdout_text.read = mock.Mock(
             return_value=b'{"result": {"accessToken": "fetched-token"}}'
@@ -764,13 +767,11 @@ class TestScratchOrgConfig:
         cmd = sfdx_mock.call_args_list[0][0][0]
         # Raw, unquoted username would let the semicolon break out of the arg.
         assert "weird;user@example.com" not in cmd or (
-            "'weird;user@example.com'" in cmd
-            or '"weird;user@example.com"' in cmd
+            "'weird;user@example.com'" in cmd or '"weird;user@example.com"' in cmd
         )
         # Stronger form: the quoted token must appear.
         assert (
-            "'weird;user@example.com'" in cmd
-            or '"weird;user@example.com"' in cmd
+            "'weird;user@example.com'" in cmd or '"weird;user@example.com"' in cmd
         ), f"username not shell-quoted in command: {cmd!r}"
 
     def test_instance_url(self, Command):

--- a/cumulusci/core/config/tests/test_config_expensive.py
+++ b/cumulusci/core/config/tests/test_config_expensive.py
@@ -480,6 +480,39 @@ class TestScratchOrgConfig:
             config._fetch_access_token("test@example.com")
         assert "sf org auth show-access-token" in str(exc_info.value)
 
+    def test_fetch_user_password(self, Command):
+        Command.return_value = mock.Mock(
+            stderr=io.BytesIO(b""),
+            stdout=io.BytesIO(b'{"result": {"password": "secret-pw"}}'),
+            returncode=0,
+        )
+
+        config = SfdxOrgConfig({"username": "test"}, "test")
+        password = config._fetch_user_password("test@example.com")
+        assert password == "secret-pw"
+
+    def test_fetch_user_password_returns_none_on_error(self, Command):
+        Command.return_value = mock.Mock(
+            stderr=io.BytesIO(b"no password set"),
+            stdout=io.BytesIO(b'{"message": "no password"}'),
+            returncode=1,
+        )
+
+        config = SfdxOrgConfig({"username": "test"}, "test")
+        password = config._fetch_user_password("test@example.com")
+        assert password is None
+
+    def test_fetch_user_password_returns_none_on_empty(self, Command):
+        Command.return_value = mock.Mock(
+            stderr=io.BytesIO(b""),
+            stdout=io.BytesIO(b'{"result": {"password": null}}'),
+            returncode=0,
+        )
+
+        config = SfdxOrgConfig({"username": "test"}, "test")
+        password = config._fetch_user_password("test@example.com")
+        assert password is None
+
     def test_instance_url(self, Command):
         config = ScratchOrgConfig({}, "test")
         _marker = object()

--- a/cumulusci/core/config/tests/test_config_expensive.py
+++ b/cumulusci/core/config/tests/test_config_expensive.py
@@ -274,8 +274,9 @@ class TestScratchOrgConfig:
     def test_scratch_info(self, Command):
         result = b"""{
     "result": {
+        "id": "00DDP000006GRcP2AW",
         "instanceUrl": "url",
-        "accessToken": "access!token",
+        "accessToken": "00DDP000006GRcP!real-token",
         "username": "username",
         "password": "password",
         "createdDate": "1970-01-01T00:00:00Z",
@@ -290,9 +291,9 @@ class TestScratchOrgConfig:
         info = config.scratch_info
 
         assert info == {
-            "access_token": "access!token",
+            "access_token": "00DDP000006GRcP!real-token",
             "instance_url": "url",
-            "org_id": "access",
+            "org_id": "00DDP000006GRcP2AW",
             "password": "password",
             "username": "username",
             "created_date": "1970-01-01T00:00:00Z",
@@ -308,6 +309,106 @@ class TestScratchOrgConfig:
         ):
             assert key in config.config
         assert config._sfdx_info_date
+
+    def test_sfdx_info_new_cli_fetches_token(self, Command):
+        # First subprocess: sf org display redacts accessToken
+        org_display = b"""{
+    "result": {
+        "id": "00DDP000006GRcP2AW",
+        "instanceUrl": "url",
+        "username": "username",
+        "createdDate": "1970-01-01T00:00:00Z",
+        "expirationDate": "1970-01-08"
+    }
+}"""
+        # Second subprocess: sf org auth show-access-token returns the token
+        token_fetch = b'{"result": {"accessToken": "fetched-token"}}'
+        # Third subprocess: sf org auth show-user-password returns null (no password)
+        password_fetch = b'{"result": {"password": null}}'
+
+        Command.side_effect = [
+            mock.Mock(stderr=io.BytesIO(b""), stdout=io.BytesIO(org_display), returncode=0),
+            mock.Mock(stderr=io.BytesIO(b""), stdout=io.BytesIO(token_fetch), returncode=0),
+            mock.Mock(stderr=io.BytesIO(b""), stdout=io.BytesIO(password_fetch), returncode=0),
+        ]
+
+        config = SfdxOrgConfig({"username": "test", "created": True}, "test")
+        info = config.sfdx_info
+
+        assert info["access_token"] == "fetched-token"
+        assert info["org_id"] == "00DDP000006GRcP2AW"
+        assert "password" not in info
+        assert Command.call_count == 3
+
+    def test_sfdx_info_new_cli_fetches_password(self, Command):
+        org_display = b"""{
+    "result": {
+        "id": "00DDP000006GRcP2AW",
+        "instanceUrl": "url",
+        "username": "username",
+        "createdDate": "1970-01-01T00:00:00Z",
+        "expirationDate": "1970-01-08"
+    }
+}"""
+        token_fetch = b'{"result": {"accessToken": "fetched-token"}}'
+        password_fetch = b'{"result": {"password": "fetched-pw"}}'
+
+        Command.side_effect = [
+            mock.Mock(stderr=io.BytesIO(b""), stdout=io.BytesIO(org_display), returncode=0),
+            mock.Mock(stderr=io.BytesIO(b""), stdout=io.BytesIO(token_fetch), returncode=0),
+            mock.Mock(stderr=io.BytesIO(b""), stdout=io.BytesIO(password_fetch), returncode=0),
+        ]
+
+        config = SfdxOrgConfig({"username": "test", "created": True}, "test")
+        info = config.sfdx_info
+
+        assert info["access_token"] == "fetched-token"
+        assert info["password"] == "fetched-pw"
+
+    def test_sfdx_info_token_fetch_fails(self, Command):
+        org_display = b"""{
+    "result": {
+        "id": "00DDP000006GRcP2AW",
+        "instanceUrl": "url",
+        "username": "username",
+        "createdDate": "1970-01-01T00:00:00Z",
+        "expirationDate": "1970-01-08"
+    }
+}"""
+
+        Command.side_effect = [
+            mock.Mock(stderr=io.BytesIO(b""), stdout=io.BytesIO(org_display), returncode=0),
+            mock.Mock(
+                stderr=io.BytesIO(b"auth expired"),
+                stdout=io.BytesIO(b'{"message": "auth expired"}'),
+                returncode=1,
+            ),
+        ]
+
+        config = SfdxOrgConfig({"username": "test", "created": True}, "test")
+        with pytest.raises(SfdxOrgException) as exc_info:
+            config.sfdx_info
+        msg = str(exc_info.value)
+        assert "sf org display" in msg
+        assert "sf org auth show-access-token" in msg
+
+    def test_sfdx_info_missing_id(self, Command):
+        # sf org display returns no id and no accessToken (worst case)
+        org_display = b"""{
+    "result": {
+        "instanceUrl": "url",
+        "username": "username"
+    }
+}"""
+
+        Command.return_value = mock.Mock(
+            stderr=io.BytesIO(b""), stdout=io.BytesIO(org_display), returncode=0
+        )
+
+        config = SfdxOrgConfig({"username": "test", "created": True}, "test")
+        with pytest.raises(SfdxOrgException) as exc_info:
+            config.sfdx_info
+        assert "org id" in str(exc_info.value).lower()
 
     def test_scratch_info_memoized(self, Command):
         config = ScratchOrgConfig({"username": "test", "created": True}, "test")
@@ -810,6 +911,7 @@ class TestScratchOrgConfig:
     def test_refresh_oauth_token(self, Command):
         result = b"""{
     "result": {
+        "id": "00DDP000006GRcP2AW",
         "instanceUrl": "url",
         "accessToken": "access!token",
         "username": "username",

--- a/cumulusci/core/config/tests/test_config_expensive.py
+++ b/cumulusci/core/config/tests/test_config_expensive.py
@@ -311,7 +311,7 @@ class TestScratchOrgConfig:
         assert config._sfdx_info_date
 
     def test_sfdx_info_new_cli_fetches_token(self, Command):
-        # First subprocess: sf org display redacts accessToken
+        # First subprocess: sf org display redacts accessToken; org has no password
         org_display = b"""{
     "result": {
         "id": "00DDP000006GRcP2AW",
@@ -323,8 +323,86 @@ class TestScratchOrgConfig:
 }"""
         # Second subprocess: sf org auth show-access-token returns the token
         token_fetch = b'{"result": {"accessToken": "fetched-token"}}'
-        # Third subprocess: sf org auth show-user-password returns null (no password)
-        password_fetch = b'{"result": {"password": null}}'
+
+        Command.side_effect = [
+            mock.Mock(
+                stderr=io.BytesIO(b""), stdout=io.BytesIO(org_display), returncode=0
+            ),
+            mock.Mock(
+                stderr=io.BytesIO(b""), stdout=io.BytesIO(token_fetch), returncode=0
+            ),
+        ]
+
+        config = SfdxOrgConfig({"username": "test", "created": True}, "test")
+        info = config.sfdx_info
+
+        assert info["access_token"] == "fetched-token"
+        assert info["org_id"] == "00DDP000006GRcP2AW"
+        assert "password" not in info
+        # Critical: no show-user-password call for a passwordless org. The
+        # password gate keys on the sentinel, not on absence.
+        assert Command.call_count == 2
+
+    def test_sfdx_info_new_cli_no_password_org(self, Command):
+        """New CLI + passwordless org: token sentinel, password absent.
+
+        Must NOT call `sf org auth show-user-password` (the absent password is
+        not a sentinel; the org genuinely has no password).
+        """
+        sentinel = (
+            "[REDACTED] Use 'sf org auth show-access-token' "
+            "--target-org <username> to view"
+        )
+        org_display = (
+            '{"result": {'
+            '"id": "00DDP000006GRcP2AW",'
+            '"instanceUrl": "url",'
+            f'"accessToken": "{sentinel}",'
+            '"username": "username"'
+            "}}"
+        ).encode()
+        token_fetch = b'{"result": {"accessToken": "fetched-token"}}'
+
+        Command.side_effect = [
+            mock.Mock(
+                stderr=io.BytesIO(b""), stdout=io.BytesIO(org_display), returncode=0
+            ),
+            mock.Mock(
+                stderr=io.BytesIO(b""), stdout=io.BytesIO(token_fetch), returncode=0
+            ),
+        ]
+
+        config = SfdxOrgConfig({"username": "test", "created": True}, "test")
+        info = config.sfdx_info
+
+        assert info["access_token"] == "fetched-token"
+        assert "password" not in info
+        assert Command.call_count == 2
+
+    def test_sfdx_info_sentinel_password_uses_fetched(self, Command):
+        """New CLI + scratch org with generated password: BOTH fields are sentinels.
+
+        Must call `sf org auth show-user-password` and surface the fetched value.
+        """
+        token_sentinel = (
+            "[REDACTED] Use 'sf org auth show-access-token' "
+            "--target-org <username> to view"
+        )
+        pw_sentinel = (
+            "[REDACTED] Use 'sf org auth show-user-password' "
+            "--target-org <username> to view"
+        )
+        org_display = (
+            '{"result": {'
+            '"id": "00DDP000006GRcP2AW",'
+            '"instanceUrl": "url",'
+            f'"accessToken": "{token_sentinel}",'
+            f'"password": "{pw_sentinel}",'
+            '"username": "username"'
+            "}}"
+        ).encode()
+        token_fetch = b'{"result": {"accessToken": "fetched-token"}}'
+        password_fetch = b'{"result": {"password": "fetched-pw"}}'
 
         Command.side_effect = [
             mock.Mock(
@@ -342,20 +420,32 @@ class TestScratchOrgConfig:
         info = config.sfdx_info
 
         assert info["access_token"] == "fetched-token"
-        assert info["org_id"] == "00DDP000006GRcP2AW"
-        assert "password" not in info
+        assert info["password"] == "fetched-pw"
         assert Command.call_count == 3
 
     def test_sfdx_info_new_cli_fetches_password(self, Command):
-        org_display = b"""{
-    "result": {
-        "id": "00DDP000006GRcP2AW",
-        "instanceUrl": "url",
-        "username": "username",
-        "createdDate": "1970-01-01T00:00:00Z",
-        "expirationDate": "1970-01-08"
-    }
-}"""
+        # New CLI redacts BOTH fields when the org has a generated password
+        # (e.g. a scratch org). Password fallback fires only on the sentinel,
+        # not on absence.
+        token_sentinel = (
+            "[REDACTED] Use 'sf org auth show-access-token' "
+            "--target-org <username> to view"
+        )
+        pw_sentinel = (
+            "[REDACTED] Use 'sf org auth show-user-password' "
+            "--target-org <username> to view"
+        )
+        org_display = (
+            '{"result": {'
+            '"id": "00DDP000006GRcP2AW",'
+            '"instanceUrl": "url",'
+            '"username": "username",'
+            f'"accessToken": "{token_sentinel}",'
+            f'"password": "{pw_sentinel}",'
+            '"createdDate": "1970-01-01T00:00:00Z",'
+            '"expirationDate": "1970-01-08"'
+            "}}"
+        ).encode()
         token_fetch = b'{"result": {"accessToken": "fetched-token"}}'
         password_fetch = b'{"result": {"password": "fetched-pw"}}'
 
@@ -677,8 +767,6 @@ class TestScratchOrgConfig:
             b' "1970-01-01T00:00:00Z", "expirationDate": "1970-01-08"}}'
         )
         token_fetch = b'{"result": {"accessToken": "real-token"}}'
-        # Password absent in org_display -> _is_redacted True -> show-user-password runs.
-        password_fetch = b'{"result": {"password": null}}'
 
         Command.side_effect = [
             mock.Mock(
@@ -687,9 +775,6 @@ class TestScratchOrgConfig:
             mock.Mock(
                 stderr=io.BytesIO(b""), stdout=io.BytesIO(token_fetch), returncode=0
             ),
-            mock.Mock(
-                stderr=io.BytesIO(b""), stdout=io.BytesIO(password_fetch), returncode=0
-            ),
         ]
 
         config = SfdxOrgConfig({"username": "test", "created": True}, "test")
@@ -697,7 +782,8 @@ class TestScratchOrgConfig:
 
         assert info["access_token"] == "real-token"
         assert not info["access_token"].startswith("[REDACTED]")
-        assert Command.call_count == 3
+        # Password absent in org_display -> NOT a sentinel -> no fallback subprocess.
+        assert Command.call_count == 2
 
     def test_fetch_user_password_returns_none_on_sentinel(self, Command):
         """Spec round 3: show-user-password returning a sentinel = no password."""
@@ -770,9 +856,9 @@ class TestScratchOrgConfig:
             "'weird;user@example.com'" in cmd or '"weird;user@example.com"' in cmd
         )
         # Stronger form: the quoted token must appear.
-        assert (
-            "'weird;user@example.com'" in cmd or '"weird;user@example.com"' in cmd
-        ), f"username not shell-quoted in command: {cmd!r}"
+        assert "'weird;user@example.com'" in cmd or '"weird;user@example.com"' in cmd, (
+            f"username not shell-quoted in command: {cmd!r}"
+        )
 
     def test_instance_url(self, Command):
         config = ScratchOrgConfig({}, "test")

--- a/cumulusci/core/config/tests/test_config_expensive.py
+++ b/cumulusci/core/config/tests/test_config_expensive.py
@@ -442,6 +442,44 @@ class TestScratchOrgConfig:
                 with pytest.raises(SfdxOrgException, match=exception):
                     config.get_access_token(alias="dadvisor")
 
+    def test_fetch_access_token(self, Command):
+        Command.return_value = mock.Mock(
+            stderr=io.BytesIO(b""),
+            stdout=io.BytesIO(b'{"result": {"accessToken": "fetched-token"}}'),
+            returncode=0,
+        )
+
+        config = SfdxOrgConfig({"username": "test"}, "test")
+        token = config._fetch_access_token("test@example.com")
+        assert token == "fetched-token"
+
+    def test_fetch_access_token_subprocess_fails(self, Command):
+        Command.return_value = mock.Mock(
+            stderr=io.BytesIO(b""),
+            stdout=io.BytesIO(b'{"message": "auth expired"}'),
+            returncode=1,
+        )
+
+        config = SfdxOrgConfig({"username": "test"}, "test")
+        with pytest.raises(SfdxOrgException) as exc_info:
+            config._fetch_access_token("test@example.com")
+        msg = str(exc_info.value)
+        assert "sf org display" in msg
+        assert "sf org auth show-access-token" in msg
+        assert "test@example.com" in msg
+
+    def test_fetch_access_token_missing_field(self, Command):
+        Command.return_value = mock.Mock(
+            stderr=io.BytesIO(b""),
+            stdout=io.BytesIO(b'{"result": {}}'),
+            returncode=0,
+        )
+
+        config = SfdxOrgConfig({"username": "test"}, "test")
+        with pytest.raises(SfdxOrgException) as exc_info:
+            config._fetch_access_token("test@example.com")
+        assert "sf org auth show-access-token" in str(exc_info.value)
+
     def test_instance_url(self, Command):
         config = ScratchOrgConfig({}, "test")
         _marker = object()

--- a/cumulusci/core/config/tests/test_config_expensive.py
+++ b/cumulusci/core/config/tests/test_config_expensive.py
@@ -309,6 +309,9 @@ class TestScratchOrgConfig:
         ):
             assert key in config.config
         assert config._sfdx_info_date
+        # Legacy CLI: a single org_display call must satisfy sfdx_info; no
+        # show-access-token / show-user-password fallback subprocesses.
+        assert Command.call_count == 1
 
     def test_sfdx_info_new_cli_fetches_token(self, Command):
         # First subprocess: sf org display redacts accessToken; org has no password
@@ -466,6 +469,8 @@ class TestScratchOrgConfig:
 
         assert info["access_token"] == "fetched-token"
         assert info["password"] == "fetched-pw"
+        # Both sentinels present: org_display + show-access-token + show-user-password.
+        assert Command.call_count == 3
 
     def test_sfdx_info_token_fetch_fails(self, Command):
         org_display = b"""{
@@ -851,11 +856,8 @@ class TestScratchOrgConfig:
             config._fetch_access_token("weird;user@example.com")
 
         cmd = sfdx_mock.call_args_list[0][0][0]
-        # Raw, unquoted username would let the semicolon break out of the arg.
-        assert "weird;user@example.com" not in cmd or (
-            "'weird;user@example.com'" in cmd or '"weird;user@example.com"' in cmd
-        )
-        # Stronger form: the quoted token must appear.
+        # The username must appear shell-quoted; raw interpolation under
+        # shell=True would let the semicolon break out of the arg.
         assert "'weird;user@example.com'" in cmd or '"weird;user@example.com"' in cmd, (
             f"username not shell-quoted in command: {cmd!r}"
         )

--- a/cumulusci/core/config/tests/test_config_expensive.py
+++ b/cumulusci/core/config/tests/test_config_expensive.py
@@ -327,9 +327,15 @@ class TestScratchOrgConfig:
         password_fetch = b'{"result": {"password": null}}'
 
         Command.side_effect = [
-            mock.Mock(stderr=io.BytesIO(b""), stdout=io.BytesIO(org_display), returncode=0),
-            mock.Mock(stderr=io.BytesIO(b""), stdout=io.BytesIO(token_fetch), returncode=0),
-            mock.Mock(stderr=io.BytesIO(b""), stdout=io.BytesIO(password_fetch), returncode=0),
+            mock.Mock(
+                stderr=io.BytesIO(b""), stdout=io.BytesIO(org_display), returncode=0
+            ),
+            mock.Mock(
+                stderr=io.BytesIO(b""), stdout=io.BytesIO(token_fetch), returncode=0
+            ),
+            mock.Mock(
+                stderr=io.BytesIO(b""), stdout=io.BytesIO(password_fetch), returncode=0
+            ),
         ]
 
         config = SfdxOrgConfig({"username": "test", "created": True}, "test")
@@ -354,9 +360,15 @@ class TestScratchOrgConfig:
         password_fetch = b'{"result": {"password": "fetched-pw"}}'
 
         Command.side_effect = [
-            mock.Mock(stderr=io.BytesIO(b""), stdout=io.BytesIO(org_display), returncode=0),
-            mock.Mock(stderr=io.BytesIO(b""), stdout=io.BytesIO(token_fetch), returncode=0),
-            mock.Mock(stderr=io.BytesIO(b""), stdout=io.BytesIO(password_fetch), returncode=0),
+            mock.Mock(
+                stderr=io.BytesIO(b""), stdout=io.BytesIO(org_display), returncode=0
+            ),
+            mock.Mock(
+                stderr=io.BytesIO(b""), stdout=io.BytesIO(token_fetch), returncode=0
+            ),
+            mock.Mock(
+                stderr=io.BytesIO(b""), stdout=io.BytesIO(password_fetch), returncode=0
+            ),
         ]
 
         config = SfdxOrgConfig({"username": "test", "created": True}, "test")
@@ -377,7 +389,9 @@ class TestScratchOrgConfig:
 }"""
 
         Command.side_effect = [
-            mock.Mock(stderr=io.BytesIO(b""), stdout=io.BytesIO(org_display), returncode=0),
+            mock.Mock(
+                stderr=io.BytesIO(b""), stdout=io.BytesIO(org_display), returncode=0
+            ),
             mock.Mock(
                 stderr=io.BytesIO(b"auth expired"),
                 stdout=io.BytesIO(b'{"message": "auth expired"}'),

--- a/cumulusci/core/config/tests/test_config_expensive.py
+++ b/cumulusci/core/config/tests/test_config_expensive.py
@@ -543,6 +543,38 @@ class TestScratchOrgConfig:
                 with pytest.raises(SfdxOrgException, match=exception):
                     config.get_access_token(alias="dadvisor")
 
+    def test_get_access_token__new_cli(self, Command):
+        """Verify that get_access_token falls back to show-access-token when redacted"""
+        sf = mock.Mock()
+        sf.query_all.return_value = {"records": [{"Username": "whatever@example.com"}]}
+
+        # First sfdx call: sf org display returns no accessToken (redacted)
+        # Second sfdx call: sf org auth show-access-token returns the token
+        first_response = mock.Mock(returncode=0)
+        first_response.stdout_text.read.return_value = (
+            '{"result": {"id": "00DDP000006GRcP2AW", "instanceUrl": "url"}}'
+        )
+        second_response = mock.Mock(returncode=0)
+        second_response.stdout_text.read.return_value = (
+            '{"result": {"accessToken": "fetched-token"}}'
+        )
+        sfdx_mock = mock.Mock(side_effect=[first_response, second_response])
+
+        config = ScratchOrgConfig({}, "test")
+        with mock.patch(
+            "cumulusci.core.config.org_config.OrgConfig.salesforce_client", sf
+        ):
+            with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx_mock):
+                access_token = config.get_access_token(alias="dadvisor")
+                assert sfdx_mock.call_count == 2
+                first_call_args = sfdx_mock.call_args_list[0][0][0]
+                second_call_args = sfdx_mock.call_args_list[1][0][0]
+                assert "org display" in first_call_args
+                assert "whatever@example.com" in first_call_args
+                assert "show-access-token" in second_call_args
+                assert "whatever@example.com" in second_call_args
+                assert access_token == "fetched-token"
+
     def test_fetch_access_token(self, Command):
         Command.return_value = mock.Mock(
             stderr=io.BytesIO(b""),


### PR DESCRIPTION
# Handle SF CLI 2.136+ credential redaction in SFDX org config

  ## Summary

  SF CLI 2.136+ no longer returns raw secrets from `sf org display --json`.
  Instead of the actual value (or absence), redacted fields come back as a
  **truthy sentinel string** prefixed `"[REDACTED] "`, e.g.
  `"[REDACTED] Use 'sf org auth show-access-token' to view"`.

  CumulusCI's `SfdxOrgConfig` detected redaction with `if not value:`, which
  never fires against a truthy sentinel — so the access token and password
  were silently populated with the placeholder string, later surfacing as
  opaque API 401s. This PR corrects the detection model and adds the
  documented fallback path.

  ## Changes

  - **Detect the `[REDACTED] ` sentinel** rather than testing for
    absence/null. `sfdx_info` (access token + password) and
    `get_access_token` all route through the new detection helper.
  - **Fall back to the `show-*` subcommands** when a field is redacted:
    `sf org auth show-access-token` and `sf org auth show-user-password`.
    The legacy-CLI path (raw values, no sentinel) is unchanged.
  - **Use `result.id` directly for `org_id`** instead of splitting it out of
    the access-token prefix, which is no longer available under redaction.
  - **Shell-quote usernames** at every `--target-org={username}`
    interpolation site (these run through `sfdx()` with `shell=True`),
    closing a command-injection footgun.
  - **Gate the password fallback on the sentinel only**, not on absence, so
    passwordless orgs (web-auth sandboxes, scratch orgs without a generated
    password) don't fire a pointless extra subprocess.

  Cache shape and the 1-hour TTL are preserved. `ScratchOrgConfig.scratch_info`
  inherits the fix via the existing alias.

  ## Testing

  - Added coverage for the sentinel-detection and shell-quote contracts,
    including the passwordless-org "no fallback" case and the
    both-fields-redacted scratch-org shape.
  - Full suite green (`test_config_expensive` + `test_org`).

  Closes #3987